### PR TITLE
fix: Windows title bar overlaps Settings and Mastermind buttons

### DIFF
--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -131,8 +131,8 @@ export function AppLayout() {
           ))}
         </div>
 
-        {/* Global actions — pinned right */}
-        <div className="no-drag absolute right-4 flex items-center gap-1">
+        {/* Global actions — pinned right; windows-titlebar-actions offsets on Windows to avoid title bar overlay */}
+        <div className="no-drag absolute right-4 flex items-center gap-1 windows-titlebar-actions">
           <Button
             variant="ghost"
             size="sm"

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -85,6 +85,8 @@ html, body, #root {
 [data-platform="win32"] .windows-titlebar-pad { padding-right: 150px; }
 /* ── Windows: any top-right header that sits behind the overlay needs right padding too ── */
 [data-platform="win32"] .windows-titlebar-safe { padding-right: 150px; }
+/* ── Windows: shift absolutely-positioned right-side buttons left of the overlay ── */
+[data-platform="win32"] .windows-titlebar-actions { right: 154px; }
 
 /* ── Scrollbar ────────────────────────────────── */
 ::-webkit-scrollbar { width: 5px; height: 5px; }


### PR DESCRIPTION
## Summary
- Settings gear and Mastermind toggle buttons in the top bar are hidden behind Windows title bar overlay (minimize/maximize/close)
- The buttons use `absolute right-4` positioning which ignores the parent's `padding-right`
- Added `windows-titlebar-actions` CSS class that shifts `right` offset on Windows so buttons are visible and clickable
- Transcript panel header already handled via `windows-titlebar-safe` class

## Before
Settings and Mastermind buttons hidden behind min/max/close buttons on Windows.

## After
Buttons shifted left of the title bar overlay, fully visible and clickable.

## Test plan
- [ ] Open 20x on Windows — Settings gear and Mastermind button visible in top bar
- [ ] Click Settings — opens settings panel
- [ ] Click Mastermind — toggles orchestrator panel
- [ ] Verify no overlap with min/max/close buttons
- [ ] Verify Mac layout unchanged (no `data-platform="win32"` on Mac)

🤖 Generated with [Claude Code](https://claude.com/claude-code)