### PR TITLE
fix: opencode agent doesn't load providers on Apple Silicon

### DIFF
--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -977,7 +977,7 @@ export class AgentManager extends EventEmitter {
       join(homedir(), '.opencode', 'bin'),
       ...(process.platform === 'win32'
         ? [join(homedir(), 'AppData', 'Roaming', 'npm')]
-        : ['/usr/local/bin']),
+        : ['/opt/homebrew/bin', '/usr/local/bin']),
       join(homedir(), '.local', 'bin')
     ].filter(p => !currentPath.includes(p))
 
@@ -3189,7 +3189,11 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       // Default to home directory so project-scoped OpenCode configs are picked up
       const dir = directory || homedir()
 
-      const ocClient = OpenCodeSDK.createOpencodeClient({ baseUrl, fetch: noTimeoutFetch })
+      // Use this.serverUrl (verified by startServer/findAccessibleServer) instead of
+      // the raw baseUrl from the frontend, which may use 'localhost' that resolves
+      // to IPv6 on some macOS systems while the server only listens on IPv4
+      const resolvedUrl = this.serverUrl || baseUrl
+      const ocClient = OpenCodeSDK.createOpencodeClient({ baseUrl: resolvedUrl, fetch: noTimeoutFetch })
       const result = await ocClient.config.providers({
         query: { directory: dir }
       })


### PR DESCRIPTION
## Summary
- Add `/opt/homebrew/bin` to `ensureBinaryPaths()` so the `opencode` binary is discoverable on Apple Silicon Macs when the Electron app is launched from Finder (where PATH doesn't include Homebrew paths)
- Use the verified `this.serverUrl` (resolved by `startServer`/`findAccessibleServer`) instead of the raw frontend `baseUrl` when creating the SDK client for provider queries, preventing IPv6/IPv4 mismatch issues on macOS

## Root Cause
On Apple Silicon Macs, Homebrew installs binaries to `/opt/homebrew/bin`. The `ensureBinaryPaths()` method only included `/usr/local/bin` (Intel Mac path), `~/.opencode/bin`, and `~/.local/bin`. When the Electron app launches from Finder (not terminal), `/opt/homebrew/bin` isn't in PATH, so `opencode serve` fails to spawn, `getProviders()` returns null, and the agent editor shows no models.

Additionally, `getProviders()` was creating the SDK client with the raw `baseUrl` from the frontend (`http://localhost:4096`) instead of `this.serverUrl` which had been verified accessible by `findAccessibleServer`. On macOS, `localhost` can resolve to IPv6 `::1` while the server only listens on IPv4 `127.0.0.1`.

## Test plan
- [x] All 1073 tests pass
- [x] Lint and typecheck pass
- [x] Build succeeds
- [ ] Verify on Apple Silicon Mac: launch 20x from Finder, create/edit agent with OpenCode, confirm featherless models appear in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)