### PR TITLE
feat: edit agent from task view + block unconfigured agents

### DIFF
--- a/src/mobile/pages/TaskDetailPage.test.tsx
+++ b/src/mobile/pages/TaskDetailPage.test.tsx
@@ -195,6 +195,74 @@ describe('TaskDetailPage', () => {
     expect(titles).toEqual(['Earlier Subtask', 'Later Subtask'])
   })
 
+  it('blocks Start and shows a config warning when the assigned agent has no provider/model', () => {
+    const unconfiguredAgent = {
+      id: 'agent-1',
+      name: 'Test Agent',
+      server_url: 'http://local:4096',
+      config: {} as Record<string, unknown>,
+      is_default: true,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z'
+    }
+    useAgentStore.setState({ agents: [unconfiguredAgent] })
+    const task = makeTask({ agent_id: 'agent-1' })
+    useTaskStore.setState({ tasks: [task], isLoading: false })
+
+    const { container } = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
+
+    // Warning is visible
+    expect(container.querySelector('[data-testid="agent-config-warning"]')).toBeTruthy()
+    // Start button (exact label) must not render
+    const startButton = Array.from(container.querySelectorAll('button'))
+      .find((b) => b.textContent?.trim() === 'Start')
+    expect(startButton).toBeUndefined()
+  })
+
+  it('blocks Triage and shows a config warning naming the default agent when unconfigured', () => {
+    const unconfiguredDefault = {
+      id: 'agent-default',
+      name: 'Default Agent',
+      server_url: 'http://local:4096',
+      config: { coding_agent: 'claude_code' } as Record<string, unknown>, // missing model
+      is_default: true,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z'
+    }
+    useAgentStore.setState({ agents: [unconfiguredDefault] })
+    const task = makeTask({ agent_id: null })
+    useTaskStore.setState({ tasks: [task], isLoading: false })
+
+    const { container } = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
+
+    const warning = container.querySelector('[data-testid="agent-config-warning"]')
+    expect(warning).toBeTruthy()
+    expect(warning?.textContent).toMatch(/Default Agent/)
+    expect(warning?.textContent).toMatch(/Triage is disabled/i)
+    // Triage button (with exact "Triage" label) must not be present
+    const triageButton = Array.from(container.querySelectorAll('button'))
+      .find((b) => b.textContent?.trim() === 'Triage')
+    expect(triageButton).toBeUndefined()
+  })
+
+  it('does not show a config warning when the assigned agent is fully configured', () => {
+    const configuredAgent = {
+      id: 'agent-ok',
+      name: 'Ready',
+      server_url: 'http://local:4096',
+      config: { coding_agent: 'claude_code', model: 'anthropic/claude-sonnet-4' } as Record<string, unknown>,
+      is_default: true,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z'
+    }
+    useAgentStore.setState({ agents: [configuredAgent] })
+    const task = makeTask({ agent_id: 'agent-ok' })
+    useTaskStore.setState({ tasks: [task], isLoading: false })
+
+    const { container } = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
+    expect(container.querySelector('[data-testid="agent-config-warning"]')).toBeFalsy()
+  })
+
   it('does not crash when task store updates with new object references', () => {
     // Simulates what happens when fetchTasks polling replaces task objects
     const task = makeTask({ id: 'task-1', title: 'Test task' })

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useCallback, useState, useRef } from 'react'
 import { TaskStatus } from '@shared/constants'
+import { isAgentConfigured, getAgentConfigIssue } from '@shared/agent-utils'
 import { CollapsibleDescription } from '../components/CollapsibleDescription'
 import { useTaskStore, type Task } from '../stores/task-store'
 import { useAgentStore, SessionStatus } from '../stores/agent-store'
@@ -242,11 +243,21 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
     )
   }
 
+  // Agent configuration gating — block start/triage when the relevant agent is
+  // missing a provider or model. Mirrors the desktop TaskDetailView behavior.
+  const assignedAgent = task.agent_id ? agents.find((a) => a.id === task.agent_id) : null
+  const triageAgent = !task.agent_id ? (agents.find((a) => a.is_default) || agents[0] || null) : null
+  const assignedAgentConfigured = isAgentConfigured(assignedAgent)
+  const triageAgentConfigured = isAgentConfigured(triageAgent)
+  const unconfiguredAgent = assignedAgent && !assignedAgentConfigured
+    ? assignedAgent
+    : (triageAgent && !triageAgentConfigured ? triageAgent : null)
+
   // Session state logic — don't show Resume if session is already running
-  const canStart = task.agent_id && !task.session_id && (!session || session.status === SessionStatus.IDLE) && task.status !== TaskStatus.Completed
+  const canStart = task.agent_id && assignedAgentConfigured && !task.session_id && (!session || session.status === SessionStatus.IDLE) && task.status !== TaskStatus.Completed
   const canResume = task.agent_id && task.session_id && !isSessionRunning && (!session?.sessionId) && (!session || session.status === SessionStatus.IDLE)
   const canStop = isSessionRunning
-  const canTriage = !task.agent_id && agents.length > 0 && task.status !== TaskStatus.Completed && task.status !== TaskStatus.Triaging && !isSessionRunning
+  const canTriage = !task.agent_id && agents.length > 0 && triageAgentConfigured && task.status !== TaskStatus.Completed && task.status !== TaskStatus.Triaging && !isSessionRunning
   const canComplete = task.status !== TaskStatus.Completed && !isSessionRunning
   const hasMessages = session && session.messages.length > 0
 
@@ -368,6 +379,23 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
                   {session.status === SessionStatus.ERROR && '● Error'}
                   {session.status === SessionStatus.WAITING_APPROVAL && '● Waiting'}
                 </span>
+              )}
+              {unconfiguredAgent && task.status !== TaskStatus.Completed && (
+                <div
+                  data-testid="agent-config-warning"
+                  className="w-full mt-1 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-300"
+                >
+                  <svg className="h-3.5 w-3.5 shrink-0 mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="12" cy="12" r="10" />
+                    <line x1="12" x2="12" y1="8" y2="12" />
+                    <line x1="12" x2="12.01" y1="16" y2="16" />
+                  </svg>
+                  <p className="flex-1 leading-snug">
+                    {assignedAgent
+                      ? `${getAgentConfigIssue(unconfiguredAgent) || 'Agent is not fully configured'}. Start is disabled — edit this agent on desktop to continue.`
+                      : `The default agent "${unconfiguredAgent.name}" is not fully configured (${(getAgentConfigIssue(unconfiguredAgent) || 'missing settings').toLowerCase()}). Triage is disabled — edit the agent on desktop to continue.`}
+                  </p>
+                </div>
               )}
             </div>
 

--- a/src/renderer/src/components/tasks/TaskDetailView.test.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { TaskDetailView } from './TaskDetailView'
-import { TaskStatus } from '@/types'
-import type { WorkfloTask } from '@/types'
+import { CodingAgentType, TaskStatus } from '@/types'
+import type { Agent, WorkfloTask } from '@/types'
 
 // Mock CollapsibleDescription to avoid markdown rendering complexity
 vi.mock('@/components/ui/CollapsibleDescription', () => ({
@@ -60,16 +60,38 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
 
 const noopFn = vi.fn()
 
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'agent-1',
+    name: 'Test Agent',
+    server_url: 'http://localhost:4096',
+    config: {
+      coding_agent: CodingAgentType.CLAUDE_CODE,
+      model: 'anthropic/claude-sonnet-4-20250514'
+    },
+    is_default: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides
+  } as Agent
+}
+
 function renderDetailView(overrides: {
   task?: Partial<WorkfloTask>
+  agents?: Agent[]
   parentTask?: WorkfloTask | null
   onNavigateToTask?: (taskId: string) => void
+  onEditAgent?: (agentId: string) => void
+  onTriage?: () => void
+  canTriage?: boolean
+  onStartAgent?: () => void
+  canStartAgent?: boolean
 } = {}) {
   const task = makeTask(overrides.task)
   return render(
     <TaskDetailView
       task={task}
-      agents={[]}
+      agents={overrides.agents ?? []}
       onEdit={noopFn}
       onDelete={noopFn}
       onUpdateAttachments={noopFn}
@@ -80,6 +102,11 @@ function renderDetailView(overrides: {
       onAddRepos={noopFn}
       parentTask={overrides.parentTask ?? null}
       onNavigateToTask={overrides.onNavigateToTask}
+      onEditAgent={overrides.onEditAgent}
+      onTriage={overrides.onTriage}
+      canTriage={overrides.canTriage}
+      onStartAgent={overrides.onStartAgent}
+      canStartAgent={overrides.canStartAgent}
     />
   )
 }
@@ -181,5 +208,94 @@ describe('TaskDetailView – parent task context panel', () => {
 
     // Should not crash, status badges should still show
     expect(screen.getByText('No Desc Parent')).toBeInTheDocument()
+  })
+})
+
+describe('TaskDetailView – edit agent action', () => {
+  it('shows an Edit agent button when an agent is assigned', () => {
+    const agent = makeAgent()
+    const onEditAgent = vi.fn()
+    renderDetailView({
+      task: { agent_id: agent.id },
+      agents: [agent],
+      onEditAgent
+    })
+    const btn = screen.getByTestId('edit-agent-button')
+    expect(btn).toBeInTheDocument()
+    fireEvent.click(btn)
+    expect(onEditAgent).toHaveBeenCalledWith(agent.id)
+  })
+
+  it('does not render the Edit agent button when no agent is assigned', () => {
+    renderDetailView({ task: { agent_id: null }, agents: [makeAgent()], onEditAgent: vi.fn() })
+    expect(screen.queryByTestId('edit-agent-button')).not.toBeInTheDocument()
+  })
+})
+
+describe('TaskDetailView – unconfigured agent blocking', () => {
+  const unconfiguredAgent = makeAgent({
+    id: 'agent-unconfigured',
+    name: 'Unconfigured',
+    is_default: true,
+    config: { coding_agent: undefined, model: undefined }
+  })
+  const configuredAgent = makeAgent({ id: 'agent-ok', name: 'Ready' })
+
+  it('renders a warning when the assigned agent is missing provider and model', () => {
+    renderDetailView({
+      task: { agent_id: unconfiguredAgent.id },
+      agents: [unconfiguredAgent],
+      onEditAgent: vi.fn(),
+      // canStartAgent is expected to be false upstream — but the warning does
+      // not depend on that flag.
+      canStartAgent: false
+    })
+    const warning = screen.getByTestId('agent-config-warning')
+    expect(warning).toBeInTheDocument()
+    expect(warning.textContent).toMatch(/Provider and model are not selected/i)
+    expect(warning.textContent).toMatch(/Start is disabled/i)
+  })
+
+  it('renders a warning naming the default agent when unassigned + default is unconfigured', () => {
+    renderDetailView({
+      task: { agent_id: null },
+      agents: [unconfiguredAgent],
+      onEditAgent: vi.fn(),
+      canTriage: false
+    })
+    const warning = screen.getByTestId('agent-config-warning')
+    expect(warning.textContent).toMatch(/Unconfigured/)
+    expect(warning.textContent).toMatch(/Triage is disabled/i)
+  })
+
+  it('clicking the warning\'s Edit agent button invokes onEditAgent with the target agent id', () => {
+    const onEditAgent = vi.fn()
+    renderDetailView({
+      task: { agent_id: unconfiguredAgent.id },
+      agents: [unconfiguredAgent],
+      onEditAgent
+    })
+    fireEvent.click(screen.getByTestId('agent-config-warning-edit'))
+    expect(onEditAgent).toHaveBeenCalledWith(unconfiguredAgent.id)
+  })
+
+  it('does not render the warning when assigned agent is fully configured', () => {
+    renderDetailView({
+      task: { agent_id: configuredAgent.id },
+      agents: [configuredAgent],
+      onEditAgent: vi.fn(),
+      canStartAgent: true
+    })
+    expect(screen.queryByTestId('agent-config-warning')).not.toBeInTheDocument()
+  })
+
+  it('does not render the warning when the default triage agent is fully configured', () => {
+    renderDetailView({
+      task: { agent_id: null },
+      agents: [configuredAgent],
+      onEditAgent: vi.fn(),
+      canTriage: true
+    })
+    expect(screen.queryByTestId('agent-config-warning')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -480,19 +480,6 @@ export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachm
                       </div>
                     )
                   })()}
-                  {task.agent_id && onEditAgent && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onEditAgent(task.agent_id!)}
-                      className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
-                      title="Edit agent configuration"
-                      data-testid="edit-agent-button"
-                    >
-                      <Settings2 className="h-3 w-3" />
-                      Edit agent
-                    </Button>
-                  )}
                   {canTriage && onTriage && (
                     <Button variant="default" size="sm" onClick={onTriage} className="h-7 gap-1.5 px-3">
                       <Sparkles className="h-3 w-3" />
@@ -517,14 +504,30 @@ export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachm
                       Start
                     </Button>
                   )}
+                </div>
+                <div className="flex items-center gap-1 flex-wrap">
+                  {task.agent_id && onEditAgent && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onEditAgent(task.agent_id!)}
+                      className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
+                      title="Edit agent configuration"
+                      data-testid="edit-agent-button"
+                    >
+                      <Settings2 className="h-3 w-3" />
+                      Edit agent
+                    </Button>
+                  )}
                   <Button
                     variant="ghost"
-                    size="icon"
+                    size="sm"
                     onClick={handleOpenFolder}
-                    className="h-7 w-7"
+                    className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
                     title="Open workspace folder"
                   >
-                    <Folder className="h-3.5 w-3.5" />
+                    <Folder className="h-3 w-3" />
+                    Open workspace folder
                   </Button>
                 </div>
                 <AgentConfigWarning

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Pencil, Trash2, Calendar, User, Tag, Clock, Bot, Play, History, GitBranch, Plus, X, BookOpen, AlarmClockOff, BellRing, Folder, Repeat, Star, Sparkles, ListTree, ArrowLeft, ChevronRight, ChevronDown, GripVertical } from 'lucide-react'
+import { Pencil, Trash2, Calendar, User, Tag, Clock, Bot, Play, History, GitBranch, Plus, X, BookOpen, AlarmClockOff, BellRing, Folder, Repeat, Star, Sparkles, ListTree, ArrowLeft, ChevronRight, ChevronDown, GripVertical, Settings2, AlertCircle } from 'lucide-react'
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core'
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -18,6 +18,7 @@ import { TaskStatus, CodingAgentType } from '@/types'
 import type { WorkfloTask, FileAttachment, OutputField, Agent, RecurrencePattern, RecurrencePatternObject } from '@/types'
 import { AnthropicLogo, OpenCodeLogo, OpenAILogo } from '@/components/icons/AgentLogos'
 import { HeartbeatSection } from './HeartbeatSection'
+import { isAgentConfigured, getAgentConfigIssue } from '@shared/agent-utils'
 
 function ordinal(n: number): string {
   if (n >= 11 && n <= 13) return `${n}th`
@@ -292,6 +293,51 @@ function ParentTaskContext({ parentTask, onNavigateToTask }: { parentTask: Workf
   )
 }
 
+/**
+ * Inline warning shown under the Agent row when the task's agent (or, when no
+ * agent is assigned, the default agent picked by Triage) is missing a provider
+ * or model. Blocks the user from starting/triaging until they fix it.
+ */
+function AgentConfigWarning({ task, agents, onEditAgent }: { task: WorkfloTask; agents: Agent[]; onEditAgent?: (agentId: string) => void }) {
+  // When a specific agent is assigned, warn about that agent.
+  // Otherwise, warn about the default agent used by Triage.
+  const assignedAgent = task.agent_id ? agents.find((a) => a.id === task.agent_id) : null
+  const triageAgent = !task.agent_id ? (agents.find((a) => a.is_default) || agents[0] || null) : null
+  const targetAgent = assignedAgent || triageAgent
+  if (!targetAgent) return null
+  if (isAgentConfigured(targetAgent)) return null
+
+  const issue = getAgentConfigIssue(targetAgent) || 'Agent is not fully configured'
+  const isAssigned = !!assignedAgent
+  const action = isAssigned ? 'Start' : 'Triage'
+  const message = isAssigned
+    ? `${issue}. ${action} is disabled — edit the agent to continue.`
+    : `The default agent "${targetAgent.name}" is not fully configured (${issue.toLowerCase()}). ${action} is disabled — edit the agent to continue.`
+
+  return (
+    <div
+      data-testid="agent-config-warning"
+      className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-300"
+    >
+      <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0 space-y-1.5">
+        <p className="leading-snug">{message}</p>
+        {onEditAgent && (
+          <button
+            type="button"
+            onClick={() => onEditAgent(targetAgent.id)}
+            className="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/10 hover:bg-amber-500/20 px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors cursor-pointer"
+            data-testid="agent-config-warning-edit"
+          >
+            <Settings2 className="h-3 w-3" />
+            Edit agent
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
 interface TaskDetailViewProps {
   task: WorkfloTask
   agents: Agent[]
@@ -316,6 +362,8 @@ interface TaskDetailViewProps {
   onReassign?: (userIds: string[], displayName: string) => Promise<void>
   onTriage?: () => void
   canTriage?: boolean
+  /** Open the agent editor dialog for a specific agent (or the currently assigned one). */
+  onEditAgent?: (agentId: string) => void
   subtasks?: WorkfloTask[]
   parentTask?: WorkfloTask | null
   onNavigateToTask?: (taskId: string) => void
@@ -323,7 +371,7 @@ interface TaskDetailViewProps {
   onReorderSubtasks?: (orderedIds: string[]) => void
 }
 
-export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onAddSkills, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage, subtasks, parentTask, onNavigateToTask, onAddSubtask, onReorderSubtasks }: TaskDetailViewProps) {
+export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onAddSkills, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage, onEditAgent, subtasks, parentTask, onNavigateToTask, onAddSubtask, onReorderSubtasks }: TaskDetailViewProps) {
   const { skills, fetchSkills } = useSkillStore()
   const isActive = task.status !== TaskStatus.Completed
 
@@ -402,68 +450,88 @@ export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachm
             </>
             <>
               <span className="text-muted-foreground flex items-center gap-2"><Bot className="h-3.5 w-3.5" /> Agent</span>
-              <div className="flex items-center gap-2">
-                <select
-                  value={task.agent_id || ''}
-                  onChange={(e) => onAssignAgent(e.target.value || null)}
-                  className="bg-transparent border border-border rounded px-2 py-1 text-sm cursor-pointer"
-                >
-                  <option value="">No agent assigned</option>
-                  {agents.map((agent) => (
-                    <option key={agent.id} value={agent.id}>{agent.name}</option>
-                  ))}
-                </select>
-                {canTriage && onTriage && (
-                  <Button variant="default" size="sm" onClick={onTriage} className="h-7 gap-1.5 px-3">
-                    <Sparkles className="h-3 w-3" />
-                    Triage
-                  </Button>
-                )}
-                {task.agent_id && agents.find(a => a.id === task.agent_id)?.config.coding_agent && (() => {
-                  const agent = agents.find(a => a.id === task.agent_id)
-                  const codingAgent = agent?.config.coding_agent
-                  const agentName = codingAgent === CodingAgentType.CLAUDE_CODE ? 'Claude Code' :
-                                   codingAgent === CodingAgentType.OPENCODE ? 'OpenCode' :
-                                   'Codex'
-                  const LogoComponent = codingAgent === CodingAgentType.CLAUDE_CODE ? AnthropicLogo :
-                                       codingAgent === CodingAgentType.OPENCODE ? OpenCodeLogo :
-                                       OpenAILogo
-                  return (
-                    <div
-                      className="w-4 h-4 flex items-center justify-center opacity-70 hover:opacity-100 transition-opacity"
-                      title={agentName}
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <select
+                    value={task.agent_id || ''}
+                    onChange={(e) => onAssignAgent(e.target.value || null)}
+                    className="bg-transparent border border-border rounded px-2 py-1 text-sm cursor-pointer"
+                  >
+                    <option value="">No agent assigned</option>
+                    {agents.map((agent) => (
+                      <option key={agent.id} value={agent.id}>{agent.name}</option>
+                    ))}
+                  </select>
+                  {task.agent_id && agents.find(a => a.id === task.agent_id)?.config.coding_agent && (() => {
+                    const agent = agents.find(a => a.id === task.agent_id)
+                    const codingAgent = agent?.config.coding_agent
+                    const agentName = codingAgent === CodingAgentType.CLAUDE_CODE ? 'Claude Code' :
+                                     codingAgent === CodingAgentType.OPENCODE ? 'OpenCode' :
+                                     'Codex'
+                    const LogoComponent = codingAgent === CodingAgentType.CLAUDE_CODE ? AnthropicLogo :
+                                         codingAgent === CodingAgentType.OPENCODE ? OpenCodeLogo :
+                                         OpenAILogo
+                    return (
+                      <div
+                        className="w-4 h-4 flex items-center justify-center opacity-70 hover:opacity-100 transition-opacity"
+                        title={agentName}
+                      >
+                        <LogoComponent className="w-full h-full" />
+                      </div>
+                    )
+                  })()}
+                  {task.agent_id && onEditAgent && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onEditAgent(task.agent_id!)}
+                      className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
+                      title="Edit agent configuration"
+                      data-testid="edit-agent-button"
                     >
-                      <LogoComponent className="w-full h-full" />
-                    </div>
-                  )
-                })()}
-                {canResumeAgent && onResumeAgent && (
-                  <Button variant="default" size="sm" onClick={onResumeAgent} className="h-7 gap-1.5 px-3">
-                    <History className="h-3 w-3" />
-                    Resume session
+                      <Settings2 className="h-3 w-3" />
+                      Edit agent
+                    </Button>
+                  )}
+                  {canTriage && onTriage && (
+                    <Button variant="default" size="sm" onClick={onTriage} className="h-7 gap-1.5 px-3">
+                      <Sparkles className="h-3 w-3" />
+                      Triage
+                    </Button>
+                  )}
+                  {canResumeAgent && onResumeAgent && (
+                    <Button variant="default" size="sm" onClick={onResumeAgent} className="h-7 gap-1.5 px-3">
+                      <History className="h-3 w-3" />
+                      Resume session
+                    </Button>
+                  )}
+                  {canRestartAgent && onRestartAgent && (
+                    <Button variant="default" size="sm" onClick={onRestartAgent} className="h-7 gap-1.5 px-3">
+                      <Play className="h-3 w-3" />
+                      Restart session
+                    </Button>
+                  )}
+                  {canStartAgent && onStartAgent && (
+                    <Button variant="default" size="sm" onClick={onStartAgent} className="h-7 gap-1.5 px-3">
+                      <Play className="h-3 w-3" />
+                      Start
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={handleOpenFolder}
+                    className="h-7 w-7"
+                    title="Open workspace folder"
+                  >
+                    <Folder className="h-3.5 w-3.5" />
                   </Button>
-                )}
-                {canRestartAgent && onRestartAgent && (
-                  <Button variant="default" size="sm" onClick={onRestartAgent} className="h-7 gap-1.5 px-3">
-                    <Play className="h-3 w-3" />
-                    Restart session
-                  </Button>
-                )}
-                {canStartAgent && onStartAgent && (
-                  <Button variant="default" size="sm" onClick={onStartAgent} className="h-7 gap-1.5 px-3">
-                    <Play className="h-3 w-3" />
-                    Start
-                  </Button>
-                )}
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleOpenFolder}
-                  className="h-7 w-7"
-                  title="Open workspace folder"
-                >
-                  <Folder className="h-3.5 w-3.5" />
-                </Button>
+                </div>
+                <AgentConfigWarning
+                  task={task}
+                  agents={agents}
+                  onEditAgent={onEditAgent}
+                />
               </div>
             </>
             <>

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -10,6 +10,7 @@ import { GhCliSetupDialog } from '@/components/github/GhCliSetupDialog'
 import { OrgPickerDialog } from '@/components/github/OrgPickerDialog'
 import { RepoSelectorDialog } from '@/components/github/RepoSelectorDialog'
 import { SkillSelectorDialog } from '@/components/skills/SkillSelectorDialog'
+import { AgentFormDialog } from '@/components/settings/forms/AgentFormDialog'
 import { WorktreeProgressOverlay } from '@/components/github/WorktreeProgressOverlay'
 import { useAgentSession } from '@/hooks/use-agent-session'
 import { useAgentStore, SessionStatus } from '@/stores/agent-store'
@@ -18,8 +19,9 @@ import { useTaskStore } from '@/stores/task-store'
 import { taskApi, worktreeApi, taskSourceApi, onAgentIncompatibleSession, onWorktreeProgress } from '@/lib/ipc-client'
 import { useEffect, useCallback, useRef, useState, useMemo } from 'react'
 import { TaskStatus } from '@/types'
-import type { WorkfloTask, FileAttachment, OutputField, Agent } from '@/types'
+import type { WorkfloTask, FileAttachment, OutputField, Agent, UpdateAgentDTO, CreateAgentDTO } from '@/types'
 import type { GitHubRepo } from '@/types/electron'
+import { isAgentConfigured } from '@shared/agent-utils'
 
 interface TaskWorkspaceProps {
   task?: WorkfloTask
@@ -47,13 +49,14 @@ export function TaskWorkspace({
   onNavigateToTask
 }: TaskWorkspaceProps) {
   const { session, start, resume, abort, stop, sendMessage, approve } = useAgentSession(task?.id)
-  const { removeSession } = useAgentStore()
+  const { removeSession, updateAgent } = useAgentStore()
   const { githubOrg, checkGhCli, checkGlabCli, setGithubOrg, fetchSettings } = useSettingsStore()
 
   const [showGhSetup, setShowGhSetup] = useState(false)
   const [showOrgPicker, setShowOrgPicker] = useState(false)
   const [showRepoSelector, setShowRepoSelector] = useState(false)
   const [showSkillSelector, setShowSkillSelector] = useState(false)
+  const [editingAgentId, setEditingAgentId] = useState<string | null>(null)
   const [orgProvider, setOrgProvider] = useState<GitProvider>('github')
   const [isSettingUpWorktree, setIsSettingUpWorktree] = useState(false)
   const [showFeedback, setShowFeedback] = useState(false)
@@ -597,12 +600,25 @@ Update existing skills that were helpful or create new ones for patterns worth r
 
   // Show panel if session exists (active or past transcript with messages)
   const showPanel = session.status !== SessionStatus.IDLE || session.messages.length > 0
+  const assignedAgent = task.agent_id ? agents.find((a) => a.id === task.agent_id) : null
+  const assignedAgentConfigured = isAgentConfigured(assignedAgent)
+  // Triage uses the default agent (or the first agent in the list as a fallback).
+  const triageAgent = !task.agent_id ? (agents.find((a) => a.is_default) || agents[0] || null) : null
+  const triageAgentConfigured = isAgentConfigured(triageAgent)
   const canResume = task.agent_id && task.session_id && !session.sessionId && session.status === SessionStatus.IDLE && session.messages.length === 0
   const canRestart = task.agent_id && task.session_id && !session.sessionId && session.status === SessionStatus.IDLE && session.messages.length > 0
-  const canStart = task.agent_id && !task.session_id && !session.sessionId && session.status === SessionStatus.IDLE
+  const canStart = task.agent_id && assignedAgentConfigured && !task.session_id && !session.sessionId && session.status === SessionStatus.IDLE
     && task.status !== TaskStatus.Completed
-  const canTriage = !task.agent_id && agents.length > 0 && session.status === SessionStatus.IDLE
+  const canTriage = !task.agent_id && agents.length > 0 && triageAgentConfigured && session.status === SessionStatus.IDLE
     && task.status !== TaskStatus.Completed && task.status !== TaskStatus.Triaging
+
+  const handleEditAgent = (agentId: string) => setEditingAgentId(agentId)
+  const handleSaveAgent = async (data: CreateAgentDTO | UpdateAgentDTO) => {
+    if (!editingAgentId) return
+    await updateAgent(editingAgentId, data as UpdateAgentDTO)
+    setEditingAgentId(null)
+  }
+  const editingAgent = editingAgentId ? agents.find((a) => a.id === editingAgentId) : undefined
 
   return (
     <>
@@ -640,6 +656,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
             onReassign={handleReassign}
             onTriage={handleTriage}
             canTriage={!!canTriage}
+            onEditAgent={handleEditAgent}
             subtasks={subtasks}
             parentTask={parentTask}
             onNavigateToTask={onNavigateToTask}
@@ -715,6 +732,13 @@ Update existing skills that were helpful or create new ones for patterns worth r
         onOpenChange={setShowIncompatibleSession}
         onStartFresh={handleStartFreshSession}
         error={incompatibleSessionError}
+      />
+
+      <AgentFormDialog
+        agent={editingAgent}
+        open={!!editingAgentId}
+        onClose={() => setEditingAgentId(null)}
+        onSubmit={handleSaveAgent}
       />
     </>
   )

--- a/src/shared/agent-utils.test.ts
+++ b/src/shared/agent-utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { isAgentConfigured, getAgentConfigIssue } from './agent-utils'
+
+describe('isAgentConfigured', () => {
+  it('returns false when agent is null/undefined', () => {
+    expect(isAgentConfigured(null)).toBe(false)
+    expect(isAgentConfigured(undefined)).toBe(false)
+  })
+
+  it('returns false when config is missing', () => {
+    expect(isAgentConfigured({})).toBe(false)
+    expect(isAgentConfigured({ config: null })).toBe(false)
+  })
+
+  it('returns false when coding_agent is missing', () => {
+    expect(isAgentConfigured({ config: { model: 'anthropic/claude-3-5' } })).toBe(false)
+  })
+
+  it('returns false when model is missing', () => {
+    expect(isAgentConfigured({ config: { coding_agent: 'claude_code' } })).toBe(false)
+  })
+
+  it('returns false when either field is an empty string', () => {
+    expect(isAgentConfigured({ config: { coding_agent: '', model: 'anthropic/claude-3-5' } })).toBe(false)
+    expect(isAgentConfigured({ config: { coding_agent: 'claude_code', model: '' } })).toBe(false)
+    expect(isAgentConfigured({ config: { coding_agent: '  ', model: 'x' } })).toBe(false)
+  })
+
+  it('returns true when both coding_agent and model are set', () => {
+    expect(
+      isAgentConfigured({ config: { coding_agent: 'claude_code', model: 'anthropic/claude-3-5' } })
+    ).toBe(true)
+  })
+
+  it('handles unknown-typed config (mobile agent shape)', () => {
+    const mobileAgent = { config: { coding_agent: 'opencode', model: 'openai/gpt-4' } as Record<string, unknown> }
+    expect(isAgentConfigured(mobileAgent)).toBe(true)
+  })
+})
+
+describe('getAgentConfigIssue', () => {
+  it('returns a message when no agent is supplied', () => {
+    expect(getAgentConfigIssue(null)).toBe('No agent selected')
+  })
+
+  it('reports both missing', () => {
+    expect(getAgentConfigIssue({ config: {} })).toBe('Provider and model are not selected')
+  })
+
+  it('reports missing provider', () => {
+    expect(getAgentConfigIssue({ config: { model: 'm' } })).toBe('Provider is not selected')
+  })
+
+  it('reports missing model', () => {
+    expect(getAgentConfigIssue({ config: { coding_agent: 'claude_code' } })).toBe('Model is not selected')
+  })
+
+  it('returns null when fully configured', () => {
+    expect(
+      getAgentConfigIssue({ config: { coding_agent: 'claude_code', model: 'anthropic/claude-3-5' } })
+    ).toBeNull()
+  })
+})

--- a/src/shared/agent-utils.ts
+++ b/src/shared/agent-utils.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared agent utilities — safe to import from main, renderer, and mobile.
+ *
+ * Keep this file free of framework imports (no React, no Electron, no Node-only
+ * modules) so it can be pulled in from every entry point.
+ */
+
+/** Shape this helper expects from an agent-like value. */
+export interface AgentConfigLike {
+  coding_agent?: string | null
+  model?: string | null
+}
+
+export interface AgentLike {
+  config?: AgentConfigLike | Record<string, unknown> | null
+}
+
+function readConfigField(config: AgentLike['config'], key: 'coding_agent' | 'model'): string | undefined {
+  if (!config || typeof config !== 'object') return undefined
+  const value = (config as Record<string, unknown>)[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * Returns true when the agent has both a provider (coding_agent) and a model
+ * selected — the minimum required to start/triage a task with this agent.
+ *
+ * An agent is considered "unconfigured" when either field is missing/empty,
+ * and the UI should block start/triage actions until the user edits it.
+ */
+export function isAgentConfigured(agent: AgentLike | null | undefined): boolean {
+  if (!agent) return false
+  const codingAgent = readConfigField(agent.config, 'coding_agent')
+  const model = readConfigField(agent.config, 'model')
+  return Boolean(codingAgent && codingAgent.trim() && model && model.trim())
+}
+
+/**
+ * Returns a short, user-facing reason why the agent is unconfigured. Returns
+ * null when the agent is fully configured.
+ */
+export function getAgentConfigIssue(agent: AgentLike | null | undefined): string | null {
+  if (!agent) return 'No agent selected'
+  const codingAgent = readConfigField(agent.config, 'coding_agent')
+  const model = readConfigField(agent.config, 'model')
+  const hasProvider = Boolean(codingAgent && codingAgent.trim())
+  const hasModel = Boolean(model && model.trim())
+  if (!hasProvider && !hasModel) return 'Provider and model are not selected'
+  if (!hasProvider) return 'Provider is not selected'
+  if (!hasModel) return 'Model is not selected'
+  return null
+}


### PR DESCRIPTION
## Summary
- Adds an **Edit agent** action on the task detail view (desktop) — opens `AgentFormDialog` inline so users don't have to navigate to Settings.
- Adds **validation-based blocking** of Start / Triage when the target agent is missing a provider or model, with a clear warning that names the action being blocked and (for unassigned tasks) the default agent used for triage.
- Parity on mobile: same warning is rendered; mobile directs the user to the desktop app to edit the agent (mobile has no agent edit UI today).
- Introduces `src/shared/agent-utils.ts` with `isAgentConfigured` and `getAgentConfigIssue`, used by both desktop (typed `AgentConfig`) and mobile (`Record<string, unknown>` config shape).

## Behavior
- **Assigned agent unconfigured** → Start button is not rendered; warning reads e.g. `Provider and model are not selected. Start is disabled — edit the agent to continue.` Clicking **Edit agent** opens the agent form.
- **Unassigned task + default agent unconfigured** → Triage button is not rendered; warning names the default agent, e.g. `The default agent "Default Agent" is not fully configured (model is not selected). Triage is disabled — edit the agent to continue.`
- **Fully configured agent** → no warning, Start / Triage work as before.

## Test plan
- [x] `pnpm test` — all suites pass including new unit tests in `src/shared/agent-utils.test.ts`, `TaskDetailView.test.tsx`, `TaskDetailPage.test.tsx`
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (only pre-existing warnings in unrelated files)
- [ ] Manual: assign an agent with blank provider/model → Start is hidden, warning appears with Edit agent button that opens the agent dialog
- [ ] Manual: remove assignment, mark default agent unconfigured → Triage is hidden, warning names the default agent
- [ ] Manual: save a valid provider+model in the agent dialog → warning disappears, Start/Triage re-enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)