### PR TITLE
fix: resolve message duplication on follow-up messages

### DIFF
--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -2660,4 +2660,123 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
       expect(loggedLines.some((line) => line.includes('agent_message_chunk: turnId='))).toBe(false)
     })
   })
+
+  describe('getAllMessages turn state isolation', () => {
+    /**
+     * Regression test for codex message duplication.
+     *
+     * When getAllMessages() is called from replayMissedTranscriptPartsBeforeIdle
+     * after a follow-up response, the session's turn counters have already
+     * advanced. If getAllMessages() processes permanent messages with that
+     * advanced state, historical events get different turn-based IDs
+     * (e.g. agent-response-5 instead of agent-response-1), bypassing
+     * seenPartIds dedup and causing every old message to reappear.
+     *
+     * The fix: getAllMessages() snapshots and resets turn state before
+     * processing, then restores it afterward.
+     */
+    it('getAllMessages produces stable IDs regardless of current session turn state', async () => {
+      const session = createMockSession('test-session')
+      adapterPrivate(adapter).sessions.set('test-session', session)
+
+      // Simulate permanent messages from a session with one assistant response
+      const historyEvents = [
+        {
+          method: 'session/update',
+          params: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'Hello from history' }
+            }
+          }
+        },
+        {
+          method: 'session/update',
+          params: {
+            update: {
+              sessionUpdate: 'tool_call',
+              toolCallId: 'tool-1',
+              kind: 'exec_command',
+              status: 'in_progress',
+              rawInput: { command: 'ls' }
+            }
+          }
+        },
+        {
+          method: 'session/update',
+          params: {
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: 'tool-1',
+              kind: 'exec_command',
+              status: 'completed',
+              rawOutput: { stdout: 'file.txt' }
+            }
+          }
+        },
+        {
+          method: 'session/update',
+          params: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'After tool call' }
+            }
+          }
+        }
+      ]
+
+      session.permanentMessages.push(...historyEvents)
+
+      // First call: session is fresh (like during resumeSession)
+      const firstResult = await adapter.getAllMessages('test-session', {} as any)
+      const firstPartIds = firstResult.flatMap(m => m.parts.map(p => p.id))
+
+      // Now simulate what happens after a follow-up: advance turn state
+      // as if the agent had already responded to a second prompt
+      session.currentTurnId = 5
+      session.activeTurnId = 5
+      session.currentUserTurnId = 2
+      session.lastChunkTime = Date.now()
+      session.lastSessionUpdateType = 'agent_message_chunk'
+      session.pendingAssistantTurnSplit = true
+
+      // Second call: session state is advanced (like during replayMissedTranscriptPartsBeforeIdle)
+      const secondResult = await adapter.getAllMessages('test-session', {} as any)
+      const secondPartIds = secondResult.flatMap(m => m.parts.map(p => p.id))
+
+      // Part IDs should be identical regardless of session turn state
+      expect(secondPartIds).toEqual(firstPartIds)
+    })
+
+    it('getAllMessages restores session turn state after processing', async () => {
+      const session = createMockSession('test-session')
+      adapterPrivate(adapter).sessions.set('test-session', session)
+
+      session.permanentMessages.push({
+        method: 'session/update',
+        params: {
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Test message' }
+          }
+        }
+      })
+
+      // Set specific turn state
+      session.currentTurnId = 7
+      session.activeTurnId = 7
+      session.currentUserTurnId = 3
+      session.pendingAssistantTurnSplit = true
+      session.lastSessionUpdateType = 'tool_call'
+
+      await adapter.getAllMessages('test-session', {} as any)
+
+      // Turn state should be restored to pre-call values
+      expect(session.currentTurnId).toBe(7)
+      expect(session.activeTurnId).toBe(7)
+      expect(session.currentUserTurnId).toBe(3)
+      expect(session.pendingAssistantTurnSplit).toBe(true)
+      expect(session.lastSessionUpdateType).toBe('tool_call')
+    })
+  })
 })

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -783,6 +783,36 @@ export class AcpAdapter implements CodingAgentAdapter {
     // Use a Map to keep only the latest version of each part (by ID)
     const partsByIdAndRole = new Map<string, MessagePart>()
 
+    // Snapshot turn-related session state before processing.
+    // convertAcpEventToMessageParts() mutates turn counters (currentTurnId,
+    // activeTurnId, pendingAssistantTurnSplit, etc.) as it processes events.
+    // When getAllMessages() is called from replayMissedTranscriptPartsBeforeIdle
+    // AFTER a follow-up response, the session state has already advanced.
+    // Re-processing all permanent messages from the beginning with that
+    // advanced state produces DIFFERENT turn-based IDs (e.g. agent-response-5
+    // instead of agent-response-1), which bypass the seenPartIds dedup and
+    // cause every historical message to appear again in the transcript.
+    // By resetting to zero and restoring afterward, we ensure getAllMessages()
+    // always generates deterministic, stable IDs from the permanent history.
+    const savedTurnState = {
+      currentTurnId: session.currentTurnId,
+      activeTurnId: session.activeTurnId,
+      currentUserTurnId: session.currentUserTurnId,
+      lastChunkTime: session.lastChunkTime,
+      lastSessionUpdateType: session.lastSessionUpdateType,
+      pendingAssistantTurnSplit: session.pendingAssistantTurnSplit,
+      toolCallMetadata: new Map(session.toolCallMetadata),
+    }
+
+    // Reset to initial state so turn IDs are computed deterministically
+    session.currentTurnId = 0
+    session.activeTurnId = null
+    session.currentUserTurnId = 0
+    session.lastChunkTime = null
+    session.lastSessionUpdateType = null
+    session.pendingAssistantTurnSplit = false
+    session.toolCallMetadata = new Map()
+
     // Process all permanent messages
     for (const event of session.permanentMessages) {
       const parts = this.convertAcpEventToMessageParts(
@@ -802,6 +832,17 @@ export class AcpAdapter implements CodingAgentAdapter {
         }
       }
     }
+
+    // Restore live session state so polling / follow-up prompts continue
+    // from where they left off. The turn IDs computed above are only used
+    // for the returned messages — they must not leak into the live session.
+    session.currentTurnId = savedTurnState.currentTurnId
+    session.activeTurnId = savedTurnState.activeTurnId
+    session.currentUserTurnId = savedTurnState.currentUserTurnId
+    session.lastChunkTime = savedTurnState.lastChunkTime
+    session.lastSessionUpdateType = savedTurnState.lastSessionUpdateType
+    session.pendingAssistantTurnSplit = savedTurnState.pendingAssistantTurnSplit
+    session.toolCallMetadata = savedTurnState.toolCallMetadata
 
     const allParts = Array.from(partsByIdAndRole.values())
 

--- a/src/main/adapters/claude-code-adapter.test.ts
+++ b/src/main/adapters/claude-code-adapter.test.ts
@@ -678,3 +678,80 @@ describe('ClaudeCodeAdapter task_progress handling', () => {
     expect(progressUpdate!.tool!.title).toContain('15s')
   })
 })
+
+describe('ClaudeCodeAdapter loadSessionHistory stable IDs (regression)', () => {
+  it('convertSDKMessageToParts generates stable IDs using message.id (not streaming UUID)', () => {
+    const adapter = new ClaudeCodeAdapter()
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+
+    // Simulate an assistant message with stable API message ID
+    const chunk = {
+      type: 'assistant',
+      uuid: 'streaming-uuid-123', // unstable streaming UUID
+      message: {
+        id: 'msg_01ABC', // stable API message ID
+        content: [
+          { type: 'text', text: 'Hello from Claude' },
+          { type: 'tool_use', id: 'toolu_01XYZ', name: 'Read', input: { file_path: '/tmp/test' } }
+        ]
+      }
+    }
+
+    const parts = (adapter as any).convertSDKMessageToParts(chunk, seenPartIds, partContentLengths)
+
+    // Text part ID should use stable message ID: `${stableId}-text-${blockIdx}`
+    const textPart = parts.find((p: any) => p.type === 'text')
+    expect(textPart).toBeDefined()
+    expect(textPart!.id).toBe('msg_01ABC-text-0')
+
+    // Tool part ID should use tool_use_id: `tool-${tool_use_id}`
+    const toolPart = parts.find((p: any) => p.type === 'tool')
+    expect(toolPart).toBeDefined()
+    expect(toolPart!.id).toBe('tool-toolu_01XYZ')
+  })
+
+  it('emits update for streaming text parts with grown content', () => {
+    const adapter = new ClaudeCodeAdapter()
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+
+    // First streaming chunk — empty text (partial)
+    const chunk1 = {
+      type: 'assistant',
+      uuid: 'uuid-1',
+      message: { id: 'msg_01DEF', content: [{ type: 'text', text: '' }] }
+    }
+    const parts1 = (adapter as any).convertSDKMessageToParts(chunk1, seenPartIds, partContentLengths)
+    expect(parts1).toHaveLength(1)
+    expect(parts1[0].text).toBe('')
+
+    // Second streaming chunk — same message, text has grown
+    const chunk2 = {
+      type: 'assistant',
+      uuid: 'uuid-2', // different UUID but same message.id
+      message: { id: 'msg_01DEF', content: [{ type: 'text', text: 'Full response text' }] }
+    }
+    const parts2 = (adapter as any).convertSDKMessageToParts(chunk2, seenPartIds, partContentLengths)
+    expect(parts2).toHaveLength(1)
+    expect(parts2[0].update).toBe(true)
+    expect(parts2[0].text).toBe('Full response text')
+  })
+
+  it('surfaces non-error result text when no assistant text was emitted', () => {
+    const adapter = new ClaudeCodeAdapter()
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+
+    const resultMsg = {
+      type: 'result',
+      uuid: 'uuid-result',
+      is_error: false,
+      result: 'Final answer from the agent'
+    }
+
+    const parts = (adapter as any).convertSDKMessageToParts(resultMsg, seenPartIds, partContentLengths)
+    expect(parts).toHaveLength(1)
+    expect(parts[0].text).toBe('Final answer from the agent')
+  })
+})

--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -431,13 +431,19 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
         }
 
         // Parse message content
+        // Use the stable API message ID for part IDs — must match the pattern
+        // in convertSDKMessageToParts so that dedup state from loadSessionHistory
+        // correctly prevents re-emission of historical messages during streaming replay.
+        const stableId = entry.message?.id || entry.uuid || entry.type
         if (entry.message?.content) {
-          for (const contentPart of entry.message.content) {
+          for (let blockIdx = 0; blockIdx < entry.message.content.length; blockIdx++) {
+            const contentPart = entry.message.content[blockIdx]
             if (contentPart.type === 'text') {
               // Skip empty text blocks (corrupt messages)
               if (!contentPart.text || contentPart.text.trim() === '') continue
 
               message.parts.push({
+                id: `${stableId}-text-${blockIdx}`,
                 type: MessagePartType.TEXT,
                 text: contentPart.text,
                 content: contentPart.text
@@ -486,7 +492,8 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
                 }
               }
 
-              message.parts.push({ type: partType as MessagePartType, tool: toolObj })
+              const toolPartId = contentPart.id ? `tool-${contentPart.id}` : `${stableId}-tool_use-${contentPart.id || blockIdx}`
+              message.parts.push({ id: toolPartId, type: partType as MessagePartType, tool: toolObj })
               if (contentPart.id) toolUseParts.set(contentPart.id, toolObj)
             } else if (contentPart.type === 'tool_result' && contentPart.tool_use_id) {
               // Merge result into the matching tool_use part instead of creating separate entry
@@ -1208,18 +1215,37 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
         // For text blocks (no id), use stable message ID + block index for consistent dedup.
         // For tool_use blocks, blockWithProps.id is the tool_use_id which is already stable.
         const partId = `${stableId}-${blockWithProps.type}-${blockWithProps.id || blockIdx}`
-        if (seenPartIds.has(partId)) continue
-        seenPartIds.add(partId)
 
         if (blockWithProps.type === 'text') {
           const text = blockWithProps.text || ''
+          if (seenPartIds.has(partId)) {
+            // Check if text content has grown since last seen (streaming update).
+            // Without this, the first chunk (possibly empty/partial) gets recorded
+            // and all subsequent chunks with the actual text are silently dropped,
+            // causing missing assistant responses in the UI.
+            const previousLength = partContentLengths.get(partId)
+            if (previousLength !== undefined && String(text.length) !== previousLength && text.length > 0) {
+              partContentLengths.set(partId, String(text.length))
+              parts.push({
+                id: partId,
+                type: MessagePartType.TEXT,
+                text,
+                update: true,
+              })
+            }
+            continue
+          }
+          seenPartIds.add(partId)
           partContentLengths.set(partId, String(text.length))
           parts.push({
             id: partId,
             type: MessagePartType.TEXT,
             text,
           })
+        } else if (seenPartIds.has(partId)) {
+          continue
         } else if (blockWithProps.type === 'tool_use') {
+          seenPartIds.add(partId)
           const toolName = blockWithProps.name || 'unknown'
           const rawInput = blockWithProps.input as Record<string, unknown> | undefined
           const input = rawInput ? JSON.stringify(rawInput, null, 2) : undefined
@@ -1469,6 +1495,35 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
             text: errorText,
             role: 'system',
           })
+        }
+      } else {
+        // Non-error result: extract the final assistant text as a safety net.
+        // Normally the text was already sent in a preceding assistant message event,
+        // but if the first streaming chunk had empty text and no subsequent chunk
+        // updated it, the result message is the only source of the final response.
+        const resultText = typeof resultMsg.result === 'string' ? resultMsg.result : ''
+        if (resultText) {
+          // Check if any assistant text part was already emitted with non-empty content.
+          // If so, skip — the text is already shown.  If not, emit it now.
+          let hasNonEmptyText = false
+          for (const [pid, len] of partContentLengths) {
+            if (pid.includes('-text-') && parseInt(len, 10) > 0) {
+              hasNonEmptyText = true
+              break
+            }
+          }
+          if (!hasNonEmptyText) {
+            const partId = `result-text-${msgWithProps.uuid || Date.now()}`
+            if (!seenPartIds.has(partId)) {
+              seenPartIds.add(partId)
+              partContentLengths.set(partId, String(resultText.length))
+              parts.push({
+                id: partId,
+                type: MessagePartType.TEXT,
+                text: resultText,
+              })
+            }
+          }
         }
       }
     } else if (msgWithProps.type === 'system') {

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -940,6 +940,72 @@ describe('AgentManager transitionToIdle — enterprise task completion after fee
     expect(replayCall).toBeDefined()
     expect(sessionWithAdapter.seenPartIds.has('final-part')).toBe(true)
   })
+
+  it('resumeAdapterSession uses same IDs for batch replay and dedup state (regression: dual-loop bug)', async () => {
+    // This test ensures the batch replay IDs and dedup state IDs are identical.
+    // Previously, two separate loops each called Date.now() + Math.random() for
+    // parts without an id, producing different IDs — causing message duplication
+    // on follow-up messages.
+    const mockDb = createMockDb({})
+    const mgr = new AgentManager(mockDb)
+    const sendSpy = vi.spyOn(mgr as any, 'sendToRenderer')
+
+    const adapter = {
+      initialize: vi.fn(async () => {}),
+      resumeSession: vi.fn(async () => [
+        {
+          id: 'msg-1',
+          role: MessageRole.ASSISTANT,
+          parts: [
+            // Part WITHOUT an id — triggers random ID generation
+            { type: MessagePartType.TEXT, text: 'Hello world', content: 'Hello world' },
+          ]
+        },
+        {
+          id: 'msg-2',
+          role: MessageRole.ASSISTANT,
+          parts: [
+            // Part WITH an id — uses stable id
+            { id: 'stable-part-id', type: MessagePartType.TEXT, text: 'Stable', content: 'Stable' },
+          ]
+        }
+      ]),
+    }
+
+    vi.spyOn(mgr as any, 'getAdapter').mockReturnValue(adapter)
+    vi.spyOn(mgr as any, 'db', 'get').mockReturnValue({
+      ...mockDb,
+      getWorkspaceDir: vi.fn(() => '/tmp/ws'),
+    })
+
+    await (mgr as any).resumeAdapterSession(adapter, 'agent-1', 'task-1', 'session-1', {
+      replayToRenderer: true
+    })
+
+    // Get the batch messages sent to renderer
+    const batchCall = sendSpy.mock.calls.find(
+      ([channel]) => channel === 'agent:output-batch'
+    )
+    expect(batchCall).toBeDefined()
+    const batchMessages = (batchCall![1] as any).messages as Array<{ id: string }>
+
+    // Get the session's dedup state
+    const session = (mgr as any).sessions.get('session-1')
+    expect(session).toBeDefined()
+
+    // CRITICAL: Every batch message ID must be in the dedup state
+    for (const msg of batchMessages) {
+      expect(session.seenPartIds.has(msg.id)).toBe(true)
+    }
+
+    // Stable part should use its own id
+    expect(batchMessages.find((m: { id: string }) => m.id === 'stable-part-id')).toBeDefined()
+    expect(session.seenPartIds.has('stable-part-id')).toBe(true)
+
+    // Message-level IDs should also be tracked for codex-style message dedup
+    expect(session.seenMessageIds.has('msg-1')).toBe(true)
+    expect(session.seenMessageIds.has('msg-2')).toBe(true)
+  })
 })
 
 describe('AgentManager shutdown', () => {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -2000,13 +2000,33 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
 
     const shouldReplayToRenderer = options?.replayToRenderer !== false
 
-    // Replay messages to renderer in a single batch to avoid UI freeze
-    if (shouldReplayToRenderer) {
-      const batchMessages: Array<{ id: string; role: string; content: string; partType?: string; tool?: unknown; taskProgress?: unknown }> = []
-      for (const message of messages) {
-        for (const part of message.parts) {
+    // Build replay batch AND dedup state in a SINGLE pass so that both use
+    // the same generated IDs.  Previously two separate loops each called
+    // `Date.now() + Math.random()` for parts without an id, producing
+    // different IDs.  The frontend's `seen` set then held the batch IDs while
+    // the session's seenPartIds held different IDs, so when polling started
+    // on a follow-up message the streaming replay (with yet another set of
+    // stableId-based IDs) was not deduped by either — causing every
+    // historical message to appear twice.
+    const batchMessages: Array<{ id: string; role: string; content: string; partType?: string; tool?: unknown; taskProgress?: unknown }> = []
+    const resumedSeenMessageIds = new Set<string>()
+    const resumedSeenPartIds = new Set<string>()
+    const resumedPartContentLengths = new Map<string, string>()
+    for (const message of messages) {
+      // Track message-level IDs so adapters that dedup by message ID
+      // (e.g. Codex pollMessages) won't re-send historical messages.
+      if (message.id) resumedSeenMessageIds.add(message.id)
+      for (const part of message.parts) {
+        const partId = part.id || `${message.role}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+        // Dedup state
+        resumedSeenPartIds.add(partId)
+        if (part.content || part.text) {
+          resumedPartContentLengths.set(partId, String((part.content || part.text || '').length))
+        }
+        // Batch message (only if we're replaying to the renderer)
+        if (shouldReplayToRenderer) {
           batchMessages.push({
-            id: part.id || `${message.role}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            id: partId,
             role: message.role,
             content: part.content || part.text || '',
             partType: part.type,
@@ -2015,28 +2035,13 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           })
         }
       }
-      if (batchMessages.length > 0) {
-        this.sendToRenderer('agent:output-batch', {
-          sessionId: adapterSessionId,
-          taskId,
-          messages: batchMessages
-        })
-      }
     }
-
-    // Build dedup state from replayed messages so that when polling starts
-    // (on follow-up message), it won't re-send messages already shown in the UI.
-    const resumedSeenMessageIds = new Set<string>()
-    const resumedSeenPartIds = new Set<string>()
-    const resumedPartContentLengths = new Map<string, string>()
-    for (const message of messages) {
-      for (const part of message.parts) {
-        const partId = part.id || `${message.role}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-        resumedSeenPartIds.add(partId)
-        if (part.content || part.text) {
-          resumedPartContentLengths.set(partId, String((part.content || part.text || '').length))
-        }
-      }
+    if (shouldReplayToRenderer && batchMessages.length > 0) {
+      this.sendToRenderer('agent:output-batch', {
+        sessionId: adapterSessionId,
+        taskId,
+        messages: batchMessages
+      })
     }
 
     // Store session in sessions map — idle until user sends a message


### PR DESCRIPTION
## Summary

- **Re-applies the fix from e5ad3e6** that was inadvertently regressed by 02f34fb (sync attachments PR #213)
- **Merges the dual-loop in `resumeAdapterSession`** back into a single pass so batch replay IDs and dedup state IDs are identical — prevents historical messages from being re-sent on follow-up messages
- **Restores stable part ID generation** in `loadSessionHistory` (`${stableId}-text-${blockIdx}`) so dedup state matches streaming replay IDs
- **Restores streaming text update detection** — when first chunk has empty text and subsequent chunks have real content, they're now emitted as updates instead of silently dropped
- **Adds `message.id` to `resumedSeenMessageIds`** so codex-style message-level dedup works after resume

## Root Cause

Commit 02f34fb split the single-pass loop in `resumeAdapterSession` back into two separate loops. Each loop called `Date.now() + Math.random()` for parts without stable IDs, producing different random IDs. The frontend's `seen` set held the batch IDs while the session's `seenPartIds` held different IDs, so when polling started on a follow-up message, historical messages were not deduped — causing every previous agent message to appear twice.

## Test plan

- [x] All 1086 existing tests pass
- [x] Added regression test: `resumeAdapterSession uses same IDs for batch replay and dedup state`
- [x] Added regression test: `convertSDKMessageToParts generates stable IDs using message.id`
- [x] Added regression test: `emits update for streaming text parts with grown content`
- [x] Added regression test: `surfaces non-error result text when no assistant text was emitted`
- [x] Lint, typecheck, and build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)