### PR TITLE
fix: sync mobile task changes to desktop in real-time

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,7 +19,7 @@ import { registerIpcHandlers } from './ipc-handlers'
 import { RecurrenceScheduler } from './recurrence-scheduler'
 import { setTaskApiNotifier } from './task-api-server'
 import { startSecretBroker, stopSecretBroker, writeSecretShellWrapper } from './secret-broker'
-import { startMobileApiServer, stopMobileApiServer, broadcastToMobileClients } from './mobile-api-server'
+import { startMobileApiServer, stopMobileApiServer, broadcastToMobileClients, setMobileApiNotifier } from './mobile-api-server'
 
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
@@ -103,6 +103,13 @@ function createWindow(): void {
 
   // Wire up task-api-server notifications to the renderer
   setTaskApiNotifier((channel, data) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(channel, data)
+    }
+  })
+
+  // Wire up mobile-api-server notifications to the renderer
+  setMobileApiNotifier((channel, data) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send(channel, data)
     }

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -23,6 +23,7 @@ let agentRef: AgentManager | null = null
 let githubRef: GitHubManager | null = null
 let syncManagerRef: SyncManager | null = null
 let authToken: string | null = null
+let notifyDesktop: ((channel: string, data: unknown) => void) | null = null
 
 const wsClients = new Set<WebSocket>()
 
@@ -116,6 +117,14 @@ export function startMobileApiServer(
 
     server.on('error', reject)
   })
+}
+
+/**
+ * Set a callback to notify the desktop (Electron renderer) of events
+ * originating from the mobile API (e.g. task created/updated).
+ */
+export function setMobileApiNotifier(fn: (channel: string, data: unknown) => void): void {
+  notifyDesktop = fn
 }
 
 export function stopMobileApiServer(): void {
@@ -374,6 +383,7 @@ async function routePost(pathname: string, params: Record<string, unknown>): Pro
     const task = db.createTask(params as unknown as Parameters<DatabaseManager['createTask']>[0])
     if (!task) throw Object.assign(new Error('Failed to create task'), { status: 500 })
     broadcastToMobileClients('task:created', { task })
+    if (notifyDesktop) notifyDesktop('task:created', { task })
     return task
   }
 
@@ -384,6 +394,10 @@ async function routePost(pathname: string, params: Record<string, unknown>): Pro
     const existing = db.getTask(taskId)
     if (!existing) throw Object.assign(new Error('Task not found'), { status: 404 })
     const updated = db.updateTask(taskId, params as Parameters<DatabaseManager['updateTask']>[1])
+    if (updated) {
+      broadcastToMobileClients('task:updated', { taskId, updates: updated })
+      if (notifyDesktop) notifyDesktop('task:updated', { taskId, updates: updated })
+    }
     return updated
   }
 


### PR DESCRIPTION
## Summary

- **Bug**: Tasks created or updated from the mobile web UI did not appear on the desktop app until manual refresh/restart
- **Root cause**: `mobile-api-server.ts` only called `broadcastToMobileClients()` (WebSocket to other mobile clients) but never notified the Electron renderer via `webContents.send()` IPC
- **Fix**: Added a `setMobileApiNotifier()` callback (mirroring the existing `setTaskApiNotifier()` pattern from `task-api-server.ts`) that forwards `task:created` and `task:updated` events to the desktop renderer. Also added the missing `task:updated` broadcast to mobile clients on the update route.

## Test plan

- [ ] Create a task from mobile web → verify it appears on desktop immediately without refresh
- [ ] Update a task from mobile web → verify the change reflects on desktop immediately
- [ ] Create a task from desktop → verify it still works and appears on mobile
- [ ] Verify no duplicate tasks appear when creating from mobile (dedup logic in both stores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)