### PR TITLE
Center task board columns on wide screens

### DIFF
--- a/src/renderer/src/components/dashboard/TaskBoard.tsx
+++ b/src/renderer/src/components/dashboard/TaskBoard.tsx
@@ -209,12 +209,12 @@ export function TaskBoard() {
 
       {isLoading ? (
         <>
-          <div className="flex gap-4 pb-2">
+          <div className="flex gap-4 pb-2 justify-center">
             {COLUMNS.map((col) => (
               <ColumnHeader key={col.key} column={col} count={0} />
             ))}
           </div>
-          <div className="flex gap-4 pb-2">
+          <div className="flex gap-4 pb-2 justify-center">
             {COLUMNS.map((col) => (
               <div key={col.key} className="min-w-[200px] max-w-[260px] flex-1 space-y-2">
                 {[1, 2].map((i) => (
@@ -236,7 +236,7 @@ export function TaskBoard() {
       ) : (
         <>
           {/* Sticky column headers — pinned when dashboard scrolls */}
-          <div className="flex gap-4 sticky top-0 bg-background z-10 pb-2">
+          <div className="flex gap-4 sticky top-0 bg-background z-10 pb-2 justify-center">
             {COLUMNS.map((col) => (
               <ColumnHeader
                 key={col.key}
@@ -246,7 +246,7 @@ export function TaskBoard() {
             ))}
           </div>
           {/* Card columns */}
-          <div className="flex gap-4 pb-2">
+          <div className="flex gap-4 pb-2 justify-center">
             {COLUMNS.map((col) => (
               <ColumnCards
                 key={col.key}


### PR DESCRIPTION
## Summary
- Add `justify-center` to all flex containers in TaskBoard (headers, card columns, and loading skeleton) so columns center horizontally when the viewport is wider than the combined max-width of all 5 columns (~1300px + gaps)
- On narrower screens where columns fill the available space via `flex-1`, behaviour is unchanged

## Test plan
- [x] All 1062 existing tests pass
- [x] Lint, typecheck, and build pass
- [ ] Visually verify on a wide screen (>1400px) that task board columns are centered
- [ ] Verify on a narrow screen that columns still fill available width normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)