### PR TITLE
fix: prevent concurrent token refresh race causing auth_clear_missing_refresh_token

### DIFF
--- a/src/main/enterprise-auth.test.ts
+++ b/src/main/enterprise-auth.test.ts
@@ -4,7 +4,7 @@ import { EnterpriseAuth } from './enterprise-auth'
 const authMock = {
   signOut: vi.fn(async () => ({})),
   refreshSession: vi.fn(async (): Promise<{
-    data: { session: null }
+    data: { session: { access_token: string; refresh_token: string } | null }
     error: { message: string; status?: number } | null
   }> => ({ data: { session: null }, error: null })),
   signInWithPassword: vi.fn(async () => ({ data: null, error: null }))
@@ -86,6 +86,94 @@ describe('EnterpriseAuth logging', () => {
     expect(
       warnSpy.mock.calls.some((call) => call[0].includes('auth_clear_supabase_refresh_failed'))
     ).toBe(true)
+  })
+
+  it('deduplicates concurrent refresh calls (prevents race condition)', async () => {
+    // Seed a stored refresh token so refreshToken() gets past the guard
+    db.setSetting('enterprise_supabase_refresh_token', Buffer.from('refresh-tok', 'utf8').toString('base64'))
+    db.setSetting('enterprise_tenant_id', 'tenant-1')
+
+    let resolveRefresh: ((v: { data: unknown; error: null }) => void) | null = null
+    authMock.refreshSession.mockImplementation(
+      () => new Promise((r) => { resolveRefresh = r as never })
+    )
+
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ token: 'jwt-new', expiresIn: 3600 })
+    }))
+    vi.stubGlobal('fetch', fetchFn)
+
+    const auth = new EnterpriseAuth(db as never)
+
+    // Fire two concurrent refreshes
+    const p1 = auth.refreshToken()
+    const p2 = auth.refreshToken()
+
+    // Supabase should only have been called ONCE (dedup)
+    expect(authMock.refreshSession).toHaveBeenCalledTimes(1)
+
+    // Resolve the single in-flight refresh
+    resolveRefresh!({
+      data: {
+        session: {
+          access_token: 'new-access',
+          refresh_token: 'new-refresh'
+        }
+      },
+      error: null
+    })
+
+    const [r1, r2] = await Promise.all([p1, p2])
+    expect(r1.token).toBe('jwt-new')
+    expect(r2.token).toBe('jwt-new')
+
+    // Still only one Supabase call
+    expect(authMock.refreshSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows a new refresh after the previous one completes', async () => {
+    db.setSetting('enterprise_supabase_refresh_token', Buffer.from('refresh-tok', 'utf8').toString('base64'))
+    db.setSetting('enterprise_tenant_id', 'tenant-1')
+
+    authMock.refreshSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'access-1',
+          refresh_token: 'refresh-1'
+        }
+      },
+      error: null
+    })
+
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ token: 'jwt-tok', expiresIn: 3600 })
+    }))
+    vi.stubGlobal('fetch', fetchFn)
+
+    const auth = new EnterpriseAuth(db as never)
+
+    // First refresh completes
+    await auth.refreshToken()
+    expect(authMock.refreshSession).toHaveBeenCalledTimes(1)
+
+    // Second refresh should start a NEW call (not reuse the completed promise)
+    await auth.refreshToken()
+    expect(authMock.refreshSession).toHaveBeenCalledTimes(2)
+  })
+
+  it('concurrent callers all receive the error when refresh fails', async () => {
+    // No refresh token stored → immediate failure
+    const auth = new EnterpriseAuth(db as never)
+
+    const p1 = auth.refreshToken()
+    const p2 = auth.refreshToken()
+
+    await expect(p1).rejects.toThrow('No refresh token available')
+    await expect(p2).rejects.toThrow('No refresh token available')
   })
 
   it('logs reason when API request 401 retry path ends in auth clear', async () => {

--- a/src/main/enterprise-auth.ts
+++ b/src/main/enterprise-auth.ts
@@ -108,6 +108,9 @@ export class EnterpriseAuth {
   private cachedJwt: string | null = null
   private cachedJwtExpiresAt: number = 0
 
+  // Mutex: in-flight refresh promise to prevent concurrent refresh races
+  private refreshInFlight: Promise<{ token: string }> | null = null
+
   constructor(db: DatabaseManager) {
     this.db = db
 
@@ -270,6 +273,22 @@ export class EnterpriseAuth {
   // ── Refresh Token ────────────────────────────────────────────────
 
   async refreshToken(): Promise<{ token: string }> {
+    // Deduplicate concurrent refresh calls: if a refresh is already
+    // in-flight, all callers share the same promise instead of racing
+    // and accidentally rotating the Supabase refresh token out from
+    // under each other (which causes auth_clear_missing_refresh_token).
+    if (this.refreshInFlight) {
+      return this.refreshInFlight
+    }
+
+    this.refreshInFlight = this.executeRefresh().finally(() => {
+      this.refreshInFlight = null
+    })
+
+    return this.refreshInFlight
+  }
+
+  private async executeRefresh(): Promise<{ token: string }> {
     // First refresh the Supabase session
     const refreshToken = this.getStoredSupabaseRefreshToken()
     if (!refreshToken) {


### PR DESCRIPTION
## Summary
- **Root cause**: When multiple API requests hit an expired JWT simultaneously, they all call `refreshToken()` concurrently. The first caller rotates the Supabase refresh token on the server; subsequent callers find the old token invalid (or already cleared) and wipe all stored auth data, forcing re-login.
- **Fix**: Added Promise deduplication to `refreshToken()` — concurrent callers share a single in-flight refresh instead of racing. Once the refresh completes (success or failure), the next call starts a fresh refresh.
- Added 3 new tests verifying dedup, sequential refresh after completion, and shared error propagation.

## Test plan
- [x] All 1068 existing tests pass
- [x] 3 new tests verify the concurrent refresh deduplication behavior
- [x] TypeScript type-check passes
- [x] ESLint passes (0 errors, pre-existing warnings only)
- [x] Full build succeeds (main, preload, renderer, mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)