### PR TITLE
fix(security): harden MCP/agent processes against SSRF and env var leakage

### DIFF
--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -17,6 +17,7 @@ import type {
   MessagePart,
 } from './coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './coding-agent-adapter'
+import { sanitizeEnvForChild } from '../security-utils'
 
 type ClaudeSDK = typeof import('@anthropic-ai/claude-agent-sdk')
 type Query = import('@anthropic-ai/claude-agent-sdk').Query
@@ -202,7 +203,6 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
    * so every bash command fetches secrets from the broker transparently.
    */
   private buildClaudeEnvironment(): Record<string, string> {
-    const { sanitizeEnvForChild } = require('../security-utils')
     const env = sanitizeEnvForChild()
 
     // Remove CLAUDECODE to prevent nested session error

--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -202,7 +202,8 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
    * so every bash command fetches secrets from the broker transparently.
    */
   private buildClaudeEnvironment(): Record<string, string> {
-    const env = { ...process.env } as Record<string, string>
+    const { sanitizeEnvForChild } = require('../security-utils')
+    const env = sanitizeEnvForChild()
 
     // Remove CLAUDECODE to prevent nested session error
     delete env.CLAUDECODE

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -20,6 +20,7 @@ import { SessionStatusType, MessagePartType, MessageRole } from './adapters/codi
 import { getTaskApiPort, waitForTaskApiServer } from './task-api-server'
 import { randomUUID } from 'crypto'
 import { registerSecretSession, unregisterSecretSession, getSecretBrokerPort, writeSecretShellWrapper } from './secret-broker'
+import { sanitizeEnvForChild } from './security-utils'
 
 let OpenCodeSDK: typeof import('@opencode-ai/sdk') | null = null
 
@@ -903,7 +904,7 @@ export class AgentManager extends EventEmitter {
 
     // Read OpenCode auth.json to inject API keys as env vars
     // OpenCode stores credentials in auth.json but expects env vars at runtime
-    const serverEnv: Record<string, string> = { ...process.env } as Record<string, string>
+    const serverEnv: Record<string, string> = sanitizeEnvForChild()
     try {
       const authPath = join(homedir(), '.local', 'share', 'opencode', 'auth.json')
       if (existsSync(authPath)) {
@@ -3024,7 +3025,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       const proc = spawn(serverData.command!, serverData.args || [], {
         stdio: ['pipe', 'pipe', 'pipe'],
         ...(needsShell ? { shell: true } : {}),
-        env: { ...process.env, npm_config_yes: 'true', ...(serverData.environment || {}), ...extraEnv }
+        env: sanitizeEnvForChild({ npm_config_yes: 'true', ...(serverData.environment || {}), ...extraEnv })
       })
 
       let buffer = ''

--- a/src/main/mcp-tool-caller.js
+++ b/src/main/mcp-tool-caller.js
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process'
 import { getTaskApiPort } from './task-api-server'
+import { sanitizeEnvForChild, validateUrlNotLocal, redactSensitiveData } from './security-utils'
 
 /**
  * @typedef {{ success: boolean, result?: unknown, error?: string }} McpToolCallResult
@@ -25,7 +26,7 @@ export class McpToolCaller {
       ? await this.callRemoteTool(server, toolName, toolArgs)
       : await this.callLocalTool(server, toolName, toolArgs)
     if (result.success) {
-      console.log('[mcp] callTool result:', toolName, JSON.stringify(result.result).slice(0, 500))
+      console.log('[mcp] callTool result:', toolName, redactSensitiveData(JSON.stringify(result.result).slice(0, 500)))
     } else {
       console.error('[mcp] callTool failed:', result.error)
     }
@@ -91,15 +92,14 @@ export class McpToolCaller {
     const proc = spawn(server.command, server.args || [], {
       stdio: ['pipe', 'pipe', 'pipe'],
       ...(needsShell ? { shell: true } : {}),
-      env: {
-        ...process.env,
+      env: sanitizeEnvForChild({
         npm_config_yes: 'true',
         ...server.environment,
         // Inject TASK_API_URL for task-management MCP server
         ...(server.name === 'task-management' && getTaskApiPort()
           ? { TASK_API_URL: `http://127.0.0.1:${getTaskApiPort()}` }
           : {})
-      }
+      })
     })
 
     /** @type {LocalMcpSession} */
@@ -251,6 +251,13 @@ export class McpToolCaller {
   async callRemoteTool(server, toolName, toolArgs) {
     if (!server.url) {
       return { success: false, error: 'No URL specified' }
+    }
+
+    // Block requests to localhost / private IPs to prevent SSRF
+    const urlCheck = validateUrlNotLocal(server.url)
+    if (!urlCheck.safe) {
+      console.error('[mcp] SSRF blocked:', urlCheck.reason)
+      return { success: false, error: urlCheck.reason }
     }
 
     try {

--- a/src/main/mcp-tool-caller.test.ts
+++ b/src/main/mcp-tool-caller.test.ts
@@ -35,6 +35,20 @@ describe('McpToolCaller', () => {
       expect(result.error).toBe('No URL specified')
     })
 
+    it('blocks localhost URLs (SSRF protection)', async () => {
+      const server = makeServer({ type: 'remote', url: 'http://127.0.0.1:9999/secrets/export' })
+      const result = await caller.callTool(server, 'test_tool', {})
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Blocked')
+    })
+
+    it('blocks private IP URLs (SSRF protection)', async () => {
+      const server = makeServer({ type: 'remote', url: 'http://10.0.0.1:8080/api' })
+      const result = await caller.callTool(server, 'test_tool', {})
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('private')
+    })
+
     it('returns error on HTTP failure', async () => {
       const server = makeServer({ type: 'remote', url: 'https://api.test.com' })
       const mockFetch = vi.fn().mockResolvedValue({

--- a/src/main/mcp-tool-caller.ts
+++ b/src/main/mcp-tool-caller.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process'
 import type { McpServerRecord } from './database'
 import { getTaskApiPort } from './task-api-server'
+import { sanitizeEnvForChild, validateUrlNotLocal, redactSensitiveData } from './security-utils'
 
 export interface McpToolCallResult {
   success: boolean
@@ -26,7 +27,7 @@ export class McpToolCaller {
       ? await this.callRemoteTool(server, toolName, toolArgs)
       : await this.callLocalTool(server, toolName, toolArgs)
     if (result.success) {
-      console.log('[mcp] callTool result:', toolName, JSON.stringify(result.result).slice(0, 500))
+      console.log('[mcp] callTool result:', toolName, redactSensitiveData(JSON.stringify(result.result).slice(0, 500)))
     } else {
       console.error('[mcp] callTool failed:', result.error)
     }
@@ -96,15 +97,14 @@ export class McpToolCaller {
     const proc = spawn(server.command!, server.args || [], {
       stdio: ['pipe', 'pipe', 'pipe'],
       ...(needsShell ? { shell: true } : {}),
-      env: {
-        ...process.env,
+      env: sanitizeEnvForChild({
         npm_config_yes: 'true',
         ...server.environment,
         // Inject TASK_API_URL for task-management MCP server
         ...(server.name === 'task-management' && getTaskApiPort()
           ? { TASK_API_URL: `http://127.0.0.1:${getTaskApiPort()}` }
           : {})
-      }
+      })
     })
 
     const session: LocalMcpSession = {
@@ -263,6 +263,13 @@ export class McpToolCaller {
   ): Promise<McpToolCallResult> {
     if (!server.url) {
       return { success: false, error: 'No URL specified' }
+    }
+
+    // Block requests to localhost / private IPs to prevent SSRF
+    const urlCheck = validateUrlNotLocal(server.url)
+    if (!urlCheck.safe) {
+      console.error('[mcp] SSRF blocked:', urlCheck.reason)
+      return { success: false, error: urlCheck.reason! }
     }
 
     try {

--- a/src/main/secret-broker.ts
+++ b/src/main/secret-broker.ts
@@ -52,7 +52,7 @@ export function startSecretBroker(db: DatabaseManager): Promise<number> {
       if (url.pathname === '/secrets/export') {
         const token = url.searchParams.get('token')
         if (!token || !activeSessions.has(token)) {
-          console.log(`[SecretBroker] 403 — invalid/missing token: ${token ? token.substring(0, 8) + '...' : 'null'}`)
+          console.log(`[SecretBroker] 403 — invalid or missing token`)
           res.writeHead(403, { 'Content-Type': 'text/plain' })
           res.end('')
           return
@@ -66,9 +66,9 @@ export function startSecretBroker(db: DatabaseManager): Promise<number> {
           return
         }
 
-        console.log(`[SecretBroker] Fetching secrets for agent ${session.agentId}, secretIds: [${session.secretIds.join(', ')}]`)
+        console.log(`[SecretBroker] Fetching secrets for agent ${session.agentId} (${session.secretIds.length} secret(s))`)
         const secrets = dbRef.getSecretsWithValues(session.secretIds)
-        console.log(`[SecretBroker] Found ${secrets.length} secret(s): [${secrets.map(s => `${s.env_var_name}(${s.value.length} chars)`).join(', ')}]`)
+        console.log(`[SecretBroker] Found ${secrets.length} secret(s)`)
 
         // Return shell export statements
         // Single-quote values and escape embedded single quotes
@@ -76,7 +76,7 @@ export function startSecretBroker(db: DatabaseManager): Promise<number> {
           .map(s => `export ${s.env_var_name}='${s.value.replace(/'/g, "'\\''")}'`)
           .join('\n')
 
-        console.log(`[SecretBroker] Response body length: ${exports.length} bytes`)
+        console.log(`[SecretBroker] Serving ${secrets.length} export(s) to agent ${session.agentId}`)
         res.writeHead(200, { 'Content-Type': 'text/plain' })
         res.end(exports)
         return

--- a/src/main/security-utils.js
+++ b/src/main/security-utils.js
@@ -1,0 +1,116 @@
+/**
+ * Security utilities for defense-in-depth hardening.
+ *
+ * - Strips sensitive env vars from child process environments
+ * - Validates URLs to block SSRF against localhost / private networks
+ * - Redacts sensitive content from log output
+ */
+
+/**
+ * Environment variable names that must never be forwarded to child processes.
+ * Includes Secret Broker credentials and other sensitive internal vars.
+ */
+const SENSITIVE_ENV_VARS = [
+  '_20X_SB_PORT',
+  '_20X_SB_TOKEN',
+  '_20X_REAL_SHELL',
+]
+
+/**
+ * Create a sanitized copy of process.env with sensitive vars removed.
+ * Use this instead of `{ ...process.env }` when spawning child processes.
+ * @param {Record<string, string>} extra
+ * @returns {Record<string, string>}
+ */
+export function sanitizeEnvForChild(extra = {}) {
+  const env = { ...process.env, ...extra }
+  for (const key of SENSITIVE_ENV_VARS) {
+    delete env[key]
+  }
+  return env
+}
+
+/**
+ * Hostnames and IP patterns considered "local" or "private".
+ */
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '[::1]',
+  '0.0.0.0',
+])
+
+/**
+ * Check if an IP address falls within RFC-1918 private ranges.
+ * @param {string} ip
+ * @returns {boolean}
+ */
+function isPrivateIP(ip) {
+  const v4Match = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+  const v4 = v4Match ? v4Match[1] : ip
+
+  const parts = v4.split('.').map(Number)
+  if (parts.length !== 4 || parts.some(isNaN)) return false
+
+  const [a, b] = parts
+  if (a === 10) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  if (a === 169 && b === 254) return true
+  if (a === 127) return true
+  if (a === 0) return true
+
+  return false
+}
+
+/**
+ * Validate that a URL does not target localhost or private network addresses.
+ * @param {string} url
+ * @returns {{ safe: boolean, reason?: string }}
+ */
+export function validateUrlNotLocal(url) {
+  try {
+    const parsed = new URL(url)
+    const hostname = parsed.hostname.toLowerCase()
+
+    const bare = hostname.replace(/^\[|\]$/g, '')
+
+    if (BLOCKED_HOSTNAMES.has(hostname) || BLOCKED_HOSTNAMES.has(bare)) {
+      return { safe: false, reason: `Blocked request to local address: ${hostname}` }
+    }
+
+    if (isPrivateIP(bare)) {
+      return { safe: false, reason: `Blocked request to private IP: ${hostname}` }
+    }
+
+    return { safe: true }
+  } catch {
+    return { safe: false, reason: `Invalid URL: ${url}` }
+  }
+}
+
+/**
+ * Patterns that indicate sensitive data in log output.
+ */
+const SENSITIVE_PATTERNS = [
+  /(?:api[_-]?key|token|secret|password|bearer|authorization|credential)["\s:=]+["']?[A-Za-z0-9_\-./+=]{8,}/gi,
+  /(?:sk|pk|rk|ak|xox[bpas])-[A-Za-z0-9_\-]{10,}/gi,
+  /ghp_[A-Za-z0-9]{36}/gi,
+  /gho_[A-Za-z0-9]{36}/gi,
+  /glpat-[A-Za-z0-9_\-]{20}/gi,
+]
+
+/**
+ * Redact potentially sensitive values from a string before logging.
+ * @param {string} input
+ * @returns {string}
+ */
+export function redactSensitiveData(input) {
+  let result = input
+  for (const pattern of SENSITIVE_PATTERNS) {
+    pattern.lastIndex = 0
+    result = result.replace(pattern, '[REDACTED]')
+  }
+  return result
+}

--- a/src/main/security-utils.test.ts
+++ b/src/main/security-utils.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { sanitizeEnvForChild, validateUrlNotLocal, redactSensitiveData } from './security-utils'
+
+describe('security-utils', () => {
+  describe('sanitizeEnvForChild', () => {
+    const originalEnv = { ...process.env }
+
+    beforeEach(() => {
+      process.env._20X_SB_PORT = '12345'
+      process.env._20X_SB_TOKEN = 'secret-uuid-token'
+      process.env._20X_REAL_SHELL = '/bin/bash'
+      process.env.PATH = '/usr/bin'
+      process.env.HOME = '/home/test'
+    })
+
+    afterEach(() => {
+      process.env = { ...originalEnv }
+    })
+
+    it('strips _20X_SB_PORT from child env', () => {
+      const env = sanitizeEnvForChild()
+      expect(env._20X_SB_PORT).toBeUndefined()
+    })
+
+    it('strips _20X_SB_TOKEN from child env', () => {
+      const env = sanitizeEnvForChild()
+      expect(env._20X_SB_TOKEN).toBeUndefined()
+    })
+
+    it('strips _20X_REAL_SHELL from child env', () => {
+      const env = sanitizeEnvForChild()
+      expect(env._20X_REAL_SHELL).toBeUndefined()
+    })
+
+    it('preserves non-sensitive env vars', () => {
+      const env = sanitizeEnvForChild()
+      expect(env.PATH).toBe('/usr/bin')
+      expect(env.HOME).toBe('/home/test')
+    })
+
+    it('merges extra vars into result', () => {
+      const env = sanitizeEnvForChild({ npm_config_yes: 'true', CUSTOM: 'value' })
+      expect(env.npm_config_yes).toBe('true')
+      expect(env.CUSTOM).toBe('value')
+      // Still strips sensitive vars
+      expect(env._20X_SB_PORT).toBeUndefined()
+    })
+
+    it('does not modify process.env', () => {
+      sanitizeEnvForChild()
+      expect(process.env._20X_SB_PORT).toBe('12345')
+    })
+  })
+
+  describe('validateUrlNotLocal', () => {
+    it('allows public URLs', () => {
+      expect(validateUrlNotLocal('https://api.example.com/mcp')).toEqual({ safe: true })
+      expect(validateUrlNotLocal('https://8.8.8.8/api')).toEqual({ safe: true })
+    })
+
+    it('blocks localhost', () => {
+      const result = validateUrlNotLocal('http://localhost:3000/secrets')
+      expect(result.safe).toBe(false)
+      expect(result.reason).toContain('local')
+    })
+
+    it('blocks 127.0.0.1', () => {
+      const result = validateUrlNotLocal('http://127.0.0.1:9999/secrets/export')
+      expect(result.safe).toBe(false)
+      expect(result.reason).toContain('local')
+    })
+
+    it('blocks ::1 (IPv6 loopback)', () => {
+      const result = validateUrlNotLocal('http://[::1]:8080/api')
+      expect(result.safe).toBe(false)
+    })
+
+    it('blocks 0.0.0.0', () => {
+      const result = validateUrlNotLocal('http://0.0.0.0:8080/api')
+      expect(result.safe).toBe(false)
+    })
+
+    it('blocks 10.x.x.x (RFC-1918)', () => {
+      const result = validateUrlNotLocal('http://10.0.0.1:8080/api')
+      expect(result.safe).toBe(false)
+      expect(result.reason).toContain('private')
+    })
+
+    it('blocks 172.16.x.x (RFC-1918)', () => {
+      const result = validateUrlNotLocal('http://172.16.0.5:3000/')
+      expect(result.safe).toBe(false)
+    })
+
+    it('allows 172.15.x.x (not in private range)', () => {
+      expect(validateUrlNotLocal('http://172.15.0.1:3000/')).toEqual({ safe: true })
+    })
+
+    it('blocks 192.168.x.x (RFC-1918)', () => {
+      const result = validateUrlNotLocal('http://192.168.1.1/')
+      expect(result.safe).toBe(false)
+    })
+
+    it('blocks 169.254.x.x (link-local)', () => {
+      const result = validateUrlNotLocal('http://169.254.169.254/latest/meta-data/')
+      expect(result.safe).toBe(false)
+    })
+
+    it('rejects invalid URLs', () => {
+      const result = validateUrlNotLocal('not-a-url')
+      expect(result.safe).toBe(false)
+      expect(result.reason).toContain('Invalid URL')
+    })
+
+    it('blocks 127.x.x.x (full loopback range)', () => {
+      const result = validateUrlNotLocal('http://127.0.0.2:8080/')
+      expect(result.safe).toBe(false)
+    })
+  })
+
+  describe('redactSensitiveData', () => {
+    it('redacts API key patterns', () => {
+      const input = 'Got api_key: sk-abc123def456ghi789jkl012'
+      const result = redactSensitiveData(input)
+      expect(result).not.toContain('sk-abc123')
+      expect(result).toContain('[REDACTED]')
+    })
+
+    it('redacts bearer tokens', () => {
+      const input = 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc'
+      const result = redactSensitiveData(input)
+      expect(result).toContain('[REDACTED]')
+    })
+
+    it('redacts GitHub personal access tokens', () => {
+      const input = 'token: ghp_ABCDEFghijKLMNOP1234567890abcdefGHIJ'
+      const result = redactSensitiveData(input)
+      expect(result).not.toContain('ghp_ABCDEF')
+      expect(result).toContain('[REDACTED]')
+    })
+
+    it('preserves non-sensitive content', () => {
+      const input = 'Tool returned: {"status": "ok", "count": 42}'
+      const result = redactSensitiveData(input)
+      expect(result).toBe(input)
+    })
+
+    it('redacts Stripe-style keys', () => {
+      const input = 'sk-live-abcdef123456789012345678'
+      const result = redactSensitiveData(input)
+      expect(result).toContain('[REDACTED]')
+    })
+
+    it('handles empty string', () => {
+      expect(redactSensitiveData('')).toBe('')
+    })
+  })
+})

--- a/src/main/security-utils.ts
+++ b/src/main/security-utils.ts
@@ -1,0 +1,116 @@
+/**
+ * Security utilities for defense-in-depth hardening.
+ *
+ * - Strips sensitive env vars from child process environments
+ * - Validates URLs to block SSRF against localhost / private networks
+ * - Redacts sensitive content from log output
+ */
+
+/**
+ * Environment variable names that must never be forwarded to child processes.
+ * Includes Secret Broker credentials and other sensitive internal vars.
+ */
+const SENSITIVE_ENV_VARS = [
+  '_20X_SB_PORT',
+  '_20X_SB_TOKEN',
+  '_20X_REAL_SHELL',
+]
+
+/**
+ * Create a sanitized copy of process.env with sensitive vars removed.
+ * Use this instead of `{ ...process.env }` when spawning child processes.
+ */
+export function sanitizeEnvForChild(extra: Record<string, string> = {}): Record<string, string> {
+  const env = { ...process.env, ...extra } as Record<string, string>
+  for (const key of SENSITIVE_ENV_VARS) {
+    delete env[key]
+  }
+  return env
+}
+
+/**
+ * Hostnames and IP patterns considered "local" or "private".
+ * Used to block SSRF to internal services.
+ */
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '[::1]',
+  '0.0.0.0',
+])
+
+/**
+ * Check if an IP address falls within RFC-1918 private ranges or
+ * other non-routable address spaces:
+ *   10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16
+ */
+function isPrivateIP(ip: string): boolean {
+  // IPv4 mapped in IPv6 — extract the v4 portion
+  const v4Match = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+  const v4 = v4Match ? v4Match[1] : ip
+
+  const parts = v4.split('.').map(Number)
+  if (parts.length !== 4 || parts.some(isNaN)) return false
+
+  const [a, b] = parts
+  if (a === 10) return true                               // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true        // 172.16.0.0/12
+  if (a === 192 && b === 168) return true                 // 192.168.0.0/16
+  if (a === 169 && b === 254) return true                 // 169.254.0.0/16
+  if (a === 127) return true                              // 127.0.0.0/8 (full loopback)
+  if (a === 0) return true                                // 0.0.0.0/8
+
+  return false
+}
+
+/**
+ * Validate that a URL does not target localhost or private network addresses.
+ * Returns `{ safe: true }` if the URL is acceptable, or `{ safe: false, reason }` if blocked.
+ */
+export function validateUrlNotLocal(url: string): { safe: boolean; reason?: string } {
+  try {
+    const parsed = new URL(url)
+    const hostname = parsed.hostname.toLowerCase()
+
+    // Strip brackets from IPv6 addresses for checking
+    const bare = hostname.replace(/^\[|\]$/g, '')
+
+    if (BLOCKED_HOSTNAMES.has(hostname) || BLOCKED_HOSTNAMES.has(bare)) {
+      return { safe: false, reason: `Blocked request to local address: ${hostname}` }
+    }
+
+    if (isPrivateIP(bare)) {
+      return { safe: false, reason: `Blocked request to private IP: ${hostname}` }
+    }
+
+    return { safe: true }
+  } catch {
+    return { safe: false, reason: `Invalid URL: ${url}` }
+  }
+}
+
+/**
+ * Patterns that indicate sensitive data in log output.
+ */
+const SENSITIVE_PATTERNS = [
+  /(?:api[_-]?key|token|secret|password|bearer|authorization|credential)["\s:=]+["']?[A-Za-z0-9_\-./+=]{8,}/gi,
+  /(?:sk|pk|rk|ak|xox[bpas])-[A-Za-z0-9_\-]{10,}/gi,      // API key prefixes (Stripe, Slack, etc.)
+  /ghp_[A-Za-z0-9]{36}/gi,                                    // GitHub personal access tokens
+  /gho_[A-Za-z0-9]{36}/gi,                                    // GitHub OAuth tokens
+  /glpat-[A-Za-z0-9_\-]{20}/gi,                               // GitLab personal access tokens
+]
+
+/**
+ * Redact potentially sensitive values from a string before logging.
+ * Replaces matches with `[REDACTED]`.
+ */
+export function redactSensitiveData(input: string): string {
+  let result = input
+  for (const pattern of SENSITIVE_PATTERNS) {
+    // Reset lastIndex for global regexes
+    pattern.lastIndex = 0
+    result = result.replace(pattern, '[REDACTED]')
+  }
+  return result
+}


### PR DESCRIPTION
## Summary
- **Env var stripping**: Remove `_20X_SB_PORT`, `_20X_SB_TOKEN`, `_20X_REAL_SHELL` from environments passed to child processes (MCP servers, agents, Claude Code adapter) via a new `sanitizeEnvForChild()` helper
- **SSRF URL validation**: Block remote MCP tool calls targeting `localhost`, `127.0.0.0/8`, `::1`, `0.0.0.0`, and RFC-1918 private IP ranges (`10.x`, `172.16-31.x`, `192.168.x`, `169.254.x`) before any `fetch()` is made
- **Log sanitization**: Redact API keys, tokens, and other sensitive patterns from MCP tool call result logs using `redactSensitiveData()`
- **Secret Broker log hardening**: Remove secret IDs, env var names, value lengths, response body sizes, and partial token values from broker logs

## Context
These are defense-in-depth hardening fixes based on a security review that identified theoretical SSRF pathways through the MCP/agent architecture. While the described attack chain was assessed as LOW severity (MCP server URLs are admin-configured, not attacker-controllable), these fixes add multiple layers of protection.

## Files Changed
- **`security-utils.ts/.js`** (NEW): Shared module with `sanitizeEnvForChild()`, `validateUrlNotLocal()`, `redactSensitiveData()`
- **`mcp-tool-caller.ts/.js`**: Use sanitized env for MCP server processes, add URL validation for remote tool calls, redact log output
- **`agent-manager.ts`**: Use sanitized env for OpenCode server spawn and MCP server spawn
- **`claude-code-adapter.ts`**: Use sanitized env for Claude Code process
- **`secret-broker.ts`**: Reduce log verbosity — no longer logs secret IDs, env var names, value lengths, or partial tokens

## Test plan
- [x] 24 new unit tests for `security-utils` (env stripping, URL validation, log redaction)
- [x] 2 new SSRF protection tests in `mcp-tool-caller.test.ts` (localhost + private IP blocking)
- [x] All 30 tests pass
- [x] TypeScript build passes (`tsc --build --noEmit`)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)