### PR TITLE
fix: stop heartbeat activity for completed tasks

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2013,9 +2013,9 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
       WHERE heartbeat_enabled = 1
         AND heartbeat_next_check_at IS NOT NULL
         AND heartbeat_next_check_at <= ?
-        AND status != 'completed'
+        AND status != ?
       ORDER BY heartbeat_next_check_at ASC
-    `).all(now) as TaskRow[]
+    `).all(now, TaskStatus.Completed) as TaskRow[]
     return rows.map(deserializeTask)
   }
 

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2005,7 +2005,7 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
 
   // ── Heartbeat CRUD ──────────────────────────────────────────
 
-  /** Get all tasks that have heartbeat due (enabled + next_check_at <= now). */
+  /** Get all tasks that have heartbeat due (enabled + next_check_at <= now, excluding completed tasks). */
   getHeartbeatDueTasks(): TaskRecord[] {
     const now = new Date().toISOString()
     const rows = this.db.prepare(`
@@ -2013,6 +2013,7 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
       WHERE heartbeat_enabled = 1
         AND heartbeat_next_check_at IS NOT NULL
         AND heartbeat_next_check_at <= ?
+        AND status != 'completed'
       ORDER BY heartbeat_next_check_at ASC
     `).all(now) as TaskRow[]
     return rows.map(deserializeTask)

--- a/src/main/heartbeat-scheduler.test.ts
+++ b/src/main/heartbeat-scheduler.test.ts
@@ -687,6 +687,39 @@ describe('HeartbeatScheduler', () => {
     })
   })
 
+  // ── completed task handling ────────────────────────────
+
+  describe('checkHeartbeats skips completed tasks', () => {
+    it('disables heartbeat for completed tasks returned by getHeartbeatDueTasks', async () => {
+      const completedTask = makeTask({ id: 'completed-task', status: 'completed' as TaskRecord['status'] })
+      ;(db.getHeartbeatDueTasks as ReturnType<typeof vi.fn>).mockReturnValue([completedTask])
+
+      const mockWindow = { webContents: { send: vi.fn() }, isDestroyed: vi.fn().mockReturnValue(false) }
+      scheduler.start(mockWindow as unknown as import('electron').BrowserWindow)
+
+      // Wait for the initial checkHeartbeats to run
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(db.updateTask).toHaveBeenCalledWith('completed-task', {
+        heartbeat_enabled: false,
+        heartbeat_next_check_at: null,
+      })
+    })
+
+    it('does not run heartbeat for completed tasks even if they have heartbeat enabled', async () => {
+      const completedTask = makeTask({ id: 'completed-task', status: 'completed' as TaskRecord['status'] })
+      ;(db.getHeartbeatDueTasks as ReturnType<typeof vi.fn>).mockReturnValue([completedTask])
+
+      const mockWindow = { webContents: { send: vi.fn() }, isDestroyed: vi.fn().mockReturnValue(false) }
+      scheduler.start(mockWindow as unknown as import('electron').BrowserWindow)
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Agent session should NOT have been started for the completed task
+      expect(agent.startHeartbeatSession).not.toHaveBeenCalled()
+    })
+  })
+
   // ── resolveAgentId ─────────────────────────────────────
 
   describe('resolveAgentId', () => {

--- a/src/main/heartbeat-scheduler.test.ts
+++ b/src/main/heartbeat-scheduler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { HeartbeatScheduler } from './heartbeat-scheduler'
-import { HeartbeatStatus, HEARTBEAT_OK_TOKEN, HEARTBEAT_INFO_TOKEN, HEARTBEAT_DEFAULTS } from '../shared/constants'
+import { HeartbeatStatus, HEARTBEAT_OK_TOKEN, HEARTBEAT_INFO_TOKEN, HEARTBEAT_DEFAULTS, TaskStatus } from '../shared/constants'
 import type { DatabaseManager, TaskRecord } from './database'
 import type { AgentManager } from './agent-manager'
 
@@ -691,7 +691,7 @@ describe('HeartbeatScheduler', () => {
 
   describe('checkHeartbeats skips completed tasks', () => {
     it('disables heartbeat for completed tasks returned by getHeartbeatDueTasks', async () => {
-      const completedTask = makeTask({ id: 'completed-task', status: 'completed' as TaskRecord['status'] })
+      const completedTask = makeTask({ id: 'completed-task', status: TaskStatus.Completed as TaskRecord['status'] })
       ;(db.getHeartbeatDueTasks as ReturnType<typeof vi.fn>).mockReturnValue([completedTask])
 
       const mockWindow = { webContents: { send: vi.fn() }, isDestroyed: vi.fn().mockReturnValue(false) }
@@ -707,7 +707,7 @@ describe('HeartbeatScheduler', () => {
     })
 
     it('does not run heartbeat for completed tasks even if they have heartbeat enabled', async () => {
-      const completedTask = makeTask({ id: 'completed-task', status: 'completed' as TaskRecord['status'] })
+      const completedTask = makeTask({ id: 'completed-task', status: TaskStatus.Completed as TaskRecord['status'] })
       ;(db.getHeartbeatDueTasks as ReturnType<typeof vi.fn>).mockReturnValue([completedTask])
 
       const mockWindow = { webContents: { send: vi.fn() }, isDestroyed: vi.fn().mockReturnValue(false) }

--- a/src/main/heartbeat-scheduler.ts
+++ b/src/main/heartbeat-scheduler.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util'
 import { join } from 'path'
 import type { DatabaseManager, TaskRecord } from './database'
 import type { AgentManager } from './agent-manager'
-import { HeartbeatStatus, HEARTBEAT_OK_TOKEN, HEARTBEAT_INFO_TOKEN, HEARTBEAT_DEFAULTS } from '../shared/constants'
+import { HeartbeatStatus, HEARTBEAT_OK_TOKEN, HEARTBEAT_INFO_TOKEN, HEARTBEAT_DEFAULTS, TaskStatus } from '../shared/constants'
 
 const execFileAsync = promisify(execFile)
 
@@ -251,7 +251,7 @@ export class HeartbeatScheduler {
         }
 
         // Skip completed tasks and disable their heartbeat
-        if (task.status === 'completed') {
+        if (task.status === TaskStatus.Completed) {
           console.log(`[HeartbeatScheduler] Task ${task.id} is completed, disabling heartbeat`)
           this.disableHeartbeat(task.id)
           continue

--- a/src/main/heartbeat-scheduler.ts
+++ b/src/main/heartbeat-scheduler.ts
@@ -250,6 +250,13 @@ export class HeartbeatScheduler {
           continue
         }
 
+        // Skip completed tasks and disable their heartbeat
+        if (task.status === 'completed') {
+          console.log(`[HeartbeatScheduler] Task ${task.id} is completed, disabling heartbeat`)
+          this.disableHeartbeat(task.id)
+          continue
+        }
+
         // Verify heartbeat.md still exists
         if (!this.hasHeartbeatFile(task.id)) {
           console.log(`[HeartbeatScheduler] No heartbeat.md for task ${task.id}, disabling heartbeat`)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -18,6 +18,7 @@ import type {
   UpdateSecretData
 } from './database'
 import type { AgentManager } from './agent-manager'
+import { TaskStatus } from '../shared/constants'
 import type { GitHubManager } from './github-manager'
 import type { GitLabManager } from './gitlab-manager'
 import type { WorktreeManager } from './worktree-manager'
@@ -108,7 +109,7 @@ export function registerIpcHandlers(
     const updated = db.updateTask(id, data)
 
     // Auto-disable heartbeat when task is completed
-    if (heartbeatScheduler && data.status === 'completed' && updated?.heartbeat_enabled) {
+    if (heartbeatScheduler && data.status === TaskStatus.Completed && updated?.heartbeat_enabled) {
       heartbeatScheduler.disableHeartbeat(id)
     }
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -107,6 +107,11 @@ export function registerIpcHandlers(
 
     const updated = db.updateTask(id, data)
 
+    // Auto-disable heartbeat when task is completed
+    if (heartbeatScheduler && data.status === 'completed' && updated?.heartbeat_enabled) {
+      heartbeatScheduler.disableHeartbeat(id)
+    }
+
     // Record status change event for enterprise sync
     // Note: for completions, only emit task_completed (not both status_changed + completed)
     // to avoid double-counting in downstream aggregation


### PR DESCRIPTION
## Summary
- **Bug**: Heartbeat monitoring continued running for tasks after they were marked as `completed`, wasting agent resources and potentially sending spurious notifications
- **Root cause**: `getHeartbeatDueTasks()` SQL query had no `status` filter, and no code auto-disabled heartbeat when a task transitioned to completed
- **Fix**: Three-layer defense: (1) SQL filter excludes completed tasks, (2) auto-disable heartbeat on task completion in IPC handler, (3) safety check in scheduler loop catches any stragglers

## Test plan
- [x] Added 2 new unit tests verifying completed tasks are skipped and heartbeat is disabled
- [x] All 67 heartbeat scheduler tests pass
- [x] Full test suite passes (1062 tests, 69 files)
- [x] TypeScript build passes (`tsc --build --noEmit`)
- [x] Lint passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)