### PR TITLE
fix: ensure all MCP servers are visible to codex ACP sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release": "bash scripts/release.sh"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.92",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.104",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -36,7 +36,7 @@
     "@paralleldrive/cuid2": "^2.2.2",
     "@supabase/supabase-js": "^2.49.4",
     "@zed-industries/claude-code-acp": "^0.16.1",
-    "@zed-industries/codex-acp": "^0.9.5",
+    "@zed-industries/codex-acp": "^0.11.1",
     "better-sqlite3": "^12.6.2",
     "cron-parser": "^5.5.0",
     "electron-updater": "^6.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.2.92
-        version: 0.2.92(zod@4.3.6)
+        specifier: ^0.2.104
+        version: 0.2.104(zod@4.3.6)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -42,8 +42,8 @@ importers:
         specifier: ^0.16.1
         version: 0.16.1(zod@4.3.6)
       '@zed-industries/codex-acp':
-        specifier: ^0.9.5
-        version: 0.9.5
+        specifier: ^0.11.1
+        version: 0.11.1
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -221,14 +221,14 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@anthropic-ai/claude-agent-sdk@0.2.92':
-    resolution: {integrity: sha512-loYyxVUC5gBwHjGi9Fv0b84mduJTp9Z3Pum+y/7IVQDb4NynKfVQl6l4VeDKZaW+1QTQtd25tY4hwUznD7Krqw==}
+  '@anthropic-ai/claude-agent-sdk@0.2.104':
+    resolution: {integrity: sha512-lVm+nS79r6WWlDnv5AgRzTtAlbP8O6M6kkWmDZAWE3nt9agmngxls9frJFvH55uzws2+6l0yyup/JYspfijkzw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.80.0':
-    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
+  '@anthropic-ai/sdk@0.81.0':
+    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2159,44 +2159,44 @@ packages:
     resolution: {integrity: sha512-/fKDYLCtiKthYUeOu4vPHSE79arh0ciYnBd5uSTY8OWMURJoelBwkK5QGZZSmxjAwG9tHkvjxUjxhMDgC071VA==}
     hasBin: true
 
-  '@zed-industries/codex-acp-darwin-arm64@0.9.5':
-    resolution: {integrity: sha512-VZsC/VOxY2/vCXV3/k09bKg1gQzaRnVoYoPgBF8JbZbPLLBiJZVCTGq5uND9wH8O3FAoIAEDm9icFsIL1eUd3g==}
+  '@zed-industries/codex-acp-darwin-arm64@0.11.1':
+    resolution: {integrity: sha512-zJ/CsOSH1NniKGF/liBtWokdkFtymTWeELV4lDlgMgzVSqMHQTB+t6fFSrxhwOcXHK86TErxAT81Z61e+bq5gg==}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@zed-industries/codex-acp-darwin-x64@0.9.5':
-    resolution: {integrity: sha512-K+HQzbdzfsCEFdjsMDT9mUXPAy/b63Har1Zzy+/bFRv8bVti52Nfv9SYnnHsEVVRSSwzStYbWNP9cXUywO2X1w==}
+  '@zed-industries/codex-acp-darwin-x64@0.11.1':
+    resolution: {integrity: sha512-UZjIsEZPLeYMk+fj2ot1oT+tWuJpw+iZS9awnbmJYxTEEXMpY8BE6xQXMy7iyyxJ346We5MEpAdxg730vcem5Q==}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@zed-industries/codex-acp-linux-arm64@0.9.5':
-    resolution: {integrity: sha512-BtgoSxxKkDjZPtovdhmLpLFk2LBS2qY9wVOAAzO8b6PRS8t1ufaGTocJheb/Cb6kb5cHAqXtvo0sexDh8LwiiA==}
+  '@zed-industries/codex-acp-linux-arm64@0.11.1':
+    resolution: {integrity: sha512-I1f6WoSLbLlsWq4zH+vtwdoc4Y41mqRXPpSkfgIifxBw34QmWJmi37etZ7lKTYp6R+J/Z4PUN0rsmnsmKpBZTw==}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@zed-industries/codex-acp-linux-x64@0.9.5':
-    resolution: {integrity: sha512-8TGNNP6HAAxy+Y8cBzAySKzKSpb4Sgraz1Yl5b0VzvSV7iYg77hIAyR4zsywymK3fzF1MGUO1ZNYt2JR1ZnPMw==}
+  '@zed-industries/codex-acp-linux-x64@0.11.1':
+    resolution: {integrity: sha512-30vSoZuW1DP6Nuz24Gg3jgVC37IYe0bZ/Fgc5+372gc0h72NN4zHYAbu5bRd/gUJ9GdwABKrrEPCoFPlOTVTnQ==}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@zed-industries/codex-acp-win32-arm64@0.9.5':
-    resolution: {integrity: sha512-5UVyGMDia0YZi8yf/4ZvuCUy+WA83kXQkfucroCmAnxWDyrp3KKIOpAgTzBb5MHQkEtYGNjR6eA9UkPbwj9fPg==}
+  '@zed-industries/codex-acp-win32-arm64@0.11.1':
+    resolution: {integrity: sha512-yisGPG7JMJBtOTOB6qwzroOLfiQebDrBnybzvjOfWiSIHeha25Jf1nTlWrlZcEiV/eeX3/lERuU1MxftjK3Vgg==}
     cpu: [arm64]
     os: [win32]
     hasBin: true
 
-  '@zed-industries/codex-acp-win32-x64@0.9.5':
-    resolution: {integrity: sha512-jCzCjmj1wpq78jXC6lVm86bA69dYGm/l3DbeVyiMiUF3uimeNieauNK9sLDXbrWpLGVju3lqsFax8vIposahBQ==}
+  '@zed-industries/codex-acp-win32-x64@0.11.1':
+    resolution: {integrity: sha512-nOdlp/xHQGzqt+GnB2rrpk0sT7pPJVKkL9M+UhmoFPSFwjWrkzAOJukbT4P59wU1mVBTe84dEW6UnzydWIrGJw==}
     cpu: [x64]
     os: [win32]
     hasBin: true
 
-  '@zed-industries/codex-acp@0.9.5':
-    resolution: {integrity: sha512-rS3Mv+N9N2eUpjiGmUT+P3fBO2ZXnDtH1L+efvL9q3Shm9EVG2FByNrDRI1+NxQzmgtsgTpm+xTxg/9jdwXYlA==}
+  '@zed-industries/codex-acp@0.11.1':
+    resolution: {integrity: sha512-My2VSlBtvJipJhImHjFDej2ut/p00QqOISRnZgLgLrSIzjgvdcQvAhaZviWj7XPhk4UIdIb0OoA+Lrls824uiQ==}
     hasBin: true
 
   abbrev@1.1.1:
@@ -5128,9 +5128,9 @@ snapshots:
     dependencies:
       zod: 4.3.6
 
-  '@anthropic-ai/claude-agent-sdk@0.2.92(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.2.104(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.80.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -5147,7 +5147,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -7117,7 +7117,7 @@ snapshots:
   '@zed-industries/claude-code-acp@0.16.1(zod@4.3.6)':
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
-      '@anthropic-ai/claude-agent-sdk': 0.2.92(zod@4.3.6)
+      '@anthropic-ai/claude-agent-sdk': 0.2.104(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
       diff: 8.0.3
       minimatch: 10.1.2
@@ -7126,32 +7126,32 @@ snapshots:
       - supports-color
       - zod
 
-  '@zed-industries/codex-acp-darwin-arm64@0.9.5':
+  '@zed-industries/codex-acp-darwin-arm64@0.11.1':
     optional: true
 
-  '@zed-industries/codex-acp-darwin-x64@0.9.5':
+  '@zed-industries/codex-acp-darwin-x64@0.11.1':
     optional: true
 
-  '@zed-industries/codex-acp-linux-arm64@0.9.5':
+  '@zed-industries/codex-acp-linux-arm64@0.11.1':
     optional: true
 
-  '@zed-industries/codex-acp-linux-x64@0.9.5':
+  '@zed-industries/codex-acp-linux-x64@0.11.1':
     optional: true
 
-  '@zed-industries/codex-acp-win32-arm64@0.9.5':
+  '@zed-industries/codex-acp-win32-arm64@0.11.1':
     optional: true
 
-  '@zed-industries/codex-acp-win32-x64@0.9.5':
+  '@zed-industries/codex-acp-win32-x64@0.11.1':
     optional: true
 
-  '@zed-industries/codex-acp@0.9.5':
+  '@zed-industries/codex-acp@0.11.1':
     optionalDependencies:
-      '@zed-industries/codex-acp-darwin-arm64': 0.9.5
-      '@zed-industries/codex-acp-darwin-x64': 0.9.5
-      '@zed-industries/codex-acp-linux-arm64': 0.9.5
-      '@zed-industries/codex-acp-linux-x64': 0.9.5
-      '@zed-industries/codex-acp-win32-arm64': 0.9.5
-      '@zed-industries/codex-acp-win32-x64': 0.9.5
+      '@zed-industries/codex-acp-darwin-arm64': 0.11.1
+      '@zed-industries/codex-acp-darwin-x64': 0.11.1
+      '@zed-industries/codex-acp-linux-arm64': 0.11.1
+      '@zed-industries/codex-acp-linux-x64': 0.11.1
+      '@zed-industries/codex-acp-win32-arm64': 0.11.1
+      '@zed-industries/codex-acp-win32-x64': 0.11.1
 
   abbrev@1.1.1: {}
 

--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -45,6 +45,8 @@ interface AcpAdapterPrivate {
   handleRpcMessage(session: AcpSessionForTest, message: unknown): void
   authenticateSession(session: AcpSessionForTest, initResult: unknown): Promise<void>
   sendRpcRequest(session: AcpSessionForTest, method: string, params?: unknown): Promise<unknown>
+  convertMcpServers(servers?: Record<string, unknown>, agentCaps?: { supportsHttp: boolean; supportsSse: boolean }): unknown[]
+  extractAgentCapabilities(initResult: unknown): { supportsHttp: boolean; supportsSse: boolean }
 }
 
 interface JsonRpcRequestForTest {
@@ -2659,5 +2661,156 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
       const loggedLines = logSpy.mock.calls.map((call) => String(call[0]))
       expect(loggedLines.some((line) => line.includes('agent_message_chunk: turnId='))).toBe(false)
     })
+  })
+})
+
+// ─── MCP Server Capability Filtering Tests ───────────────────────────────────
+
+describe('AcpAdapter - extractAgentCapabilities', () => {
+  let adapter: AcpAdapter
+
+  beforeEach(() => {
+    adapter = new AcpAdapter('codex')
+  })
+
+  it('should return defaults when initResult is null', () => {
+    const caps = adapterPrivate(adapter).extractAgentCapabilities(null)
+    expect(caps).toEqual({ supportsHttp: false, supportsSse: false })
+  })
+
+  it('should return defaults when initResult has no agentCapabilities', () => {
+    const caps = adapterPrivate(adapter).extractAgentCapabilities({ protocolVersion: 1 })
+    expect(caps).toEqual({ supportsHttp: false, supportsSse: false })
+  })
+
+  it('should return defaults when agentCapabilities has no mcpCapabilities', () => {
+    const caps = adapterPrivate(adapter).extractAgentCapabilities({
+      agentCapabilities: { loadSession: true }
+    })
+    expect(caps).toEqual({ supportsHttp: false, supportsSse: false })
+  })
+
+  it('should detect http support', () => {
+    const caps = adapterPrivate(adapter).extractAgentCapabilities({
+      agentCapabilities: { mcpCapabilities: { http: true } }
+    })
+    expect(caps).toEqual({ supportsHttp: true, supportsSse: false })
+  })
+
+  it('should detect sse support', () => {
+    const caps = adapterPrivate(adapter).extractAgentCapabilities({
+      agentCapabilities: { mcpCapabilities: { sse: true } }
+    })
+    expect(caps).toEqual({ supportsHttp: false, supportsSse: true })
+  })
+
+  it('should detect both http and sse support', () => {
+    const caps = adapterPrivate(adapter).extractAgentCapabilities({
+      agentCapabilities: { mcpCapabilities: { http: true, sse: true } }
+    })
+    expect(caps).toEqual({ supportsHttp: true, supportsSse: true })
+  })
+})
+
+describe('AcpAdapter - convertMcpServers transport filtering', () => {
+  let adapter: AcpAdapter
+
+  beforeEach(() => {
+    adapter = new AcpAdapter('codex')
+  })
+
+  it('should always include stdio servers regardless of capabilities', () => {
+    const servers = {
+      'my-server': { type: 'stdio' as const, command: '/usr/bin/server', args: ['--flag'], env: { KEY: 'val' } }
+    }
+    const noCaps = { supportsHttp: false, supportsSse: false }
+    const result = adapterPrivate(adapter).convertMcpServers(servers, noCaps)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      name: 'my-server',
+      command: '/usr/bin/server',
+      args: ['--flag'],
+      env: [{ name: 'KEY', value: 'val' }]
+    })
+  })
+
+  it('should skip http servers when agent does not support http', () => {
+    const servers = {
+      'remote-api': { type: 'http' as const, url: 'https://api.example.com/mcp', headers: { Authorization: 'Bearer tok' } }
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = adapterPrivate(adapter).convertMcpServers(servers, { supportsHttp: false, supportsSse: false })
+    expect(result).toHaveLength(0)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes('does not support HTTP transport'))).toBe(true)
+    warnSpy.mockRestore()
+  })
+
+  it('should include http servers when agent supports http', () => {
+    const servers = {
+      'remote-api': { type: 'http' as const, url: 'https://api.example.com/mcp', headers: { Authorization: 'Bearer tok' } }
+    }
+    const result = adapterPrivate(adapter).convertMcpServers(servers, { supportsHttp: true, supportsSse: false })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      type: 'http',
+      name: 'remote-api',
+      url: 'https://api.example.com/mcp',
+      headers: [{ name: 'Authorization', value: 'Bearer tok' }]
+    })
+  })
+
+  it('should skip sse servers when agent does not support sse', () => {
+    const servers = {
+      'event-stream': { type: 'sse' as const, url: 'https://events.example.com/mcp', headers: {} }
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = adapterPrivate(adapter).convertMcpServers(servers, { supportsHttp: false, supportsSse: false })
+    expect(result).toHaveLength(0)
+    expect(warnSpy.mock.calls.some((call) => String(call[0]).includes('does not support SSE transport'))).toBe(true)
+    warnSpy.mockRestore()
+  })
+
+  it('should include sse servers when agent supports sse', () => {
+    const servers = {
+      'event-stream': { type: 'sse' as const, url: 'https://events.example.com/mcp', headers: { 'X-Key': 'abc' } }
+    }
+    const result = adapterPrivate(adapter).convertMcpServers(servers, { supportsHttp: false, supportsSse: true })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      type: 'sse',
+      name: 'event-stream',
+      url: 'https://events.example.com/mcp',
+      headers: [{ name: 'X-Key', value: 'abc' }]
+    })
+  })
+
+  it('should filter mixed servers based on capabilities', () => {
+    const servers = {
+      'local-tool': { type: 'stdio' as const, command: '/usr/bin/tool', args: [], env: {} },
+      'remote-api': { type: 'http' as const, url: 'https://api.example.com/mcp', headers: {} },
+      'event-stream': { type: 'sse' as const, url: 'https://events.example.com/mcp', headers: {} }
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // Agent only supports http, not sse
+    const result = adapterPrivate(adapter).convertMcpServers(servers, { supportsHttp: true, supportsSse: false })
+    expect(result).toHaveLength(2)
+    expect((result[0] as Record<string, unknown>).name).toBe('local-tool')
+    expect((result[1] as Record<string, unknown>).name).toBe('remote-api')
+    warnSpy.mockRestore()
+  })
+
+  it('should include all servers when no agentCaps provided (backward compat)', () => {
+    const servers = {
+      'local-tool': { type: 'stdio' as const, command: '/usr/bin/tool', args: [], env: {} },
+      'remote-api': { type: 'http' as const, url: 'https://api.example.com/mcp', headers: {} }
+    }
+    // No agentCaps → don't filter (backward compatibility)
+    const result = adapterPrivate(adapter).convertMcpServers(servers, undefined)
+    expect(result).toHaveLength(2)
+  })
+
+  it('should return empty array when servers is undefined', () => {
+    const result = adapterPrivate(adapter).convertMcpServers(undefined)
+    expect(result).toEqual([])
   })
 })

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -411,11 +411,14 @@ export class AcpAdapter implements CodingAgentAdapter {
       }
     })
 
+    // Extract agent capabilities for transport filtering
+    const agentCaps = this.extractAgentCapabilities(initResult)
+
     // Authenticate if required
     await this.authenticateSession(session, initResult)
 
     // Create ACP session (only accepts cwd and mcpServers per ACP spec)
-    const convertedMcpServers = this.convertMcpServers(config.mcpServers) || []
+    const convertedMcpServers = this.convertMcpServers(config.mcpServers, agentCaps) || []
     console.log(`[AcpAdapter/${this.agentType}] session/new mcpServers:`, JSON.stringify(convertedMcpServers))
     const result = await this.sendRpcRequest(session, 'session/new', {
       cwd: config.workspaceDir,
@@ -584,6 +587,9 @@ export class AcpAdapter implements CodingAgentAdapter {
       }
     })
 
+    // Extract agent capabilities for transport filtering
+    const agentCaps = this.extractAgentCapabilities(initResult)
+
     // Authenticate if required
     await this.authenticateSession(session, initResult)
 
@@ -592,7 +598,7 @@ export class AcpAdapter implements CodingAgentAdapter {
       await this.sendRpcRequest(session, 'session/load', {
         sessionId: sessionId,
         cwd: config.workspaceDir,
-        mcpServers: this.convertMcpServers(config.mcpServers) || []
+        mcpServers: this.convertMcpServers(config.mcpServers, agentCaps) || []
       })
 
       console.log(`[AcpAdapter/${this.agentType}] Session loaded successfully: ${sessionId}`)
@@ -1341,6 +1347,28 @@ export class AcpAdapter implements CodingAgentAdapter {
   }
 
   /**
+   * Extract agent capabilities from the ACP initialize response.
+   * Used to determine which MCP server transport types the agent supports.
+   * Per ACP spec, all agents MUST support stdio; http and sse are optional.
+   */
+  private extractAgentCapabilities(initResult: unknown): { supportsHttp: boolean; supportsSse: boolean } {
+    const defaults = { supportsHttp: false, supportsSse: false }
+    if (!initResult || typeof initResult !== 'object') return defaults
+
+    const obj = initResult as Record<string, unknown>
+    const caps = obj.agentCapabilities as Record<string, unknown> | undefined
+    if (!caps) return defaults
+
+    const mcpCaps = caps.mcpCapabilities as Record<string, unknown> | undefined
+    if (!mcpCaps) return defaults
+
+    return {
+      supportsHttp: mcpCaps.http === true,
+      supportsSse: mcpCaps.sse === true
+    }
+  }
+
+  /**
    * Convert internal McpServerConfig map to ACP-spec McpServer array.
    * ACP spec: https://agentclientprotocol.com/protocol/schema
    *
@@ -1348,8 +1376,12 @@ export class AcpAdapter implements CodingAgentAdapter {
    * - stdio variant: { name, command, args: string[], env: EnvVariable[] }
    * - http variant:  { type: "http", name, url, headers: HttpHeader[] }
    * - EnvVariable / HttpHeader = { name: string, value: string }
+   *
+   * Per ACP spec, Clients MUST check agentCapabilities.mcpCapabilities before
+   * sending HTTP or SSE transport servers. Unsupported transports are skipped
+   * with a warning so users know why a server is missing.
    */
-  private convertMcpServers(servers?: Record<string, McpServerConfig>): unknown[] {
+  private convertMcpServers(servers?: Record<string, McpServerConfig>, agentCaps?: { supportsHttp: boolean; supportsSse: boolean }): unknown[] {
     if (!servers) return []
 
     const result: unknown[] = []
@@ -1366,9 +1398,42 @@ export class AcpAdapter implements CodingAgentAdapter {
           args: config.args || [],
           env: envArray
         })
+      } else if (config.type === 'http') {
+        // Per ACP spec, client MUST check mcpCapabilities.http before sending
+        if (agentCaps && !agentCaps.supportsHttp) {
+          console.warn(`[AcpAdapter/${this.agentType}] Skipping MCP server "${name}" — agent does not support HTTP transport`)
+          continue
+        }
+
+        const headersArray = config.headers
+          ? Object.entries(config.headers).map(([k, v]) => ({ name: k, value: v }))
+          : []
+
+        result.push({
+          type: config.type,
+          name,
+          url: config.url,
+          headers: headersArray
+        })
+      } else if (config.type === 'sse') {
+        // Per ACP spec, client MUST check mcpCapabilities.sse before sending
+        if (agentCaps && !agentCaps.supportsSse) {
+          console.warn(`[AcpAdapter/${this.agentType}] Skipping MCP server "${name}" — agent does not support SSE transport`)
+          continue
+        }
+
+        const headersArray = config.headers
+          ? Object.entries(config.headers).map(([k, v]) => ({ name: k, value: v }))
+          : []
+
+        result.push({
+          type: config.type,
+          name,
+          url: config.url,
+          headers: headersArray
+        })
       } else {
-        // http or sse — ACP requires a "type" discriminator for non-stdio variants
-        // Convert headers from Record<string,string> to ACP HttpHeader[]
+        // Unknown transport type — include as-is (forward compatibility)
         const headersArray = config.headers
           ? Object.entries(config.headers).map(([k, v]) => ({ name: k, value: v }))
           : []

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -413,6 +413,8 @@ export class AcpAdapter implements CodingAgentAdapter {
 
     // Extract agent capabilities for transport filtering
     const agentCaps = this.extractAgentCapabilities(initResult)
+    console.log(`[AcpAdapter/${this.agentType}] initialize response capabilities:`, JSON.stringify(initResult))
+    console.log(`[AcpAdapter/${this.agentType}] MCP transport support: http=${agentCaps.supportsHttp}, sse=${agentCaps.supportsSse}`)
 
     // Authenticate if required
     await this.authenticateSession(session, initResult)
@@ -589,6 +591,8 @@ export class AcpAdapter implements CodingAgentAdapter {
 
     // Extract agent capabilities for transport filtering
     const agentCaps = this.extractAgentCapabilities(initResult)
+    console.log(`[AcpAdapter/${this.agentType}] initialize response capabilities:`, JSON.stringify(initResult))
+    console.log(`[AcpAdapter/${this.agentType}] MCP transport support: http=${agentCaps.supportsHttp}, sse=${agentCaps.supportsSse}`)
 
     // Authenticate if required
     await this.authenticateSession(session, initResult)

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -369,12 +369,16 @@ export class AgentManager extends EventEmitter {
         }
 
         // Inject enterprise JWT for Workflo MCP Dev Server
-        if (mcpServer.name === '[Workflo] MCP Dev Server' && this.enterpriseAuth) {
-          try {
-            const jwt = await this.enterpriseAuth.getJwt()
-            finalHeaders = { ...finalHeaders, Authorization: `Bearer ${jwt}` }
-          } catch (err) {
-            console.warn('[AgentManager] Failed to inject enterprise JWT for MCP Dev Server:', err)
+        if (mcpServer.name === '[Workflo] MCP Dev Server') {
+          if (this.enterpriseAuth) {
+            try {
+              const jwt = await this.enterpriseAuth.getJwt()
+              finalHeaders = { ...finalHeaders, Authorization: `Bearer ${jwt}` }
+            } catch (err) {
+              console.warn('[AgentManager] Failed to inject enterprise JWT for MCP Dev Server:', err)
+            }
+          } else {
+            console.warn('[AgentManager] buildMcpServersForAdapter - enterpriseAuth is null, MCP Dev Server will have no auth headers (agent: ' + agentId + ')')
           }
         }
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -331,7 +331,10 @@ export class AgentManager extends EventEmitter {
     for (const entry of mcpEntries) {
       const serverId = typeof entry === 'string' ? entry : (entry as AgentMcpServerEntry).serverId
       const mcpServer = this.db.getMcpServer(serverId)
-      if (!mcpServer) continue
+      if (!mcpServer) {
+        console.warn(`[AgentManager] buildMcpServersForAdapter - MCP server not found in DB, skipping: ${serverId} (agent: ${agentId})`)
+        continue
+      }
 
       if (mcpServer.type === 'local') {
         // Inject TASK_API_URL for the task-management MCP server

--- a/src/main/enterprise-sync.test.ts
+++ b/src/main/enterprise-sync.test.ts
@@ -750,3 +750,105 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
     })
   })
 })
+
+// ── Sync Ordering: MCP servers before agents ──────────────────────────────
+
+describe('EnterpriseSyncManager — MCP servers synced before agents', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockDb: any
+  let mockApiClient: Record<string, ReturnType<typeof vi.fn>>
+  let syncManager: EnterpriseSyncManager
+
+  beforeEach(() => {
+    mockDb = {
+      db: {
+        pragma: vi.fn().mockReturnValue([{ name: 'enterprise_skill_id' }, { name: 'uses_at_last_sync' }]),
+        exec: vi.fn()
+      },
+      getSkills: vi.fn().mockReturnValue([]),
+      getSkill: vi.fn(),
+      getSkillByName: vi.fn().mockReturnValue(undefined),
+      getSkillByEnterpriseId: vi.fn().mockReturnValue(undefined),
+      getDeletedEnterpriseSkills: vi.fn().mockReturnValue([]),
+      createSkill: vi.fn().mockImplementation((data) => ({ id: 'new-local-id', ...data })),
+      updateSkill: vi.fn().mockImplementation((id, data) => ({ id, ...data })),
+      deleteSkill: vi.fn(),
+      hardDeleteSkill: vi.fn().mockReturnValue(true),
+      getAgents: vi.fn().mockReturnValue([]),
+      createAgent: vi.fn(),
+      updateAgent: vi.fn(),
+      getMcpServers: vi.fn().mockReturnValue([]),
+      createMcpServer: vi.fn(),
+      updateMcpServer: vi.fn(),
+      getTaskSources: vi.fn().mockReturnValue([]),
+      createTaskSource: vi.fn()
+    }
+
+    mockApiClient = {
+      listOrgNodes: vi.fn().mockResolvedValue([]),
+      getOrgNode: vi.fn().mockResolvedValue({
+        node: makeOrgNode(),
+        mcpServers: [],
+        taskSources: []
+      }),
+      listSkills: vi.fn().mockResolvedValue([]),
+      batchSyncSkills: vi.fn().mockResolvedValue({ created: 0, updated: 0, skills: [] }),
+      createSkill: vi.fn().mockResolvedValue(makeServerSkill()),
+      updateSkill: vi.fn().mockResolvedValue(makeServerSkill()),
+      deleteSkill: vi.fn().mockResolvedValue(undefined),
+      updateOrgNode: vi.fn().mockResolvedValue(makeOrgNode()),
+      cleanupDuplicateSkills: vi.fn().mockResolvedValue({ deleted: 0, kept: 0 })
+    }
+
+    syncManager = new EnterpriseSyncManager(mockDb as never, mockApiClient as never)
+  })
+
+  it('should sync MCP servers before agents so agent MCP references resolve', async () => {
+    const callOrder: string[] = []
+
+    // Node has both agents and MCP servers
+    const node = makeOrgNode({
+      agents: [{
+        id: 'agent-1',
+        name: 'Test Agent',
+        config: { coding_agent: 'codex' },
+        mcpServerIds: ['mcp-srv-1'],
+        systemPrompt: null
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }] as any
+    })
+
+    mockApiClient.listOrgNodes.mockResolvedValue([node])
+
+    // getOrgNode returns MCP server details
+    mockApiClient.getOrgNode.mockResolvedValue({
+      node,
+      mcpServers: [{
+        id: 'mcp-srv-1',
+        name: 'My MCP Server',
+        type: 'local',
+        isActive: true,
+        config: { command: '/usr/bin/mcp', args: [], environment: {} },
+        updatedAt: '2026-03-10T00:00:00Z'
+      }],
+      taskSources: []
+    })
+
+    // Track call order for MCP server creation vs agent creation
+    mockDb.createMcpServer.mockImplementation(() => {
+      callOrder.push('createMcpServer')
+    })
+    mockDb.createAgent.mockImplementation(() => {
+      callOrder.push('createAgent')
+    })
+
+    await syncManager.syncAll('user-1')
+
+    // MCP server should be created BEFORE agent
+    const mcpIdx = callOrder.indexOf('createMcpServer')
+    const agentIdx = callOrder.indexOf('createAgent')
+    expect(mcpIdx).toBeGreaterThanOrEqual(0)
+    expect(agentIdx).toBeGreaterThanOrEqual(0)
+    expect(mcpIdx).toBeLessThan(agentIdx)
+  })
+})

--- a/src/main/enterprise-sync.ts
+++ b/src/main/enterprise-sync.ts
@@ -232,16 +232,13 @@ export class EnterpriseSyncManager {
     node: WorkfloOrgNode,
     result: EnterpriseSyncResult
   ): Promise<void> {
-    // Sync agents from node
-    if (node.agents && node.agents.length > 0) {
-      await this.syncAgents(node.agents, result)
-    }
-
     // Fetch node details to get MCP servers and task sources
+    // MCP servers MUST be synced BEFORE agents so that agent configs
+    // referencing MCP server IDs can be resolved immediately.
     try {
       const detail = await this.apiClient.getOrgNode(node.id)
 
-      // Sync MCP servers
+      // Sync MCP servers FIRST — agents reference these by ID
       if (detail.mcpServers && detail.mcpServers.length > 0) {
         await this.syncMcpServers(detail.mcpServers, result)
       }
@@ -253,6 +250,11 @@ export class EnterpriseSyncManager {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       result.errors.push(`Node ${node.name} detail fetch failed: ${msg}`)
+    }
+
+    // Sync agents AFTER MCP servers so their mcp_servers IDs resolve correctly
+    if (node.agents && node.agents.length > 0) {
+      await this.syncAgents(node.agents, result)
     }
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -564,6 +564,10 @@ app.whenReady().then(async () => {
 
         syncManager.setEnterpriseConnection(apiClient, enterpriseSyncMgr, session.userId, enterpriseStateSyncInstance)
 
+        // Pass enterprise auth to agent manager so it can inject JWT into MCP Dev Server requests.
+        // Without this, buildMcpServersForAdapter sees enterpriseAuth=null after app restart.
+        agentManager.setEnterpriseAuth(enterpriseAuth)
+
         console.log('[Main] Enterprise connection restored on startup (with heartbeat)')
         console.log('[EnterpriseAuth] auth_session_restore_result {"status":"restored"}')
       } else {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1004,6 +1004,11 @@ export function registerIpcHandlers(
 
         // Wire enterprise connection (after state sync is ready)
         syncManager.setEnterpriseConnection(apiClient, enterpriseSyncMgr, session.userId, enterpriseStateSync)
+
+        // Pass enterprise auth to agent manager so it can inject JWT into MCP Dev Server requests.
+        // Without this, buildMcpServersForAdapter sees enterpriseAuth=null and the MCP Dev Server
+        // gets empty auth headers, making it unusable after app restart.
+        agentManager.setEnterpriseAuth(enterpriseAuth)
       } catch (err) {
         console.error('[enterprise] Failed to restore connection:', err)
       }


### PR DESCRIPTION
## Summary
- **Fix enterprise sync race condition**: MCP servers are now synced BEFORE agents (was reversed), so agent configs referencing MCP server IDs resolve immediately instead of silently failing
- **Add ACP spec-compliant transport filtering**: Extract `mcpCapabilities` from the agent's `initialize` response and skip HTTP/SSE servers when the agent doesn't support those transports (with warning logs)
- **Add warning logs for missing MCP servers**: `buildMcpServersForAdapter()` now logs when an MCP server ID referenced by an agent can't be found in the DB, making silent drops visible

## Root Cause
Enterprise sync in `syncNode()` synced agents first, then fetched node details and synced MCP servers. Agents were saved with prefixed MCP server IDs (e.g. `wf_server-123`), but those servers didn't exist in the DB yet. When `buildMcpServersForAdapter()` ran, it silently skipped any unresolved ID with `continue`, causing MCP servers to disappear from ACP sessions.

## Test plan
- [x] Added tests for `extractAgentCapabilities` (6 tests)
- [x] Added tests for `convertMcpServers` transport filtering (8 tests)
- [x] Added test verifying MCP servers are synced before agents in enterprise sync
- [x] All 1088 existing tests pass
- [x] TypeScript build passes (`tsc --build --noEmit`)
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)