### PR TITLE
ci: use release environment for mac signing job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-mac:
     runs-on: macos-latest
-    environment: main
+    environment: release
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- switch the macOS release job from environment main to environment release
- keep the existing secret validation and signing/notarization flow intact

## Verification
- validated .github/workflows/release.yml parses as YAML with Ruby YAML.load_file