### PR TITLE
Reduce spammy ACP backend logs

### DIFF
--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -2596,4 +2596,68 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
       expect(parts[0].text).not.toContain('codex_error_info')
     })
   })
+
+  describe('verbose RPC logging toggle', () => {
+    it('suppresses high-frequency RPC logs by default', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const session = createMockSession('test-session')
+
+      adapterPrivate(adapter).handleRpcMessage(session, {
+        jsonrpc: '2.0',
+        method: 'agent/ping'
+      })
+
+      const loggedLines = logSpy.mock.calls.map((call) => String(call[0]))
+      expect(loggedLines.some((line) => line.includes('Received RPC message'))).toBe(false)
+      expect(loggedLines.some((line) => line.includes('<< Notification'))).toBe(false)
+    })
+
+    it('enables detailed RPC logs when ACP_VERBOSE_RPC_LOGS=true', () => {
+      const originalValue = process.env.ACP_VERBOSE_RPC_LOGS
+      process.env.ACP_VERBOSE_RPC_LOGS = 'true'
+
+      try {
+        const verboseAdapter = new AcpAdapter('codex')
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        const session = createMockSession('test-session')
+
+        adapterPrivate(verboseAdapter).handleRpcMessage(session, {
+          jsonrpc: '2.0',
+          method: 'agent/ping'
+        })
+
+        const loggedLines = logSpy.mock.calls.map((call) => String(call[0]))
+        expect(loggedLines.some((line) => line.includes('Received RPC message'))).toBe(true)
+        expect(loggedLines.some((line) => line.includes('<< Notification: agent/ping'))).toBe(true)
+      } finally {
+        if (originalValue === undefined) {
+          delete process.env.ACP_VERBOSE_RPC_LOGS
+        } else {
+          process.env.ACP_VERBOSE_RPC_LOGS = originalValue
+        }
+      }
+    })
+
+    it('suppresses per-chunk assistant logs by default', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      adapterPrivate(adapter).convertAcpEventToMessageParts(
+        {
+          method: 'session/update',
+          params: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'hello' }
+            }
+          }
+        },
+        new Set<string>(),
+        new Set<string>(),
+        new Map<string, string>()
+      )
+
+      const loggedLines = logSpy.mock.calls.map((call) => String(call[0]))
+      expect(loggedLines.some((line) => line.includes('agent_message_chunk: turnId='))).toBe(false)
+    })
+  })
 })

--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -2612,9 +2612,9 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
       expect(loggedLines.some((line) => line.includes('<< Notification'))).toBe(false)
     })
 
-    it('enables detailed RPC logs when ACP_VERBOSE_RPC_LOGS=true', () => {
-      const originalValue = process.env.ACP_VERBOSE_RPC_LOGS
-      process.env.ACP_VERBOSE_RPC_LOGS = 'true'
+    it('enables detailed RPC logs when LOG_LEVEL=debug', () => {
+      const originalValue = process.env.LOG_LEVEL
+      process.env.LOG_LEVEL = 'debug'
 
       try {
         const verboseAdapter = new AcpAdapter('codex')
@@ -2631,9 +2631,9 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
         expect(loggedLines.some((line) => line.includes('<< Notification: agent/ping'))).toBe(true)
       } finally {
         if (originalValue === undefined) {
-          delete process.env.ACP_VERBOSE_RPC_LOGS
+          delete process.env.LOG_LEVEL
         } else {
-          process.env.ACP_VERBOSE_RPC_LOGS = originalValue
+          process.env.LOG_LEVEL = originalValue
         }
       }
     })

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -131,6 +131,7 @@ export class AcpAdapter implements CodingAgentAdapter {
   private agentType: AcpAgentType
   private agentConfig: AcpAgentConfig
   private sessions = new Map<string, AcpSession>()
+  private verboseRpcLogs: boolean
 
   /** Callback set by agent-manager to trigger an immediate poll cycle */
   onDataAvailable?: (sessionId: string) => void
@@ -138,6 +139,13 @@ export class AcpAdapter implements CodingAgentAdapter {
   constructor(agentType: AcpAgentType) {
     this.agentType = agentType
     this.agentConfig = this.getAgentConfig(agentType)
+    this.verboseRpcLogs = AcpAdapter.isTruthyEnv(process.env.ACP_VERBOSE_RPC_LOGS)
+  }
+
+  private static isTruthyEnv(value: string | undefined): boolean {
+    if (!value) return false
+    const normalized = value.trim().toLowerCase()
+    return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on'
   }
 
   /**
@@ -963,7 +971,9 @@ export class AcpAdapter implements CodingAgentAdapter {
   }
 
   private handleRpcMessage(session: AcpSession, message: JsonRpcMessage): void {
-    console.log(`[AcpAdapter/${this.agentType}] Received RPC message:`, JSON.stringify(message))
+    if (this.verboseRpcLogs) {
+      console.log(`[AcpAdapter/${this.agentType}] Received RPC message:`, JSON.stringify(message))
+    }
 
     // Handle responses to our requests
     if ('id' in message && message.id !== undefined && !('method' in message)) {
@@ -1025,7 +1035,9 @@ export class AcpAdapter implements CodingAgentAdapter {
     // Handle requests from agent (e.g., session/request_permission)
     if ('method' in message && 'id' in message && message.id !== undefined) {
       const request = message as JsonRpcRequest
-      console.log(`[AcpAdapter/${this.agentType}] << Request: ${request.method}`)
+      if (this.verboseRpcLogs) {
+        console.log(`[AcpAdapter/${this.agentType}] << Request: ${request.method}`)
+      }
 
       if (request.method === 'session/request_permission') {
         this.handlePermissionRequest(session, request)
@@ -1043,10 +1055,12 @@ export class AcpAdapter implements CodingAgentAdapter {
     if ('method' in message && !('id' in message)) {
       const notification = message as JsonRpcNotification
 
-      console.log(`[AcpAdapter/${this.agentType}] << Notification: ${notification.method}`)
-      if (notification.method === 'session/update') {
-        const params = notification.params as { update?: SessionUpdate } | undefined
-        console.log(`[AcpAdapter/${this.agentType}]    sessionUpdate: ${params?.update?.sessionUpdate}`)
+      if (this.verboseRpcLogs) {
+        console.log(`[AcpAdapter/${this.agentType}] << Notification: ${notification.method}`)
+        if (notification.method === 'session/update') {
+          const params = notification.params as { update?: SessionUpdate } | undefined
+          console.log(`[AcpAdapter/${this.agentType}]    sessionUpdate: ${params?.update?.sessionUpdate}`)
+        }
       }
 
       // Store notification directly (no wrapping needed)
@@ -1694,7 +1708,9 @@ export class AcpAdapter implements CodingAgentAdapter {
         // Format: { content: { type: 'text', text: '...' } }
         const turnId = session ? this.getAssistantTurnId(session) : 0
         const messageId = turnId > 0 ? `agent-response-${turnId}` : 'agent-response'
-        console.log(`[AcpAdapter] agent_message_chunk: turnId=${turnId}, messageId=${messageId}`)
+        if (this.verboseRpcLogs) {
+          console.log(`[AcpAdapter] agent_message_chunk: turnId=${turnId}, messageId=${messageId}`)
+        }
 
         const chunk = this.extractTextFromUpdateContent(update.content)
 

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -131,7 +131,7 @@ export class AcpAdapter implements CodingAgentAdapter {
   private agentType: AcpAgentType
   private agentConfig: AcpAgentConfig
   private sessions = new Map<string, AcpSession>()
-  private verboseRpcLogs: boolean
+  private debugRpcLogs: boolean
 
   /** Callback set by agent-manager to trigger an immediate poll cycle */
   onDataAvailable?: (sessionId: string) => void
@@ -139,13 +139,13 @@ export class AcpAdapter implements CodingAgentAdapter {
   constructor(agentType: AcpAgentType) {
     this.agentType = agentType
     this.agentConfig = this.getAgentConfig(agentType)
-    this.verboseRpcLogs = AcpAdapter.isTruthyEnv(process.env.ACP_VERBOSE_RPC_LOGS)
+    this.debugRpcLogs = AcpAdapter.isDebugLogLevel(process.env.LOG_LEVEL)
   }
 
-  private static isTruthyEnv(value: string | undefined): boolean {
+  private static isDebugLogLevel(value: string | undefined): boolean {
     if (!value) return false
     const normalized = value.trim().toLowerCase()
-    return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on'
+    return normalized === 'debug' || normalized === 'trace'
   }
 
   /**
@@ -971,7 +971,7 @@ export class AcpAdapter implements CodingAgentAdapter {
   }
 
   private handleRpcMessage(session: AcpSession, message: JsonRpcMessage): void {
-    if (this.verboseRpcLogs) {
+    if (this.debugRpcLogs) {
       console.log(`[AcpAdapter/${this.agentType}] Received RPC message:`, JSON.stringify(message))
     }
 
@@ -1035,7 +1035,7 @@ export class AcpAdapter implements CodingAgentAdapter {
     // Handle requests from agent (e.g., session/request_permission)
     if ('method' in message && 'id' in message && message.id !== undefined) {
       const request = message as JsonRpcRequest
-      if (this.verboseRpcLogs) {
+      if (this.debugRpcLogs) {
         console.log(`[AcpAdapter/${this.agentType}] << Request: ${request.method}`)
       }
 
@@ -1055,7 +1055,7 @@ export class AcpAdapter implements CodingAgentAdapter {
     if ('method' in message && !('id' in message)) {
       const notification = message as JsonRpcNotification
 
-      if (this.verboseRpcLogs) {
+      if (this.debugRpcLogs) {
         console.log(`[AcpAdapter/${this.agentType}] << Notification: ${notification.method}`)
         if (notification.method === 'session/update') {
           const params = notification.params as { update?: SessionUpdate } | undefined
@@ -1708,7 +1708,7 @@ export class AcpAdapter implements CodingAgentAdapter {
         // Format: { content: { type: 'text', text: '...' } }
         const turnId = session ? this.getAssistantTurnId(session) : 0
         const messageId = turnId > 0 ? `agent-response-${turnId}` : 'agent-response'
-        if (this.verboseRpcLogs) {
+        if (this.debugRpcLogs) {
           console.log(`[AcpAdapter] agent_message_chunk: turnId=${turnId}, messageId=${messageId}`)
         }
 


### PR DESCRIPTION
## Summary
- gate high-frequency ACP RPC transport logs behind an opt-in env flag
- keep detailed logs available via ACP_VERBOSE_RPC_LOGS for debugging
- suppress per-chunk assistant stream trace logs by default
- add unit tests for default-off behavior and explicit opt-in behavior

## Validation
- pnpm --dir 20x test:run src/main/adapters/acp-adapter.test.ts
- pnpm --dir 20x test:run
- pnpm --dir 20x typecheck