### PR TITLE
fix: close settings when clicking task or skill in sidebar

### DIFF
--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -38,6 +38,7 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
   const [filtersOpen, setFiltersOpen] = useState(false)
   const {
     sidebarView, setSidebarView,
+    activeModal, closeModal,
     statusFilter, priorityFilter, sourceFilter, sortField, searchQuery,
     setStatusFilter, setPriorityFilter, setSourceFilter, setSortField, setSearchQuery
   } = useUIStore()
@@ -92,7 +93,10 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
           {(['tasks', 'skills'] as SidebarView[]).map((view) => (
             <button
               key={view}
-              onClick={() => setSidebarView(view)}
+              onClick={() => {
+                if (activeModal === 'settings') closeModal()
+                setSidebarView(view)
+              }}
               className={`flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer ${
                 sidebarView === view
                   ? 'bg-background text-foreground shadow-sm'
@@ -244,7 +248,10 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
           <div className="mx-3 border-t" />
 
           <div className="flex-1 overflow-y-auto pt-1">
-            <TaskList tasks={tasks} selectedTaskId={selectedTaskId} onSelectTask={onSelectTask} />
+            <TaskList tasks={tasks} selectedTaskId={selectedTaskId} onSelectTask={(id) => {
+              if (activeModal === 'settings') closeModal()
+              onSelectTask(id)
+            }} />
           </div>
 
           <div className="px-4 py-2.5 border-t text-xs text-muted-foreground tabular-nums">
@@ -268,7 +275,10 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
           <div className="mx-3 border-t" />
 
           <div className="flex-1 overflow-y-auto pt-1">
-            <SkillList skills={skills} selectedSkillId={selectedSkillId} onSelectSkill={selectSkill} />
+            <SkillList skills={skills} selectedSkillId={selectedSkillId} onSelectSkill={(id) => {
+              if (activeModal === 'settings') closeModal()
+              selectSkill(id)
+            }} />
           </div>
 
           <div className="px-4 py-2.5 border-t text-xs text-muted-foreground tabular-nums">


### PR DESCRIPTION
## Summary
- When the settings page is open and the user clicks a task, skill, or sidebar tab, the settings modal is now closed so the selected item is displayed
- Adds `activeModal` and `closeModal` checks to the sidebar tab switcher, task list click handler, and skill list click handler

## Test plan
- [ ] Open settings page
- [ ] Click on a task in the sidebar → settings closes, task is shown
- [ ] Open settings page again
- [ ] Click on a skill in the sidebar → settings closes, skill is shown
- [ ] Open settings page again
- [ ] Click the Tasks/Skills tab → settings closes, correct view is shown
- [ ] Verify normal navigation (without settings open) still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)