### PR TITLE
fix: guard against non-array repos causing auto-run crash

### DIFF
--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -190,7 +190,7 @@ export class AgentManager extends EventEmitter {
 
     const task = this.db.getTask(taskId)
     if (!task) return undefined
-    if (!task.repos || task.repos.length === 0) return undefined
+    if (!task.repos || !Array.isArray(task.repos) || task.repos.length === 0) return undefined
 
     const workspaceDir = this.db.getWorkspaceDir(taskId)
     const missingRepoFolders = task.repos.some((repo) => {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -1327,7 +1327,7 @@ export class AgentManager extends EventEmitter {
         }
 
         // Append output field instructions
-        if (currentTask?.output_fields && currentTask.output_fields.length > 0) {
+        if (currentTask?.output_fields && Array.isArray(currentTask.output_fields) && currentTask.output_fields.length > 0) {
           promptText += this.buildOutputFieldInstructions(currentTask.output_fields)
         }
 

--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -109,6 +109,31 @@ describe('JSON deserialization', () => {
     expect(task.repos).toEqual(['owner/repo1'])
   })
 
+  it('deserializes double-stringified repos safely as array', () => {
+    // Simulate corrupted data: repos stored as double-stringified JSON
+    const task = db.createTask(makeTask({ repos: ['owner/repo1'] }))!
+    const rawDb = (db as unknown as { db: import('better-sqlite3').Database }).db
+    // Write a double-stringified value directly to the database
+    rawDb.prepare('UPDATE tasks SET repos = ? WHERE id = ?')
+      .run(JSON.stringify(JSON.stringify(['owner/repo1'])), task.id)
+    const reloaded = db.getTask(task.id)!
+    expect(Array.isArray(reloaded.repos)).toBe(true)
+    // The double-stringified value becomes a string after one parse;
+    // ensureArray wraps it into an array
+    expect(reloaded.repos).toEqual(['["owner/repo1"]'])
+  })
+
+  it('deserializes scalar string repos safely as array', () => {
+    const task = db.createTask(makeTask())!
+    const rawDb = (db as unknown as { db: import('better-sqlite3').Database }).db
+    // Write a scalar string value (not an array) to the repos column
+    rawDb.prepare('UPDATE tasks SET repos = ? WHERE id = ?')
+      .run(JSON.stringify('owner/repo1'), task.id)
+    const reloaded = db.getTask(task.id)!
+    expect(Array.isArray(reloaded.repos)).toBe(true)
+    expect(reloaded.repos).toEqual(['owner/repo1'])
+  })
+
   it('deserializes output_fields as objects', () => {
     const outputFields = [{ id: 'f1', name: 'Result', type: 'text' }]
     const task = db.createTask(makeTask({ output_fields: outputFields }))!

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -409,12 +409,19 @@ const UPDATABLE_COLUMNS = new Set([
 
 const JSON_COLUMNS = new Set(['labels', 'attachments', 'repos', 'output_fields', 'skill_ids'])
 
+/** Ensure a parsed JSON value is a string array (guards against double-stringified or scalar values) */
+function ensureArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value as string[]
+  if (typeof value === 'string' && value.length > 0) return [value]
+  return []
+}
+
 function deserializeTask(row: TaskRow): TaskRecord {
   return {
     ...row,
     labels: JSON.parse(row.labels) as string[],
     attachments: JSON.parse(row.attachments) as FileAttachmentRecord[],
-    repos: JSON.parse(row.repos) as string[],
+    repos: ensureArray(JSON.parse(row.repos || '[]')),
     output_fields: JSON.parse(row.output_fields || '[]') as OutputFieldRecord[],
     agent_id: row.agent_id ?? null,
     external_id: row.external_id ?? null,

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -409,24 +409,30 @@ const UPDATABLE_COLUMNS = new Set([
 
 const JSON_COLUMNS = new Set(['labels', 'attachments', 'repos', 'output_fields', 'skill_ids'])
 
-/** Ensure a parsed JSON value is a string array (guards against double-stringified or scalar values) */
-function ensureArray(value: unknown): string[] {
-  if (Array.isArray(value)) return value as string[]
-  if (typeof value === 'string' && value.length > 0) return [value]
+/** Ensure a parsed JSON value is always an array (guards against double-stringified or scalar values) */
+function ensureArray<T = string>(value: unknown): T[] {
+  if (Array.isArray(value)) return value as T[]
+  if (value != null && value !== '') return [value] as T[]
   return []
+}
+
+/** Safely parse a JSON column that should be an array */
+function parseJsonArray<T = string>(raw: string | null | undefined, fallback = '[]'): T[] {
+  const parsed = JSON.parse(raw || fallback)
+  return ensureArray<T>(parsed)
 }
 
 function deserializeTask(row: TaskRow): TaskRecord {
   return {
     ...row,
-    labels: JSON.parse(row.labels) as string[],
-    attachments: JSON.parse(row.attachments) as FileAttachmentRecord[],
-    repos: ensureArray(JSON.parse(row.repos || '[]')),
-    output_fields: JSON.parse(row.output_fields || '[]') as OutputFieldRecord[],
+    labels: parseJsonArray(row.labels),
+    attachments: parseJsonArray<FileAttachmentRecord>(row.attachments),
+    repos: parseJsonArray(row.repos),
+    output_fields: parseJsonArray<OutputFieldRecord>(row.output_fields),
     agent_id: row.agent_id ?? null,
     external_id: row.external_id ?? null,
     source_id: row.source_id ?? null,
-    skill_ids: row.skill_ids ? JSON.parse(row.skill_ids) as string[] : null,
+    skill_ids: row.skill_ids ? parseJsonArray(row.skill_ids) : null,
     session_id: row.session_id ?? null,
     snoozed_until: row.snoozed_until ?? null,
     resolution: row.resolution ?? null,

--- a/src/main/recurrence-scheduler.ts
+++ b/src/main/recurrence-scheduler.ts
@@ -4,6 +4,12 @@ import type { DatabaseManager, RecurrencePatternRecord, RecurrencePatternObject,
 import { createId } from '@paralleldrive/cuid2'
 import { TaskStatus } from '../shared/constants'
 
+/** Safely parse a JSON column that should be an array */
+function safeParseArray<T = string>(raw: string | null | undefined): T[] {
+  const parsed = JSON.parse(raw || '[]')
+  return Array.isArray(parsed) ? parsed : (parsed != null && parsed !== '' ? [parsed] : [])
+}
+
 /** Raw row shape returned by SQLite for the tasks table (before JSON deserialization). */
 interface RawTaskRow {
   id: string
@@ -374,14 +380,14 @@ export class RecurrenceScheduler {
   private deserializeTaskRow(row: RawTaskRow): TaskRecord {
     return {
       ...row,
-      labels: JSON.parse(row.labels || '[]'),
-      attachments: JSON.parse(row.attachments || '[]'),
-      repos: (() => { const v = JSON.parse(row.repos || '[]'); return Array.isArray(v) ? v : (typeof v === 'string' && v.length > 0 ? [v] : []); })(),
-      output_fields: JSON.parse(row.output_fields || '[]'),
+      labels: safeParseArray(row.labels),
+      attachments: safeParseArray(row.attachments),
+      repos: safeParseArray(row.repos),
+      output_fields: safeParseArray(row.output_fields),
       agent_id: row.agent_id ?? null,
       external_id: row.external_id ?? null,
       source_id: row.source_id ?? null,
-      skill_ids: row.skill_ids ? JSON.parse(row.skill_ids) : null,
+      skill_ids: row.skill_ids ? safeParseArray(row.skill_ids) : null,
       session_id: row.session_id ?? null,
       snoozed_until: row.snoozed_until ?? null,
       resolution: row.resolution ?? null,

--- a/src/main/recurrence-scheduler.ts
+++ b/src/main/recurrence-scheduler.ts
@@ -376,7 +376,7 @@ export class RecurrenceScheduler {
       ...row,
       labels: JSON.parse(row.labels || '[]'),
       attachments: JSON.parse(row.attachments || '[]'),
-      repos: JSON.parse(row.repos || '[]'),
+      repos: (() => { const v = JSON.parse(row.repos || '[]'); return Array.isArray(v) ? v : (typeof v === 'string' && v.length > 0 ? [v] : []); })(),
       output_fields: JSON.parse(row.output_fields || '[]'),
       agent_id: row.agent_id ?? null,
       external_id: row.external_id ?? null,

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -564,14 +564,18 @@ async function handleRoute(db: DatabaseManager, route: string, params: Record<st
   }
 }
 
+function safeParseArray(raw: string | null | undefined): unknown[] {
+  const parsed = JSON.parse((raw as string) || '[]')
+  return Array.isArray(parsed) ? parsed : (parsed != null && parsed !== '' ? [parsed] : [])
+}
+
 function parseTask(task: Record<string, unknown>) {
   if (!task) return task
-  task.labels = JSON.parse((task.labels as string) || '[]')
-  task.skill_ids = JSON.parse((task.skill_ids as string) || '[]')
-  task.attachments = JSON.parse((task.attachments as string) || '[]')
-  task.output_fields = JSON.parse((task.output_fields as string) || '[]')
-  const parsedRepos = JSON.parse((task.repos as string) || '[]')
-  task.repos = Array.isArray(parsedRepos) ? parsedRepos : (typeof parsedRepos === 'string' && parsedRepos.length > 0 ? [parsedRepos] : [])
+  task.labels = safeParseArray(task.labels as string)
+  task.skill_ids = safeParseArray(task.skill_ids as string)
+  task.attachments = safeParseArray(task.attachments as string)
+  task.output_fields = safeParseArray(task.output_fields as string)
+  task.repos = safeParseArray(task.repos as string)
   task.feedback_rating = task.feedback_rating ?? null
   task.feedback_comment = task.feedback_comment ?? null
   return task

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -243,7 +243,12 @@ async function handleRoute(db: DatabaseManager, route: string, params: Record<st
       if (params.labels !== undefined) { updates.push('labels = ?'); qParams.push(JSON.stringify(params.labels)) }
       if (params.skill_ids !== undefined) { updates.push('skill_ids = ?'); qParams.push(JSON.stringify(params.skill_ids)) }
       if (params.agent_id !== undefined) { updates.push('agent_id = ?'); qParams.push(params.agent_id) }
-      if (params.repos !== undefined) { updates.push('repos = ?'); qParams.push(JSON.stringify(params.repos)) }
+      if (params.repos !== undefined) {
+        const normalizedRepos = Array.isArray(params.repos)
+          ? params.repos
+          : (typeof params.repos === 'string' && params.repos.length > 0 ? [params.repos] : [])
+        updates.push('repos = ?'); qParams.push(JSON.stringify(normalizedRepos))
+      }
       if (params.priority) { updates.push('priority = ?'); qParams.push(params.priority) }
       if (params.output_fields !== undefined) { updates.push('output_fields = ?'); qParams.push(JSON.stringify(params.output_fields)) }
 
@@ -565,7 +570,8 @@ function parseTask(task: Record<string, unknown>) {
   task.skill_ids = JSON.parse((task.skill_ids as string) || '[]')
   task.attachments = JSON.parse((task.attachments as string) || '[]')
   task.output_fields = JSON.parse((task.output_fields as string) || '[]')
-  task.repos = JSON.parse((task.repos as string) || '[]')
+  const parsedRepos = JSON.parse((task.repos as string) || '[]')
+  task.repos = Array.isArray(parsedRepos) ? parsedRepos : (typeof parsedRepos === 'string' && parsedRepos.length > 0 ? [parsedRepos] : [])
   task.feedback_rating = task.feedback_rating ?? null
   task.feedback_comment = task.feedback_comment ?? null
   return task


### PR DESCRIPTION
## Summary
- `task.repos.some()` throws `TypeError: task.repos.some is not a function` when starting auto-run because `repos` can be deserialized as a string instead of an array (e.g., from a scalar string or double-stringified JSON in the database)
- Added `ensureArray` helper in `deserializeTask` to guarantee `repos` is always a `string[]`
- Added input normalization in `task-api-server` `/update_task` to coerce scalar string repos into arrays before storage
- Added defensive `Array.isArray` guard in `setupWorktreeIfNeeded` as a safety net
- Applied the same fix in `recurrence-scheduler` and `task-api-server` `parseTask`
- Added 2 regression tests for double-stringified and scalar string repos

## Test plan
- [x] All 1062 existing tests pass
- [x] 2 new tests verify corrupted repos data is handled gracefully
- [ ] Verify auto-run starts without error on tasks with repos assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)