### PR TITLE
feat: add explicit auth method selector for Claude Code

### DIFF
--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -153,13 +153,12 @@ export class AcpAdapter implements CodingAgentAdapter {
         }
       case 'claude-code':
         // claude-code-acp is also a Node.js script
+        // Note: ANTHROPIC_API_KEY is NOT included here — it is handled per-session
+        // in createSession/resumeSession based on config.authMethod
         return {
           command: 'node',
           args: [require.resolve('@zed-industries/claude-code-acp/dist/index.js')],
-          env: {
-            // Claude Code requires ANTHROPIC_API_KEY
-            ...(process.env.ANTHROPIC_API_KEY && { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY })
-          }
+          env: {}
         }
       default:
         throw new Error(`Unsupported ACP agent type: ${agentType}`)
@@ -215,8 +214,25 @@ export class AcpAdapter implements CodingAgentAdapter {
       env.OPENAI_API_KEY = config.apiKeys.openai
       env.CODEX_API_KEY = config.apiKeys.openai
     }
-    if (config.apiKeys?.anthropic) {
-      env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
+
+    // Claude Code auth method handling
+    if (this.agentType === 'claude-code') {
+      const authMethod = config.authMethod || 'subscription' // default to subscription
+      if (authMethod === 'api_key') {
+        // API Key mode: use configured key, or fall back to env var
+        if (config.apiKeys?.anthropic) {
+          env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
+        }
+        // If neither configured key nor env var exists, warn below
+      } else {
+        // Subscription mode: MUST NOT pass ANTHROPIC_API_KEY so Claude Code uses OAuth
+        delete env.ANTHROPIC_API_KEY
+        console.log(`[AcpAdapter/claude-code] Subscription auth: removed ANTHROPIC_API_KEY from env`)
+      }
+    } else {
+      if (config.apiKeys?.anthropic) {
+        env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
+      }
     }
 
     // Inject secret env vars directly into process environment
@@ -232,8 +248,11 @@ export class AcpAdapter implements CodingAgentAdapter {
         console.warn('[AcpAdapter/codex] No OPENAI_API_KEY or CODEX_API_KEY in environment — relying on agent\'s own auth')
       }
     } else if (this.agentType === 'claude-code') {
-      if (!env.ANTHROPIC_API_KEY) {
-        console.warn('[AcpAdapter/claude-code] No ANTHROPIC_API_KEY in environment — relying on agent\'s own auth')
+      const authMethod = config.authMethod || 'subscription'
+      if (authMethod === 'api_key' && !env.ANTHROPIC_API_KEY) {
+        console.warn('[AcpAdapter/claude-code] API key auth selected but no ANTHROPIC_API_KEY available')
+      } else if (authMethod === 'subscription') {
+        console.log('[AcpAdapter/claude-code] Using subscription auth (OAuth)')
       }
     }
 
@@ -354,8 +373,24 @@ export class AcpAdapter implements CodingAgentAdapter {
       env.OPENAI_API_KEY = config.apiKeys.openai
       env.CODEX_API_KEY = config.apiKeys.openai
     }
-    if (config.apiKeys?.anthropic) {
-      env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
+
+    // Claude Code auth method handling
+    if (this.agentType === 'claude-code') {
+      const authMethod = config.authMethod || 'subscription' // default to subscription
+      if (authMethod === 'api_key') {
+        // API Key mode: use configured key, or fall back to env var
+        if (config.apiKeys?.anthropic) {
+          env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
+        }
+      } else {
+        // Subscription mode: MUST NOT pass ANTHROPIC_API_KEY so Claude Code uses OAuth
+        delete env.ANTHROPIC_API_KEY
+        console.log(`[AcpAdapter/claude-code] Subscription auth: removed ANTHROPIC_API_KEY from env`)
+      }
+    } else {
+      if (config.apiKeys?.anthropic) {
+        env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
+      }
     }
 
     console.log(`[AcpAdapter/${this.agentType}] Environment after config:`, {
@@ -377,8 +412,11 @@ export class AcpAdapter implements CodingAgentAdapter {
         console.warn('[AcpAdapter/codex] No OPENAI_API_KEY or CODEX_API_KEY in environment — relying on agent\'s own auth')
       }
     } else if (this.agentType === 'claude-code') {
-      if (!env.ANTHROPIC_API_KEY) {
-        console.warn('[AcpAdapter/claude-code] No ANTHROPIC_API_KEY in environment — relying on agent\'s own auth')
+      const authMethod = config.authMethod || 'subscription'
+      if (authMethod === 'api_key' && !env.ANTHROPIC_API_KEY) {
+        console.warn('[AcpAdapter/claude-code] API key auth selected but no ANTHROPIC_API_KEY available')
+      } else if (authMethod === 'subscription') {
+        console.log('[AcpAdapter/claude-code] Using subscription auth (OAuth)')
       }
     }
 

--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -44,6 +44,8 @@ export interface SessionConfig {
   tools?: Record<string, boolean>
   promptAbort?: AbortController
   mcpServers?: Record<string, McpServerConfig>
+  /** Claude Code auth method: 'subscription' (OAuth/Pro/Max) or 'api_key' (pay-per-use). Defaults to 'subscription'. */
+  authMethod?: 'subscription' | 'api_key'
   apiKeys?: {
     openai?: string
     anthropic?: string

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -300,6 +300,7 @@ export class AgentManager extends EventEmitter {
       model: agent.config?.model,
       systemPrompt: agent.config?.system_prompt,
       mcpServers,
+      authMethod: agent.config?.auth_method,
       apiKeys: agent.config?.api_keys
     }
 
@@ -939,6 +940,7 @@ export class AgentManager extends EventEmitter {
       model: agent.config?.model,
       systemPrompt: agent.config?.system_prompt,
       mcpServers,
+      authMethod: agent.config?.auth_method,
       apiKeys: agent.config?.api_keys
     }
 
@@ -1390,6 +1392,7 @@ export class AgentManager extends EventEmitter {
       model: agent.config?.model,
       systemPrompt: baseSystemPrompt + taskContext,
       mcpServers,
+      authMethod: agent.config?.auth_method,
       apiKeys: agent.config?.api_keys
     }
 

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -34,6 +34,7 @@ export interface AgentMcpServerEntry {
 export interface AgentConfigRecord {
   coding_agent?: 'opencode' | 'claude-code' | 'codex'
   model?: string
+  auth_method?: 'subscription' | 'api_key'
   system_prompt?: string
   mcp_servers?: Array<string | AgentMcpServerEntry>
   skill_ids?: string[]

--- a/src/renderer/src/components/agents/AgentForm.tsx
+++ b/src/renderer/src/components/agents/AgentForm.tsx
@@ -9,7 +9,7 @@ import { agentConfigApi } from '@/lib/ipc-client'
 import { useMcpStore } from '@/stores/mcp-store'
 import { SkillSelector } from '@/components/skills/SkillSelector'
 import { SecretSelector } from '@/components/secrets/SecretSelector'
-import type { Agent, CreateAgentDTO, UpdateAgentDTO, AgentMcpServerEntry } from '@/types'
+import type { Agent, CreateAgentDTO, UpdateAgentDTO, AgentMcpServerEntry, ClaudeAuthMethod } from '@/types'
 import { CodingAgentType, CODING_AGENTS, CLAUDE_MODELS, CODEX_MODELS } from '@/types'
 
 interface AgentFormProps {
@@ -50,6 +50,11 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
     () => parseMcpSelection(agent?.config.mcp_servers)
   )
   const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set())
+
+  // Auth method state (Claude Code only)
+  const [authMethod, setAuthMethod] = useState<ClaudeAuthMethod>(
+    agent?.config.auth_method ?? 'subscription'
+  )
 
   // API keys state
   const [openaiApiKey, setOpenaiApiKey] = useState(agent?.config.api_keys?.openai ?? '')
@@ -93,6 +98,13 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
       setModel('')
     }
   }, [codingAgent, serverUrl])
+
+  // Reset auth method when switching away from Claude Code
+  useEffect(() => {
+    if (codingAgent !== CodingAgentType.CLAUDE_CODE) {
+      setAuthMethod('subscription')
+    }
+  }, [codingAgent])
 
   const fetchModels = async () => {
     setIsLoadingModels(true)
@@ -182,6 +194,7 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
       config: {
         coding_agent: codingAgent || undefined,
         model: model.trim() || undefined,
+        auth_method: codingAgent === CodingAgentType.CLAUDE_CODE ? authMethod : undefined,
         system_prompt: systemPrompt.trim() || undefined,
         max_parallel_sessions: maxParallelSessions,
         mcp_servers: mcpServersConfig.length > 0 ? mcpServersConfig : undefined,
@@ -189,7 +202,10 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
         secret_ids: secretIds.length > 0 ? secretIds : undefined,
         api_keys: {
           openai: openaiApiKey.trim() || undefined,
-          anthropic: anthropicApiKey.trim() || undefined
+          // Only save anthropic key when in api_key mode
+          anthropic: (codingAgent === CodingAgentType.CLAUDE_CODE && authMethod === 'api_key')
+            ? (anthropicApiKey.trim() || undefined)
+            : undefined
         }
       }
     })
@@ -387,33 +403,60 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
         </div>
       )}
 
-      {/* API Key Configuration for Claude Code */}
+      {/* Auth Method & API Key Configuration for Claude Code */}
       {codingAgent === CodingAgentType.CLAUDE_CODE && (
-        <div className="space-y-1.5">
-          <Label htmlFor="anthropic-api-key">Anthropic API Key (Optional)</Label>
-          <Input
-            id="anthropic-api-key"
-            type="password"
-            value={anthropicApiKey}
-            onChange={(e) => setAnthropicApiKey(e.target.value)}
-            placeholder={hasAnthropicEnv ? '••••••••' : 'sk-ant-...'}
-          />
-          {anthropicApiKey && (
-            <p className="text-xs text-muted-foreground">
-              Using provided API key
-            </p>
+        <>
+          <div className="space-y-1.5">
+            <Label htmlFor="claude-auth-method">Authentication Method</Label>
+            <select
+              id="claude-auth-method"
+              value={authMethod}
+              onChange={(e) => setAuthMethod(e.target.value as ClaudeAuthMethod)}
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm cursor-pointer"
+            >
+              <option value="subscription">Pro/Max Subscription (default)</option>
+              <option value="api_key">API Key (pay-per-use)</option>
+            </select>
+            {authMethod === 'subscription' && (
+              <p className="text-xs text-muted-foreground">
+                Uses Claude Code's built-in OAuth login. Your Pro or Max subscription will be used for billing.
+                {hasAnthropicEnv && (
+                  <span className="block mt-1 text-yellow-500">
+                    Note: ANTHROPIC_API_KEY found in environment but will be ignored in subscription mode.
+                  </span>
+                )}
+              </p>
+            )}
+          </div>
+
+          {authMethod === 'api_key' && (
+            <div className="space-y-1.5">
+              <Label htmlFor="anthropic-api-key">Anthropic API Key</Label>
+              <Input
+                id="anthropic-api-key"
+                type="password"
+                value={anthropicApiKey}
+                onChange={(e) => setAnthropicApiKey(e.target.value)}
+                placeholder={hasAnthropicEnv ? '••••••••' : 'sk-ant-...'}
+              />
+              {anthropicApiKey && (
+                <p className="text-xs text-muted-foreground">
+                  Using provided API key
+                </p>
+              )}
+              {!anthropicApiKey && hasAnthropicEnv && (
+                <p className="text-xs text-muted-foreground">
+                  ✓ Using ANTHROPIC_API_KEY from environment
+                </p>
+              )}
+              {!anthropicApiKey && !hasAnthropicEnv && (
+                <p className="text-xs text-destructive">
+                  Required: Enter your API key or set ANTHROPIC_API_KEY environment variable
+                </p>
+              )}
+            </div>
           )}
-          {!anthropicApiKey && hasAnthropicEnv && (
-            <p className="text-xs text-muted-foreground">
-              ✓ Using ANTHROPIC_API_KEY from environment
-            </p>
-          )}
-          {!anthropicApiKey && !hasAnthropicEnv && (
-            <p className="text-xs text-muted-foreground">
-              Claude Code uses CLI authentication - no API key required
-            </p>
-          )}
-        </div>
+        </>
       )}
 
       <div className="space-y-1.5">

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -26,6 +26,8 @@ export enum CodingAgentType {
   CODEX = 'codex'
 }
 
+export type ClaudeAuthMethod = 'subscription' | 'api_key'
+
 export const CODING_AGENTS: { value: CodingAgentType; label: string }[] = [
   { value: CodingAgentType.OPENCODE, label: 'OpenCode' },
   { value: CodingAgentType.CLAUDE_CODE, label: 'Claude Code' },
@@ -125,6 +127,7 @@ export interface UpdateMcpServerDTO {
 export interface AgentConfig {
   coding_agent?: CodingAgentType
   model?: string
+  auth_method?: ClaudeAuthMethod
   system_prompt?: string
   mcp_servers?: Array<string | AgentMcpServerEntry>
   skill_ids?: string[]


### PR DESCRIPTION
## Summary

- Adds an **Authentication Method** dropdown to the Claude Code agent form with two options: **Pro/Max Subscription** (default) and **API Key (pay-per-use)**
- When subscription mode is selected, `ANTHROPIC_API_KEY` is actively **removed** from the child process environment, forcing Claude Code to use its built-in OAuth flow — even if the env var is set in the user's shell
- When API key mode is selected, the existing behavior is preserved (configured key or env var passthrough)
- Backward compatible: existing agents default to subscription mode (no database migration needed)

### Files changed (6)
| File | Change |
|------|--------|
| `src/renderer/src/types/index.ts` | Add `ClaudeAuthMethod` type, `auth_method` field to `AgentConfig` |
| `src/main/database.ts` | Add `auth_method` to `AgentConfigRecord` |
| `src/main/adapters/coding-agent-adapter.ts` | Add `authMethod` to `SessionConfig` |
| `src/main/agent-manager.ts` | Pass `authMethod` through 3 `SessionConfig` construction sites |
| `src/main/adapters/acp-adapter.ts` | Auth-method-aware env handling in `createSession` & `resumeSession` |
| `src/renderer/src/components/agents/AgentForm.tsx` | Auth method selector UI, conditional API key field |

## Test plan

- [ ] Select Claude Code as coding agent → verify "Pro/Max Subscription" is the default in the Authentication Method dropdown
- [ ] With `ANTHROPIC_API_KEY` set in environment → create agent with subscription mode → verify console logs "removed ANTHROPIC_API_KEY from env" and agent uses OAuth
- [ ] Switch to "API Key" mode → enter a key or rely on env var → verify it is passed to the child process
- [ ] With `ANTHROPIC_API_KEY` set → verify yellow warning text "ANTHROPIC_API_KEY found in environment but will be ignored" appears in subscription mode
- [ ] Edit an existing agent (created before this change) → verify it defaults to subscription mode
- [ ] Switch coding agent type away from Claude Code and back → verify auth method resets to subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)