### PR TITLE
fix: preserve mobile messages on WebSocket reconnect

### DIFF
--- a/src/mobile/App.tsx
+++ b/src/mobile/App.tsx
@@ -47,6 +47,7 @@ export function App() {
   const connected = useConnectionStore((s) => s.connected)
   const setOnReconnect = useConnectionStore((s) => s.setOnReconnect)
   const setOnFirstConnect = useConnectionStore((s) => s.setOnFirstConnect)
+  const setOnVisibilityReconnect = useConnectionStore((s) => s.setOnVisibilityReconnect)
   const fetchTasks = useTaskStore((s) => s.fetchTasks)
   const fetchAgents = useAgentStore((s) => s.fetchAgents)
   const fetchSkills = useAgentStore((s) => s.fetchSkills)
@@ -68,7 +69,13 @@ export function App() {
       fetchTasks()
       syncActiveSessions()
     })
-  }, [connect, fetchTasks, fetchAgents, fetchSkills, syncActiveSessions, setOnReconnect, setOnFirstConnect])
+
+    // Re-sync when page becomes visible (phone wakes) even if connection stayed alive,
+    // because messages may have been missed while JS was suspended on mobile
+    setOnVisibilityReconnect(() => {
+      syncActiveSessions()
+    })
+  }, [connect, fetchTasks, fetchAgents, fetchSkills, syncActiveSessions, setOnReconnect, setOnFirstConnect, setOnVisibilityReconnect])
 
   // Poll tasks every 10s as a fallback
   useEffect(() => {

--- a/src/mobile/api/websocket.ts
+++ b/src/mobile/api/websocket.ts
@@ -14,6 +14,7 @@ let hasConnectedBefore = false
 let onStatusChange: ((connected: boolean) => void) | null = null
 let onReconnect: (() => void) | null = null
 let onFirstConnect: (() => void) | null = null
+let onVisibilityReconnect: (() => void) | null = null
 
 // Ping/pong heartbeat state
 const PING_INTERVAL_MS = 15_000
@@ -32,6 +33,10 @@ export function setReconnectHandler(fn: () => void): void {
 
 export function setFirstConnectHandler(fn: () => void): void {
   onFirstConnect = fn
+}
+
+export function setVisibilityReconnectHandler(fn: () => void): void {
+  onVisibilityReconnect = fn
 }
 
 export function connectWebSocket(): void {
@@ -177,5 +182,9 @@ function handleVisibilityChange(): void {
       console.warn('[WS] Pong timeout after visibility change — closing stale connection')
       ws?.close()
     }, PONG_TIMEOUT_MS)
+
+    // Even if the connection is alive, sync any messages missed during
+    // the time the page was hidden (JS was suspended on mobile).
+    onVisibilityReconnect?.()
   }
 }

--- a/src/mobile/stores/agent-store.test.ts
+++ b/src/mobile/stores/agent-store.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import { useAgentStore, type AgentMessage, type TaskSession } from './agent-store'
+import { api } from '../api/client'
+
+beforeEach(() => {
+  useAgentStore.setState({
+    agents: [],
+    skills: [],
+    sessions: new Map()
+  })
+  vi.clearAllMocks()
+})
+
+function makeMessage(id: string, role: 'user' | 'assistant' | 'system' = 'assistant', content = `msg-${id}`): AgentMessage {
+  return { id, role, content, timestamp: new Date() }
+}
+
+function setSession(taskId: string, session: Partial<TaskSession>): void {
+  useAgentStore.setState((state) => ({
+    sessions: new Map(state.sessions).set(taskId, {
+      sessionId: session.sessionId ?? 'sess-1',
+      agentId: session.agentId ?? 'agent-1',
+      taskId,
+      status: session.status ?? 'working',
+      messages: session.messages ?? []
+    })
+  }))
+}
+
+describe('useAgentStore', () => {
+  describe('syncActiveSessions', () => {
+    it('does nothing when no active sessions are returned', async () => {
+      // Pre-populate a session with messages
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        messages: [makeMessage('m1'), makeMessage('m2')]
+      })
+      ;(api.sessions.list as unknown as Mock).mockResolvedValue([])
+
+      await useAgentStore.getState().syncActiveSessions()
+
+      // Messages should be untouched
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session?.messages).toHaveLength(2)
+      expect(session?.messages[0].id).toBe('m1')
+    })
+
+    it('preserves existing messages when same session reconnects', async () => {
+      // Pre-populate a session with messages (simulating pre-disconnect state)
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        agentId: 'agent-1',
+        status: 'working',
+        messages: [makeMessage('m1'), makeMessage('m2'), makeMessage('m3')]
+      })
+
+      // Server returns the same session as active
+      ;(api.sessions.list as unknown as Mock).mockResolvedValue([
+        { sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: 'working' }
+      ])
+      ;(api.sessions.sync as unknown as Mock).mockResolvedValue({ success: true, status: 'working' })
+
+      await useAgentStore.getState().syncActiveSessions()
+
+      // Messages should be PRESERVED (not cleared)
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session?.messages).toHaveLength(3)
+      expect(session?.messages[0].id).toBe('m1')
+      expect(session?.messages[1].id).toBe('m2')
+      expect(session?.messages[2].id).toBe('m3')
+
+      // api.sessions.sync should still be called (to fetch missed messages)
+      expect(api.sessions.sync).toHaveBeenCalledWith('sess-1')
+    })
+
+    it('preserves messages when sync request fails on same session', async () => {
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        messages: [makeMessage('m1'), makeMessage('m2')]
+      })
+
+      ;(api.sessions.list as unknown as Mock).mockResolvedValue([
+        { sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: 'working' }
+      ])
+      // Sync fails (network error, server error, etc.)
+      ;(api.sessions.sync as unknown as Mock).mockRejectedValue(new Error('Network error'))
+
+      await useAgentStore.getState().syncActiveSessions()
+
+      // Messages should STILL be preserved even though sync failed
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session?.messages).toHaveLength(2)
+      expect(session?.messages[0].id).toBe('m1')
+      expect(session?.messages[1].id).toBe('m2')
+    })
+
+    it('clears messages when session ID changes (new/restarted session)', async () => {
+      // Pre-populate with old session messages
+      setSession('task-1', {
+        sessionId: 'old-sess',
+        messages: [makeMessage('old-m1'), makeMessage('old-m2')]
+      })
+
+      // Server returns a DIFFERENT session ID for the same task
+      ;(api.sessions.list as unknown as Mock).mockResolvedValue([
+        { sessionId: 'new-sess', agentId: 'agent-1', taskId: 'task-1', status: 'working' }
+      ])
+      ;(api.sessions.sync as unknown as Mock).mockResolvedValue({ success: true, status: 'working' })
+
+      await useAgentStore.getState().syncActiveSessions()
+
+      // Messages should be CLEARED (new session, full reset)
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session?.messages).toHaveLength(0)
+      expect(session?.sessionId).toBe('new-sess')
+    })
+
+    it('creates new session entry when no existing session for task', async () => {
+      // No pre-existing session
+      ;(api.sessions.list as unknown as Mock).mockResolvedValue([
+        { sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: 'working' }
+      ])
+      ;(api.sessions.sync as unknown as Mock).mockResolvedValue({ success: true, status: 'working' })
+
+      await useAgentStore.getState().syncActiveSessions()
+
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session).toBeDefined()
+      expect(session?.sessionId).toBe('sess-1')
+      expect(session?.agentId).toBe('agent-1')
+      expect(session?.status).toBe('working')
+      expect(session?.messages).toHaveLength(0)
+    })
+
+    it('updates status from server while preserving messages on same session', async () => {
+      // Session was "working" on client, server reports "waiting_approval"
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        status: 'working',
+        messages: [makeMessage('m1')]
+      })
+
+      ;(api.sessions.list as unknown as Mock).mockResolvedValue([
+        { sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: 'waiting_approval' }
+      ])
+      ;(api.sessions.sync as unknown as Mock).mockResolvedValue({ success: true, status: 'waiting_approval' })
+
+      await useAgentStore.getState().syncActiveSessions()
+
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session?.status).toBe('waiting_approval')
+      expect(session?.messages).toHaveLength(1)
+      expect(session?.messages[0].id).toBe('m1')
+    })
+
+    it('does not affect other sessions when syncing active ones', async () => {
+      // Two sessions: task-1 is active, task-2 is idle (not returned by server)
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        messages: [makeMessage('m1')]
+      })
+      setSession('task-2', {
+        sessionId: 'sess-2',
+        status: 'idle',
+        messages: [makeMessage('m2-1'), makeMessage('m2-2')]
+      })
+
+      ;(api.sessions.list as unknown as Mock).mockResolvedValue([
+        { sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: 'working' }
+      ])
+      ;(api.sessions.sync as unknown as Mock).mockResolvedValue({ success: true, status: 'working' })
+
+      await useAgentStore.getState().syncActiveSessions()
+
+      // task-2 should be completely untouched
+      const session2 = useAgentStore.getState().sessions.get('task-2')
+      expect(session2?.messages).toHaveLength(2)
+      expect(session2?.sessionId).toBe('sess-2')
+      expect(session2?.status).toBe('idle')
+    })
+
+    it('handles multiple active sessions with mixed same/different IDs', async () => {
+      // task-1: same session (reconnect), task-2: different session (restarted)
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        messages: [makeMessage('t1-m1'), makeMessage('t1-m2')]
+      })
+      setSession('task-2', {
+        sessionId: 'old-sess-2',
+        messages: [makeMessage('t2-old-m1')]
+      })
+
+      ;(api.sessions.list as unknown as Mock).mockResolvedValue([
+        { sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: 'working' },
+        { sessionId: 'new-sess-2', agentId: 'agent-2', taskId: 'task-2', status: 'working' }
+      ])
+      ;(api.sessions.sync as unknown as Mock).mockResolvedValue({ success: true, status: 'working' })
+
+      await useAgentStore.getState().syncActiveSessions()
+
+      // task-1: same session — messages preserved
+      const s1 = useAgentStore.getState().sessions.get('task-1')
+      expect(s1?.messages).toHaveLength(2)
+      expect(s1?.messages[0].id).toBe('t1-m1')
+
+      // task-2: different session — messages cleared
+      const s2 = useAgentStore.getState().sessions.get('task-2')
+      expect(s2?.messages).toHaveLength(0)
+      expect(s2?.sessionId).toBe('new-sess-2')
+    })
+
+    it('handles api.sessions.list failure gracefully', async () => {
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        messages: [makeMessage('m1')]
+      })
+
+      ;(api.sessions.list as unknown as Mock).mockRejectedValue(new Error('Server down'))
+
+      await useAgentStore.getState().syncActiveSessions()
+
+      // Messages should be completely untouched
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session?.messages).toHaveLength(1)
+      expect(session?.messages[0].id).toBe('m1')
+    })
+  })
+
+  describe('initSession', () => {
+    it('creates a new session entry', () => {
+      useAgentStore.getState().initSession('task-1', 'sess-1', 'agent-1')
+
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session).toBeDefined()
+      expect(session?.sessionId).toBe('sess-1')
+      expect(session?.agentId).toBe('agent-1')
+      expect(session?.status).toBe('working')
+      expect(session?.messages).toHaveLength(0)
+    })
+
+    it('preserves existing messages when updating session', () => {
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        messages: [makeMessage('m1')]
+      })
+
+      useAgentStore.getState().initSession('task-1', 'sess-1', 'agent-1')
+
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session?.messages).toHaveLength(1)
+    })
+  })
+
+  describe('endSession', () => {
+    it('sets session to idle and clears sessionId', () => {
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        status: 'working',
+        messages: [makeMessage('m1')]
+      })
+
+      useAgentStore.getState().endSession('task-1')
+
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session?.sessionId).toBeNull()
+      expect(session?.status).toBe('idle')
+      expect(session?.messages).toHaveLength(1) // Messages preserved
+    })
+  })
+
+  describe('removeSession', () => {
+    it('removes the session entirely', () => {
+      setSession('task-1', { sessionId: 'sess-1' })
+
+      useAgentStore.getState().removeSession('task-1')
+
+      expect(useAgentStore.getState().sessions.get('task-1')).toBeUndefined()
+    })
+  })
+
+  describe('clearMessageDedup', () => {
+    it('clears messages for a task', () => {
+      setSession('task-1', {
+        sessionId: 'sess-1',
+        messages: [makeMessage('m1'), makeMessage('m2')]
+      })
+
+      useAgentStore.getState().clearMessageDedup('task-1')
+
+      const session = useAgentStore.getState().sessions.get('task-1')
+      expect(session?.messages).toHaveLength(0)
+    })
+  })
+})

--- a/src/mobile/stores/agent-store.ts
+++ b/src/mobile/stores/agent-store.ts
@@ -339,6 +339,12 @@ export const useAgentStore = create<AgentState>((set, get) => {
     /**
      * Fetch active sessions from the server and sync with any running ones.
      * This allows the mobile UI to connect to sessions already running in Electron.
+     *
+     * On reconnect (same session still active), we preserve existing messages
+     * and only add new ones missed during disconnect. This prevents the flash
+     * of empty state and avoids losing messages if the sync request fails.
+     *
+     * On first connect or session change, we do a full reset + replay.
      */
     syncActiveSessions: async () => {
       try {
@@ -352,23 +358,39 @@ export const useAgentStore = create<AgentState>((set, get) => {
           const nextSessions = new Map(state.sessions)
 
           for (const active of activeSessions) {
-            // Clear dedup and messages so the full replay from server
-            // is accepted without stale data mixing in
-            seenIds.delete(active.taskId)
-            stepStartTimes.delete(active.taskId)
-            nextSessions.set(active.taskId, {
-              sessionId: active.sessionId,
-              agentId: active.agentId,
-              taskId: active.taskId,
-              status: active.status as SessionStatus,
-              messages: []
-            })
+            const existing = state.sessions.get(active.taskId)
+            const isSameSession = existing && existing.sessionId === active.sessionId
+
+            if (isSameSession) {
+              // Same session — preserve messages so missed ones are appended
+              // by the replay batch (dedup via seenIds filters out duplicates)
+              nextSessions.set(active.taskId, {
+                sessionId: active.sessionId,
+                agentId: active.agentId,
+                taskId: active.taskId,
+                status: active.status as SessionStatus,
+                messages: existing.messages
+              })
+            } else {
+              // New or different session — full reset so replay populates fresh
+              seenIds.delete(active.taskId)
+              stepStartTimes.delete(active.taskId)
+              nextSessions.set(active.taskId, {
+                sessionId: active.sessionId,
+                agentId: active.agentId,
+                taskId: active.taskId,
+                status: active.status as SessionStatus,
+                messages: []
+              })
+            }
           }
 
           return { sessions: nextSessions }
         })
 
-        // Replay messages from each active session (will arrive via WebSocket)
+        // Replay messages from each active session (will arrive via WebSocket).
+        // For same-session reconnects: only messages not in seenIds are added.
+        // For new sessions: all messages are added (seenIds was cleared above).
         for (const active of activeSessions) {
           try {
             await api.sessions.sync(active.sessionId)

--- a/src/mobile/stores/connection-store.ts
+++ b/src/mobile/stores/connection-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { connectWebSocket, setStatusChangeHandler, setReconnectHandler, setFirstConnectHandler } from '../api/websocket'
+import { connectWebSocket, setStatusChangeHandler, setReconnectHandler, setFirstConnectHandler, setVisibilityReconnectHandler } from '../api/websocket'
 
 type Callback = () => void
 
@@ -8,6 +8,7 @@ interface ConnectionState {
   connect: () => void
   setOnReconnect: (fn: Callback) => void
   setOnFirstConnect: (fn: Callback) => void
+  setOnVisibilityReconnect: (fn: Callback) => void
 }
 
 export const useConnectionStore = create<ConnectionState>((set) => {
@@ -23,6 +24,9 @@ export const useConnectionStore = create<ConnectionState>((set) => {
     },
     setOnFirstConnect: (fn: Callback) => {
       setFirstConnectHandler(fn)
+    },
+    setOnVisibilityReconnect: (fn: Callback) => {
+      setVisibilityReconnectHandler(fn)
     }
   }
 })


### PR DESCRIPTION
## Summary
- **Root cause:** `syncActiveSessions()` eagerly cleared all messages and dedup state *before* the replay batch arrived via WebSocket. If the sync HTTP request failed (network error, session removed, etc.), messages were permanently lost with no rollback.
- **Fix:** When reconnecting with the **same session ID**, preserve existing messages — the replay batch only adds missed messages (dedup filters duplicates). When the **session ID changes** (restarted session), do a full reset + replay as before.
- **Bonus fix:** Added visibility-change sync so messages missed while JS was suspended on mobile (phone locked) are recovered even if the WebSocket connection stayed alive.

## Test plan
- [x] 13 new unit tests covering all sync scenarios (same session, different session, sync failure, mixed sessions, etc.)
- [x] 36/36 mobile tests pass
- [x] 197/197 renderer tests pass (no regressions)
- [x] TypeScript type check passes clean
- [ ] Manual: Open mobile web, start an agent session, lock phone for 30s, unlock → messages should still be visible
- [ ] Manual: Kill network briefly while agent is working, wait for reconnect → messages should be preserved and new ones appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)