### PR TITLE
feat: include domain name in enterprise cloud error logs

### DIFF
--- a/src/main/enterprise-auth.test.ts
+++ b/src/main/enterprise-auth.test.ts
@@ -55,12 +55,19 @@ describe('EnterpriseAuth logging', () => {
     vi.clearAllMocks()
   })
 
-  it('logs reason for manual logout', async () => {
+  it('logs reason for manual logout with domain', async () => {
     const auth = new EnterpriseAuth(db as never)
     await auth.logout()
 
-    expect(warnSpy).toHaveBeenCalledWith('[EnterpriseAuth] auth_logout_manual')
-    expect(warnSpy).toHaveBeenCalledWith('[EnterpriseAuth] auth_state_cleared')
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('auth_logout_manual')
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('auth_state_cleared')
+    )
+    // Domain should be included in log messages
+    const logoutCall = warnSpy.mock.calls.find((c) => c[0].includes('auth_logout_manual'))
+    expect(logoutCall?.[0]).toMatch(/\(domain: .+\)/)
   })
 
   it('logs reason when refresh token is missing and credentials are cleared', async () => {
@@ -68,8 +75,12 @@ describe('EnterpriseAuth logging', () => {
 
     await expect(auth.refreshToken()).rejects.toThrow('No refresh token available')
 
-    expect(warnSpy).toHaveBeenCalledWith('[EnterpriseAuth] auth_clear_missing_refresh_token')
-    expect(warnSpy).toHaveBeenCalledWith('[EnterpriseAuth] auth_state_cleared')
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('auth_clear_missing_refresh_token')
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('auth_state_cleared')
+    )
   })
 
   it('logs reason when supabase refresh fails', async () => {
@@ -176,6 +187,27 @@ describe('EnterpriseAuth logging', () => {
     await expect(p2).rejects.toThrow('No refresh token available')
   })
 
+  it('getDomain() returns hostname from configured API URL', () => {
+    const auth = new EnterpriseAuth(db as never)
+    const domain = auth.getDomain()
+    // Returns a valid hostname (varies by env config: localhost, stage-api.peakflo.ai, etc.)
+    expect(domain).toBeTruthy()
+    expect(typeof domain).toBe('string')
+    expect(domain.length).toBeGreaterThan(0)
+  })
+
+  it('includes domain in all logAuthEvent messages', async () => {
+    const auth = new EnterpriseAuth(db as never)
+    await auth.logout()
+
+    // Every warn call should include "(domain: ...)"
+    for (const call of warnSpy.mock.calls) {
+      if (call[0].startsWith('[EnterpriseAuth]')) {
+        expect(call[0]).toMatch(/\(domain: .+\)/)
+      }
+    }
+  })
+
   it('logs reason when API request 401 retry path ends in auth clear', async () => {
     db.setSetting('enterprise_jwt', Buffer.from('jwt-token', 'utf8').toString('base64'))
     // Keep JWT valid beyond the 5-minute early-refresh window so apiRequest()
@@ -194,5 +226,52 @@ describe('EnterpriseAuth logging', () => {
     expect(
       warnSpy.mock.calls.some((call) => call[0].includes('auth_clear_after_api_401_retry_failed'))
     ).toBe(true)
+  })
+
+  it('includes domain in API error logs for 403 responses', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    db.setSetting('enterprise_jwt', Buffer.from('jwt-token', 'utf8').toString('base64'))
+    db.setSetting('enterprise_jwt_expires_at', String(Date.now() + 10 * 60_000))
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({ message: 'Forbidden', details: { role: 'viewer' } })
+    })))
+
+    const auth = new EnterpriseAuth(db as never)
+
+    await expect(auth.apiRequest('GET', '/api/nodes')).rejects.toThrow('Forbidden')
+
+    const errCall = errorSpy.mock.calls.find((c) =>
+      c[0].includes('[EnterpriseAuth] Permission denied')
+    )
+    expect(errCall).toBeDefined()
+    expect(errCall![0]).toMatch(/\(domain: .+\)/)
+
+    errorSpy.mockRestore()
+  })
+
+  it('includes domain in API error logs for non-ok responses', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    db.setSetting('enterprise_jwt', Buffer.from('jwt-token', 'utf8').toString('base64'))
+    db.setSetting('enterprise_jwt_expires_at', String(Date.now() + 10 * 60_000))
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ message: 'Internal Server Error' })
+    })))
+
+    const auth = new EnterpriseAuth(db as never)
+
+    await expect(auth.apiRequest('POST', '/api/skills')).rejects.toThrow('Internal Server Error')
+
+    const errCall = errorSpy.mock.calls.find((c) =>
+      c[0].includes('[EnterpriseAuth] API error')
+    )
+    expect(errCall).toBeDefined()
+    expect(errCall![0]).toMatch(/\(domain: .+\)/)
+    expect(errCall![0]).toContain('500')
+
+    errorSpy.mockRestore()
   })
 })

--- a/src/main/enterprise-auth.ts
+++ b/src/main/enterprise-auth.ts
@@ -131,6 +131,19 @@ export class EnterpriseAuth {
     return this.apiUrl
   }
 
+  /**
+   * Extract the domain (hostname) from the configured API URL.
+   * Used in error/warning logs so operators can identify which
+   * enterprise cloud instance produced the error.
+   */
+  getDomain(): string {
+    try {
+      return new URL(this.apiUrl).hostname
+    } catch {
+      return this.apiUrl
+    }
+  }
+
   async getJwt(): Promise<string> {
     return this.getValidJwt()
   }
@@ -389,7 +402,7 @@ export class EnterpriseAuth {
 
     if (response.status === 403) {
       const errorBody = await response.json().catch(() => ({}))
-      console.error(`[EnterpriseAuth] Permission denied ${method} ${path}:`, JSON.stringify(errorBody))
+      console.error(`[EnterpriseAuth] Permission denied ${method} ${path} (domain: ${this.getDomain()}):`, JSON.stringify(errorBody))
       // Include diagnostic details from the server so users/developers
       // can understand WHY permission was denied (e.g. missing role)
       const details = errorBody.details ? ` (${JSON.stringify(errorBody.details)})` : ''
@@ -398,7 +411,7 @@ export class EnterpriseAuth {
 
     if (!response.ok) {
       const errorBody = await response.json().catch(() => ({}))
-      console.error(`[EnterpriseAuth] API error ${response.status} ${method} ${path}:`, JSON.stringify(errorBody))
+      console.error(`[EnterpriseAuth] API error ${response.status} ${method} ${path} (domain: ${this.getDomain()}):`, JSON.stringify(errorBody))
       const detail = errorBody.details ? ` ${JSON.stringify(errorBody.details)}` : ''
       throw new Error(errorBody.message || errorBody.error || `API request failed (${response.status})${detail}`)
     }
@@ -437,6 +450,7 @@ export class EnterpriseAuth {
     }
 
     if (!response.ok) {
+      console.error(`[EnterpriseAuth] File download failed ${response.status} ${path} (domain: ${this.getDomain()})`)
       throw new Error(`File download failed (${response.status})`)
     }
 
@@ -592,11 +606,12 @@ export class EnterpriseAuth {
   }
 
   private logAuthEvent(event: string, details?: Record<string, unknown>): void {
+    const domain = this.getDomain()
     if (details) {
-      console.warn(`[EnterpriseAuth] ${event} ${JSON.stringify(details)}`)
+      console.warn(`[EnterpriseAuth] ${event} (domain: ${domain}) ${JSON.stringify(details)}`)
       return
     }
-    console.warn(`[EnterpriseAuth] ${event}`)
+    console.warn(`[EnterpriseAuth] ${event} (domain: ${domain})`)
   }
 
   private describeError(error: unknown): Record<string, unknown> {

--- a/src/main/enterprise-heartbeat.test.ts
+++ b/src/main/enterprise-heartbeat.test.ts
@@ -8,11 +8,12 @@ import { EnterpriseHeartbeat } from './enterprise-heartbeat'
 
 describe('EnterpriseHeartbeat', () => {
   let heartbeat: EnterpriseHeartbeat
-  let mockApiClient: { sendHeartbeat: ReturnType<typeof vi.fn> }
+  let mockApiClient: { sendHeartbeat: ReturnType<typeof vi.fn>; getDomain: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     mockApiClient = {
-      sendHeartbeat: vi.fn().mockResolvedValue({ ok: true, timestamp: new Date().toISOString() })
+      sendHeartbeat: vi.fn().mockResolvedValue({ ok: true, timestamp: new Date().toISOString() }),
+      getDomain: vi.fn().mockReturnValue('api.peakflo.ai')
     }
     heartbeat = new EnterpriseHeartbeat(mockApiClient as never)
   })
@@ -75,7 +76,8 @@ describe('EnterpriseHeartbeat', () => {
 
   it('can update API client', () => {
     const newClient = {
-      sendHeartbeat: vi.fn().mockResolvedValue({ ok: true, timestamp: new Date().toISOString() })
+      sendHeartbeat: vi.fn().mockResolvedValue({ ok: true, timestamp: new Date().toISOString() }),
+      getDomain: vi.fn().mockReturnValue('api.peakflo.ai')
     }
 
     heartbeat.setApiClient(newClient as never)
@@ -104,5 +106,23 @@ describe('EnterpriseHeartbeat', () => {
       userEmail: undefined,
       userName: undefined
     })
+  })
+
+  it('includes domain name in error logs on heartbeat failure', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockApiClient.sendHeartbeat.mockRejectedValue(new Error('Connection refused'))
+
+    heartbeat.start()
+    // Wait for the async sendHeartbeat to complete
+    await vi.waitFor(() => {
+      expect(warnSpy).toHaveBeenCalled()
+    })
+
+    const failCall = warnSpy.mock.calls.find((c) => c[0].includes('[EnterpriseHeartbeat] Failed'))
+    expect(failCall).toBeDefined()
+    expect(failCall![0]).toContain('(domain: api.peakflo.ai)')
+    expect(failCall![0]).toContain('Connection refused')
+
+    warnSpy.mockRestore()
   })
 })

--- a/src/main/enterprise-heartbeat.ts
+++ b/src/main/enterprise-heartbeat.ts
@@ -32,6 +32,11 @@ export class EnterpriseHeartbeat {
     this.apiClient = apiClient
   }
 
+  /** Shorthand for the enterprise cloud domain (for error logs). */
+  private get domain(): string {
+    return this.apiClient.getDomain()
+  }
+
   /**
    * Attach an EnterpriseStateSync instance so pending events
    * are flushed alongside every heartbeat (every 60s).
@@ -101,21 +106,21 @@ export class EnterpriseHeartbeat {
       if (this.stateSync) {
         this.stateSync.flush().catch((err) => {
           const msg = err instanceof Error ? err.message : String(err)
-          console.warn(`[EnterpriseHeartbeat] State sync flush error (non-fatal): ${msg}`)
+          console.warn(`[EnterpriseHeartbeat] State sync flush error (non-fatal) (domain: ${this.domain}): ${msg}`)
         })
       }
     } catch (err) {
       this.consecutiveErrors++
       const msg = err instanceof Error ? err.message : String(err)
       console.warn(
-        `[EnterpriseHeartbeat] Failed (${this.consecutiveErrors}/${this.MAX_CONSECUTIVE_ERRORS}): ${msg}`
+        `[EnterpriseHeartbeat] Failed (${this.consecutiveErrors}/${this.MAX_CONSECUTIVE_ERRORS}) (domain: ${this.domain}): ${msg}`
       )
 
       // After too many consecutive errors, stop to avoid log spam.
       // The heartbeat will be restarted on next successful auth.
       if (this.consecutiveErrors >= this.MAX_CONSECUTIVE_ERRORS) {
         console.error(
-          '[EnterpriseHeartbeat] Too many consecutive errors, stopping.'
+          `[EnterpriseHeartbeat] Too many consecutive errors (domain: ${this.domain}), stopping.`
         )
         this.stop()
       }

--- a/src/main/enterprise-state-sync.test.ts
+++ b/src/main/enterprise-state-sync.test.ts
@@ -21,11 +21,13 @@ describe('EnterpriseStateSync', () => {
   let stateSync: EnterpriseStateSync
   let mockApiClient: {
     sendSyncEvents: ReturnType<typeof vi.fn>
+    getDomain: ReturnType<typeof vi.fn>
   }
 
   beforeEach(() => {
     mockApiClient = {
-      sendSyncEvents: vi.fn().mockResolvedValue({ ok: true, inserted: 0 })
+      sendSyncEvents: vi.fn().mockResolvedValue({ ok: true, inserted: 0 }),
+      getDomain: vi.fn().mockReturnValue('stage-api.peakflo.ai')
     }
     stateSync = new EnterpriseStateSync(mockApiClient as never)
     stateSync.setUserName('Test User')
@@ -133,6 +135,24 @@ describe('EnterpriseStateSync', () => {
 
       // Events should be re-queued
       expect(stateSync.pendingCount).toBe(1)
+    })
+
+    it('includes domain in error log on flush failure', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const task = makeTask()
+      stateSync.recordTaskCreated(task)
+
+      mockApiClient.sendSyncEvents.mockRejectedValue(new Error('network error'))
+
+      await stateSync.flush()
+
+      const failCall = warnSpy.mock.calls.find((c) =>
+        c[0].includes('[EnterpriseStateSync] Failed to send events')
+      )
+      expect(failCall).toBeDefined()
+      expect(failCall![0]).toContain('(domain: stage-api.peakflo.ai)')
+
+      warnSpy.mockRestore()
     })
 
     it('prevents concurrent flushes', async () => {

--- a/src/main/enterprise-state-sync.ts
+++ b/src/main/enterprise-state-sync.ts
@@ -29,6 +29,11 @@ export class EnterpriseStateSync {
     this.apiClient = apiClient
   }
 
+  /** Shorthand for the enterprise cloud domain (for error logs). */
+  private get domain(): string {
+    return this.apiClient.getDomain()
+  }
+
   /**
    * Set the display name used in changelog entries.
    */
@@ -197,7 +202,7 @@ export class EnterpriseStateSync {
           // Re-queue events on failure (they'll be sent next flush)
           this.pendingEvents.unshift(...events)
           const msg = err instanceof Error ? err.message : String(err)
-          console.warn(`[EnterpriseStateSync] Failed to send events: ${msg}`)
+          console.warn(`[EnterpriseStateSync] Failed to send events (domain: ${this.domain}): ${msg}`)
         }
       }
     } finally {

--- a/src/main/enterprise-sync.test.ts
+++ b/src/main/enterprise-sync.test.ts
@@ -100,7 +100,8 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
       updateSkill: vi.fn().mockResolvedValue(makeServerSkill()),
       deleteSkill: vi.fn().mockResolvedValue(undefined),
       updateOrgNode: vi.fn().mockResolvedValue(makeOrgNode()),
-      cleanupDuplicateSkills: vi.fn().mockResolvedValue({ deleted: 0, kept: 0 })
+      cleanupDuplicateSkills: vi.fn().mockResolvedValue({ deleted: 0, kept: 0 }),
+      getDomain: vi.fn().mockReturnValue('api.peakflo.ai')
     }
 
     syncManager = new EnterpriseSyncManager(mockDb as never, mockApiClient as never)
@@ -497,7 +498,7 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
       expect(result.errors.length).toBe(0)
     })
 
-    it('reports errors in result without crashing', async () => {
+    it('reports errors in result without crashing and includes domain', async () => {
       mockApiClient.listOrgNodes.mockRejectedValue(new Error('Network down'))
       mockApiClient.batchSyncSkills.mockResolvedValue({
         created: 0,
@@ -508,6 +509,7 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
       const result = await syncManager.syncAll('user-1')
 
       expect(result.errors).toContainEqual(expect.stringContaining('Org node sync failed'))
+      expect(result.errors).toContainEqual(expect.stringContaining('(domain: api.peakflo.ai)'))
     })
 
     it('assigns skills to multiple user nodes', async () => {
@@ -582,7 +584,7 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
       )
     })
 
-    it('handles assign skills failure gracefully', async () => {
+    it('handles assign skills failure gracefully with domain in error', async () => {
       const localSkill = makeLocalSkill({ enterprise_skill_id: null })
       mockDb.getSkills.mockReturnValue([localSkill])
       mockApiClient.batchSyncSkills.mockResolvedValue({
@@ -600,6 +602,7 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
       const result = await syncManager.syncAll('user-1')
 
       expect(result.errors).toContainEqual(expect.stringContaining('Assign skills to node'))
+      expect(result.errors).toContainEqual(expect.stringContaining('(domain: api.peakflo.ai)'))
       expect(result.skills.pushed).toBe(1)
     })
 

--- a/src/main/enterprise-sync.ts
+++ b/src/main/enterprise-sync.ts
@@ -51,6 +51,11 @@ export class EnterpriseSyncManager {
     private apiClient: WorkfloApiClient
   ) {}
 
+  /** Shorthand for the enterprise cloud domain (for error logs). */
+  private get domain(): string {
+    return this.apiClient.getDomain()
+  }
+
   /**
    * Ensure the enterprise_skill_id column exists before syncing.
    * This is a safety net in case the database migration didn't run.
@@ -75,7 +80,7 @@ export class EnterpriseSyncManager {
       }
       this.migrationChecked = true
     } catch (err) {
-      console.error('[EnterpriseSyncManager] Failed to ensure skill column:', err)
+      console.error(`[EnterpriseSyncManager] Failed to ensure skill column (domain: ${this.domain}):`, err)
     }
   }
 
@@ -157,9 +162,9 @@ export class EnterpriseSyncManager {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      result.errors.push(`Org node sync failed: ${msg}`)
+      result.errors.push(`Org node sync failed (domain: ${this.domain}): ${msg}`)
       console.warn(
-        '[EnterpriseSyncManager] Org node sync failed, continuing with skills sync:',
+        `[EnterpriseSyncManager] Org node sync failed (domain: ${this.domain}), continuing with skills sync:`,
         msg
       )
     }
@@ -214,7 +219,7 @@ export class EnterpriseSyncManager {
       console.log(`[EnterpriseSyncManager] Skills sync completed in ${skillSyncMs}ms`)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      result.errors.push(`Skills 2-way sync failed: ${msg}`)
+      result.errors.push(`Skills 2-way sync failed (domain: ${this.domain}): ${msg}`)
     }
 
     const totalSyncMs = Date.now() - syncStartTime
@@ -252,7 +257,7 @@ export class EnterpriseSyncManager {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      result.errors.push(`Node ${node.name} detail fetch failed: ${msg}`)
+      result.errors.push(`Node ${node.name} detail fetch failed (domain: ${this.domain}): ${msg}`)
     }
   }
 
@@ -300,7 +305,7 @@ export class EnterpriseSyncManager {
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
-        result.errors.push(`Agent ${agent.name}: ${msg}`)
+        result.errors.push(`Agent ${agent.name} (domain: ${this.domain}): ${msg}`)
       }
     }
   }
@@ -433,8 +438,8 @@ export class EnterpriseSyncManager {
         )
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
-        result.errors.push(`Batch sync chunk ${i + 1}/${chunks.length} failed: ${msg}`)
-        console.error(`[EnterpriseSyncManager] Batch sync chunk ${i + 1} failed after retries:`, msg)
+        result.errors.push(`Batch sync chunk ${i + 1}/${chunks.length} failed (domain: ${this.domain}): ${msg}`)
+        console.error(`[EnterpriseSyncManager] Batch sync chunk ${i + 1} failed after retries (domain: ${this.domain}):`, msg)
       }
     }
 
@@ -451,7 +456,7 @@ export class EnterpriseSyncManager {
           allServerSkills = await this.apiClient.listSkills() ?? []
         } catch (listErr) {
           const msg = listErr instanceof Error ? listErr.message : String(listErr)
-          result.errors.push(`Fallback listSkills failed: ${msg}`)
+          result.errors.push(`Fallback listSkills failed (domain: ${this.domain}): ${msg}`)
         }
       }
     }
@@ -574,7 +579,7 @@ export class EnterpriseSyncManager {
       )
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      result.errors.push(`Assign skills to node ${nodeId}: ${msg}`)
+      result.errors.push(`Assign skills to node ${nodeId} (domain: ${this.domain}): ${msg}`)
     }
   }
 
@@ -677,7 +682,7 @@ export class EnterpriseSyncManager {
         result.skills.created++
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
-        result.errors.push(`Pull skill ${skill.name}: ${msg}`)
+        result.errors.push(`Pull skill ${skill.name} (domain: ${this.domain}): ${msg}`)
       }
     }
   }
@@ -749,7 +754,7 @@ export class EnterpriseSyncManager {
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
-        result.errors.push(`MCP Server ${server.name}: ${msg}`)
+        result.errors.push(`MCP Server ${server.name} (domain: ${this.domain}): ${msg}`)
       }
     }
   }
@@ -838,7 +843,7 @@ export class EnterpriseSyncManager {
         // Don't update existing — user may have customized locally
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
-        result.errors.push(`Task Source ${source.name}: ${msg}`)
+        result.errors.push(`Task Source ${source.name} (domain: ${this.domain}): ${msg}`)
       }
     }
   }

--- a/src/main/workflo-api-client.ts
+++ b/src/main/workflo-api-client.ts
@@ -154,6 +154,14 @@ export interface WorkfloSyncEvent {
 export class WorkfloApiClient {
   constructor(private auth: EnterpriseAuth) {}
 
+  /**
+   * Get the domain (hostname) of the enterprise cloud API.
+   * Delegates to EnterpriseAuth for use in error logging by consumers.
+   */
+  getDomain(): string {
+    return this.auth.getDomain()
+  }
+
   // ── Tasks ─────────────────────────────────────────────────────────────
 
   /**


### PR DESCRIPTION
## Summary
- Add API hostname (e.g. `api.peakflo.ai`, `stage-api.peakflo.ai`) to all error/warning log messages across enterprise modules (`enterprise-auth`, `enterprise-sync`, `enterprise-state-sync`, `enterprise-heartbeat`)
- Add `getDomain()` method to `EnterpriseAuth` and expose it via `WorkfloApiClient` so all downstream consumers can include the domain in their logs
- Makes it easy for operators to identify which enterprise cloud instance produced an error when reviewing backend logs

## Test plan
- [x] All 67 enterprise-specific tests pass (including new domain-related tests)
- [x] Full test suite passes — 1079 tests, 0 failures
- [x] Lint, typecheck, and build all pass
- [x] New tests verify domain appears in error logs for: auth events, API 403/500 responses, heartbeat failures, state sync failures, and sync errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)