### PR TITLE
fix: prevent dashboard reload on tab switch and eliminate UI flicker

### DIFF
--- a/src/renderer/src/components/dashboard/ApplicationsList.tsx
+++ b/src/renderer/src/components/dashboard/ApplicationsList.tsx
@@ -267,7 +267,8 @@ export function ApplicationsList() {
     return <ExpandedView />
   }
 
-  if (applicationsLoading) {
+  // Only show loading skeleton on initial load when there's no cached data
+  if (applicationsLoading && applications.length === 0) {
     return (
       <section>
         <div className="rounded-lg border border-border/50 bg-card p-6">

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
@@ -92,9 +92,13 @@ beforeEach(() => {
     presetupLoading: false,
     presetupProvisioning: null,
     statsLoading: false,
+    hasFetchedOnce: false,
     applicationsError: null,
     statsError: null,
     fetchAll: vi.fn(),
+    fetchAllIfNeeded: vi.fn(),
+    startPeriodicRefresh: vi.fn(),
+    stopPeriodicRefresh: vi.fn(),
     updateLocalStats: vi.fn()
   })
   useEnterpriseStore.setState({
@@ -267,13 +271,37 @@ describe('DashboardWorkspace', () => {
     expect(screen.getByText(/No tasks yet/)).toBeDefined()
   })
 
-  it('calls fetchAll on mount when authenticated', () => {
-    const mockFetchAll = vi.fn()
-    useDashboardStore.setState({ fetchAll: mockFetchAll })
+  it('calls fetchAllIfNeeded on mount when authenticated (no reload on tab switch)', () => {
+    const mockFetchAllIfNeeded = vi.fn()
+    const mockStartPeriodicRefresh = vi.fn()
+    useDashboardStore.setState({
+      fetchAllIfNeeded: mockFetchAllIfNeeded,
+      startPeriodicRefresh: mockStartPeriodicRefresh
+    })
     useEnterpriseStore.setState({ isAuthenticated: true })
 
     render(<DashboardWorkspace />)
-    expect(mockFetchAll).toHaveBeenCalledOnce()
+    expect(mockFetchAllIfNeeded).toHaveBeenCalledOnce()
+    expect(mockStartPeriodicRefresh).toHaveBeenCalledOnce()
+  })
+
+  it('does not refetch when component remounts (tab switch) if data already loaded', () => {
+    const mockFetchAll = vi.fn()
+    const mockFetchAllIfNeeded = vi.fn()
+    useDashboardStore.setState({
+      fetchAll: mockFetchAll,
+      fetchAllIfNeeded: mockFetchAllIfNeeded,
+      startPeriodicRefresh: vi.fn(),
+      stopPeriodicRefresh: vi.fn(),
+      hasFetchedOnce: true
+    })
+    useEnterpriseStore.setState({ isAuthenticated: true })
+
+    render(<DashboardWorkspace />)
+    // fetchAllIfNeeded is called but should be a no-op since hasFetchedOnce is true
+    expect(mockFetchAllIfNeeded).toHaveBeenCalledOnce()
+    // fetchAll should NOT be called directly
+    expect(mockFetchAll).not.toHaveBeenCalled()
   })
 
   it('computes local stats on mount even when not authenticated', () => {

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { RefreshCw, Loader2, Cloud, Plus } from 'lucide-react'
+import { RefreshCw, Cloud, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { useDashboardStore, type TimeWindow } from '@/stores/dashboard-store'
 import { useEnterpriseStore } from '@/stores/enterprise-store'
@@ -30,11 +30,8 @@ export function DashboardWorkspace() {
     startPeriodicRefresh,
     stopPeriodicRefresh,
     updateLocalStats,
-    applicationsLoading,
-    statsLoading
+    isRefreshing
   } = useDashboardStore()
-
-  const isLoading = applicationsLoading || statsLoading
 
   // Restore saved enterprise session on mount
   useEffect(() => {
@@ -99,14 +96,10 @@ export function DashboardWorkspace() {
                 variant="ghost"
                 size="sm"
                 onClick={fetchAll}
-                disabled={isLoading}
+                disabled={isRefreshing}
                 title="Refresh all"
               >
-                {isLoading ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <RefreshCw className="h-3.5 w-3.5" />
-                )}
+                <RefreshCw className={`h-3.5 w-3.5 transition-transform ${isRefreshing ? 'animate-spin' : ''}`} />
               </Button>
             )}
           </div>

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -26,6 +26,9 @@ export function DashboardWorkspace() {
     timeWindow,
     setTimeWindow,
     fetchAll,
+    fetchAllIfNeeded,
+    startPeriodicRefresh,
+    stopPeriodicRefresh,
     updateLocalStats,
     applicationsLoading,
     statsLoading
@@ -43,11 +46,13 @@ export function DashboardWorkspace() {
     updateLocalStats(tasks)
   }, [tasks, timeWindow])
 
-  // Fetch cloud data when authenticated
+  // Fetch cloud data when authenticated — only on first load, then periodically
   useEffect(() => {
     if (isAuthenticated) {
-      fetchAll()
+      fetchAllIfNeeded()
+      startPeriodicRefresh()
     }
+    return () => stopPeriodicRefresh()
   }, [isAuthenticated])
 
   return (

--- a/src/renderer/src/components/dashboard/PresetupSection.tsx
+++ b/src/renderer/src/components/dashboard/PresetupSection.tsx
@@ -119,7 +119,8 @@ export function PresetupSection() {
     settingsApi.set(COLLAPSED_KEY, String(next)).catch(() => {})
   }
 
-  if (presetupLoading || !loaded) {
+  // Only show skeleton on initial load when there's no cached data
+  if ((presetupLoading && presetupTemplates.length === 0) || !loaded) {
     return (
       <section>
         <h2 className="text-sm font-semibold mb-3">Get Started</h2>

--- a/src/renderer/src/components/dashboard/StatsSection.tsx
+++ b/src/renderer/src/components/dashboard/StatsSection.tsx
@@ -55,6 +55,9 @@ export function StatsSection() {
   // Use cloud stats when available, otherwise fall back to local stats
   const effectiveStats = stats || localStats
 
+  // Only show skeleton loaders when there's no data at all (initial load)
+  const showLoading = statsLoading && !effectiveStats
+
   return (
     <section>
       <h2 className="text-sm font-semibold mb-3">Stats Overview</h2>
@@ -68,7 +71,7 @@ export function StatsSection() {
               : 'Tasks without human review'
           }
           icon={Bot}
-          loading={statsLoading}
+          loading={showLoading}
           accent="#82819F"
         />
         <StatCard
@@ -76,7 +79,7 @@ export function StatsSection() {
           value={formatPercent(effectiveStats?.agentSuccessRate ?? null)}
           description={`${formatNumber(effectiveStats?.totalAgentRuns)} total runs`}
           icon={Cpu}
-          loading={statsLoading}
+          loading={showLoading}
           accent="#A6BF91"
         />
         <StatCard
@@ -84,14 +87,14 @@ export function StatsSection() {
           value={formatNumber(effectiveStats?.tasksCreatedInWindow)}
           description={`${formatNumber(effectiveStats?.totalTasks)} total`}
           icon={PlusCircle}
-          loading={statsLoading}
+          loading={showLoading}
         />
         <StatCard
           title="Completed"
           value={formatNumber(effectiveStats?.tasksCompletedInWindow)}
           description="In selected window"
           icon={CheckCircle2}
-          loading={statsLoading}
+          loading={showLoading}
         />
       </div>
     </section>

--- a/src/renderer/src/stores/dashboard-store.ts
+++ b/src/renderer/src/stores/dashboard-store.ts
@@ -124,6 +124,9 @@ export interface ApplicationTab {
   executionStatus: string | null
 }
 
+/** How often to background-refresh dashboard data (ms). */
+const REFRESH_INTERVAL_MS = 60_000 // 1 minute
+
 interface DashboardState {
   // Data
   applications: ApplicationItem[]
@@ -137,15 +140,21 @@ interface DashboardState {
   activeTabId: string | null       // currently visible tab workflowId
   expandedView: boolean            // true = showing tabs+iframe, false = showing cards
 
-  // Loading states
+  // Loading states — only true on *initial* load (no cached data yet)
   applicationsLoading: boolean
   presetupLoading: boolean
   presetupProvisioning: string | null  // slug being provisioned
   statsLoading: boolean
 
+  // Whether we have fetched at least once (prevents reload on tab switch)
+  hasFetchedOnce: boolean
+
   // Error states
   applicationsError: string | null
   statsError: string | null
+
+  // Periodic refresh
+  _refreshTimer: ReturnType<typeof setInterval> | null
 
   // Actions
   setTimeWindow: (window: TimeWindow) => void
@@ -154,6 +163,12 @@ interface DashboardState {
   provisionPresetup: (slug: string) => Promise<void>
   fetchStats: () => Promise<void>
   fetchAll: () => Promise<void>
+  /** Fetch all if not fetched yet; otherwise no-op. */
+  fetchAllIfNeeded: () => Promise<void>
+  /** Start periodic background refresh (idempotent). */
+  startPeriodicRefresh: () => void
+  /** Stop periodic background refresh. */
+  stopPeriodicRefresh: () => void
   updateLocalStats: (tasks: WorkfloTask[]) => void
   openApplication: (workflowId: string) => Promise<void>
   switchTab: (workflowId: string) => void
@@ -234,8 +249,12 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   presetupProvisioning: null,
   statsLoading: false,
 
+  hasFetchedOnce: false,
+
   applicationsError: null,
   statsError: null,
+
+  _refreshTimer: null,
 
   setTimeWindow: (timeWindow) => {
     set({ timeWindow })
@@ -249,7 +268,10 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   },
 
   fetchApplications: async () => {
-    set({ applicationsLoading: true, applicationsError: null })
+    const hasData = get().applications.length > 0
+    // Only show loading skeleton on initial fetch (no cached data)
+    if (!hasData) set({ applicationsLoading: true })
+    set({ applicationsError: null })
     try {
       // Must use lowercase 'application_trigger' to match the NodeType enum value in workflow-builder
       const result = await enterpriseApi.apiRequest('GET', '/api/workflows?triggerType=application_trigger') as {
@@ -286,7 +308,9 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   },
 
   fetchPresetups: async () => {
-    set({ presetupLoading: true })
+    const hasData = get().presetupTemplates.length > 0
+    // Only show loading skeleton on initial fetch (no cached data)
+    if (!hasData) set({ presetupLoading: true })
     try {
       const result = await enterpriseApi.apiRequest('GET', '/api/presetup/status') as {
         templates: PresetupTemplate[]
@@ -294,7 +318,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       set({ presetupTemplates: result.templates || [], presetupLoading: false })
     } catch {
       // Silently fail — presetups are optional, don't block the dashboard
-      set({ presetupTemplates: [], presetupLoading: false })
+      if (!hasData) set({ presetupTemplates: [], presetupLoading: false })
     }
   },
 
@@ -314,7 +338,10 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   },
 
   fetchStats: async () => {
-    set({ statsLoading: true, statsError: null })
+    const hasData = get().stats !== null || get().localStats !== null
+    // Only show loading skeleton on initial fetch (no cached data)
+    if (!hasData) set({ statsLoading: true })
+    set({ statsError: null })
     try {
       const { timeWindow } = get()
       const result = await enterpriseApi.apiRequest('GET', `/api/20x/sync/stats?window=${timeWindow}`) as {
@@ -336,6 +363,39 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       state.fetchPresetups(),
       state.fetchStats()
     ])
+    set({ hasFetchedOnce: true })
+  },
+
+  fetchAllIfNeeded: async () => {
+    if (get().hasFetchedOnce) return
+    await get().fetchAll()
+  },
+
+  startPeriodicRefresh: () => {
+    // Idempotent — don't start multiple timers
+    if (get()._refreshTimer) return
+    const timer = setInterval(() => {
+      // Only refresh if authenticated
+      const isAuth = useEnterpriseStore.getState().isAuthenticated
+      if (isAuth) {
+        const state = get()
+        // Background refresh — loading flags won't be set because data already exists
+        Promise.allSettled([
+          state.fetchApplications(),
+          state.fetchPresetups(),
+          state.fetchStats()
+        ])
+      }
+    }, REFRESH_INTERVAL_MS)
+    set({ _refreshTimer: timer })
+  },
+
+  stopPeriodicRefresh: () => {
+    const timer = get()._refreshTimer
+    if (timer) {
+      clearInterval(timer)
+      set({ _refreshTimer: null })
+    }
   },
 
   openApplication: async (workflowId: string) => {

--- a/src/renderer/src/stores/dashboard-store.ts
+++ b/src/renderer/src/stores/dashboard-store.ts
@@ -149,6 +149,9 @@ interface DashboardState {
   // Whether we have fetched at least once (prevents reload on tab switch)
   hasFetchedOnce: boolean
 
+  // True while a manual refresh is in-flight (for animating the refresh button)
+  isRefreshing: boolean
+
   // Error states
   applicationsError: string | null
   statsError: string | null
@@ -250,6 +253,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   statsLoading: false,
 
   hasFetchedOnce: false,
+  isRefreshing: false,
 
   applicationsError: null,
   statsError: null,
@@ -357,13 +361,14 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   },
 
   fetchAll: async () => {
+    set({ isRefreshing: true })
     const state = get()
     await Promise.allSettled([
       state.fetchApplications(),
       state.fetchPresetups(),
       state.fetchStats()
     ])
-    set({ hasFetchedOnce: true })
+    set({ hasFetchedOnce: true, isRefreshing: false })
   },
 
   fetchAllIfNeeded: async () => {


### PR DESCRIPTION
## Summary
- **No more full reload on tab switch**: Dashboard data is cached in the Zustand store with a `hasFetchedOnce` flag. `fetchAllIfNeeded()` replaces `fetchAll()` on component mount, so switching between sidebar tabs (tasks → dashboard → tasks → dashboard) no longer triggers a server refetch.
- **Background periodic refresh**: A 60-second interval silently refreshes metrics, applications, and presetups in the background without touching loading flags.
- **No UI flicker**: Loading skeletons only appear on the initial fetch when there's no cached data. Background refreshes seamlessly update the existing data in place — no spinners, no layout jumps.

## Files Changed
- `dashboard-store.ts` — Added `hasFetchedOnce`, `fetchAllIfNeeded()`, `startPeriodicRefresh()`, `stopPeriodicRefresh()`; fetch methods only set loading flags when no cached data exists
- `DashboardWorkspace.tsx` — Uses `fetchAllIfNeeded` + periodic refresh instead of `fetchAll` on mount
- `StatsSection.tsx` — Only shows skeleton when no effective stats data exists
- `ApplicationsList.tsx` — Only shows loading spinner when no cached applications exist
- `PresetupSection.tsx` — Only shows skeleton when no cached templates exist
- `DashboardWorkspace.test.tsx` — Updated and added tests for new behavior

## Test plan
- [x] All 25 existing dashboard tests pass
- [ ] Verify switching between sidebar tabs does not trigger network requests after first load
- [ ] Verify data refreshes silently every 60s without UI flicker
- [ ] Verify first visit still shows appropriate loading skeletons
- [ ] Verify manual refresh button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)