### PR TITLE
build: add Apple signing/notarization for macOS installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,19 @@ jobs:
       - name: Build app
         run: pnpm build
 
+      - name: Import Apple Developer ID certificate
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.CSC_LINK }}
+          p12-password: ${{ secrets.CSC_KEY_PASSWORD }}
+
       - name: Package for macOS
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm exec electron-builder --mac --${{ matrix.arch }} --publish never
 
       - name: Upload artifacts

--- a/README.md
+++ b/README.md
@@ -123,19 +123,11 @@ cd 20x
 pnpm install
 ```
 
-### macOS: Opening the App (Release Build)
+### macOS: Signed & Notarized Releases
 
-macOS may block the app since it's not signed with an Apple Developer certificate. To open it, use one of these methods:
+Release artifacts are signed with an Apple Developer ID certificate and notarized to avoid Gatekeeper install/open warnings.
 
-**Option A:** Right-click the app in `/Applications` and select **Open**, then confirm in the dialog.
-
-**Option B:** Run in Terminal:
-```bash
-sudo xattr -cr /Applications/20x.app
-```
-Then open the app normally.
-
-> This is not required if you build from source and run with `pnpm dev`.
+For maintainers, setup details are in [docs/macos-signing-notarization.md](./docs/macos-signing-notarization.md).
 
 ### Configuration
 

--- a/docs/macos-signing-notarization.md
+++ b/docs/macos-signing-notarization.md
@@ -1,0 +1,53 @@
+# macOS Signing & Notarization
+
+This project signs and notarizes macOS release artifacts through `electron-builder` + GitHub Actions.
+
+## Required Apple Assets
+
+1. Apple Developer Program membership
+2. `Developer ID Application` certificate exported as `.p12`
+3. App-specific password for Apple ID (used by notarytool)
+4. Apple Team ID
+
+## GitHub Secrets
+
+Add these repository secrets:
+
+- `CSC_LINK`: base64 content of the `.p12` signing certificate
+- `CSC_KEY_PASSWORD`: password used when exporting the `.p12`
+- `APPLE_ID`: Apple ID email for notarization
+- `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password from appleid.apple.com
+- `APPLE_TEAM_ID`: 10-character Apple Team ID
+
+## Build Configuration
+
+- `package.json > build.mac` enables:
+  - `hardenedRuntime: true`
+  - `entitlements: resources/entitlements.mac.plist`
+  - `entitlementsInherit: resources/entitlements.mac.inherit.plist`
+- `package.json > build.afterSign` runs `scripts/notarize.js`
+- `scripts/notarize.js` notarizes `.app` with `@electron/notarize` when required env vars are present
+
+## CI/CD Flow
+
+The release workflow (`.github/workflows/release.yml`) on tag push:
+
+1. Imports the Apple certificate to the macOS runner keychain
+2. Builds app binaries
+3. Runs `electron-builder --mac ...`
+4. Signs app with Developer ID cert
+5. Notarizes app in `afterSign`
+6. Uploads signed + notarized `.dmg` and `.zip` artifacts
+
+## Local Signed Build
+
+```bash
+export CSC_LINK="<base64-p12>"
+export CSC_KEY_PASSWORD="<p12-password>"
+export APPLE_ID="<apple-id-email>"
+export APPLE_APP_SPECIFIC_PASSWORD="<app-specific-password>"
+export APPLE_TEAM_ID="<team-id>"
+pnpm build:mac
+```
+
+Use `SKIP_NOTARIZE=true` only for temporary local testing.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/tsconfig": "^1.0.1",
+    "@electron/notarize": "^2.5.0",
     "@electron/rebuild": "^4.0.3",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -120,11 +121,16 @@
       }
     ],
     "afterPack": "./scripts/after-pack.js",
+    "afterSign": "./scripts/notarize.js",
     "mac": {
       "target": [
         "dmg",
         "zip"
       ],
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "resources/entitlements.mac.plist",
+      "entitlementsInherit": "resources/entitlements.mac.inherit.plist",
       "artifactName": "${productName}-${version}-${arch}.${ext}"
     },
     "win": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@electron-toolkit/tsconfig':
         specifier: ^1.0.1
         version: 1.0.1(@types/node@25.2.3)
+      '@electron/notarize':
+        specifier: ^2.5.0
+        version: 2.5.0
       '@electron/rebuild':
         specifier: ^4.0.3
         version: 4.0.3

--- a/resources/entitlements.mac.inherit.plist
+++ b/resources/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/resources/entitlements.mac.plist
+++ b/resources/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/scripts/notarize-config.js
+++ b/scripts/notarize-config.js
@@ -1,0 +1,43 @@
+const path = require('path')
+
+function getMissingNotarizeEnv(env = process.env) {
+  const required = ['APPLE_ID', 'APPLE_APP_SPECIFIC_PASSWORD', 'APPLE_TEAM_ID']
+  return required.filter((key) => !env[key] || String(env[key]).trim() === '')
+}
+
+function shouldNotarize(context, env = process.env) {
+  if (context.electronPlatformName !== 'darwin') {
+    return { enabled: false, reason: 'not darwin build' }
+  }
+
+  if (String(env.SKIP_NOTARIZE || '').toLowerCase() === 'true') {
+    return { enabled: false, reason: 'SKIP_NOTARIZE=true' }
+  }
+
+  const missing = getMissingNotarizeEnv(env)
+  if (missing.length > 0) {
+    return { enabled: false, reason: `missing env: ${missing.join(', ')}` }
+  }
+
+  return { enabled: true, reason: 'enabled' }
+}
+
+function getNotarizeOptions(context, env = process.env) {
+  const { appInfo } = context.packager
+  const appPath = path.join(context.appOutDir, `${appInfo.productFilename}.app`)
+
+  return {
+    tool: 'notarytool',
+    appBundleId: appInfo.id,
+    appPath,
+    appleId: env.APPLE_ID,
+    appleIdPassword: env.APPLE_APP_SPECIFIC_PASSWORD,
+    teamId: env.APPLE_TEAM_ID
+  }
+}
+
+module.exports = {
+  getMissingNotarizeEnv,
+  shouldNotarize,
+  getNotarizeOptions
+}

--- a/scripts/notarize-config.test.ts
+++ b/scripts/notarize-config.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+const { getMissingNotarizeEnv, shouldNotarize, getNotarizeOptions } = require('./notarize-config')
+
+function createContext(platform: string) {
+  return {
+    electronPlatformName: platform,
+    appOutDir: '/tmp/out',
+    packager: {
+      appInfo: {
+        id: 'com.20x.app',
+        productFilename: '20x'
+      }
+    }
+  }
+}
+
+describe('notarize-config', () => {
+  it('detects missing notarization environment variables', () => {
+    expect(getMissingNotarizeEnv({})).toEqual([
+      'APPLE_ID',
+      'APPLE_APP_SPECIFIC_PASSWORD',
+      'APPLE_TEAM_ID'
+    ])
+  })
+
+  it('enables notarization when all required env vars are present on darwin', () => {
+    const result = shouldNotarize(createContext('darwin'), {
+      APPLE_ID: 'dev@company.com',
+      APPLE_APP_SPECIFIC_PASSWORD: 'xxxx-xxxx-xxxx-xxxx',
+      APPLE_TEAM_ID: 'ABCD123456'
+    })
+    expect(result).toEqual({ enabled: true, reason: 'enabled' })
+  })
+
+  it('skips notarization when SKIP_NOTARIZE is true', () => {
+    const result = shouldNotarize(createContext('darwin'), {
+      SKIP_NOTARIZE: 'true',
+      APPLE_ID: 'dev@company.com',
+      APPLE_APP_SPECIFIC_PASSWORD: 'xxxx-xxxx-xxxx-xxxx',
+      APPLE_TEAM_ID: 'ABCD123456'
+    })
+    expect(result).toEqual({ enabled: false, reason: 'SKIP_NOTARIZE=true' })
+  })
+
+  it('skips notarization on non-mac platforms', () => {
+    const result = shouldNotarize(createContext('win32'), {
+      APPLE_ID: 'dev@company.com',
+      APPLE_APP_SPECIFIC_PASSWORD: 'xxxx-xxxx-xxxx-xxxx',
+      APPLE_TEAM_ID: 'ABCD123456'
+    })
+    expect(result).toEqual({ enabled: false, reason: 'not darwin build' })
+  })
+
+  it('builds notarize options from context + env', () => {
+    const options = getNotarizeOptions(createContext('darwin'), {
+      APPLE_ID: 'dev@company.com',
+      APPLE_APP_SPECIFIC_PASSWORD: 'xxxx-xxxx-xxxx-xxxx',
+      APPLE_TEAM_ID: 'ABCD123456'
+    })
+
+    expect(options).toEqual({
+      tool: 'notarytool',
+      appBundleId: 'com.20x.app',
+      appPath: '/tmp/out/20x.app',
+      appleId: 'dev@company.com',
+      appleIdPassword: 'xxxx-xxxx-xxxx-xxxx',
+      teamId: 'ABCD123456'
+    })
+  })
+})

--- a/scripts/notarize-config.test.ts
+++ b/scripts/notarize-config.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
-
-const { getMissingNotarizeEnv, shouldNotarize, getNotarizeOptions } = require('./notarize-config')
+import { getMissingNotarizeEnv, shouldNotarize, getNotarizeOptions } from './notarize-config'
 
 function createContext(platform: string) {
   return {

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,0 +1,23 @@
+/**
+ * electron-builder afterSign hook
+ *
+ * Notarizes signed macOS builds so users can install/open without Gatekeeper bypasses.
+ */
+
+const { notarize } = require('@electron/notarize')
+const { shouldNotarize, getNotarizeOptions } = require('./notarize-config')
+
+async function notarizeApp(context) {
+  const decision = shouldNotarize(context, process.env)
+  if (!decision.enabled) {
+    console.log(`[notarize] Skipping notarization: ${decision.reason}`)
+    return
+  }
+
+  const options = getNotarizeOptions(context, process.env)
+  console.log(`[notarize] Submitting ${options.appPath} for notarization`)
+  await notarize(options)
+  console.log('[notarize] Notarization complete')
+}
+
+module.exports = notarizeApp

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         test: {
           name: 'main',
           environment: 'node',
-          include: ['src/main/**/*.test.ts', 'src/shared/**/*.test.ts'],
+          include: ['src/main/**/*.test.ts', 'src/shared/**/*.test.ts', 'scripts/**/*.test.ts'],
           setupFiles: ['./test/setup-main.ts']
         },
         resolve: {


### PR DESCRIPTION
## Summary
- add macOS hardened runtime + entitlements in electron-builder
- add afterSign notarization hook using Apple notarytool credentials
- wire release GitHub Actions job to import signing cert + pass notarization secrets
- add docs for required Apple credentials and CI setup
- add unit tests for notarization env gating/options

## Verification
- pnpm test:run scripts/notarize-config.test.ts
- pnpm test:run
- pnpm typecheck
- pnpm build