### PR TITLE
ci: add mac signing diagnostics for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,11 @@ on:
 
 jobs:
   build-mac:
-    runs-on: macos-latest
+    runs-on: macos-14
     environment: release
 
     strategy:
+      fail-fast: false
       matrix:
         arch: [x64, arm64]
 
@@ -53,8 +54,14 @@ jobs:
           p12-file-base64: ${{ secrets.CSC_LINK }}
           p12-password: ${{ secrets.CSC_KEY_PASSWORD }}
 
+      - name: Inspect signing identities
+        run: |
+          security find-identity -v -p codesigning
+          security list-keychains
+
       - name: Package for macOS
         env:
+          DEBUG: electron-builder,electron-notarize*
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}


### PR DESCRIPTION
## Summary
- pin macOS release builds to macos-14 instead of macos-latest
- disable matrix fail-fast so x64 and arm64 both report their own signing result
- print available codesigning identities and keychains after certificate import
- enable electron-builder and electron-notarize debug logging during packaging

## Verification
- validated .github/workflows/release.yml parses as YAML with Ruby YAML.load_file