### PR TITLE
fix: exclude recurring parent template tasks from task listings

### DIFF
--- a/src/main/task-api-server.test.ts
+++ b/src/main/task-api-server.test.ts
@@ -553,6 +553,53 @@ describe('Triage lifecycle with output_fields', () => {
   })
 })
 
+describe('/list_tasks - excludes recurring parent templates', () => {
+  it('excludes recurring parent template tasks from list_tasks results', () => {
+    // Create a normal task
+    db.createTask(makeTask({ title: 'Normal Task' }))
+
+    // Create a recurring template (is_recurring=1, recurrence_parent_id=NULL)
+    const template = db.createTask(makeTask({ title: 'Daily Standup Template' }))!
+    rawDb.prepare('UPDATE tasks SET is_recurring = 1, recurrence_pattern = ? WHERE id = ?')
+      .run('0 9 * * *', template.id)
+
+    // Create a recurring instance (is_recurring=0, recurrence_parent_id set)
+    const instance = db.createTask(makeTask({ title: 'Daily Standup - Apr 9' }))!
+    rawDb.prepare('UPDATE tasks SET recurrence_parent_id = ? WHERE id = ?')
+      .run(template.id, instance.id)
+
+    // Simulate /list_tasks query — should exclude recurring parent templates
+    const query = 'SELECT * FROM tasks WHERE NOT (is_recurring = 1 AND recurrence_parent_id IS NULL) ORDER BY created_at DESC'
+    const tasks = rawDb.prepare(query).all() as Record<string, unknown>[]
+
+    expect(tasks).toHaveLength(2)
+    const titles = tasks.map((t) => t.title)
+    expect(titles).toContain('Normal Task')
+    expect(titles).toContain('Daily Standup - Apr 9')
+    expect(titles).not.toContain('Daily Standup Template')
+  })
+
+  it('includes recurring instances (tasks with recurrence_parent_id)', () => {
+    const template = db.createTask(makeTask({ title: 'Template' }))!
+    rawDb.prepare('UPDATE tasks SET is_recurring = 1, recurrence_pattern = ? WHERE id = ?')
+      .run('0 9 * * *', template.id)
+
+    // Create two instances from the template
+    const i1 = db.createTask(makeTask({ title: 'Instance 1' }))!
+    rawDb.prepare('UPDATE tasks SET recurrence_parent_id = ? WHERE id = ?').run(template.id, i1.id)
+    const i2 = db.createTask(makeTask({ title: 'Instance 2' }))!
+    rawDb.prepare('UPDATE tasks SET recurrence_parent_id = ? WHERE id = ?').run(template.id, i2.id)
+
+    const query = 'SELECT * FROM tasks WHERE NOT (is_recurring = 1 AND recurrence_parent_id IS NULL) ORDER BY created_at DESC'
+    const tasks = rawDb.prepare(query).all() as Record<string, unknown>[]
+
+    const titles = tasks.map((t) => t.title)
+    expect(titles).toContain('Instance 1')
+    expect(titles).toContain('Instance 2')
+    expect(titles).not.toContain('Template')
+  })
+})
+
 describe('agent_workload statistics - uses agent_working status', () => {
   it('counts tasks with agent_working status as active', () => {
     const agent = db.createAgent(makeAgent({ name: 'Stats Agent' }))!

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -116,7 +116,8 @@ async function handleRoute(db: DatabaseManager, route: string, params: Record<st
 
   switch (route) {
     case '/list_tasks': {
-      let query = 'SELECT * FROM tasks WHERE 1=1'
+      // Exclude recurring parent template tasks — they are not actionable tasks
+      let query = 'SELECT * FROM tasks WHERE NOT (is_recurring = 1 AND recurrence_parent_id IS NULL)'
       const qParams: unknown[] = []
 
       if (params.status) { query += ' AND status = ?'; qParams.push(params.status) }

--- a/src/renderer/src/components/dashboard/TaskBoard.tsx
+++ b/src/renderer/src/components/dashboard/TaskBoard.tsx
@@ -158,9 +158,9 @@ export function TaskBoard() {
   const { openDashboardPreview } = useUIStore()
   const snoozeTick = useSnoozeTick(tasks)
 
-  // Only show top-level tasks that are not snoozed (not subtasks)
+  // Only show top-level tasks that are not snoozed (not subtasks) and not recurring templates
   const topLevelTasks = useMemo(
-    () => tasks.filter((t) => !t.parent_task_id && !isSnoozed(t.snoozed_until)),
+    () => tasks.filter((t) => !t.parent_task_id && !isSnoozed(t.snoozed_until) && !(t.is_recurring && !t.recurrence_parent_id)),
     [tasks, snoozeTick]
   )
 

--- a/src/renderer/src/hooks/use-agent-auto-start.test.tsx
+++ b/src/renderer/src/hooks/use-agent-auto-start.test.tsx
@@ -117,6 +117,93 @@ describe('useAgentAutoStart', () => {
     expect(updateCallOrder).toBeLessThan(startCallOrder)
   })
 
+  it('does not triage recurring parent template tasks', async () => {
+    const templateTask = makeTask({
+      id: 'template-1',
+      title: 'Daily standup template',
+      is_recurring: true,
+      recurrence_parent_id: null,
+      recurrence_pattern: '0 9 * * 1-5'
+    })
+    const triageAgent = makeAgent({ id: 'agent-triage', is_default: true })
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [templateTask],
+        agents: [triageAgent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    // Should NOT update status or start a session for the template
+    expect(mockElectronAPI.db.updateTask).not.toHaveBeenCalled()
+    expect(mockElectronAPI.agentSession.start).not.toHaveBeenCalled()
+  })
+
+  it('does not auto-start recurring parent template tasks with assigned agent', async () => {
+    const templateTask = makeTask({
+      id: 'template-2',
+      title: 'Weekly report template',
+      is_recurring: true,
+      recurrence_parent_id: null,
+      recurrence_pattern: '0 10 * * 1',
+      agent_id: 'agent-1',
+      status: TaskStatus.NotStarted
+    })
+    const agent = makeAgent({ id: 'agent-1', is_default: false })
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [templateTask],
+        agents: [agent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    // Should NOT start a session for the template
+    expect(mockElectronAPI.agentSession.start).not.toHaveBeenCalled()
+  })
+
+  it('still triages recurring instances (tasks with recurrence_parent_id)', async () => {
+    const instanceTask = makeTask({
+      id: 'instance-1',
+      title: 'Daily standup - 2026-04-09',
+      is_recurring: false,
+      recurrence_parent_id: 'template-1'
+    })
+    const triageAgent = makeAgent({ id: 'agent-triage', is_default: true })
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [instanceTask],
+        agents: [triageAgent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    // Should triage the instance normally
+    expect(mockElectronAPI.db.updateTask).toHaveBeenCalledWith(instanceTask.id, { status: TaskStatus.Triaging })
+    expect(mockElectronAPI.agentSession.start).toHaveBeenCalledWith(triageAgent.id, instanceTask.id, undefined, undefined)
+  })
+
   it('starts assigned agent immediately after successful triage completion', async () => {
     const task = makeTask({ id: 'task-2', title: 'Needs triage' })
     const triageAgent = makeAgent({ id: 'agent-triage', is_default: true, name: 'Triage Agent' })

--- a/src/renderer/src/hooks/use-agent-auto-start.ts
+++ b/src/renderer/src/hooks/use-agent-auto-start.ts
@@ -53,11 +53,19 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
     return new Date(snoozedUntil) > new Date()
   }, [])
 
+  // Helper: Check if task is a recurring parent template (should never be triaged or auto-started)
+  const isRecurringTemplate = useCallback((task: WorkfloTask): boolean => {
+    return task.is_recurring && !task.recurrence_parent_id
+  }, [])
+
   // Helper: Select triage candidates (tasks with no agent_id that need triage)
   const selectTriageCandidates = useCallback(
     (allTasks: WorkfloTask[], allSessions: Map<string, TaskSession>): string[] => {
       return allTasks
         .filter((task) => {
+          // Skip recurring parent template tasks — they are templates, not actionable tasks
+          if (isRecurringTemplate(task)) return false
+
           const isNotStarted = task.status === TaskStatus.NotStarted
           const hasNoAgent = !task.agent_id
           const notSnoozed = !isSnoozed(task.snoozed_until)
@@ -70,7 +78,7 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
         })
         .map((task) => task.id)
     },
-    [isSnoozed]
+    [isSnoozed, isRecurringTemplate]
   )
 
   // Helper: Start triage for a task
@@ -124,6 +132,9 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
       const tasksByAgent = new Map<string, string[]>()
 
       allTasks.forEach((task) => {
+        // Skip recurring parent template tasks — they are templates, not actionable tasks
+        if (isRecurringTemplate(task)) return
+
         // Log why tasks are excluded
         const isNotStarted = task.status === TaskStatus.NotStarted
         const hasAgent = !!task.agent_id
@@ -163,7 +174,7 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
 
       return tasksByAgent
     },
-    [isSnoozed]
+    [isSnoozed, isRecurringTemplate]
   )
 
   // Helper: Start tasks for an agent (respecting max parallel limit)
@@ -228,6 +239,7 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
 
       // Verify task is still eligible
       if (
+        isRecurringTemplate(task) ||
         task.status !== TaskStatus.NotStarted ||
         task.agent_id !== agentId ||
         isSnoozed(task.snoozed_until) ||
@@ -396,7 +408,9 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
     if (!isEnabled) return
 
     const unsubscribe = onTaskCreated((event) => {
-      const task = event.task
+      const task = event.task as WorkfloTask
+      // Skip recurring parent template tasks
+      if (task.is_recurring && !task.recurrence_parent_id) return
       if (
         task.status === TaskStatus.NotStarted &&
         !task.agent_id &&
@@ -428,6 +442,9 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
 
       // Merge event updates with stale task to get current state
       const task = { ...staleTask, ...event.updates } as WorkfloTask
+
+      // Skip recurring parent template tasks
+      if (task.is_recurring && !task.recurrence_parent_id) return
 
       // Check if task is eligible for auto-start (has agent_id)
       if (

--- a/src/renderer/src/stores/dashboard-store.test.ts
+++ b/src/renderer/src/stores/dashboard-store.test.ts
@@ -346,6 +346,19 @@ describe('computeLocalStats', () => {
     expect(stats.tasksByStatus[TaskStatus.AgentWorking]).toBeUndefined()
   })
 
+  it('excludes recurring parent template tasks from counts', () => {
+    const tasks: WorkfloTask[] = [
+      makeTask({ id: 'normal', status: TaskStatus.NotStarted }),
+      makeTask({ id: 'template', status: TaskStatus.NotStarted, is_recurring: true, recurrence_parent_id: null }),
+      makeTask({ id: 'instance', status: TaskStatus.NotStarted, is_recurring: false, recurrence_parent_id: 'template' })
+    ]
+
+    const stats = computeLocalStats(tasks, 'all')
+
+    // Template should be excluded; normal + instance should be counted
+    expect(stats.totalTasks).toBe(2)
+  })
+
   it('sets single-user defaults', () => {
     const stats = computeLocalStats([], 'all')
 

--- a/src/renderer/src/stores/dashboard-store.ts
+++ b/src/renderer/src/stores/dashboard-store.ts
@@ -67,8 +67,8 @@ function getWindowStart(timeWindow: TimeWindow): Date | null {
 
 /** Compute dashboard stats from local tasks (no cloud required). */
 export function computeLocalStats(tasks: WorkfloTask[], timeWindow: TimeWindow): DashboardStats {
-  // Filter to top-level, non-snoozed tasks only (consistent with TaskBoard)
-  const topLevel = tasks.filter((t) => !t.parent_task_id && !isSnoozed(t.snoozed_until))
+  // Filter to top-level, non-snoozed, non-template tasks only (consistent with TaskBoard)
+  const topLevel = tasks.filter((t) => !t.parent_task_id && !isSnoozed(t.snoozed_until) && !(t.is_recurring && !t.recurrence_parent_id))
   const windowStart = getWindowStart(timeWindow)
 
   const tasksByStatus: Record<string, number> = {}


### PR DESCRIPTION
## Summary
- Recurring parent template tasks (`is_recurring=true`, `recurrence_parent_id=null`) are scheduling templates that generate task instances on a schedule — they are not actionable tasks themselves
- These templates were incorrectly appearing in the MCP `list_tasks` API response (visible to agents), the dashboard kanban board (TaskBoard), and dashboard statistics
- Added SQL filter in `task-api-server.ts` to exclude templates from `/list_tasks`
- Added client-side filter in `TaskBoard.tsx` and `dashboard-store.ts` to exclude templates from kanban and stats
- Added recurring template guard in `use-agent-auto-start.ts` to prevent triage/auto-start of templates

## Test plan
- [x] Added unit tests for `/list_tasks` template exclusion (task-api-server.test.ts)
- [x] Added unit test for `computeLocalStats` template exclusion (dashboard-store.test.ts)
- [x] All existing tests pass (no regressions)
- [x] TypeScript build check passes (`tsc --build --noEmit`)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)