### PR TITLE
feat: compact skill badges with modal selector in task view

### DIFF
--- a/src/mobile/App.tsx
+++ b/src/mobile/App.tsx
@@ -7,12 +7,14 @@ import { TaskDetailPage } from './pages/TaskDetailPage'
 import { ConversationPage } from './pages/ConversationPage'
 import { RepoSelectorPage } from './pages/RepoSelectorPage'
 import { TaskFormPage } from './pages/TaskFormPage'
+import { SkillSelectorPage } from './pages/SkillSelectorPage'
 
 export type Route =
   | { page: 'list' }
   | { page: 'detail'; taskId: string }
   | { page: 'conversation'; taskId: string }
   | { page: 'repos'; taskId: string }
+  | { page: 'skills'; taskId: string }
   | { page: 'create' }
   | { page: 'edit'; taskId: string }
 
@@ -94,6 +96,9 @@ export function App() {
       )}
       {route.page === 'repos' && (
         <RepoSelectorPage taskId={route.taskId} onNavigate={navigate} />
+      )}
+      {route.page === 'skills' && (
+        <SkillSelectorPage taskId={route.taskId} onNavigate={navigate} />
       )}
       {route.page === 'create' && (
         <TaskFormPage onNavigate={navigate} />

--- a/src/mobile/pages/SkillSelectorPage.tsx
+++ b/src/mobile/pages/SkillSelectorPage.tsx
@@ -1,0 +1,168 @@
+import { useState, useMemo, useCallback } from 'react'
+import { useTaskStore } from '../stores/task-store'
+import { useAgentStore } from '../stores/agent-store'
+import type { Route } from '../App'
+
+export function SkillSelectorPage({
+  taskId,
+  onNavigate
+}: {
+  taskId: string
+  onNavigate: (route: Route) => void
+}) {
+  const task = useTaskStore((s) => s.tasks.find((t) => t.id === taskId))
+  const updateTask = useTaskStore((s) => s.updateTask)
+  const skills = useAgentStore((s) => s.skills)
+
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(task?.skill_ids ?? []))
+  const [search, setSearch] = useState('')
+
+  // Filter skills relevant to this agent
+  const agentSkills = useMemo(() => {
+    if (!task?.agent_id) return skills
+    return skills.filter((s) => !s.agent_id || s.agent_id === task.agent_id)
+  }, [skills, task?.agent_id])
+
+  const filtered = useMemo(() => {
+    if (!search) return agentSkills
+    const q = search.toLowerCase()
+    return agentSkills.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        (s.description || '').toLowerCase().includes(q)
+    )
+  }, [agentSkills, search])
+
+  const toggleSkill = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const handleConfirm = useCallback(async () => {
+    if (!task) return
+    const success = await updateTask(task.id, { skill_ids: Array.from(selected) })
+    if (success) onNavigate({ page: 'detail', taskId })
+  }, [task, selected, updateTask, onNavigate, taskId])
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="shrink-0 flex items-center gap-2 px-2 py-3 border-b border-border">
+        <button
+          onClick={() => onNavigate({ page: 'detail', taskId })}
+          className="p-2 active:opacity-60 hover:bg-accent rounded-md transition-colors"
+        >
+          <svg
+            className="w-5 h-5 text-foreground"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </button>
+        <h1 className="text-sm font-semibold truncate flex-1">Select Skills</h1>
+      </div>
+
+      {/* Search */}
+      <div className="px-4 pt-3 pb-2 shrink-0">
+        <div className="relative">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Filter skills..."
+            className="w-full rounded-md border border-input bg-transparent pl-9 pr-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring/30"
+          />
+        </div>
+      </div>
+
+      {/* Skill list */}
+      <div className="flex-1 overflow-y-auto px-4">
+        {filtered.length === 0 ? (
+          <div className="text-center py-8 text-sm text-muted-foreground">
+            {search ? 'No matching skills' : 'No skills available'}
+          </div>
+        ) : (
+          <div className="space-y-0.5">
+            {filtered.map((skill) => {
+              const isSelected = selected.has(skill.id)
+              return (
+                <button
+                  key={skill.id}
+                  onClick={() => toggleSkill(skill.id)}
+                  className="flex items-start gap-3 rounded-md p-2.5 w-full text-left hover:bg-accent/50 active:bg-accent/70 transition-colors"
+                >
+                  {/* Checkbox */}
+                  <div
+                    className={`mt-0.5 h-4 w-4 shrink-0 rounded border flex items-center justify-center transition-colors ${
+                      isSelected
+                        ? 'bg-primary border-primary text-primary-foreground'
+                        : 'border-muted-foreground/40'
+                    }`}
+                  >
+                    {isSelected && (
+                      <svg
+                        className="h-3 w-3"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="3"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    )}
+                  </div>
+
+                  {/* Skill info */}
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm font-medium">{skill.name}</span>
+                    {skill.description && (
+                      <p className="text-xs text-muted-foreground truncate mt-0.5">
+                        {skill.description}
+                      </p>
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 flex items-center justify-between px-4 py-3 border-t border-border">
+        <span className="text-xs text-muted-foreground">
+          {selected.size} skill{selected.size !== 1 ? 's' : ''} selected
+        </span>
+        <button
+          onClick={handleConfirm}
+          className="inline-flex items-center justify-center h-8 px-4 bg-primary text-primary-foreground rounded-md text-sm font-medium hover:bg-primary/90 active:opacity-80 disabled:opacity-50 disabled:pointer-events-none"
+        >
+          Confirm
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -21,7 +21,6 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
   const initSession = useAgentStore((s) => s.initSession)
   const endSession = useAgentStore((s) => s.endSession)
 
-  const [skillsExpanded, setSkillsExpanded] = useState(false)
   const [showFeedback, setShowFeedback] = useState(false)
   const { handleStart: _startSession, handleResume: _resumeSession, handleStop: _stopSession, busyRef } = useSessionControls(taskId)
 
@@ -306,51 +305,49 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
                   <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
                   Skills
                 </span>
-                <div>
-                  {task.skill_ids === null && !skillsExpanded ? (
-                    <div className="flex items-center gap-2">
+                <div className="space-y-1.5">
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    {task.skill_ids === null ? (
                       <span className="text-xs text-muted-foreground">Using agent defaults</span>
-                      <button onClick={() => setSkillsExpanded(true)} className="text-xs text-primary active:opacity-60">
-                        Customize
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="space-y-2">
-                      <div className="flex flex-wrap gap-1.5">
-                        {agentSkills.map((skill) => {
-                          const selected = task.skill_ids === null || (task.skill_ids || []).includes(skill.id)
+                    ) : (
+                      <>
+                        {task.skill_ids.map((skillId) => {
+                          const skill = agentSkills.find((s) => s.id === skillId)
+                          if (!skill) return null
                           return (
-                            <button
-                              key={skill.id}
-                              onClick={() => {
-                                const current = task.skill_ids || agentSkills.map((s) => s.id)
-                                const next = selected
-                                  ? current.filter((id) => id !== skill.id)
-                                  : [...current, skill.id]
-                                handleUpdateSkillIds(next)
-                              }}
-                              className={cn(
-                                'inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors',
-                                selected
-                                  ? 'bg-primary/20 border-primary/40 text-primary'
-                                  : 'border-border/50 text-muted-foreground'
-                              )}
-                            >
+                            <span key={skillId} className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-0.5 text-[11px] font-medium pr-1">
                               {skill.name}
-                            </button>
+                              <button
+                                onClick={() => handleUpdateSkillIds(task.skill_ids!.filter((id) => id !== skillId))}
+                                className="rounded-full hover:bg-foreground/10 p-0.5"
+                              >
+                                <svg className="h-2.5 w-2.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                  <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+                                </svg>
+                              </button>
+                            </span>
                           )
                         })}
-                      </div>
-                      {task.skill_ids !== null && (
-                        <button
-                          onClick={() => { handleUpdateSkillIds(null); setSkillsExpanded(false) }}
-                          className="text-xs text-muted-foreground active:opacity-60"
-                        >
-                          Reset to defaults
-                        </button>
-                      )}
-                    </div>
-                  )}
+                      </>
+                    )}
+                    <button
+                      onClick={() => onNavigate({ page: 'skills', taskId })}
+                      className="inline-flex items-center gap-1 h-6 px-2 text-xs text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
+                    >
+                      <svg className="h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M5 12h14"/><path d="M12 5v14"/>
+                      </svg>
+                      {task.skill_ids === null ? 'Customize' : 'Add'}
+                    </button>
+                    {task.skill_ids !== null && (
+                      <button
+                        onClick={() => handleUpdateSkillIds(null)}
+                        className="text-xs text-muted-foreground active:opacity-60"
+                      >
+                        Reset to defaults
+                      </button>
+                    )}
+                  </div>
                 </div>
               </>
             )}

--- a/src/renderer/src/components/skills/SkillSelectorDialog.tsx
+++ b/src/renderer/src/components/skills/SkillSelectorDialog.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect, useMemo } from 'react'
+import { Search } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { Checkbox } from '@/components/ui/Checkbox'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@/components/ui/Dialog'
+import { useSkillStore } from '@/stores/skill-store'
+
+interface SkillSelectorDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  initialSkillIds: string[]
+  onConfirm: (skillIds: string[]) => void
+}
+
+export function SkillSelectorDialog({ open, onOpenChange, initialSkillIds, onConfirm }: SkillSelectorDialogProps) {
+  const { skills, fetchSkills } = useSkillStore()
+  const [selected, setSelected] = useState<Set<string>>(new Set(initialSkillIds))
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      fetchSkills()
+      setSelected(new Set(initialSkillIds))
+      setSearch('')
+    }
+  }, [open, initialSkillIds])
+
+  const filtered = useMemo(() => {
+    if (!search) return skills
+    const q = search.toLowerCase()
+    return skills.filter(
+      (s) =>
+        s.name.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q) ||
+        s.tags.some((t) => t.toLowerCase().includes(q))
+    )
+  }, [skills, search])
+
+  const toggleSkill = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const handleConfirm = () => {
+    onConfirm(Array.from(selected))
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Select Skills</DialogTitle>
+        </DialogHeader>
+        <DialogBody className="space-y-4">
+          {/* Search */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Filter skills..."
+              className="w-full rounded-md border border-input bg-transparent pl-9 pr-3 py-2 text-sm placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring/30"
+            />
+          </div>
+
+          {/* Skill list */}
+          <div className="max-h-80 overflow-y-auto -mx-1 px-1 space-y-1">
+            {filtered.length === 0 ? (
+              <div className="text-center py-8 text-sm text-muted-foreground">
+                {search ? 'No matching skills' : 'No skills available. Add skills from the Skills tab.'}
+              </div>
+            ) : (
+              filtered.map((skill) => (
+                <label
+                  key={skill.id}
+                  className="flex items-start gap-3 rounded-md p-2.5 hover:bg-accent/50 cursor-pointer transition-colors"
+                >
+                  <Checkbox
+                    checked={selected.has(skill.id)}
+                    onCheckedChange={() => toggleSkill(skill.id)}
+                    className="mt-0.5"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <span className="text-sm font-medium">{skill.name}</span>
+                    {skill.description && (
+                      <p className="text-xs text-muted-foreground truncate mt-0.5">{skill.description}</p>
+                    )}
+                    {skill.tags.length > 0 && (
+                      <div className="flex gap-1 mt-1 flex-wrap">
+                        {skill.tags.map((tag) => (
+                          <span key={tag} className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </label>
+              ))
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between pt-2 border-t">
+            <span className="text-xs text-muted-foreground">
+              {selected.size} skill{selected.size !== 1 ? 's' : ''} selected
+            </span>
+            <Button onClick={handleConfirm}>Confirm</Button>
+          </div>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect } from 'react'
 import { Pencil, Trash2, Calendar, User, Tag, Clock, Bot, Play, History, GitBranch, Plus, X, BookOpen, AlarmClockOff, BellRing, Folder, Repeat, Star, Sparkles } from 'lucide-react'
 import { Markdown } from '@/components/ui/Markdown'
 import { Button } from '@/components/ui/Button'
@@ -9,7 +9,7 @@ import { TaskAttachments } from './TaskAttachments'
 import { Badge } from '@/components/ui/Badge'
 import { formatDate, formatRelativeDate, isOverdue, isDueSoon, isSnoozed } from '@/lib/utils'
 import { OutputFieldsDisplay } from './OutputFieldsDisplay'
-import { SkillSelector } from '@/components/skills/SkillSelector'
+import { useSkillStore } from '@/stores/skill-store'
 import { AssigneeSelect } from './AssigneeSelect'
 import { TaskStatus, CodingAgentType } from '@/types'
 import type { WorkfloTask, FileAttachment, OutputField, Agent, RecurrencePattern, RecurrencePatternObject } from '@/types'
@@ -97,6 +97,7 @@ interface TaskDetailViewProps {
   onUpdateRepos: (repos: string[]) => void
   onAddRepos: () => void
   onUpdateSkillIds?: (skillIds: string[] | null) => void
+  onAddSkills?: () => void
   onStartAgent?: () => void
   canStartAgent?: boolean
   onResumeAgent?: () => void
@@ -110,9 +111,16 @@ interface TaskDetailViewProps {
   canTriage?: boolean
 }
 
-export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage }: TaskDetailViewProps) {
-  const [skillsExpanded, setSkillsExpanded] = useState(false)
+export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onAddSkills, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage }: TaskDetailViewProps) {
+  const { skills, fetchSkills } = useSkillStore()
   const isActive = task.status !== TaskStatus.Completed
+
+  // Ensure skills are loaded for badge display
+  useEffect(() => {
+    if (task.agent_id && task.skill_ids !== null) {
+      fetchSkills()
+    }
+  }, [task.agent_id, task.skill_ids])
   const overdue = isActive && isOverdue(task.due_date)
   const dueSoon = isActive && !overdue && isDueSoon(task.due_date)
 
@@ -262,34 +270,41 @@ export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachm
             {task.agent_id && onUpdateSkillIds && (
               <>
                 <span className="text-muted-foreground flex items-center gap-2"><BookOpen className="h-3.5 w-3.5" /> Skills</span>
-                <div>
-                  {task.skill_ids === null && !skillsExpanded ? (
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm text-muted-foreground">Using agent defaults</span>
-                      <Button variant="ghost" size="sm" onClick={() => setSkillsExpanded(true)} className="h-6 text-xs">
-                        Customize
-                      </Button>
-                    </div>
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {task.skill_ids === null ? (
+                    <span className="text-sm text-muted-foreground">Using agent defaults</span>
                   ) : (
-                    <div className="space-y-2">
-                      <SkillSelector
-                        selectedIds={task.skill_ids === null ? undefined : task.skill_ids}
-                        onChange={(ids) => {
-                          // undefined → null (agent defaults), string[] → string[]
-                          onUpdateSkillIds(ids === undefined ? null : ids)
-                        }}
-                      />
-                      {task.skill_ids !== null && (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => { onUpdateSkillIds(null); setSkillsExpanded(false) }}
-                          className="h-6 text-xs text-muted-foreground"
-                        >
-                          Reset to agent defaults
-                        </Button>
-                      )}
-                    </div>
+                    <>
+                      {task.skill_ids.map((skillId) => {
+                        const skill = skills.find((s) => s.id === skillId)
+                        if (!skill) return null
+                        return (
+                          <Badge key={skillId} className="gap-1 pr-1">
+                            {skill.name}
+                            <button
+                              onClick={() => onUpdateSkillIds(task.skill_ids!.filter((id) => id !== skillId))}
+                              className="rounded-full hover:bg-foreground/10 p-0.5"
+                            >
+                              <X className="h-2.5 w-2.5" />
+                            </button>
+                          </Badge>
+                        )
+                      })}
+                    </>
+                  )}
+                  <Button variant="ghost" size="sm" onClick={onAddSkills} className="h-6 gap-1 px-2 text-xs text-muted-foreground">
+                    <Plus className="h-3 w-3" />
+                    {task.skill_ids === null ? 'Customize' : 'Add'}
+                  </Button>
+                  {task.skill_ids !== null && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onUpdateSkillIds(null)}
+                      className="h-6 text-xs text-muted-foreground"
+                    >
+                      Reset to defaults
+                    </Button>
                   )}
                 </div>
               </>

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -9,6 +9,7 @@ import { AgentApprovalBanner } from '@/components/agents/AgentApprovalBanner'
 import { GhCliSetupDialog } from '@/components/github/GhCliSetupDialog'
 import { OrgPickerDialog } from '@/components/github/OrgPickerDialog'
 import { RepoSelectorDialog } from '@/components/github/RepoSelectorDialog'
+import { SkillSelectorDialog } from '@/components/skills/SkillSelectorDialog'
 import { WorktreeProgressOverlay } from '@/components/github/WorktreeProgressOverlay'
 import { useAgentSession } from '@/hooks/use-agent-session'
 import { useAgentStore } from '@/stores/agent-store'
@@ -50,6 +51,7 @@ export function TaskWorkspace({
   const [showGhSetup, setShowGhSetup] = useState(false)
   const [showOrgPicker, setShowOrgPicker] = useState(false)
   const [showRepoSelector, setShowRepoSelector] = useState(false)
+  const [showSkillSelector, setShowSkillSelector] = useState(false)
   const [isSettingUpWorktree, setIsSettingUpWorktree] = useState(false)
   const [showFeedback, setShowFeedback] = useState(false)
   const [showSnooze, setShowSnooze] = useState(false)
@@ -532,6 +534,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
             onUpdateSkillIds={async (skillIds) => {
               if (onUpdateTask) await onUpdateTask(task.id, { skill_ids: skillIds })
             }}
+            onAddSkills={() => setShowSkillSelector(true)}
             onStartAgent={handleStartSession}
             canStartAgent={!!canStart}
             onResumeAgent={handleResumeSession}
@@ -583,6 +586,15 @@ Update existing skills that were helpful or create new ones for patterns worth r
           onConfirm={handleReposConfirmed}
         />
       )}
+
+      <SkillSelectorDialog
+        open={showSkillSelector}
+        onOpenChange={setShowSkillSelector}
+        initialSkillIds={task.skill_ids ?? []}
+        onConfirm={async (skillIds) => {
+          if (onUpdateTask) await onUpdateTask(task.id, { skill_ids: skillIds })
+        }}
+      />
 
       <FeedbackDialog
         open={showFeedback}


### PR DESCRIPTION
## Summary
- Replaced inline skill checkbox list with **compact removable badges** + "Add" button in the task detail view
- "Add"/"Customize" opens a **searchable modal** (desktop) or **full-screen page** (mobile) for multi-selecting skills — matching the existing repo selection UX
- Affects both Electron desktop and mobile web apps

## Before → After

### Before (inline checkboxes — cluttered with many skills)
```
┌─────────────────────────────────────────┐
│ 📖 Skills                               │
│  ☑ All Skills                           │
│  ───────────────────                    │
│  ☑ typescript-patterns                  │
│    Best practices for TypeScript...     │
│  ☑ react-hooks                          │
│    Custom hooks patterns...             │
│  ☐ api-design                           │
│    REST API conventions...              │
│  ☑ testing-strategy                     │
│    Unit and integration tests...        │
│  ☐ database-migrations                  │
│    Schema migration patterns...         │
│  ☐ error-handling                       │
│    Error boundary patterns...           │
│  ... (scrolls on with many more)        │
│                                         │
│  [Reset to agent defaults]              │
└─────────────────────────────────────────┘
```

### After (compact badges — clean & scannable)
```
┌─────────────────────────────────────────┐
│ 📖 Skills                               │
│  ┌──────────────────┐ ┌────────────┐   │
│  │typescript-patt ✕ │ │react-hooks✕│   │
│  └──────────────────┘ └────────────┘   │
│  ┌──────────────────┐                   │
│  │testing-strategy ✕│  [+ Add]          │
│  └──────────────────┘  Reset to defaults│
└─────────────────────────────────────────┘

Click "+ Add" → opens modal:
┌─────────────────────────────────────────┐
│           Select Skills              ✕  │
│─────────────────────────────────────────│
│  🔍 Filter skills...                   │
│─────────────────────────────────────────│
│  ☑ typescript-patterns                  │
│    Best practices for TypeScript...     │
│  ☑ react-hooks                          │
│    Custom hooks patterns...             │
│  ☐ api-design                           │
│    REST API conventions...              │
│  ☑ testing-strategy                     │
│    Unit and integration tests...        │
│  ☐ database-migrations                  │
│    Schema migration patterns...         │
│─────────────────────────────────────────│
│  3 skills selected           [Confirm]  │
└─────────────────────────────────────────┘
```

## Files Changed

| File | What changed |
|------|-------------|
| `src/renderer/src/components/skills/SkillSelectorDialog.tsx` | **New** — Desktop modal with search, checkboxes, confirm |
| `src/mobile/pages/SkillSelectorPage.tsx` | **New** — Full-screen mobile selector page |
| `src/renderer/src/components/tasks/TaskDetailView.tsx` | Inline checkboxes → compact badges + "Add" button |
| `src/renderer/src/components/tasks/TaskWorkspace.tsx` | Wire up `SkillSelectorDialog` state |
| `src/mobile/pages/TaskDetailPage.tsx` | Inline toggles → compact badges + navigate to selector |
| `src/mobile/App.tsx` | Add `skills` route |

## Test plan
- [ ] Desktop: Open task with agent assigned → skills show as "Using agent defaults" with "Customize" button
- [ ] Desktop: Click "Customize" → modal opens with searchable skill list → select skills → Confirm → badges appear
- [ ] Desktop: Click ✕ on a skill badge → skill removed immediately
- [ ] Desktop: Click "Reset to defaults" → reverts to "Using agent defaults"
- [ ] Desktop: Search/filter works in the skill modal
- [ ] Mobile: Same flow but "Add"/"Customize" navigates to full-screen page instead of modal
- [ ] Mobile: Back button returns to task detail from skill selector
- [ ] Verify existing `SkillSelector` in AgentForm (agent settings) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)