### PR TITLE
fix: auto-refresh dashboard after re-login

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
@@ -357,6 +357,31 @@ describe('DashboardWorkspace', () => {
     expect(useUIStore.getState().activeModal).toBe('create')
   })
 
+  it('resets hasFetchedOnce and errors when isAuthenticated goes false (re-login scenario)', () => {
+    // Simulate: previous fetch failed and set hasFetchedOnce + errors
+    useDashboardStore.setState({
+      hasFetchedOnce: true,
+      applicationsError: 'No refresh token available — please sign in again',
+      statsError: 'Session expired — please sign in again',
+      fetchAllIfNeeded: vi.fn(),
+      startPeriodicRefresh: vi.fn(),
+      stopPeriodicRefresh: vi.fn()
+    })
+    useEnterpriseStore.setState({ isAuthenticated: true })
+
+    const { rerender } = render(<DashboardWorkspace />)
+
+    // Simulate logout / session clear: isAuthenticated → false
+    useEnterpriseStore.setState({ isAuthenticated: false })
+    rerender(<DashboardWorkspace />)
+
+    // Dashboard fetch state should be reset
+    const state = useDashboardStore.getState()
+    expect(state.hasFetchedOnce).toBe(false)
+    expect(state.applicationsError).toBeNull()
+    expect(state.statsError).toBeNull()
+  })
+
   it('clicking a task card sets dashboardPreviewTaskId in UI store', () => {
     useTaskStore.setState({
       tasks: [

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -43,11 +43,20 @@ export function DashboardWorkspace() {
     updateLocalStats(tasks)
   }, [tasks, timeWindow])
 
-  // Fetch cloud data when authenticated — only on first load, then periodically
+  // Fetch cloud data when authenticated — only on first load, then periodically.
+  // When isAuthenticated goes false (logout / session expiry), reset dashboard
+  // fetch state so the next login triggers a fresh data load instead of being
+  // short-circuited by the stale hasFetchedOnce flag.
   useEffect(() => {
     if (isAuthenticated) {
       fetchAllIfNeeded()
       startPeriodicRefresh()
+    } else {
+      useDashboardStore.setState({
+        hasFetchedOnce: false,
+        applicationsError: null,
+        statsError: null
+      })
     }
     return () => stopPeriodicRefresh()
   }, [isAuthenticated])

--- a/src/renderer/src/stores/dashboard-store.test.ts
+++ b/src/renderer/src/stores/dashboard-store.test.ts
@@ -11,11 +11,19 @@ vi.mock('@/lib/ipc-client', () => ({
     getApiUrl: vi.fn().mockResolvedValue('http://localhost:2000'),
     getJwt: vi.fn().mockResolvedValue('mock-jwt-token'),
     enableIframeAuth: vi.fn().mockResolvedValue({ apiUrl: 'http://localhost:2000' }),
-    disableIframeAuth: vi.fn().mockResolvedValue(undefined)
+    disableIframeAuth: vi.fn().mockResolvedValue(undefined),
+    login: vi.fn(),
+    selectTenant: vi.fn(),
+    logout: vi.fn(),
+    getSession: vi.fn().mockResolvedValue({ isAuthenticated: false }),
+    refreshToken: vi.fn(),
+    getAuthTokens: vi.fn(),
+    listCompanies: vi.fn()
   }
 }))
 
 import { enterpriseApi } from '@/lib/ipc-client'
+import { useEnterpriseStore } from '@/stores/enterprise-store'
 
 const mockApiRequest = vi.mocked(enterpriseApi.apiRequest)
 
@@ -242,6 +250,75 @@ describe('useDashboardStore', () => {
 
     const { localStats } = useDashboardStore.getState()
     expect(localStats!.totalTasks).toBe(1)
+  })
+})
+
+describe('auth error detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useDashboardStore.setState({
+      applications: [],
+      stats: null,
+      localStats: null,
+      timeWindow: '7d',
+      applicationsLoading: false,
+      statsLoading: false,
+      applicationsError: null,
+      statsError: null
+    })
+    useEnterpriseStore.setState({
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      userEmail: 'test@example.com',
+      userId: 'user-1',
+      currentTenant: { id: 't1', name: 'Test' },
+      availableTenants: null
+    })
+  })
+
+  it('fetchApplications refreshes enterprise session on "sign in again" error', async () => {
+    const loadSessionSpy = vi.fn()
+    useEnterpriseStore.setState({ loadSession: loadSessionSpy })
+    mockApiRequest.mockRejectedValueOnce(new Error('No refresh token available — please sign in again'))
+
+    await useDashboardStore.getState().fetchApplications()
+
+    expect(loadSessionSpy).toHaveBeenCalledOnce()
+    expect(useDashboardStore.getState().applicationsError).toContain('sign in again')
+  })
+
+  it('fetchStats refreshes enterprise session on "Session expired" error', async () => {
+    const loadSessionSpy = vi.fn()
+    useEnterpriseStore.setState({ loadSession: loadSessionSpy })
+    mockApiRequest.mockRejectedValueOnce(new Error('Session expired — please sign in again'))
+
+    await useDashboardStore.getState().fetchStats()
+
+    expect(loadSessionSpy).toHaveBeenCalledOnce()
+    expect(useDashboardStore.getState().statsError).toContain('Session expired')
+  })
+
+  it('fetchApplications does NOT refresh session on non-auth error', async () => {
+    const loadSessionSpy = vi.fn()
+    useEnterpriseStore.setState({ loadSession: loadSessionSpy })
+    mockApiRequest.mockRejectedValueOnce(new Error('Network error'))
+
+    await useDashboardStore.getState().fetchApplications()
+
+    expect(loadSessionSpy).not.toHaveBeenCalled()
+    expect(useDashboardStore.getState().applicationsError).toBe('Network error')
+  })
+
+  it('fetchStats does NOT refresh session on non-auth error', async () => {
+    const loadSessionSpy = vi.fn()
+    useEnterpriseStore.setState({ loadSession: loadSessionSpy })
+    mockApiRequest.mockRejectedValueOnce(new Error('Server error'))
+
+    await useDashboardStore.getState().fetchStats()
+
+    expect(loadSessionSpy).not.toHaveBeenCalled()
+    expect(useDashboardStore.getState().statsError).toBe('Server error')
   })
 })
 

--- a/src/renderer/src/stores/dashboard-store.ts
+++ b/src/renderer/src/stores/dashboard-store.ts
@@ -5,6 +5,23 @@ import { isSnoozed } from '@/lib/utils'
 import type { WorkfloTask } from '@/types'
 import { TaskStatus } from '@/types'
 
+// ── Auth error detection ────────────────────────────────────
+// When the main process clears stored tokens (e.g. expired refresh token),
+// the renderer still thinks the user is authenticated.  Detecting auth-
+// related error messages and re-loading the session ensures the UI shows
+// the login prompt instead of a stale error.
+
+const AUTH_ERROR_PATTERNS = ['sign in again', 'refresh token', 'session expired']
+
+function isAuthError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase()
+  return AUTH_ERROR_PATTERNS.some((p) => msg.includes(p))
+}
+
+function handleAuthError(): void {
+  useEnterpriseStore.getState().loadSession()
+}
+
 // ── Types ───────────────────────────────────────────────────
 
 export interface ApplicationItem {
@@ -304,6 +321,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       }))
       set({ applications, applicationsLoading: false })
     } catch (err) {
+      if (isAuthError(err)) handleAuthError()
       set({
         applicationsLoading: false,
         applicationsError: err instanceof Error ? err.message : 'Failed to fetch applications'
@@ -353,6 +371,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       }
       set({ stats: result.stats, statsLoading: false })
     } catch (err) {
+      if (isAuthError(err)) handleAuthError()
       set({
         statsLoading: false,
         statsError: err instanceof Error ? err.message : 'Failed to fetch stats'


### PR DESCRIPTION
## Summary
- After session expiry, the dashboard showed "No refresh token available — please sign in again" and required a manual page refresh even after re-logging in
- **Root cause**: `hasFetchedOnce` flag in dashboard store was set to `true` even when all API calls failed with auth errors, preventing `fetchAllIfNeeded()` from re-fetching after re-authentication
- **Fix 1**: Reset `hasFetchedOnce` and error states when `isAuthenticated` goes false (logout/session expiry), so the next login triggers a fresh data load
- **Fix 2**: Detect auth-related API errors in `fetchApplications`/`fetchStats` and refresh the enterprise session state so the UI immediately shows the login prompt instead of a stale error

## Test plan
- [x] All 1073 existing tests pass
- [x] Added 5 new tests covering:
  - Dashboard fetch state reset when `isAuthenticated` goes false (re-login scenario)
  - Auth error detection triggers session refresh for "sign in again" errors
  - Auth error detection triggers session refresh for "Session expired" errors
  - Non-auth errors do NOT trigger session refresh (fetchApplications)
  - Non-auth errors do NOT trigger session refresh (fetchStats)
- [x] TypeScript build passes (`tsc --build --noEmit`)
- [x] Full build succeeds (`electron-vite build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)