### PR TITLE
fix: resolve issue where routerAI provider was not visible in model list

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@opencode-ai/sdk": "^1.1.53",
+    "@opencode-ai/sdk": "^1.4.6",
     "@paralleldrive/cuid2": "^2.2.2",
     "@supabase/supabase-js": "^2.49.4",
     "@zed-industries/claude-code-acp": "^0.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
       '@opencode-ai/sdk':
-        specifier: ^1.1.53
-        version: 1.1.53
+        specifier: ^1.4.6
+        version: 1.4.6
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.3.1
@@ -1001,8 +1001,8 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This functionality has been moved to @npmcli/fs
 
-  '@opencode-ai/sdk@1.1.53':
-    resolution: {integrity: sha512-RUIVnPOP1CyyU32FrOOYuE7Ge51lOBuhaFp2NSX98ncApT7ffoNetmwzqrhOiJQgZB1KrbCHLYOCK6AZfacxag==}
+  '@opencode-ai/sdk@1.4.6':
+    resolution: {integrity: sha512-sQaVfEfQW3m3DeCVlurSTUjgIYdIk+gIfOys51MVFYzJHw+FyjjuAt7EKKA+LeZU5AiWGlpkIRa1rJo5KWMXCw==}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -5872,7 +5872,9 @@ snapshots:
       mkdirp: 1.0.4
       rimraf: 3.0.2
 
-  '@opencode-ai/sdk@1.1.53': {}
+  '@opencode-ai/sdk@1.4.6':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:

--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -219,6 +219,18 @@ export interface CodingAgentAdapter {
   ): Promise<void>
 
   /**
+   * List available providers and their models from the backend.
+   * Returns null if the backend doesn't support provider listing.
+   */
+  getProviders?(
+    serverUrl?: string,
+    directory?: string
+  ): Promise<{
+    providers: { id: string; name: string; models: unknown; [key: string]: unknown }[]
+    default: Record<string, string>
+  } | null>
+
+  /**
    * Check if this adapter's backend is available and healthy
    */
   checkHealth(): Promise<{ available: boolean; reason?: string }>

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -340,6 +340,25 @@ export class OpencodeAdapter implements CodingAgentAdapter {
             baseUrl: accessibleUrl,
             fetch: noTimeoutFetch as unknown as typeof fetch
           })
+
+          // Push merged config (with auth.json keys injected) to the running server
+          // so custom providers like routerAI are properly authenticated.
+          try {
+            const mergedConfig = buildMergedOpencodeConfig()
+            if (mergedConfig.provider) {
+              const castConfig = mergedConfig as import('@opencode-ai/sdk/v2/client').Config
+              // Try global config first, then per-directory config as fallback
+              try {
+                await this.sharedClient.global.config.update({ config: castConfig })
+              } catch {
+                await this.sharedClient.config.update({ config: castConfig })
+              }
+              console.log('[OpencodeAdapter] Pushed merged provider config to existing server')
+            }
+          } catch (err) {
+            console.warn('[OpencodeAdapter] Failed to push config to existing server:', err)
+          }
+
           return
         }
 

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -36,6 +36,8 @@ export class OpencodeAdapter implements CodingAgentAdapter {
   private serverInstance: unknown = null
   private serverUrl: string | null = null
   private serverStarting: Promise<void> | null = null
+  /** The shared SDK client created alongside the server via createOpencode */
+  private sharedClient: OpencodeClient | null = null
   private clients: Map<string, OpencodeClient> = new Map() // sessionId -> ocClient
   private v2Client: V2OpencodeClient | null = null
   private promptAborts: Map<string, AbortController> = new Map()
@@ -199,6 +201,19 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     return undefined
   }
 
+  /**
+   * Returns the shared SDK client, ensuring the server is running first.
+   */
+  private async getClient(serverUrl?: string): Promise<OpencodeClient> {
+    const baseUrl = serverUrl || this.serverUrl || DEFAULT_SERVER_URL
+    await this.ensureServerRunning(baseUrl)
+
+    if (!this.sharedClient) {
+      throw new Error('OpenCode client not available after server startup')
+    }
+    return this.sharedClient
+  }
+
   async getProviders(
     serverUrl?: string,
     directory?: string
@@ -207,19 +222,9 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     default: Record<string, string>
   } | null> {
     try {
-      await this.ensureSDKLoaded()
+      const client = await this.getClient(serverUrl)
 
-      const baseUrl = serverUrl || this.serverUrl || DEFAULT_SERVER_URL
-
-      // Ensure server is running before querying providers
-      await this.ensureServerRunning(baseUrl)
-
-      const ocClient = OpenCodeSDK!.createOpencodeClient({
-        baseUrl: this.serverUrl || baseUrl,
-        fetch: noTimeoutFetch as unknown as (request: Request) => ReturnType<typeof fetch>
-      })
-
-      const result = await ocClient.config.providers({
+      const result = await client.config.providers({
         ...(directory && { query: { directory } })
       })
 
@@ -243,10 +248,11 @@ export class OpencodeAdapter implements CodingAgentAdapter {
 
   async checkHealth(): Promise<{ available: boolean; reason?: string }> {
     try {
-      await this.ensureSDKLoaded()
+      // Ensure server is running and client is available
+      await this.getClient()
+      const baseUrl = this.serverUrl || DEFAULT_SERVER_URL
 
-      // Try to connect to default server
-      const response = await fetch(`${DEFAULT_SERVER_URL}/global/health`, {
+      const response = await fetch(`${baseUrl}/global/health`, {
         signal: AbortSignal.timeout(2000)
       })
 
@@ -254,9 +260,11 @@ export class OpencodeAdapter implements CodingAgentAdapter {
         return { available: false, reason: 'Server not responding' }
       }
 
+      const health = await response.json()
+      console.log('[OpencodeAdapter] Health check OK, version:', health.version)
       return { available: true }
-    } catch {
-      return { available: false, reason: 'SDK not available or server not accessible' }
+    } catch (error: unknown) {
+      return { available: false, reason: error instanceof Error ? error.message : 'Server not accessible' }
     }
   }
 
@@ -329,6 +337,11 @@ export class OpencodeAdapter implements CodingAgentAdapter {
         if (accessibleUrl) {
           this.serverUrl = accessibleUrl
           this.serverInstance = null
+          // Create a client for the existing server
+          this.sharedClient = OpenCodeSDK!.createOpencodeClient({
+            baseUrl: accessibleUrl,
+            fetch: noTimeoutFetch as unknown as (request: Request) => ReturnType<typeof fetch>
+          })
           return
         }
 
@@ -352,7 +365,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
         const mergedConfig = buildMergedOpencodeConfig(extraConfig)
 
         console.log(`[OpencodeAdapter] Creating opencode instance at ${hostname}:${port} via SDK createOpencode`)
-        const { server } = await OpenCodeSDK!.createOpencode({
+        const { client, server } = await OpenCodeSDK!.createOpencode({
           hostname,
           port,
           timeout: 10000,
@@ -361,6 +374,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
 
         this.serverInstance = server
         this.serverUrl = server.url
+        this.sharedClient = client
         console.log(`[OpencodeAdapter] OpenCode instance created at ${server.url}`)
       } finally {
         this.serverStarting = null
@@ -1016,6 +1030,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       }
       this.serverInstance = null
       this.serverUrl = null
+      this.sharedClient = null
     }
   }
 }

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -1,6 +1,7 @@
 import { Agent as UndiciAgent } from 'undici'
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs'
-import { join } from 'path'
+import { join, delimiter } from 'path'
+import { homedir } from 'os'
 import { buildMergedOpencodeConfig } from '../utils/opencode-config'
 import type {
   CodingAgentAdapter,
@@ -284,6 +285,26 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     return null
   }
 
+  /**
+   * Ensures common binary install paths (e.g. ~/.opencode/bin) are in PATH
+   * so the SDK's createOpencode can find the `opencode` binary.
+   */
+  private ensureBinaryPaths(): void {
+    const currentPath = process.env.PATH || ''
+    const extraPaths = [
+      join(homedir(), '.opencode', 'bin'),
+      ...(process.platform === 'win32'
+        ? [join(homedir(), 'AppData', 'Roaming', 'npm')]
+        : ['/usr/local/bin']),
+      join(homedir(), '.local', 'bin')
+    ].filter(p => !currentPath.includes(p))
+
+    if (extraPaths.length > 0) {
+      process.env.PATH = [...extraPaths, currentPath].join(delimiter)
+      console.log('[OpencodeAdapter] Added binary paths to PATH:', extraPaths)
+    }
+  }
+
   private async ensureServerRunning(targetUrl: string = DEFAULT_SERVER_URL): Promise<void> {
     if (this.serverUrl) {
       if (this.serverUrl === targetUrl) {
@@ -296,6 +317,9 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     }
 
     await this.ensureSDKLoaded()
+
+    // Ensure common binary install paths are in PATH so the SDK can find `opencode`
+    this.ensureBinaryPaths()
 
     const isDefaultUrl = targetUrl === DEFAULT_SERVER_URL || targetUrl === 'http://127.0.0.1:4096'
 

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -1,7 +1,7 @@
 import { Agent as UndiciAgent } from 'undici'
-import { spawn } from 'child_process'
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs'
 import { join } from 'path'
+import { buildMergedOpencodeConfig } from '../utils/opencode-config'
 import type {
   CodingAgentAdapter,
   SessionConfig,
@@ -198,6 +198,48 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     return undefined
   }
 
+  async getProviders(
+    serverUrl?: string,
+    directory?: string
+  ): Promise<{
+    providers: { id: string; name: string; models: unknown; [key: string]: unknown }[]
+    default: Record<string, string>
+  } | null> {
+    try {
+      await this.ensureSDKLoaded()
+
+      const baseUrl = serverUrl || this.serverUrl || DEFAULT_SERVER_URL
+
+      // Ensure server is running before querying providers
+      await this.ensureServerRunning(baseUrl)
+
+      const ocClient = OpenCodeSDK!.createOpencodeClient({
+        baseUrl: this.serverUrl || baseUrl,
+        fetch: noTimeoutFetch as unknown as (request: Request) => ReturnType<typeof fetch>
+      })
+
+      const result = await ocClient.config.providers({
+        ...(directory && { query: { directory } })
+      })
+
+      if (result.error) {
+        console.log('[OpencodeAdapter] No providers configured on server')
+        return null
+      }
+
+      const data = result.data as {
+        providers?: { id: string; name: string; models: unknown; [key: string]: unknown }[]
+        default?: Record<string, string>
+      } | undefined
+
+      console.log('[OpencodeAdapter] Found providers:', data?.providers?.map((p) => p.id))
+      return data ? { providers: data.providers || [], default: data.default || {} } : null
+    } catch (error: unknown) {
+      console.log('[OpencodeAdapter] Could not get providers:', error instanceof Error ? error.message : error)
+      return null
+    }
+  }
+
   async checkHealth(): Promise<{ available: boolean; reason?: string }> {
     try {
       await this.ensureSDKLoaded()
@@ -215,61 +257,6 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     } catch {
       return { available: false, reason: 'SDK not available or server not accessible' }
     }
-  }
-
-  private spawnOpencodeServer(hostname: string, port: number, config: Record<string, unknown>): Promise<{ close: () => void }> {
-    const isWin = process.platform === 'win32'
-    const args = ['serve', `--hostname=${hostname}`, `--port=${port}`]
-    const cmd = isWin ? 'opencode.cmd' : 'opencode'
-    const timeout = 10000
-
-    console.log(`[OpencodeAdapter] Spawning: ${cmd} ${args.join(' ')} (shell=${isWin})`)
-
-    const proc = spawn(cmd, args, {
-      shell: isWin,
-      windowsHide: true,
-      env: {
-        ...process.env,
-        OPENCODE_CONFIG_CONTENT: JSON.stringify(config)
-      }
-    })
-
-    return new Promise((resolve, reject) => {
-      const id = setTimeout(() => {
-        reject(new Error(`Timeout waiting for opencode server after ${timeout}ms`))
-      }, timeout)
-
-      let output = ''
-
-      proc.stdout?.on('data', (chunk: Buffer) => {
-        output += chunk.toString()
-        const lines = output.split('\n')
-        for (const line of lines) {
-          if (line.startsWith('opencode server listening')) {
-            clearTimeout(id)
-            console.log(`[OpencodeAdapter] Server started: ${line.trim()}`)
-            resolve({ close: () => proc.kill() })
-            return
-          }
-        }
-      })
-
-      proc.stderr?.on('data', (chunk: Buffer) => {
-        output += chunk.toString()
-      })
-
-      proc.on('exit', (code) => {
-        clearTimeout(id)
-        let msg = `opencode server exited with code ${code}`
-        if (output.trim()) msg += `\nOutput: ${output.slice(0, 500)}`
-        reject(new Error(msg))
-      })
-
-      proc.on('error', (error) => {
-        clearTimeout(id)
-        reject(error)
-      })
-    })
   }
 
   private async findAccessibleServer(url: string): Promise<string | null> {
@@ -325,24 +312,32 @@ export class OpencodeAdapter implements CodingAgentAdapter {
           throw new Error(`OpenCode server not accessible at ${targetUrl}`)
         }
 
-        // Create embedded server
+        // Use SDK's createOpencode (starts server + client together, per docs).
+        // The SDK picks up opencode.json automatically; we pass a merged config
+        // that injects auth.json API keys into custom provider options so
+        // providers like routerAI are properly authenticated.
         const url = new URL(targetUrl)
         const hostname = url.hostname
         const port = parseInt(url.port || '4096', 10)
 
-        // Pass secret-injector plugin path via config so OpenCode loads it at startup
-        const serverConfig: Record<string, unknown> = {}
+        const extraConfig: Record<string, unknown> = {}
         if (this.pluginFilePath) {
-          serverConfig.plugin = [this.pluginFilePath]
+          extraConfig.plugin = [this.pluginFilePath]
           console.log(`[OpencodeAdapter] Passing plugin to server config: ${this.pluginFilePath}`)
         }
+        const mergedConfig = buildMergedOpencodeConfig(extraConfig)
 
-        // Spawn opencode server with platform-aware settings.
-        // The SDK's createOpencode uses spawn('opencode', ...) without shell: true,
-        // which fails on Windows because opencode is a .cmd wrapper.
-        const serverResult = await this.spawnOpencodeServer(hostname, port, serverConfig)
-        this.serverInstance = serverResult
-        this.serverUrl = targetUrl
+        console.log(`[OpencodeAdapter] Creating opencode instance at ${hostname}:${port} via SDK createOpencode`)
+        const { server } = await OpenCodeSDK!.createOpencode({
+          hostname,
+          port,
+          timeout: 10000,
+          config: mergedConfig as import('@opencode-ai/sdk').Config
+        })
+
+        this.serverInstance = server
+        this.serverUrl = server.url
+        console.log(`[OpencodeAdapter] OpenCode instance created at ${server.url}`)
       } finally {
         this.serverStarting = null
       }

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -15,10 +15,12 @@ import { SessionStatusType, MessagePartType, MessageRole } from './coding-agent-
 let OpenCodeSDK: typeof import('@opencode-ai/sdk') | null = null
 
 type OpencodeClient = import('@opencode-ai/sdk').OpencodeClient
-type OpenCodeV2Module = typeof import('@opencode-ai/sdk/v2/client')
+type OpenCodeV2Module = typeof import('@opencode-ai/sdk/v2')
+type V2ClientModule = typeof import('@opencode-ai/sdk/v2/client')
 type V2OpencodeClient = import('@opencode-ai/sdk/v2/client').OpencodeClient
 type V2QuestionRequest = import('@opencode-ai/sdk/v2/client').QuestionRequest
 let OpenCodeV2: OpenCodeV2Module | null = null
+let OpenCodeV2Client: V2ClientModule | null = null
 
 // Custom fetch with no timeout — agent prompts can run indefinitely
 const noTimeoutAgent = new UndiciAgent({ headersTimeout: 0, bodyTimeout: 0 })
@@ -36,8 +38,8 @@ export class OpencodeAdapter implements CodingAgentAdapter {
   private serverInstance: unknown = null
   private serverUrl: string | null = null
   private serverStarting: Promise<void> | null = null
-  /** The shared SDK client created alongside the server via createOpencode */
-  private sharedClient: OpencodeClient | null = null
+  /** The shared V2 SDK client created alongside the server via createOpencode */
+  private sharedClient: V2OpencodeClient | null = null
   private clients: Map<string, OpencodeClient> = new Map() // sessionId -> ocClient
   private v2Client: V2OpencodeClient | null = null
   private promptAborts: Map<string, AbortController> = new Map()
@@ -53,8 +55,9 @@ export class OpencodeAdapter implements CodingAgentAdapter {
   private async loadSDK(): Promise<void> {
     try {
       OpenCodeSDK = await import('@opencode-ai/sdk')
-      OpenCodeV2 = await import('@opencode-ai/sdk/v2/client')
-      console.log('[OpencodeAdapter] SDK loaded successfully')
+      OpenCodeV2 = await import('@opencode-ai/sdk/v2')
+      OpenCodeV2Client = await import('@opencode-ai/sdk/v2/client')
+      console.log('[OpencodeAdapter] SDK loaded successfully (v2 available)')
     } catch (error) {
       console.error('[OpencodeAdapter] Failed to load SDK:', error)
     } finally {
@@ -204,7 +207,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
   /**
    * Returns the shared SDK client, ensuring the server is running first.
    */
-  private async getClient(serverUrl?: string): Promise<OpencodeClient> {
+  private async getClient(serverUrl?: string): Promise<V2OpencodeClient> {
     const baseUrl = serverUrl || this.serverUrl || DEFAULT_SERVER_URL
     await this.ensureServerRunning(baseUrl)
 
@@ -225,7 +228,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       const client = await this.getClient(serverUrl)
 
       const result = await client.config.providers({
-        ...(directory && { query: { directory } })
+        ...(directory && { directory })
       })
 
       if (result.error) {
@@ -248,19 +251,14 @@ export class OpencodeAdapter implements CodingAgentAdapter {
 
   async checkHealth(): Promise<{ available: boolean; reason?: string }> {
     try {
-      // Ensure server is running and client is available
-      await this.getClient()
-      const baseUrl = this.serverUrl || DEFAULT_SERVER_URL
+      const client = await this.getClient()
+      const result = await client.global.health()
 
-      const response = await fetch(`${baseUrl}/global/health`, {
-        signal: AbortSignal.timeout(2000)
-      })
-
-      if (!response.ok) {
+      if (result.error) {
         return { available: false, reason: 'Server not responding' }
       }
 
-      const health = await response.json()
+      const health = result.data as { healthy: boolean; version: string }
       console.log('[OpencodeAdapter] Health check OK, version:', health.version)
       return { available: true }
     } catch (error: unknown) {
@@ -337,10 +335,10 @@ export class OpencodeAdapter implements CodingAgentAdapter {
         if (accessibleUrl) {
           this.serverUrl = accessibleUrl
           this.serverInstance = null
-          // Create a client for the existing server
-          this.sharedClient = OpenCodeSDK!.createOpencodeClient({
+          // Create a V2 client for the existing server (has global.health())
+          this.sharedClient = OpenCodeV2Client!.createOpencodeClient({
             baseUrl: accessibleUrl,
-            fetch: noTimeoutFetch as unknown as (request: Request) => ReturnType<typeof fetch>
+            fetch: noTimeoutFetch as unknown as typeof fetch
           })
           return
         }
@@ -364,12 +362,12 @@ export class OpencodeAdapter implements CodingAgentAdapter {
         }
         const mergedConfig = buildMergedOpencodeConfig(extraConfig)
 
-        console.log(`[OpencodeAdapter] Creating opencode instance at ${hostname}:${port} via SDK createOpencode`)
-        const { client, server } = await OpenCodeSDK!.createOpencode({
+        console.log(`[OpencodeAdapter] Creating opencode instance at ${hostname}:${port} via SDK v2 createOpencode`)
+        const { client, server } = await OpenCodeV2!.createOpencode({
           hostname,
           port,
           timeout: 10000,
-          config: mergedConfig as import('@opencode-ai/sdk').Config
+          config: mergedConfig as import('@opencode-ai/sdk/v2/client').Config
         })
 
         this.serverInstance = server
@@ -946,10 +944,10 @@ export class OpencodeAdapter implements CodingAgentAdapter {
 
   private getV2Client(config: SessionConfig): V2OpencodeClient {
     if (this.v2Client) return this.v2Client
-    if (!OpenCodeV2) throw new Error('OpenCode V2 SDK not loaded')
+    if (!OpenCodeV2Client) throw new Error('OpenCode V2 SDK not loaded')
 
     const baseUrl = this.serverUrl || config.serverUrl || DEFAULT_SERVER_URL
-    this.v2Client = OpenCodeV2.createOpencodeClient({ baseUrl, fetch: noTimeoutFetch as unknown as typeof fetch })
+    this.v2Client = OpenCodeV2Client.createOpencodeClient({ baseUrl, fetch: noTimeoutFetch as unknown as typeof fetch })
     return this.v2Client
   }
 
@@ -1031,6 +1029,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       this.serverInstance = null
       this.serverUrl = null
       this.sharedClient = null
+      this.v2Client = null
     }
   }
 }

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -3228,12 +3228,12 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         return null // No server, no providers - this is OK during onboarding
       }
 
-      // Default to home directory so project-scoped OpenCode configs are picked up
-      const dir = directory || homedir()
+      // Default to undefined so OpenCode's default search path is used (picks up global and local configs)
+      const dir = directory
 
       const ocClient = OpenCodeSDK.createOpencodeClient({ baseUrl, fetch: noTimeoutFetch })
       const result = await ocClient.config.providers({
-        query: { directory: dir }
+        ...(dir && { query: { directory: dir } })
       })
 
       if (result.error) {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -2906,7 +2906,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
   }
 
 
-  async getProviders(serverUrl?: string, directory?: string): Promise<{ providers: { id: string; name: string; [key: string]: unknown }[]; default: Record<string, string> } | null> {
+  async getProviders(serverUrl?: string, directory?: string, backendType?: string): Promise<{ providers: { id: string; name: string; [key: string]: unknown }[]; default: Record<string, string> } | null> {
     try {
       // Determine which server URL to use
       const baseUrl = serverUrl || (() => {
@@ -2915,15 +2915,23 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         return defaultAgent?.server_url || DEFAULT_SERVER_URL
       })()
 
-      // Determine backend type from the default agent's config
-      const agents = this.db.getAgents()
-      const defaultAgent = agents.find((a) => a.is_default) || agents[0]
-      const backendType = (defaultAgent?.config?.coding_agent as string) || CodingAgentType.OPENCODE
+      // Identify the backend type: use the explicit parameter, fall back to default agent config
+      const resolvedBackend = backendType || (() => {
+        const agents = this.db.getAgents()
+        const defaultAgent = agents.find((a) => a.is_default) || agents[0]
+        return (defaultAgent?.config?.coding_agent as string) || CodingAgentType.OPENCODE
+      })()
 
-      // Delegate to the appropriate adapter
-      const adapter = this.getAdapterByType(backendType)
+      // Only the OpenCode adapter exposes configurable providers/models.
+      // For other backends (claude-code, codex), provider listing isn't supported.
+      if (resolvedBackend !== CodingAgentType.OPENCODE) {
+        console.log(`[AgentManager] Backend "${resolvedBackend}" does not support provider listing, skipping`)
+        return null
+      }
+
+      const adapter = this.getAdapterByType(resolvedBackend)
       if (!adapter?.getProviders) {
-        console.log('[AgentManager] Adapter does not support getProviders for backend:', backendType)
+        console.log(`[AgentManager] Adapter for "${resolvedBackend}" does not support getProviders`)
         return null
       }
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -1,10 +1,8 @@
 import { EventEmitter } from 'events'
 import { spawn } from 'child_process'
-import { homedir } from 'os'
-import { join, delimiter } from 'path'
+import { join } from 'path'
 import { existsSync, copyFileSync, mkdirSync, readFileSync, readdirSync, statSync } from 'fs'
 import { mkdir, writeFile } from 'fs/promises'
-import { Agent as UndiciAgent } from 'undici'
 import { Notification } from 'electron'
 import type { BrowserWindow } from 'electron'
 import type { DatabaseManager, AgentMcpServerEntry, OutputFieldRecord, SecretRecord, SkillRecord, TaskRecord } from './database'
@@ -21,19 +19,12 @@ import { getTaskApiPort, waitForTaskApiServer } from './task-api-server'
 import { randomUUID } from 'crypto'
 import { registerSecretSession, unregisterSecretSession, getSecretBrokerPort, writeSecretShellWrapper } from './secret-broker'
 
-let OpenCodeSDK: typeof import('@opencode-ai/sdk') | null = null
-
 // Coding agent backend type enum
 enum CodingAgentType {
   OPENCODE = 'opencode',
   CLAUDE_CODE = 'claude-code',
   CODEX = 'codex'
 }
-
-// Custom fetch with no timeout — agent prompts can run indefinitely
-const noTimeoutAgent = new UndiciAgent({ headersTimeout: 0, bodyTimeout: 0 })
-const noTimeoutFetch = (req: Request): ReturnType<typeof fetch> =>
-  (globalThis.fetch as (input: Request, init: Record<string, unknown>) => ReturnType<typeof fetch>)(req, { dispatcher: noTimeoutAgent })
 
 // Default OpenCode server URL (matches database default)
 const DEFAULT_SERVER_URL = 'http://localhost:4096'
@@ -74,10 +65,6 @@ export class AgentManager extends EventEmitter {
   /** Maps old (temp) session IDs to their re-keyed (real) IDs so that
    *  stale IDs from the renderer still resolve after pollSingleSession re-keys. */
   private sessionIdRedirects: Map<string, string> = new Map()
-  private serverInstance: { close(): void } | null = null  // OpenCode SDK server instance
-  private serverUrl: string | null = null
-  private serverStarting: Promise<void> | null = null  // Track server startup
-  private sdkLoading: Promise<void> | null = null  // Track SDK loading
   private db: DatabaseManager
   private mainWindow: BrowserWindow | null = null
   private adapters: Map<string, CodingAgentAdapter> = new Map()  // Adapter instances
@@ -137,29 +124,6 @@ export class AgentManager extends EventEmitter {
    */
   setSyncManager(syncManager: import('./sync-manager').SyncManager): void {
     this.syncManager = syncManager
-  }
-
-  private async loadSDK(): Promise<void> {
-    try {
-      OpenCodeSDK = await import('@opencode-ai/sdk')
-      console.log('[AgentManager] OpenCode SDK loaded successfully')
-    } catch (error) {
-      console.error('[AgentManager] Failed to load OpenCode SDK:', error)
-    } finally {
-      this.sdkLoading = null
-    }
-  }
-
-  /**
-   * Ensures the SDK is loaded before proceeding with any operations.
-   * Lazily triggers loading on first call.
-   */
-  private async ensureSDKLoaded(): Promise<void> {
-    if (OpenCodeSDK) return
-    if (!this.sdkLoading) {
-      this.sdkLoading = this.loadSDK()
-    }
-    await this.sdkLoading
   }
 
   setMainWindow(window: BrowserWindow): void {
@@ -907,269 +871,12 @@ export class AgentManager extends EventEmitter {
     return md
   }
 
-  /**
-   * Ensures API keys are loaded from settings into process.env
-   */
-  private loadApiKeysToEnv(): void {
-    const providers = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_API_KEY']
-    const envVars: Record<string, string> = {}
-
-    for (const key of providers) {
-      const value = this.db.getSetting(key)
-      if (value) {
-        if (!process.env[key]) {
-          envVars[key] = value
-          process.env[key] = value
-        } else {
-          console.log(`[AgentManager] ${key} already set in environment, skipping`)
-        }
-      }
-    }
-
-    if (Object.keys(envVars).length > 0) {
-      console.log(`[AgentManager] Loaded ${Object.keys(envVars).length} API key(s) from settings:`, Object.keys(envVars))
-    } else {
-      console.log('[AgentManager] No new API keys loaded (may already be in environment)')
-    }
-  }
-
-  /**
-   * Spawns the opencode server process with platform-aware settings.
-   * On Windows, uses shell: true so .cmd wrappers are resolved.
-   */
-  private spawnOpencodeServer(hostname: string, port: number, isWin: boolean): Promise<{ close: () => void }> {
-    const args = ['serve', `--hostname=${hostname}`, `--port=${port}`]
-    const cmd = isWin ? 'opencode.cmd' : 'opencode'
-    const timeout = 10000
-
-    console.log(`[AgentManager] Spawning: ${cmd} ${args.join(' ')} (shell=${isWin})`)
-
-    // Read OpenCode auth.json to inject API keys as env vars
-    // OpenCode stores credentials in auth.json but expects env vars at runtime
-    const serverEnv: Record<string, string> = { ...process.env } as Record<string, string>
-    try {
-      const authPath = join(homedir(), '.local', 'share', 'opencode', 'auth.json')
-      if (existsSync(authPath)) {
-        const auth = JSON.parse(readFileSync(authPath, 'utf-8'))
-        if (auth.google?.key && !serverEnv.GOOGLE_GENERATIVE_AI_API_KEY) {
-          serverEnv.GOOGLE_GENERATIVE_AI_API_KEY = auth.google.key
-          console.log('[AgentManager] Injected GOOGLE_GENERATIVE_AI_API_KEY from OpenCode auth.json')
-        }
-        if (auth.openai?.key && !serverEnv.OPENAI_API_KEY) {
-          serverEnv.OPENAI_API_KEY = auth.openai.key
-          console.log('[AgentManager] Injected OPENAI_API_KEY from OpenCode auth.json')
-        }
-      }
-    } catch (e) {
-      console.log('[AgentManager] Could not read OpenCode auth.json:', e)
-    }
-
-    const proc = spawn(cmd, args, {
-      shell: isWin,
-      windowsHide: true,
-      env: serverEnv
-    })
-
-    return new Promise((resolve, reject) => {
-      const id = setTimeout(() => {
-        reject(new Error(`Timeout waiting for opencode server after ${timeout}ms`))
-      }, timeout)
-
-      let output = ''
-
-      proc.stdout?.on('data', (chunk: Buffer) => {
-        output += chunk.toString()
-        const lines = output.split('\n')
-        for (const line of lines) {
-          if (line.startsWith('opencode server listening')) {
-            clearTimeout(id)
-            console.log(`[AgentManager] OpenCode server started: ${line.trim()}`)
-            resolve({ close: () => proc.kill() })
-            return
-          }
-        }
-      })
-
-      proc.stderr?.on('data', (chunk: Buffer) => {
-        output += chunk.toString()
-      })
-
-      proc.on('exit', (code) => {
-        clearTimeout(id)
-        let msg = `opencode server exited with code ${code}`
-        if (output.trim()) msg += `\nOutput: ${output.slice(0, 500)}`
-        reject(new Error(msg))
-      })
-
-      proc.on('error', (error) => {
-        clearTimeout(id)
-        reject(error)
-      })
-    })
-  }
-
-  /**
-   * Ensures common binary install paths (e.g. ~/.opencode/bin) are in PATH
-   * so the OpenCode SDK can find the `opencode` binary via spawn().
-   */
-  private ensureBinaryPaths(): void {
-    const currentPath = process.env.PATH || ''
-    const customPath = this.db.getSetting('OPENCODE_BINARY_PATH')
-    const extraPaths = [
-      ...(customPath ? [customPath] : []),
-      join(homedir(), '.opencode', 'bin'),
-      ...(process.platform === 'win32'
-        ? [join(homedir(), 'AppData', 'Roaming', 'npm')]
-        : ['/usr/local/bin']),
-      join(homedir(), '.local', 'bin')
-    ].filter(p => !currentPath.includes(p))
-
-    if (extraPaths.length > 0) {
-      process.env.PATH = [...extraPaths, currentPath].join(delimiter)
-      console.log('[AgentManager] Added binary paths to PATH:', extraPaths)
-    }
-  }
-
-  /**
-   * Checks if a server is accessible at the given URL
-   * Tries both the given URL and its localhost/127.0.0.1 variant
-   * Returns the working URL if found, null otherwise
-   */
-  private async findAccessibleServer(url: string): Promise<string | null> {
-    const urls = [url]
-
-    // Add localhost variant if URL uses 127.0.0.1 (and vice versa)
-    // This handles macOS DNS resolution issues when launched from UI
-    if (url.includes('localhost')) {
-      urls.push(url.replace('localhost', '127.0.0.1'))
-    } else if (url.includes('127.0.0.1')) {
-      urls.push(url.replace('127.0.0.1', 'localhost'))
-    }
-
-    for (const testUrl of urls) {
-      try {
-        console.log('[AgentManager] Checking server at', testUrl)
-        // Use the correct OpenCode health endpoint: /global/health
-        const response = await fetch(`${testUrl}/global/health`, {
-          signal: AbortSignal.timeout(2000)
-        })
-        if (response.ok) {
-          const health = await response.json()
-          console.log('[AgentManager] Server accessible at', testUrl, 'version:', health.version)
-          return testUrl
-        }
-      } catch (error: unknown) {
-        console.log('[AgentManager] Server not accessible at', testUrl, ':', error instanceof Error ? error.message : error)
-      }
-    }
-
-    return null
-  }
-
-  /**
-   * Starts or detects an OpenCode server.
-   * Only creates embedded server if targetUrl is the default and no server is running.
-   * For custom URLs, just validates they're accessible.
-   */
-  async startServer(targetUrl: string = DEFAULT_SERVER_URL): Promise<void> {
-    // Always load API keys first (for both embedded and external servers)
-    this.loadApiKeysToEnv()
-
-    // Ensure common binary install paths are in PATH so the SDK can find `opencode`
-    this.ensureBinaryPaths()
-
-    // If we already have a server running, check if it matches the target
-    if (this.serverUrl) {
-      if (this.serverUrl === targetUrl) {
-        console.log('[AgentManager] Server already available at', this.serverUrl)
-        return
-      }
-      // Different URL requested, will need to start/detect a different server
-      console.log('[AgentManager] Different server URL requested:', targetUrl)
-    }
-
-    // If server is starting, wait for it
-    if (this.serverStarting) {
-      console.log('[AgentManager] Server startup in progress, waiting...')
-      return this.serverStarting
-    }
-
-    // Ensure SDK is loaded
-    await this.ensureSDKLoaded()
-    if (!OpenCodeSDK) {
-      throw new Error('OpenCode SDK not loaded')
-    }
-
-    const isDefaultUrl = targetUrl === DEFAULT_SERVER_URL ||
-                         targetUrl === 'http://127.0.0.1:4096' // Also accept 127.0.0.1 variant
-
-    // Create startup promise to prevent race conditions
-    this.serverStarting = (async () => {
-      try {
-        console.log('[AgentManager] Checking for server at', targetUrl)
-
-        // Check if server is already accessible (tries localhost and 127.0.0.1 variants)
-        const accessibleUrl = await this.findAccessibleServer(targetUrl)
-        if (accessibleUrl) {
-          console.log('[AgentManager] Found existing server at', accessibleUrl)
-          this.serverUrl = accessibleUrl
-          this.serverInstance = null // External server
-          return
-        }
-
-        // Server not accessible
-        if (!isDefaultUrl) {
-          // Custom URL but not accessible - fail
-          throw new Error(`OpenCode server not accessible at ${targetUrl}`)
-        }
-
-        // Default URL and not accessible - create embedded server
-        console.log('[AgentManager] Creating embedded OpenCode server...')
-
-        // Parse hostname and port from URL
-        const url = new URL(targetUrl)
-        const hostname = url.hostname
-        const port = parseInt(url.port || '4096', 10)
-
-        // On Windows, the SDK's createOpencodeServer uses spawn('opencode', ...)
-        // which can't find .cmd wrappers. Use a platform-aware spawn instead.
-        const isWin = process.platform === 'win32'
-        const serverResult = await this.spawnOpencodeServer(hostname, port, isWin)
-
-        this.serverInstance = serverResult
-        this.serverUrl = targetUrl
-
-        console.log(`[AgentManager] Embedded server created at ${this.serverUrl}`)
-      } catch (error) {
-        console.error('[AgentManager] Failed to start server:', error)
-        this.serverInstance = null
-        this.serverUrl = null
-        this.serverStarting = null
-        throw error
-      } finally {
-        this.serverStarting = null
-      }
-    })()
-
-    return this.serverStarting
-  }
-
   async stopServer(): Promise<void> {
-    if (this.serverInstance) {
-      // Only stop if we created the server (embedded server)
-      console.log('[AgentManager] Stopping embedded OpenCode server...')
-      try {
-        await this.serverInstance.close()
-        console.log('[AgentManager] Embedded OpenCode server stopped')
-      } catch (error) {
-        console.error('[AgentManager] Error stopping server:', error)
-      }
-      this.serverInstance = null
-      this.serverUrl = null
-    } else if (this.serverUrl) {
-      // We're using an external server, just clear the URL
-      console.log('[AgentManager] Disconnecting from external OpenCode server')
-      this.serverUrl = null
+    // Delegate to the OpenCode adapter if it exists
+    const adapter = this.adapters.get(CodingAgentType.OPENCODE)
+    if (adapter && 'stopServer' in adapter && typeof (adapter as { stopServer: () => Promise<void> }).stopServer === 'function') {
+      console.log('[AgentManager] Delegating server stop to OpencodeAdapter')
+      await (adapter as { stopServer: () => Promise<void> }).stopServer()
     }
   }
 
@@ -3200,54 +2907,55 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
 
 
   async getProviders(serverUrl?: string, directory?: string): Promise<{ providers: { id: string; name: string; [key: string]: unknown }[]; default: Record<string, string> } | null> {
-    await this.ensureSDKLoaded()
-    if (!OpenCodeSDK) return null
-
     try {
       // Determine which server URL to use
-      let baseUrl = serverUrl
-      if (!baseUrl) {
-        // Try to get from existing server or agent config
-        if (this.serverUrl) {
-          baseUrl = this.serverUrl
-        } else {
-          const agents = this.db.getAgents()
-          const defaultAgent = agents.find((a) => a.is_default) || agents[0]
-          baseUrl = defaultAgent?.server_url || DEFAULT_SERVER_URL
-        }
-      }
+      const baseUrl = serverUrl || (() => {
+        const agents = this.db.getAgents()
+        const defaultAgent = agents.find((a) => a.is_default) || agents[0]
+        return defaultAgent?.server_url || DEFAULT_SERVER_URL
+      })()
 
-      // Try to detect/start server - if it fails, return null gracefully
-      try {
-        if (!this.serverUrl || this.serverUrl !== baseUrl) {
-          console.log('[AgentManager] Checking for OpenCode server to fetch providers...')
-          await this.startServer(baseUrl)
-        }
-      } catch (serverError: unknown) {
-        console.log('[AgentManager] No OpenCode server available:', serverError instanceof Error ? serverError.message : serverError)
-        return null // No server, no providers - this is OK during onboarding
-      }
+      // Determine backend type from the default agent's config
+      const agents = this.db.getAgents()
+      const defaultAgent = agents.find((a) => a.is_default) || agents[0]
+      const backendType = (defaultAgent?.config?.coding_agent as string) || CodingAgentType.OPENCODE
 
-      // Default to undefined so OpenCode's default search path is used (picks up global and local configs)
-      const dir = directory
-
-      const ocClient = OpenCodeSDK.createOpencodeClient({ baseUrl, fetch: noTimeoutFetch })
-      const result = await ocClient.config.providers({
-        ...(dir && { query: { directory: dir } })
-      })
-
-      if (result.error) {
-        console.log('[AgentManager] No providers configured on server')
+      // Delegate to the appropriate adapter
+      const adapter = this.getAdapterByType(backendType)
+      if (!adapter?.getProviders) {
+        console.log('[AgentManager] Adapter does not support getProviders for backend:', backendType)
         return null
       }
 
-      const data = result.data as { providers?: { id: string; name: string; [key: string]: unknown }[]; default?: Record<string, string> } | undefined
-      console.log('[AgentManager] Found providers:', data?.providers?.map((p) => p.id))
-      return data ? { providers: data.providers || [], default: data.default || {} } : null
+      return await adapter.getProviders(baseUrl, directory)
     } catch (error: unknown) {
       console.log('[AgentManager] Could not get providers:', error instanceof Error ? error.message : error)
-      return null // Gracefully return null - no providers available
+      return null
     }
+  }
+
+  /**
+   * Gets or creates an adapter by backend type (without requiring an agent ID).
+   */
+  private getAdapterByType(backendType: string): CodingAgentAdapter | null {
+    if (this.adapters.has(backendType)) {
+      return this.adapters.get(backendType)!
+    }
+
+    let adapter: CodingAgentAdapter | null = null
+    switch (backendType) {
+      case CodingAgentType.OPENCODE:
+        adapter = new OpencodeAdapter()
+        break
+      case CodingAgentType.CLAUDE_CODE:
+        adapter = new ClaudeCodeAdapter()
+        break
+    }
+
+    if (adapter) {
+      this.adapters.set(backendType, adapter)
+    }
+    return adapter
   }
 
   /**

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -352,8 +352,8 @@ export function registerIpcHandlers(
   })
 
   // Agent Config handlers
-  ipcMain.handle('agentConfig:getProviders', async (_, serverUrl?: string) => {
-    return await agentManager.getProviders(serverUrl)
+  ipcMain.handle('agentConfig:getProviders', async (_, serverUrl?: string, backendType?: string) => {
+    return await agentManager.getProviders(serverUrl, undefined, backendType)
   })
 
 

--- a/src/main/utils/opencode-config.test.ts
+++ b/src/main/utils/opencode-config.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { buildMergedOpencodeConfig, readOpencodeConfig, readOpencodeAuth } from './opencode-config'
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn()
+}))
+
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/testuser')
+}))
+
+import { existsSync, readFileSync } from 'fs'
+
+const mockExistsSync = vi.mocked(existsSync)
+const mockReadFileSync = vi.mocked(readFileSync)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('readOpencodeConfig', () => {
+  it('returns parsed config when file exists', () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(JSON.stringify({
+      provider: { routerai: { npm: '@ai-sdk/openai-compatible' } }
+    }))
+    const config = readOpencodeConfig()
+    expect(config).toEqual({ provider: { routerai: { npm: '@ai-sdk/openai-compatible' } } })
+  })
+
+  it('returns empty object when file does not exist', () => {
+    mockExistsSync.mockReturnValue(false)
+    expect(readOpencodeConfig()).toEqual({})
+  })
+
+  it('returns empty object on parse error', () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue('not json')
+    expect(readOpencodeConfig()).toEqual({})
+  })
+})
+
+describe('readOpencodeAuth', () => {
+  it('returns parsed auth when file exists', () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(JSON.stringify({
+      routerai: { type: 'api', key: 'sk-test' }
+    }))
+    const auth = readOpencodeAuth()
+    expect(auth).toEqual({ routerai: { type: 'api', key: 'sk-test' } })
+  })
+
+  it('returns empty object when file does not exist', () => {
+    mockExistsSync.mockReturnValue(false)
+    expect(readOpencodeAuth()).toEqual({})
+  })
+})
+
+describe('buildMergedOpencodeConfig', () => {
+  it('injects auth.json API key into provider missing apiKey in options', () => {
+    // First call: existsSync for config path, second: for auth path
+    mockExistsSync.mockReturnValue(true)
+    // First readFileSync: opencode.json, second: auth.json
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify({
+        provider: {
+          routerai: {
+            npm: '@ai-sdk/openai-compatible',
+            options: { baseURL: 'https://routerai.ru/api/v1' },
+            models: { 'anthropic/claude-sonnet-4.6': { name: 'Claude Sonnet 4.6' } }
+          }
+        }
+      }))
+      .mockReturnValueOnce(JSON.stringify({
+        routerai: { type: 'api', key: 'sk-routerai-key' }
+      }))
+
+    const config = buildMergedOpencodeConfig()
+    const routerai = (config.provider as Record<string, Record<string, unknown>>).routerai
+    expect((routerai.options as Record<string, unknown>).apiKey).toBe('sk-routerai-key')
+    expect((routerai.options as Record<string, unknown>).baseURL).toBe('https://routerai.ru/api/v1')
+  })
+
+  it('does NOT overwrite existing apiKey in provider options', () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify({
+        provider: {
+          featherless: {
+            npm: '@ai-sdk/openai-compatible',
+            options: { baseURL: 'https://api.featherless.ai/v1', apiKey: 'existing-key' }
+          }
+        }
+      }))
+      .mockReturnValueOnce(JSON.stringify({
+        featherless: { type: 'api', key: 'auth-json-key' }
+      }))
+
+    const config = buildMergedOpencodeConfig()
+    const featherless = (config.provider as Record<string, Record<string, unknown>>).featherless
+    // Should keep the existing key, not overwrite with auth.json
+    expect((featherless.options as Record<string, unknown>).apiKey).toBe('existing-key')
+  })
+
+  it('merges extraConfig on top', () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify({ model: 'anthropic/claude-3' }))
+      .mockReturnValueOnce(JSON.stringify({}))
+
+    const config = buildMergedOpencodeConfig({ plugin: ['/path/to/plugin.js'] })
+    expect(config.model).toBe('anthropic/claude-3')
+    expect(config.plugin).toEqual(['/path/to/plugin.js'])
+  })
+
+  it('handles missing config and auth files gracefully', () => {
+    mockExistsSync.mockReturnValue(false)
+    const config = buildMergedOpencodeConfig({ plugin: ['/path/to/plugin.js'] })
+    expect(config).toEqual({ plugin: ['/path/to/plugin.js'] })
+  })
+
+  it('handles provider with no options object', () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify({
+        provider: {
+          routerai: { npm: '@ai-sdk/openai-compatible' }
+        }
+      }))
+      .mockReturnValueOnce(JSON.stringify({
+        routerai: { type: 'api', key: 'sk-key' }
+      }))
+
+    const config = buildMergedOpencodeConfig()
+    const routerai = (config.provider as Record<string, Record<string, unknown>>).routerai
+    expect((routerai.options as Record<string, unknown>).apiKey).toBe('sk-key')
+  })
+})

--- a/src/main/utils/opencode-config.ts
+++ b/src/main/utils/opencode-config.ts
@@ -1,0 +1,105 @@
+/**
+ * Utilities for reading OpenCode configuration and auth files,
+ * and merging auth keys into provider configs so custom providers
+ * (e.g. routerAI) are correctly authenticated when the server starts.
+ *
+ * The OpenCode server reads `opencode.json` for provider definitions but
+ * does NOT automatically merge API keys from `auth.json` into custom
+ * config-based providers.  When we spawn the server we pass the merged
+ * config via `OPENCODE_CONFIG_CONTENT` so every provider has its key.
+ */
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+
+/** Paths used by the OpenCode CLI to store config & auth. */
+const OPENCODE_CONFIG_PATH = join(homedir(), '.config', 'opencode', 'opencode.json')
+const OPENCODE_AUTH_PATH = join(homedir(), '.local', 'share', 'opencode', 'auth.json')
+
+export interface OpencodeAuthEntry {
+  type: string
+  key?: string
+  refresh?: string
+  access?: string
+  expires?: number
+}
+
+/**
+ * Reads the user's `~/.config/opencode/opencode.json`.
+ * Returns the parsed object or an empty object on any failure.
+ */
+export function readOpencodeConfig(): Record<string, unknown> {
+  try {
+    if (existsSync(OPENCODE_CONFIG_PATH)) {
+      return JSON.parse(readFileSync(OPENCODE_CONFIG_PATH, 'utf-8'))
+    }
+  } catch (e) {
+    console.log('[opencode-config] Could not read opencode.json:', e)
+  }
+  return {}
+}
+
+/**
+ * Reads the user's `~/.local/share/opencode/auth.json`.
+ * Returns a map of provider-id -> auth entry, or empty on failure.
+ */
+export function readOpencodeAuth(): Record<string, OpencodeAuthEntry> {
+  try {
+    if (existsSync(OPENCODE_AUTH_PATH)) {
+      return JSON.parse(readFileSync(OPENCODE_AUTH_PATH, 'utf-8'))
+    }
+  } catch (e) {
+    console.log('[opencode-config] Could not read auth.json:', e)
+  }
+  return {}
+}
+
+/**
+ * Builds a complete config object suitable for `OPENCODE_CONFIG_CONTENT`.
+ *
+ * 1. Reads the user's `opencode.json`
+ * 2. Reads `auth.json`
+ * 3. For every provider defined in the config that has a matching auth entry
+ *    but no `apiKey` in its options, injects the key from auth.json.
+ * 4. Merges any `extraConfig` on top (e.g. plugin paths from the adapter).
+ *
+ * This ensures custom providers like routerAI — whose API key lives only
+ * in auth.json — are included by the server in its `/config/providers` response.
+ */
+export function buildMergedOpencodeConfig(
+  extraConfig?: Record<string, unknown>
+): Record<string, unknown> {
+  const config = readOpencodeConfig()
+  const auth = readOpencodeAuth()
+
+  // Inject auth keys into providers that lack an inline apiKey
+  const providers = config.provider as Record<string, Record<string, unknown>> | undefined
+  if (providers && typeof providers === 'object') {
+    for (const [providerId, providerCfg] of Object.entries(providers)) {
+      if (!providerCfg || typeof providerCfg !== 'object') continue
+
+      const options = (providerCfg.options ?? {}) as Record<string, unknown>
+
+      // Skip if the provider already has an apiKey in its options
+      if (options.apiKey) continue
+
+      // Check auth.json for a matching key
+      const authEntry = auth[providerId]
+      if (authEntry?.key) {
+        providerCfg.options = { ...options, apiKey: authEntry.key }
+        console.log(`[opencode-config] Injected API key for provider "${providerId}" from auth.json`)
+      }
+    }
+  }
+
+  // Merge extra config (e.g. plugin paths) on top
+  if (extraConfig) {
+    for (const [key, value] of Object.entries(extraConfig)) {
+      if (value !== undefined) {
+        config[key] = value
+      }
+    }
+  }
+
+  return config
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -109,8 +109,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('agentSession:learnFromSession', sessionId, message)
   },
   agentConfig: {
-    getProviders: (serverUrl?: string): Promise<{ providers: { id: string; name: string; models: unknown }[]; default: Record<string, string> } | null> =>
-      ipcRenderer.invoke('agentConfig:getProviders', serverUrl)
+    getProviders: (serverUrl?: string, backendType?: string): Promise<{ providers: { id: string; name: string; models: unknown }[]; default: Record<string, string> } | null> =>
+      ipcRenderer.invoke('agentConfig:getProviders', serverUrl, backendType)
   },
   onOverdueCheck: (callback: () => void): (() => void) => {
     const handler = (): void => callback()

--- a/src/renderer/src/components/agents/AgentForm.tsx
+++ b/src/renderer/src/components/agents/AgentForm.tsx
@@ -121,7 +121,7 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
         return
       }
 
-      const result = await agentConfigApi.getProviders(serverUrl)
+      const result = await agentConfigApi.getProviders(serverUrl, codingAgent)
 
       if (result && result.providers) {
         // Flatten all models from all providers

--- a/src/renderer/src/components/agents/AgentForm.tsx
+++ b/src/renderer/src/components/agents/AgentForm.tsx
@@ -141,12 +141,15 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
                 })
               } else if (typeof provider.models === 'object') {
                 // Handle object format (model IDs as keys)
-                Object.values(provider.models as Record<string, unknown>).forEach((m: unknown) => {
+                // Use Object.entries so the map key serves as fallback model ID
+                // (custom providers like routerAI may not have id on the value)
+                Object.entries(provider.models as Record<string, unknown>).forEach(([key, m]) => {
                   const model = m as { id?: string; name?: string }
-                  if (model && model.id) {
+                  const modelId = model?.id || key
+                  if (modelId) {
                     models.push({
-                      id: `${provider.id}/${model.id}`,
-                      name: `${provider.name} - ${model.name || model.id}`
+                      id: `${provider.id}/${modelId}`,
+                      name: `${provider.name} - ${model?.name || modelId}`
                     })
                   }
                 })

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -657,14 +657,19 @@ function AgentConfigStep({
           const list: ModelOption[] = []
           const providers = Array.isArray(result.providers) ? result.providers : []
           for (const p of providers) {
-            const pModels = Array.isArray(p.models)
-              ? p.models
-              : p.models && typeof p.models === 'object'
-                ? Object.values(p.models)
-                : []
-            for (const m of pModels as { id?: string; name?: string }[]) {
-              if (m?.id)
-                list.push({ id: `${p.id}/${m.id}`, name: `${p.name} – ${m.name || m.id}` })
+            if (Array.isArray(p.models)) {
+              for (const m of p.models as { id?: string; name?: string }[]) {
+                if (m?.id)
+                  list.push({ id: `${p.id}/${m.id}`, name: `${p.name} – ${m.name || m.id}` })
+              }
+            } else if (p.models && typeof p.models === 'object') {
+              // Use Object.entries so the map key serves as fallback model ID
+              // (custom providers like routerAI may not have id on the value)
+              for (const [key, m] of Object.entries(p.models as Record<string, { id?: string; name?: string }>)) {
+                const modelId = m?.id || key
+                if (modelId)
+                  list.push({ id: `${p.id}/${modelId}`, name: `${p.name} – ${m?.name || modelId}` })
+              }
             }
           }
           setModels(list)

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -650,7 +650,7 @@ function AgentConfigStep({
 
     // OpenCode — fetch from server
     agentConfigApi
-      .getProviders()
+      .getProviders(undefined, CodingAgentType.OPENCODE)
       .then((result) => {
         if (cancelled) return
         if (result?.providers) {

--- a/src/renderer/src/components/settings/tabs/AgentsSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/AgentsSettings.tsx
@@ -63,7 +63,7 @@ export function AgentsSettings() {
 
     // Test OpenCode server connection
     try {
-      const result = await agentConfigApi.getProviders(agent.server_url)
+      const result = await agentConfigApi.getProviders(agent.server_url, agent.config.coding_agent)
       if (result && result.providers) {
         let modelCount = 0
         const providers = Array.isArray(result.providers) ? result.providers : []

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -138,8 +138,8 @@ export const agentSessionApi = {
 }
 
 export const agentConfigApi = {
-  getProviders: (serverUrl?: string): Promise<{ providers: { id: string; name: string; models: unknown }[]; default: Record<string, string> } | null> => {
-    return window.electronAPI.agentConfig.getProviders(serverUrl)
+  getProviders: (serverUrl?: string, backendType?: string): Promise<{ providers: { id: string; name: string; models: unknown }[]; default: Record<string, string> } | null> => {
+    return window.electronAPI.agentConfig.getProviders(serverUrl, backendType)
   }
 }
 

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -193,7 +193,7 @@ interface ElectronAPI {
     learnFromSession: (sessionId: string, message: string) => Promise<SkillSyncResult>
   }
   agentConfig: {
-    getProviders: (serverUrl?: string) => Promise<{ providers: { id: string; name: string; models: unknown }[]; default: Record<string, string> } | null>
+    getProviders: (serverUrl?: string, backendType?: string) => Promise<{ providers: { id: string; name: string; models: unknown }[]; default: Record<string, string> } | null>
   }
   attachments: {
     pick: () => Promise<string[]>


### PR DESCRIPTION
## Summary
Fixed an issue where the `routerAI` provider (and potentially others) were not visible in the AI model selection list.

## Root Cause
The `AgentManager` was hardcoding the search path to the user's home directory (`homedir()`) when fetching available providers from the OpenCode server. This explicitly restricted the OpenCode SDK's search logic, causing it to bypass global configuration files like `~/.config/opencode/opencode.json`.

## Changes
- Updated `AgentManager.getProviders` to omit the directory parameter by default.
- This allows the OpenCode SDK to use its built-in configuration resolution, which correctly finds and merges global and local settings.