### PR TITLE
Automatically open task view after creating new task

### DIFF
--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -154,6 +154,10 @@ export function AppLayout() {
                   await updateTask(newTask.id, { attachments })
                 }
                 closeModal()
+                // Automatically select and open the newly created task
+                if (newTask) {
+                  selectTask(newTask.id)
+                }
               }}
               onCancel={closeModal}
             />


### PR DESCRIPTION
## Summary
- When a user clicks "Create Task" and the modal closes, the main app now automatically opens and displays the newly created task
- This provides immediate visual feedback and eliminates the need to manually find the task in the list

## Changes
- Modified `AppLayout.tsx` to call `selectTask(newTask.id)` after successfully creating a task and closing the modal
- The task is selected after attachments are processed to ensure the task is fully created

## Test plan
- [ ] Click "Create Task" button
- [ ] Fill in task details
- [ ] Submit the form
- [ ] Verify the modal closes
- [ ] Verify the newly created task is automatically selected and displayed in the task view

🤖 Generated with [Claude Code](https://claude.com/claude-code)