### PR TITLE
fix: prevent duplicate image downloads on task source resync

### DIFF
--- a/src/main/plugins/linear-plugin.ts
+++ b/src/main/plugins/linear-plugin.ts
@@ -20,6 +20,7 @@ import type {
 } from './types'
 import { LinearClient, type LinearIssue } from './linear-client'
 import { replaceRemoteImageUrlsInTask } from './replace-image-urls'
+import { normalizeUrlForComparison, buildNormalizedUrlSet } from './url-utils'
 
 export class LinearPlugin implements TaskSourcePlugin {
   id = 'linear'
@@ -560,11 +561,14 @@ export class LinearPlugin implements TaskSourcePlugin {
     }
 
     const existingAttachments = task.attachments || []
-    const existingUrls = new Set(existingAttachments.map((a) => (a as unknown as { linear_url?: string }).linear_url))
+    const existingNormalizedUrls = buildNormalizedUrlSet(
+      existingAttachments as unknown as Array<Record<string, unknown>>,
+      'linear_url'
+    )
 
     for (const file of files) {
-      // Skip if already downloaded
-      if (existingUrls.has(file.url)) {
+      // Skip if already downloaded (compare without query params since signed tokens change on each API call)
+      if (existingNormalizedUrls.has(normalizeUrlForComparison(file.url))) {
         console.log(`[linear-plugin] Skipping already downloaded file: ${file.url}`)
         continue
       }
@@ -649,17 +653,22 @@ export class LinearPlugin implements TaskSourcePlugin {
 
     const existingAttachments = task.attachments || []
     console.log(`[linear-plugin] Existing attachments: ${existingAttachments.length}`)
-    const existingUrls = new Set(existingAttachments.map((a) => (a as unknown as { linear_url?: string }).linear_url))
+    const existingNormalizedUrls = buildNormalizedUrlSet(
+      existingAttachments as unknown as Array<Record<string, unknown>>,
+      'linear_url'
+    )
 
     for (const attachment of attachments) {
+      const normalizedUrl = normalizeUrlForComparison(attachment.url)
+      const alreadyExists = existingNormalizedUrls.has(normalizedUrl)
       console.log(`[linear-plugin] Processing attachment:`, {
         id: attachment.id,
         url: attachment.url,
         title: attachment.title,
-        alreadyExists: existingUrls.has(attachment.url)
+        alreadyExists
       })
-      // Skip if already downloaded
-      if (existingUrls.has(attachment.url)) continue
+      // Skip if already downloaded (compare without query params since signed tokens change on each API call)
+      if (alreadyExists) continue
 
       try {
         console.log(`[linear-plugin] Downloading attachment: ${attachment.title || attachment.url}`)

--- a/src/main/plugins/notion-plugin.test.ts
+++ b/src/main/plugins/notion-plugin.test.ts
@@ -309,6 +309,34 @@ describe('NotionPlugin', () => {
       expect(mockClientInstance.downloadFile).not.toHaveBeenCalled()
     })
 
+    it('skips already downloaded files when URL has different query params (resync)', async () => {
+      mockClientInstance.queryAllPages.mockResolvedValue([makePage()])
+      // Resync returns the same file but with a new signed URL (different query params)
+      mockClientInstance.extractFilesFromBlocks.mockReturnValue([
+        { url: 'https://s3.example.com/bucket/image.png?X-Amz-Credential=NEW&X-Amz-Expires=3600', filename: 'image.png' }
+      ])
+
+      const ctx = makeContext()
+      ;(ctx.db.getTask as ReturnType<typeof vi.fn>).mockReturnValue({
+        id: 'task-1',
+        attachments: [
+          {
+            id: 'att-1',
+            filename: 'image.png',
+            size: 100,
+            mime_type: 'image/png',
+            added_at: '',
+            notion_url: 'https://s3.example.com/bucket/image.png?X-Amz-Credential=OLD&X-Amz-Expires=3600'
+          }
+        ]
+      })
+
+      await plugin.importTasks('src-1', defaultConfig, ctx)
+
+      // downloadFile should NOT be called — same base URL, only query params differ
+      expect(mockClientInstance.downloadFile).not.toHaveBeenCalled()
+    })
+
     it('handles import errors gracefully', async () => {
       mockClientInstance.queryAllPages.mockRejectedValue(new Error('API down'))
 

--- a/src/main/plugins/notion-plugin.ts
+++ b/src/main/plugins/notion-plugin.ts
@@ -14,6 +14,7 @@ import type { TaskRecord } from '../database'
 import type { SourceUser, ReassignResult } from '../../shared/types'
 import { TaskStatus } from '../../shared/constants'
 import { replaceRemoteImageUrlsInTask } from './replace-image-urls'
+import { normalizeUrlForComparison, buildNormalizedUrlSet } from './url-utils'
 import {
   NotionClient,
   type NotionDatabase,
@@ -995,13 +996,14 @@ The integration automatically maps Notion properties to task fields:
     if (!task) return
 
     const existingAttachments = task.attachments || []
-    const existingUrls = new Set(
-      existingAttachments.map((a) => (a as unknown as { notion_url?: string }).notion_url)
+    const existingNormalizedUrls = buildNormalizedUrlSet(
+      existingAttachments as unknown as Array<Record<string, unknown>>,
+      'notion_url'
     )
 
     for (const file of files) {
-      // Skip if already downloaded
-      if (existingUrls.has(file.url)) continue
+      // Skip if already downloaded (compare without query params since signed tokens change on each API call)
+      if (existingNormalizedUrls.has(normalizeUrlForComparison(file.url))) continue
 
       try {
         console.log(`[notion] Downloading: ${file.filename}`)
@@ -1040,7 +1042,7 @@ The integration automatically maps Notion properties to task fields:
 
         // Update for next iteration
         existingAttachments.push(newAttachment)
-        existingUrls.add(file.url)
+        existingNormalizedUrls.add(normalizeUrlForComparison(file.url))
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Unknown error'
         console.error(`[notion] Failed to download ${file.filename}: ${msg}`)

--- a/src/main/plugins/url-utils.test.ts
+++ b/src/main/plugins/url-utils.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeUrlForComparison, buildNormalizedUrlSet } from './url-utils'
+
+describe('normalizeUrlForComparison', () => {
+  it('strips query parameters from a URL', () => {
+    const url = 'https://uploads.linear.app/org/team/file-id?signature=abc123&expires=999'
+    expect(normalizeUrlForComparison(url)).toBe(
+      'https://uploads.linear.app/org/team/file-id'
+    )
+  })
+
+  it('strips query parameters from Notion S3 URLs', () => {
+    const url =
+      'https://prod-files-secure.s3.us-west-2.amazonaws.com/bucket/block/image.png?X-Amz-Algorithm=AWS4&X-Amz-Credential=xxx&X-Amz-Expires=3600'
+    expect(normalizeUrlForComparison(url)).toBe(
+      'https://prod-files-secure.s3.us-west-2.amazonaws.com/bucket/block/image.png'
+    )
+  })
+
+  it('returns the same URL if it has no query params', () => {
+    const url = 'https://example.com/path/to/file.png'
+    expect(normalizeUrlForComparison(url)).toBe(url)
+  })
+
+  it('returns the original string for invalid URLs', () => {
+    expect(normalizeUrlForComparison('not-a-url')).toBe('not-a-url')
+  })
+
+  it('strips fragment identifiers as well', () => {
+    const url = 'https://example.com/file.png?token=abc#section'
+    expect(normalizeUrlForComparison(url)).toBe('https://example.com/file.png')
+  })
+})
+
+describe('buildNormalizedUrlSet', () => {
+  it('builds a set of normalized URLs from attachment records', () => {
+    const attachments = [
+      { id: '1', linear_url: 'https://uploads.linear.app/a/b/c?sig=old-token' },
+      { id: '2', linear_url: 'https://uploads.linear.app/x/y/z?sig=old-token' }
+    ]
+    const set = buildNormalizedUrlSet(attachments, 'linear_url')
+
+    expect(set.size).toBe(2)
+    expect(set.has('https://uploads.linear.app/a/b/c')).toBe(true)
+    expect(set.has('https://uploads.linear.app/x/y/z')).toBe(true)
+  })
+
+  it('ignores attachments without the specified URL key', () => {
+    const attachments = [
+      { id: '1', notion_url: 'https://s3.example.com/file.png' },
+      { id: '2' } // no notion_url
+    ]
+    const set = buildNormalizedUrlSet(attachments, 'notion_url')
+    expect(set.size).toBe(1)
+  })
+
+  it('matches URLs with different query params to the same normalized key', () => {
+    const existing = [
+      { id: '1', linear_url: 'https://uploads.linear.app/org/team/file?sig=OLD&exp=111' }
+    ]
+    const set = buildNormalizedUrlSet(existing, 'linear_url')
+
+    // A new sync returns the same file with a different signed URL
+    const newUrl = 'https://uploads.linear.app/org/team/file?sig=NEW&exp=222'
+    expect(set.has(normalizeUrlForComparison(newUrl))).toBe(true)
+  })
+})

--- a/src/main/plugins/url-utils.ts
+++ b/src/main/plugins/url-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Utility functions for URL normalization in plugin attachment handling.
+ *
+ * Remote file URLs from sources like Linear and Notion include signed query
+ * parameters (tokens, expiry timestamps) that change on every API call.
+ * Stripping these parameters gives a stable base URL that uniquely identifies
+ * the file, enabling reliable duplicate detection across resyncs.
+ */
+
+/**
+ * Strip query parameters from a URL to get its stable base path.
+ * Returns the original string if it's not a valid URL.
+ */
+export function normalizeUrlForComparison(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.origin}${parsed.pathname}`
+  } catch {
+    return url
+  }
+}
+
+/**
+ * Build a Set of normalized (query-param-stripped) URLs from existing attachment records.
+ * @param attachments - array of attachment objects from the task
+ * @param urlKey - the key that stores the source URL (e.g. 'linear_url', 'notion_url')
+ */
+export function buildNormalizedUrlSet(
+  attachments: Array<Record<string, unknown>>,
+  urlKey: string
+): Set<string> {
+  const set = new Set<string>()
+  for (const att of attachments) {
+    const url = att[urlKey]
+    if (typeof url === 'string' && url) {
+      set.add(normalizeUrlForComparison(url))
+    }
+  }
+  return set
+}


### PR DESCRIPTION
## Summary

- **Bug:** Resyncing a task source caused all images/attachments to be re-downloaded and duplicated every time, because Linear and Notion plugins compared full signed URLs (including query params with tokens/expiry) for duplicate detection — these change on every API call
- **Fix:** Normalize URLs by stripping query parameters before comparison, so the stable base URL path is used for deduplication. Added a shared `url-utils.ts` utility used by both Linear and Notion plugins
- **Note:** HubSpot was not affected — it already uses stable `hubspot_file_id` for deduplication

## Test plan

- [x] New `url-utils.test.ts` — 8 tests covering URL normalization and set building
- [x] New Notion plugin test for resync with different query params
- [x] All existing tests pass (46 plugin tests, full suite green)
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)