### PR TITLE
fix: sync attachments added mid-session into the workspace

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -11,6 +11,7 @@ vi.mock('fs', async (importOriginal) => {
     ...actual,
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
+    copyFileSync: vi.fn(),
     existsSync: vi.fn(() => false),
   }
 })
@@ -50,11 +51,13 @@ vi.mock('./secret-broker', () => ({
 }))
 
 import { mkdir as mkdirAsync, writeFile as writeFileAsync } from 'fs/promises'
-import { existsSync } from 'fs'
+import { existsSync, copyFileSync, mkdirSync } from 'fs'
 
 const mockedMkdirAsync = vi.mocked(mkdirAsync)
 const mockedWriteFileAsync = vi.mocked(writeFileAsync)
 const mockedExistsSync = vi.mocked(existsSync)
+const mockedCopyFileSync = vi.mocked(copyFileSync)
+const mockedMkdirSync = vi.mocked(mkdirSync)
 
 function makeSkillRecord(overrides: Partial<{
   id: string; name: string; description: string; content: string;
@@ -1154,5 +1157,110 @@ describe('AgentManager resumeAdapterSession — SESSION_ENDED for completed task
 
     // Should still throw for non-completed tasks
     await expect(mgr.resumeSession('agent-1', 'task-1', 'old-session-id')).rejects.toThrow()
+  })
+})
+
+describe('syncAttachmentsToWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('copies task attachments from DB storage to workspace/attachments/', () => {
+    const mockDb = {
+      ...createMockDb(),
+      getTask: vi.fn(() => ({
+        id: 'task-1',
+        title: 'Test Task',
+        attachments: [
+          { id: 'att-1', filename: 'design.png', size: 1024, mime_type: 'image/png', added_at: '2026-04-01' },
+          { id: 'att-2', filename: 'spec.pdf', size: 2048, mime_type: 'application/pdf', added_at: '2026-04-02' },
+        ],
+      })),
+      getAttachmentsDir: vi.fn(() => '/data/attachments/task-1'),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+
+    const mgr = new AgentManager(mockDb)
+
+    // All source files exist
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = String(p)
+      if (path.includes('att-1-design.png') || path.includes('att-2-spec.pdf')) return true
+      // destDir doesn't exist yet
+      if (path.endsWith('/attachments')) return false
+      return false
+    })
+
+    const refs = (mgr as any).syncAttachmentsToWorkspace('task-1', '/tmp/ws')
+
+    // Should create the destination directory
+    expect(mockedMkdirSync).toHaveBeenCalledWith('/tmp/ws/attachments', { recursive: true })
+
+    // Should copy both files
+    expect(mockedCopyFileSync).toHaveBeenCalledWith(
+      '/data/attachments/task-1/att-1-design.png',
+      '/tmp/ws/attachments/design.png'
+    )
+    expect(mockedCopyFileSync).toHaveBeenCalledWith(
+      '/data/attachments/task-1/att-2-spec.pdf',
+      '/tmp/ws/attachments/spec.pdf'
+    )
+
+    // Should return references
+    expect(refs).toEqual([
+      '- attachments/design.png',
+      '- attachments/spec.pdf',
+    ])
+  })
+
+  it('returns empty array when task has no attachments', () => {
+    const mockDb = {
+      ...createMockDb(),
+      getTask: vi.fn(() => ({
+        id: 'task-1',
+        title: 'Test Task',
+        attachments: [],
+      })),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+
+    const mgr = new AgentManager(mockDb)
+
+    const refs = (mgr as any).syncAttachmentsToWorkspace('task-1', '/tmp/ws')
+    expect(refs).toEqual([])
+    expect(mockedCopyFileSync).not.toHaveBeenCalled()
+  })
+
+  it('skips missing source files gracefully', () => {
+    const mockDb = {
+      ...createMockDb(),
+      getTask: vi.fn(() => ({
+        id: 'task-1',
+        title: 'Test Task',
+        attachments: [
+          { id: 'att-1', filename: 'exists.txt', size: 100, mime_type: 'text/plain', added_at: '2026-04-01' },
+          { id: 'att-2', filename: 'missing.txt', size: 200, mime_type: 'text/plain', added_at: '2026-04-02' },
+        ],
+      })),
+      getAttachmentsDir: vi.fn(() => '/data/attachments/task-1'),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+
+    const mgr = new AgentManager(mockDb)
+
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = String(p)
+      if (path.includes('att-1-exists.txt')) return true
+      if (path.includes('att-2-missing.txt')) return false
+      if (path.endsWith('/attachments')) return true // destDir already exists
+      return false
+    })
+
+    const refs = (mgr as any).syncAttachmentsToWorkspace('task-1', '/tmp/ws')
+
+    // Only the existing file should be copied
+    expect(mockedCopyFileSync).toHaveBeenCalledTimes(1)
+    expect(mockedCopyFileSync).toHaveBeenCalledWith(
+      '/data/attachments/task-1/att-1-exists.txt',
+      '/tmp/ws/attachments/exists.txt'
+    )
+    expect(refs).toEqual(['- attachments/exists.txt'])
   })
 })

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -485,6 +485,35 @@ export class AgentManager extends EventEmitter {
    * Returns the memory file name for an agent based on its type.
    * Claude Code agents use CLAUDE.md; all other agents use AGENTS.md.
    */
+  /**
+   * Syncs task attachments from the database storage directory into the workspace.
+   * Returns an array of relative path references (e.g., "- attachments/file.pdf")
+   * for use in prompts. Safe to call multiple times — already-copied files are
+   * overwritten (cheap for small attachments, guarantees freshness).
+   */
+  private syncAttachmentsToWorkspace(taskId: string, workspaceDir: string): string[] {
+    const task = this.db.getTask(taskId)
+    const refs: string[] = []
+    if (!task?.attachments?.length) return refs
+
+    const attachDir = this.db.getAttachmentsDir(taskId)
+    const destDir = join(workspaceDir, 'attachments')
+    if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true })
+
+    for (const att of task.attachments) {
+      const srcPath = join(attachDir, `${att.id}-${att.filename}`)
+      if (!existsSync(srcPath)) continue
+      const destPath = join(destDir, att.filename)
+      try {
+        copyFileSync(srcPath, destPath)
+        refs.push(`- attachments/${att.filename}`)
+      } catch {
+        continue
+      }
+    }
+    return refs
+  }
+
   private getMemoryFileName(agentId: string): string {
     const agent = this.db.getAgent(agentId)
     const backendType = (agent?.config?.coding_agent as string) || CodingAgentType.OPENCODE
@@ -1332,24 +1361,7 @@ export class AgentManager extends EventEmitter {
         }
 
         // Copy attachments and build references
-        const attachmentRefs: string[] = []
-        if (currentTask?.attachments?.length && workspaceDir) {
-          const attachDir = this.db.getAttachmentsDir(taskId)
-          const destDir = join(workspaceDir, 'attachments')
-          if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true })
-
-          for (const att of currentTask.attachments) {
-            const srcPath = join(attachDir, `${att.id}-${att.filename}`)
-            if (!existsSync(srcPath)) continue
-            const destPath = join(destDir, att.filename)
-            try {
-              copyFileSync(srcPath, destPath)
-              attachmentRefs.push(`- attachments/${att.filename}`)
-            } catch {
-              continue
-            }
-          }
-        }
+        const attachmentRefs = workspaceDir ? this.syncAttachmentsToWorkspace(taskId, workspaceDir) : []
         if (attachmentRefs.length > 0) {
           promptText += `\n\nAttached files (relative to your working directory):\n${attachmentRefs.join('\n')}`
         }
@@ -1857,6 +1869,11 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     let workspaceDir = await this.setupWorktreeIfNeeded(taskId)
     if (!workspaceDir) {
       workspaceDir = this.db.getWorkspaceDir(taskId)
+    }
+
+    // Sync any attachments added since the session was started/last resumed
+    if (workspaceDir) {
+      this.syncAttachmentsToWorkspace(taskId, workspaceDir)
     }
 
     // Build MCP servers config
@@ -2704,6 +2721,12 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       session.pollingStarted = false
     }
     if (!session.adapter) throw new Error('Adapter not initialized')
+
+    // Sync any attachments added mid-session into the workspace so
+    // the agent can reference them immediately.
+    if (session.workspaceDir) {
+      this.syncAttachmentsToWorkspace(session.taskId, session.workspaceDir)
+    }
 
     // Update status to working (but preserve AgentLearning if set)
     session.status = 'working'


### PR DESCRIPTION
## Summary
- **Bug**: Attachments added while a session is active were saved to DB storage but never copied into the workspace directory, making them inaccessible to the agent
- **Fix**: Extracted attachment-syncing logic into a reusable `syncAttachmentsToWorkspace()` method and call it in `resumeAdapterSession()` and `doSendAdapterMessage()` (in addition to the existing `startAdapterSession()` path)
- **Tests**: Added 3 unit tests covering the new method (happy path, empty attachments, missing source files)

## Test plan
- [x] All 1076 existing tests pass
- [x] 3 new tests for `syncAttachmentsToWorkspace` pass
- [x] TypeScript build passes with zero errors
- [x] Full production build succeeds (lint + typecheck + build + test:run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)