### PR TITLE
fix: remove gpt-5.4-codex from Codex model dropdown

### DIFF
--- a/src/main/adapters/codex-adapter.test.ts
+++ b/src/main/adapters/codex-adapter.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { DEFAULT_CODEX_MODEL } from './codex-adapter'
 
 describe('DEFAULT_CODEX_MODEL', () => {
-  it('defaults Codex sessions to GPT-5.4 Codex', () => {
-    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.4-codex')
+  it('defaults Codex sessions to GPT-5.4', () => {
+    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.4')
   })
 })
 

--- a/src/main/adapters/codex-adapter.ts
+++ b/src/main/adapters/codex-adapter.ts
@@ -20,7 +20,7 @@ import type {
 } from './coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './coding-agent-adapter'
 
-export const DEFAULT_CODEX_MODEL = 'gpt-5.4-codex'
+export const DEFAULT_CODEX_MODEL = 'gpt-5.4'
 
 interface JsonRpcRequest {
   jsonrpc: '2.0'

--- a/src/renderer/src/types/index.test.ts
+++ b/src/renderer/src/types/index.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { CODEX_MODELS, CodexModel } from './index'
 
 describe('CODEX_MODELS', () => {
-  it('lists GPT-5.4 Codex first as the recommended model', () => {
+  it('lists GPT-5.4 first as the recommended model', () => {
     expect(CODEX_MODELS[0]).toEqual({
-      id: CodexModel.GPT_5_4_CODEX,
-      name: 'GPT-5.4 Codex (Recommended)'
+      id: CodexModel.GPT_5_4,
+      name: 'GPT-5.4 (Recommended)'
     })
   })
 
@@ -16,10 +16,7 @@ describe('CODEX_MODELS', () => {
     })
   })
 
-  it('includes the standalone GPT-5.4 model', () => {
-    expect(CODEX_MODELS).toContainEqual({
-      id: CodexModel.GPT_5_4,
-      name: 'GPT-5.4'
-    })
+  it('does not include unsupported GPT-5.4 Codex model', () => {
+    expect(CODEX_MODELS.some((model) => model.name.includes('GPT-5.4 Codex'))).toBe(false)
   })
 })

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -61,7 +61,6 @@ export const CLAUDE_MODELS: { id: ClaudeModel; name: string }[] = [
 ]
 
 export enum CodexModel {
-  GPT_5_4_CODEX = 'gpt-5.4-codex',
   GPT_5_3_CODEX = 'gpt-5.3-codex',
   GPT_5_2_CODEX = 'gpt-5.2-codex',
   GPT_5_1_CODEX_MAX = 'gpt-5.1-codex-max',
@@ -74,14 +73,13 @@ export enum CodexModel {
 }
 
 export const CODEX_MODELS: { id: CodexModel; name: string }[] = [
-  { id: CodexModel.GPT_5_4_CODEX, name: 'GPT-5.4 Codex (Recommended)' },
+  { id: CodexModel.GPT_5_4, name: 'GPT-5.4 (Recommended)' },
   { id: CodexModel.GPT_5_3_CODEX, name: 'GPT-5.3 Codex' },
   { id: CodexModel.GPT_5_2_CODEX, name: 'GPT-5.2 Codex' },
   { id: CodexModel.GPT_5_1_CODEX_MAX, name: 'GPT-5.1 Codex Max' },
   { id: CodexModel.GPT_5_1_CODEX, name: 'GPT-5.1 Codex' },
   { id: CodexModel.GPT_5_1_CODEX_MINI, name: 'GPT-5.1 Codex Mini' },
   { id: CodexModel.GPT_5_CODEX, name: 'GPT-5 Codex' },
-  { id: CodexModel.GPT_5_4, name: 'GPT-5.4' },
   { id: CodexModel.GPT_5, name: 'GPT-5' },
   { id: CodexModel.GPT_5_MINI, name: 'GPT-5 Mini (Fastest)' }
 ]


### PR DESCRIPTION
## Summary\n- remove unsupported  from Codex model list used by the UI dropdown\n- make  the recommended first option in Codex models\n- switch Codex adapter default model to \n- update unit tests for model list and default Codex model\n\n## Test Evidence\n-  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/an9gb1cx82j3jg0formqc9tu".\n-  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/an9gb1cx82j3jg0formqc9tu".\n-  ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE  No package found in this workspace