### PR TITLE
[TSK-15795] fix: mobile websocket reconnection and conversation history

### DIFF
--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -1996,6 +1996,9 @@ export class AgentManager extends EventEmitter {
   /**
    * Replay all messages from a running session via the adapter.
    * Used by the mobile API to sync with an already-running session.
+   * Sends a single agent:output-batch event (matching resumeAdapterSession pattern)
+   * to avoid content filtering, step-start/step-finish absorption, and dedup issues
+   * that affect individual agent:output events.
    */
   async replaySessionMessages(sessionId: string): Promise<void> {
     const session = this.sessions.get(sessionId)
@@ -2007,31 +2010,35 @@ export class AgentManager extends EventEmitter {
       workspaceDir: session.workspaceDir || process.cwd()
     })
 
+    // Collect all message parts into a single batch (matching resumeAdapterSession pattern)
+    const batchMessages: Array<{ id: string; role: string; content: string; partType?: string; tool?: unknown }> = []
     for (const msg of messages) {
       for (const part of msg.parts) {
-        this.sendToRenderer('agent:output', {
-          sessionId,
-          taskId: session.taskId,
-          type: 'message',
-          data: {
-            id: part.id || `${msg.id}-${msg.parts.indexOf(part)}`,
-            role: msg.role === MessageRole.USER ? 'user' : msg.role === MessageRole.ASSISTANT ? 'assistant' : 'system',
-            content: part.text || part.content || '',
-            timestamp: new Date(),
-            partType: part.type?.toLowerCase(),
-            tool: part.tool ? {
-              name: part.tool.name,
-              status: part.tool.status || part.state?.status || '',
-              title: part.tool.title || part.state?.title || '',
-              input: typeof part.tool.input === 'string' ? part.tool.input : part.tool.input ? JSON.stringify(part.tool.input) : undefined,
-              output: typeof part.tool.output === 'string' ? part.tool.output : part.tool.output ? JSON.stringify(part.tool.output) : undefined,
-              error: part.tool.error || part.state?.error,
-              questions: part.tool.questions,
-              todos: part.tool.todos
-            } : undefined
-          }
+        batchMessages.push({
+          id: part.id || `${msg.id}-${msg.parts.indexOf(part)}`,
+          role: msg.role === MessageRole.USER ? 'user' : msg.role === MessageRole.ASSISTANT ? 'assistant' : 'system',
+          content: part.text || part.content || '',
+          partType: part.type?.toLowerCase(),
+          tool: part.tool ? {
+            name: part.tool.name,
+            status: part.tool.status || part.state?.status || '',
+            title: part.tool.title || part.state?.title || '',
+            input: typeof part.tool.input === 'string' ? part.tool.input : part.tool.input ? JSON.stringify(part.tool.input) : undefined,
+            output: typeof part.tool.output === 'string' ? part.tool.output : part.tool.output ? JSON.stringify(part.tool.output) : undefined,
+            error: part.tool.error || part.state?.error,
+            questions: part.tool.questions,
+            todos: part.tool.todos
+          } : undefined
         })
       }
+    }
+
+    if (batchMessages.length > 0) {
+      this.sendToRenderer('agent:output-batch', {
+        sessionId,
+        taskId: session.taskId,
+        messages: batchMessages
+      })
     }
 
     // Also send current status

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -78,6 +78,19 @@ export function startMobileApiServer(
           wsClients.add(ws)
           console.log(`[MobileAPI] WebSocket client connected (total: ${wsClients.size})`)
 
+          ws.on('message', (data) => {
+            try {
+              const msg = JSON.parse(String(data))
+              if (msg.type === 'ping') {
+                if (ws.readyState === WebSocket.OPEN) {
+                  ws.send(JSON.stringify({ type: 'pong' }))
+                }
+              }
+            } catch {
+              // ignore malformed messages
+            }
+          })
+
           ws.on('close', () => {
             wsClients.delete(ws)
             console.log(`[MobileAPI] WebSocket client disconnected (total: ${wsClients.size})`)

--- a/src/mobile/api/websocket.ts
+++ b/src/mobile/api/websocket.ts
@@ -1,6 +1,6 @@
 /**
- * WebSocket client with auto-reconnect.
- * Dispatches events to registered handlers.
+ * WebSocket client with auto-reconnect, visibility-based reconnection,
+ * and ping/pong heartbeat for reliable mobile connections.
  */
 import { getAuthToken } from './auth'
 
@@ -14,6 +14,13 @@ let hasConnectedBefore = false
 let onStatusChange: ((connected: boolean) => void) | null = null
 let onReconnect: (() => void) | null = null
 let onFirstConnect: (() => void) | null = null
+
+// Ping/pong heartbeat state
+const PING_INTERVAL_MS = 15_000
+const PONG_TIMEOUT_MS = 5_000
+let pingTimer: ReturnType<typeof setInterval> | null = null
+let pongTimer: ReturnType<typeof setTimeout> | null = null
+let visibilityListenerAdded = false
 
 export function setStatusChangeHandler(fn: (connected: boolean) => void): void {
   onStatusChange = fn
@@ -49,6 +56,7 @@ export function connectWebSocket(): void {
     hasConnectedBefore = true
     reconnectDelay = 1000
     onStatusChange?.(true)
+    startHeartbeat()
     if (isReconnect) {
       onReconnect?.()
     } else {
@@ -59,6 +67,13 @@ export function connectWebSocket(): void {
   ws.onmessage = (event) => {
     try {
       const { type, payload } = JSON.parse(event.data)
+
+      // Handle pong responses from server (heartbeat)
+      if (type === 'pong') {
+        clearPongTimeout()
+        return
+      }
+
       const fns = handlers.get(type)
       if (fns) {
         for (const fn of fns) {
@@ -72,6 +87,7 @@ export function connectWebSocket(): void {
 
   ws.onclose = () => {
     console.log('[WS] Disconnected, reconnecting...')
+    stopHeartbeat()
     onStatusChange?.(false)
     scheduleReconnect()
   }
@@ -79,9 +95,17 @@ export function connectWebSocket(): void {
   ws.onerror = () => {
     ws?.close()
   }
+
+  // Register visibility listener once so we reconnect immediately when
+  // the mobile browser tab/app comes back to the foreground.
+  if (!visibilityListenerAdded) {
+    visibilityListenerAdded = true
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+  }
 }
 
 export function disconnectWebSocket(): void {
+  stopHeartbeat()
   if (reconnectTimer) {
     clearTimeout(reconnectTimer)
     reconnectTimer = null
@@ -103,4 +127,55 @@ function scheduleReconnect(): void {
     reconnectDelay = Math.min(reconnectDelay * 1.5, 10000)
     connectWebSocket()
   }, reconnectDelay)
+}
+
+// ── Ping/pong heartbeat ──────────────────────────────────────
+
+function startHeartbeat(): void {
+  stopHeartbeat()
+  pingTimer = setInterval(() => {
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'ping' }))
+      // Expect a pong within PONG_TIMEOUT_MS, otherwise force-close
+      pongTimer = setTimeout(() => {
+        console.warn('[WS] Pong timeout — closing stale connection')
+        ws?.close()
+      }, PONG_TIMEOUT_MS)
+    }
+  }, PING_INTERVAL_MS)
+}
+
+function stopHeartbeat(): void {
+  if (pingTimer) { clearInterval(pingTimer); pingTimer = null }
+  clearPongTimeout()
+}
+
+function clearPongTimeout(): void {
+  if (pongTimer) { clearTimeout(pongTimer); pongTimer = null }
+}
+
+// ── Visibility-based reconnection ────────────────────────────
+
+function handleVisibilityChange(): void {
+  if (document.hidden) return
+
+  // Page became visible — check connection health
+  if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+    console.log('[WS] Page visible — reconnecting immediately')
+    // Cancel any pending slow reconnect and connect right away
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    reconnectDelay = 1000
+    connectWebSocket()
+  } else if (ws.readyState === WebSocket.OPEN) {
+    // Connection looks open but may be stale — send an immediate ping to verify
+    ws.send(JSON.stringify({ type: 'ping' }))
+    clearPongTimeout()
+    pongTimer = setTimeout(() => {
+      console.warn('[WS] Pong timeout after visibility change — closing stale connection')
+      ws?.close()
+    }, PONG_TIMEOUT_MS)
+  }
 }

--- a/src/mobile/stores/agent-store.ts
+++ b/src/mobile/stores/agent-store.ts
@@ -306,12 +306,10 @@ export const useAgentStore = create<AgentState>((set, get) => {
           const nextSessions = new Map(state.sessions)
 
           for (const active of activeSessions) {
-            const existing = state.sessions.get(active.taskId)
-            // Skip if we already have this session connected with messages
-            if (existing?.sessionId === active.sessionId && existing.messages.length > 0) continue
-
-            // Initialize session in the store so WebSocket events are captured
+            // Clear dedup and messages so the full replay from server
+            // is accepted without stale data mixing in
             seenIds.delete(active.taskId)
+            stepStartTimes.delete(active.taskId)
             nextSessions.set(active.taskId, {
               sessionId: active.sessionId,
               agentId: active.agentId,


### PR DESCRIPTION
## Summary
- Adds `visibilitychange` listener and ping/pong heartbeat (15s ping, 5s pong timeout) to the mobile WebSocket client so stale connections are detected immediately when the user returns to the app, instead of waiting up to 10s for the exponential backoff timer
- Adds server-side pong response handling for mobile WebSocket ping messages
- Fixes `replaySessionMessages` to send a single `agent:output-batch` event (matching the desktop `resumeAdapterSession` pattern) instead of individual `agent:output` events that get dropped by content filtering, step-start/step-finish absorption, and dedup logic — this fixes the "only last message shown on refresh" bug
- Clears stale messages and dedup state before replaying on reconnect to prevent mixing old data with fresh replay

## Test plan
- [ ] Open mobile web view, let session run, lock phone / switch apps for 30s+, return — verify "Connecting..." banner clears within ~5s (was up to 10s+)
- [ ] While on conversation page, toggle airplane mode on/off — verify reconnection happens quickly and full message history is restored
- [ ] Refresh the mobile web page during an active session — verify all conversation messages appear (not just the last one)
- [ ] Verify desktop Electron app behavior is unaffected (batch event is already handled by desktop store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)