### PR TITLE
fix: clean up stale triage session when navigating back to task

### DIFF
--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { TaskWorkspace } from './TaskWorkspace'
+import { useAgentStore } from '@/stores/agent-store'
+import { TaskStatus } from '@/types'
+import type { WorkfloTask, Agent } from '@/types'
+
+// Add missing electronAPI mocks that child components need
+const api = window.electronAPI as unknown as Record<string, unknown>
+if (!api.onGithubDeviceCode) api.onGithubDeviceCode = vi.fn(() => vi.fn())
+if (!api.tasks) api.tasks = { getWorkspaceDir: vi.fn().mockResolvedValue('/tmp') }
+
+// Minimal task factory
+function makeRendererTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
+  return {
+    id: 'task-1',
+    title: 'Test Task',
+    description: '',
+    type: 'general',
+    priority: 'medium',
+    status: TaskStatus.NotStarted,
+    assignee: '',
+    due_date: null,
+    labels: [],
+    attachments: [],
+    repos: [],
+    output_fields: [],
+    agent_id: 'agent-1',
+    session_id: null,
+    external_id: null,
+    source_id: null,
+    source: 'manual',
+    skill_ids: null,
+    snoozed_until: null,
+    resolution: null,
+    feedback_rating: null,
+    feedback_comment: null,
+    is_recurring: false,
+    recurrence_pattern: null,
+    recurrence_parent_id: null,
+    last_occurrence_at: null,
+    next_occurrence_at: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides
+  }
+}
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'agent-1',
+    name: 'Test Agent',
+    server_url: 'http://localhost:4096',
+    config: {},
+    is_default: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides
+  } as Agent
+}
+
+const noopFn = vi.fn()
+const noopAsync = vi.fn().mockResolvedValue(undefined)
+
+function renderWorkspace(task: WorkfloTask, agents: Agent[] = [makeAgent()]) {
+  return render(
+    <TaskWorkspace
+      task={task}
+      agents={agents}
+      onEdit={noopFn}
+      onDelete={noopFn}
+      onUpdateAttachments={noopFn}
+      onUpdateOutputFields={noopFn}
+      onCompleteTask={noopFn}
+      onAssignAgent={noopFn}
+      onUpdateTask={noopAsync}
+    />
+  )
+}
+
+beforeEach(() => {
+  useAgentStore.setState({
+    agents: [],
+    isLoading: false,
+    error: null,
+    sessions: new Map()
+  })
+  vi.clearAllMocks()
+})
+
+describe('TaskWorkspace – stale triage session cleanup', () => {
+  it('removes stale triage session on mount when task is no longer triaging', () => {
+    // Simulate a leftover triage session: sessionId set, idle, has messages, but task
+    // has already transitioned to NotStarted and has no persisted session_id.
+    const taskId = 'task-1'
+    useAgentStore.getState().initSession(taskId, 'triage-session-123', 'agent-1')
+    // Manually set status to idle and add a message (simulating triage completion while unmounted)
+    useAgentStore.setState((state) => {
+      const session = state.sessions.get(taskId)!
+      const updated = {
+        ...session,
+        status: 'idle' as const,
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'assistant' as const,
+            content: 'Triage complete',
+            timestamp: new Date()
+          }
+        ]
+      }
+      return { sessions: new Map(state.sessions).set(taskId, updated) }
+    })
+
+    // Sanity: session exists before render
+    expect(useAgentStore.getState().sessions.has(taskId)).toBe(true)
+
+    const task = makeRendererTask({
+      id: taskId,
+      status: TaskStatus.NotStarted,
+      agent_id: 'agent-1',
+      session_id: null // triage never persists session_id
+    })
+
+    act(() => {
+      renderWorkspace(task)
+    })
+
+    // The stale session should have been removed on mount
+    expect(useAgentStore.getState().sessions.has(taskId)).toBe(false)
+  })
+
+  it('does NOT remove session when task is still triaging', () => {
+    const taskId = 'task-1'
+    useAgentStore.getState().initSession(taskId, 'triage-session-123', 'agent-1')
+
+    // Session is working (triage still in progress)
+    expect(useAgentStore.getState().sessions.has(taskId)).toBe(true)
+
+    const task = makeRendererTask({
+      id: taskId,
+      status: TaskStatus.Triaging,
+      agent_id: null,
+      session_id: null
+    })
+
+    act(() => {
+      renderWorkspace(task)
+    })
+
+    // Session should still be present — triage is still running
+    expect(useAgentStore.getState().sessions.has(taskId)).toBe(true)
+  })
+
+  it('does NOT remove session when task has a persisted session_id (coding session)', () => {
+    const taskId = 'task-1'
+    useAgentStore.getState().initSession(taskId, 'coding-session-456', 'agent-1')
+    // Set to idle with messages (completed coding session transcript)
+    useAgentStore.setState((state) => {
+      const session = state.sessions.get(taskId)!
+      const updated = {
+        ...session,
+        status: 'idle' as const,
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'assistant' as const,
+            content: 'Coding done',
+            timestamp: new Date()
+          }
+        ]
+      }
+      return { sessions: new Map(state.sessions).set(taskId, updated) }
+    })
+
+    const task = makeRendererTask({
+      id: taskId,
+      status: TaskStatus.NotStarted,
+      agent_id: 'agent-1',
+      session_id: 'coding-session-456' // persisted — this is a real coding session
+    })
+
+    act(() => {
+      renderWorkspace(task)
+    })
+
+    // Session should still be present — it's a legitimate coding session, not stale triage
+    expect(useAgentStore.getState().sessions.has(taskId)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -130,6 +130,21 @@ export function TaskWorkspace({
     }
   }, [task?.status, session.sessionId, stop, task, githubOrg, removeSession])
 
+  // Clean up stale triage session when returning to a task that was triaged while unmounted.
+  // If the task is no longer Triaging, has no persisted session_id, but the in-memory session
+  // still has a sessionId (leftover from the triage agent), remove it so the Start button shows.
+  useEffect(() => {
+    if (
+      task &&
+      task.status !== TaskStatus.Triaging &&
+      !task.session_id &&
+      session.sessionId &&
+      session.status === 'idle'
+    ) {
+      removeSession(task.id)
+    }
+  }, [task?.id]) // intentionally run only on mount/task switch
+
   const handleStartSession = useCallback(async () => {
     if (!task?.agent_id || startingRef.current || session.sessionId) return
     startingRef.current = true


### PR DESCRIPTION
## Summary
- When triage finishes while the user is viewing another task, the `TaskWorkspace` cleanup effect never fires (component is unmounted), leaving a stale session in the agent store with `sessionId` still set
- This causes `canStart`, `canResume`, and `canRestart` to all evaluate to `false`, so no "Start coding agent" button appears when the user navigates back
- Adds a mount-time `useEffect` that detects and removes leftover triage sessions (task is no longer `Triaging`, has no persisted `session_id`, but in-memory session still has a `sessionId` with `idle` status)
- Adds 3 tests covering: cleanup on mount, no cleanup while still triaging, no cleanup for legitimate coding sessions

## Test plan
- [x] Unit tests pass (`TaskWorkspace.test.tsx` — 3 tests)
- [ ] Manual: run triage on a task → switch to another task → wait for triage to finish → switch back → verify "Start" button appears
- [ ] Manual: verify triage cleanup still works when staying on the tab (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)