### PR TITLE
fix: support Notion unique_id (ID) property in synced task descriptions

### DIFF
--- a/src/main/plugins/notion-client.ts
+++ b/src/main/plugins/notion-client.ts
@@ -44,6 +44,7 @@ export interface NotionPropertyValue {
   number?: number | null
   checkbox?: boolean
   url?: string | null
+  unique_id?: { prefix: string | null; number: number } | null
 }
 
 export interface NotionUser {

--- a/src/main/plugins/notion-plugin.ts
+++ b/src/main/plugins/notion-plugin.ts
@@ -40,7 +40,8 @@ export enum NotionPropertyType {
   LastEditedTime = 'last_edited_time',
   Formula = 'formula',
   Relation = 'relation',
-  Rollup = 'rollup'
+  Rollup = 'rollup',
+  UniqueId = 'unique_id'
 }
 
 /** Property types that support server-side filtering */
@@ -893,6 +894,11 @@ The integration automatically maps Notion properties to task fields:
         return prop.checkbox ? 'Yes' : 'No'
       case 'url':
         return prop.url || null
+      case 'unique_id': {
+        if (!prop.unique_id) return null
+        const prefix = prop.unique_id.prefix
+        return prefix ? `${prefix}-${prop.unique_id.number}` : String(prop.unique_id.number)
+      }
       default:
         return null
     }


### PR DESCRIPTION
## Summary

- Add support for Notion's `unique_id` property type (the "ID" field) so it appears in the properties table in synced task descriptions
- Add `UniqueId` to `NotionPropertyType` enum and `unique_id` field to `NotionPropertyValue` interface
- Format the ID as `PREFIX-NUMBER` (e.g. `TASK-42`) or just the number if no prefix is set

## Test plan

- [ ] Create a Notion database with an ID property configured (with a prefix like "TASK")
- [ ] Sync the database and verify the ID field appears in the task description properties table
- [ ] Verify it renders correctly as `TASK-42` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)