### PR TITLE
fix: clean packaged mac binaries before codesigning

### DIFF
--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -1,109 +1,125 @@
 /**
  * electron-builder afterPack hook
  *
- * Strips non-target-platform binaries from the packaged app to reduce size.
- * This runs after electron-builder packs files but before creating the installer.
- *
- * Targets:
- * - claude-agent-sdk vendor/ripgrep: ships all 6 platforms (~61MB), we only need 1 (~10MB)
- * - claude-agent-sdk cli.js: 11MB CLI entrypoint not needed at runtime (we use sdk.mjs)
- * - claude-agent-sdk wasm files: resvg.wasm + tree-sitter*.wasm (~4MB) not needed for SDK usage
+ * Strips non-target-platform binaries from the packaged app to reduce size and
+ * avoid codesigning foreign executables during macOS release builds.
  */
 
 const { join } = require('path')
 const { rm, readdir, stat } = require('fs/promises')
 
 /**
- * Map electron-builder arch+platform to the ripgrep directory name used by claude-agent-sdk
+ * Map electron-builder arch+platform to the ripgrep/audio-capture directory
+ * names used by claude-agent-sdk.
  */
 function getRipgrepPlatformDir(electronPlatform, electronArch) {
-  // claude-agent-sdk uses Node.js naming: arm64-darwin, x64-linux, etc.
   return `${electronArch}-${electronPlatform}`
 }
 
-async function afterPack(context) {
-  const appDir = join(context.appOutDir, 'resources', 'app.asar.unpacked')
-  const asarAppDir = join(context.appOutDir, 'resources', 'app')
-
-  // Determine which base to work with
-  let baseDir
+async function pathExists(targetPath) {
   try {
-    await stat(asarAppDir)
-    baseDir = asarAppDir
+    await stat(targetPath)
+    return true
   } catch {
-    try {
-      await stat(appDir)
-      baseDir = appDir
-    } catch {
-      // If using asar, we need to work differently
-      console.log('[after-pack] No unpacked app directory found, skipping binary cleanup')
-      return
+    return false
+  }
+}
+
+async function getExistingAppRoots(context) {
+  const productFilename = context.packager?.appInfo?.productFilename || 'app'
+  const candidateRoots = [
+    join(context.appOutDir, 'resources', 'app'),
+    join(context.appOutDir, 'resources', 'app.asar.unpacked'),
+    join(context.appOutDir, `${productFilename}.app`, 'Contents', 'Resources', 'app'),
+    join(context.appOutDir, `${productFilename}.app`, 'Contents', 'Resources', 'app.asar.unpacked')
+  ]
+
+  const existingRoots = []
+  for (const root of candidateRoots) {
+    if (await pathExists(root)) {
+      existingRoots.push(root)
     }
   }
 
-  const platform = context.electronPlatformName // 'darwin', 'linux', 'win32'
+  return existingRoots
+}
+
+async function prunePlatformSubdirs(parentDir, keepDir) {
+  const entries = await readdir(parentDir)
+  for (const entry of entries) {
+    if (entry === keepDir || entry === 'COPYING') continue
+    const entryPath = join(parentDir, entry)
+    const entryStat = await stat(entryPath)
+    if (!entryStat.isDirectory()) continue
+
+    console.log(`[after-pack] Removing ${entryPath} (not target platform)`)
+    await rm(entryPath, { recursive: true, force: true })
+  }
+}
+
+async function cleanupSdkPath(sdkPath, keepDir) {
+  for (const vendorDir of ['ripgrep', 'audio-capture']) {
+    const vendorPath = join(sdkPath, 'vendor', vendorDir)
+    try {
+      await prunePlatformSubdirs(vendorPath, keepDir)
+    } catch (err) {
+      console.log(`[after-pack] No ${vendorDir} vendor dir at ${vendorPath}: ${err.message}`)
+    }
+  }
+
+  try {
+    const cliPath = join(sdkPath, 'cli.js')
+    await stat(cliPath)
+    console.log('[after-pack] Removing cli.js (11MB, not needed at runtime)')
+    await rm(cliPath, { force: true })
+  } catch {
+    // cli.js not found, ok
+  }
+
+  for (const wasmFile of ['resvg.wasm', 'tree-sitter.wasm', 'tree-sitter-bash.wasm']) {
+    try {
+      const wasmPath = join(sdkPath, wasmFile)
+      await stat(wasmPath)
+      console.log(`[after-pack] Removing ${wasmFile}`)
+      await rm(wasmPath, { force: true })
+    } catch {
+      // File not found, ok
+    }
+  }
+
+  console.log(`[after-pack] Cleaned up ${sdkPath}`)
+}
+
+async function afterPack(context) {
+  const appRoots = await getExistingAppRoots(context)
+
+  if (appRoots.length === 0) {
+    console.log('[after-pack] No packaged app roots found, skipping binary cleanup')
+    return
+  }
+
+  const platform = context.electronPlatformName
   const arch = context.arch === 1 ? 'x64' : context.arch === 3 ? 'arm64' : 'x64'
   const keepDir = getRipgrepPlatformDir(platform, arch)
 
   console.log(`[after-pack] Target platform: ${keepDir}`)
-  console.log(`[after-pack] App directory: ${baseDir}`)
+  console.log(`[after-pack] App roots: ${appRoots.join(', ')}`)
 
-  // Find claude-agent-sdk in node_modules (may be in .pnpm structure or hoisted)
-  const possiblePaths = [
-    join(baseDir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
-    join(baseDir, 'node_modules', '.pnpm', 'node_modules', '@anthropic-ai', 'claude-agent-sdk')
-  ]
+  for (const baseDir of appRoots) {
+    const possiblePaths = [
+      join(baseDir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'),
+      join(baseDir, 'node_modules', '.pnpm', 'node_modules', '@anthropic-ai', 'claude-agent-sdk')
+    ]
 
-  for (const sdkPath of possiblePaths) {
-    try {
-      await stat(sdkPath)
-    } catch {
-      continue
+    for (const sdkPath of possiblePaths) {
+      if (!(await pathExists(sdkPath))) continue
+      await cleanupSdkPath(sdkPath, keepDir)
     }
-
-    // 1. Strip non-target ripgrep binaries
-    const ripgrepDir = join(sdkPath, 'vendor', 'ripgrep')
-    try {
-      const entries = await readdir(ripgrepDir)
-      for (const entry of entries) {
-        if (entry === keepDir || entry === 'COPYING') continue
-        const entryPath = join(ripgrepDir, entry)
-        const entryStat = await stat(entryPath)
-        if (entryStat.isDirectory()) {
-          console.log(`[after-pack] Removing ripgrep/${entry} (not target platform)`)
-          await rm(entryPath, { recursive: true, force: true })
-        }
-      }
-    } catch (err) {
-      console.log(`[after-pack] No ripgrep vendor dir at ${ripgrepDir}: ${err.message}`)
-    }
-
-    // 2. Remove cli.js (11MB) - only sdk.mjs is needed for runtime SDK usage
-    try {
-      const cliPath = join(sdkPath, 'cli.js')
-      await stat(cliPath)
-      console.log('[after-pack] Removing cli.js (11MB, not needed at runtime)')
-      await rm(cliPath, { force: true })
-    } catch {
-      // cli.js not found, ok
-    }
-
-    // 3. Remove wasm files not needed for SDK usage
-    for (const wasmFile of ['resvg.wasm', 'tree-sitter.wasm', 'tree-sitter-bash.wasm']) {
-      try {
-        const wasmPath = join(sdkPath, wasmFile)
-        await stat(wasmPath)
-        console.log(`[after-pack] Removing ${wasmFile}`)
-        await rm(wasmPath, { force: true })
-      } catch {
-        // File not found, ok
-      }
-    }
-
-    console.log(`[after-pack] Cleaned up ${sdkPath}`)
   }
 
   console.log('[after-pack] Binary cleanup complete')
 }
 
 module.exports = afterPack
+module.exports.getExistingAppRoots = getExistingAppRoots
+module.exports.getRipgrepPlatformDir = getRipgrepPlatformDir

--- a/scripts/after-pack.test.ts
+++ b/scripts/after-pack.test.ts
@@ -1,0 +1,63 @@
+import afterPack from './after-pack'
+import { mkdtemp, mkdir, rm, stat, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { afterEach, describe, expect, it } from 'vitest'
+
+async function exists(targetPath: string) {
+  try {
+    await stat(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const tempDirs: string[] = []
+
+describe('after-pack', () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  it('cleans non-target claude-agent-sdk binaries from mac app bundle resources', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'after-pack-'))
+    tempDirs.push(tempDir)
+
+    const unpackedRoot = join(
+      tempDir,
+      '20x.app',
+      'Contents',
+      'Resources',
+      'app.asar.unpacked',
+      'node_modules',
+      '@anthropic-ai',
+      'claude-agent-sdk'
+    )
+
+    await mkdir(join(unpackedRoot, 'vendor', 'ripgrep', 'x64-darwin'), { recursive: true })
+    await mkdir(join(unpackedRoot, 'vendor', 'ripgrep', 'x64-linux'), { recursive: true })
+    await mkdir(join(unpackedRoot, 'vendor', 'audio-capture', 'x64-darwin'), { recursive: true })
+    await mkdir(join(unpackedRoot, 'vendor', 'audio-capture', 'x64-win32'), { recursive: true })
+    await writeFile(join(unpackedRoot, 'cli.js'), 'console.log("remove me")')
+    await writeFile(join(unpackedRoot, 'resvg.wasm'), 'remove me')
+
+    await afterPack({
+      appOutDir: tempDir,
+      electronPlatformName: 'darwin',
+      arch: 1,
+      packager: {
+        appInfo: {
+          productFilename: '20x'
+        }
+      }
+    })
+
+    expect(await exists(join(unpackedRoot, 'vendor', 'ripgrep', 'x64-darwin'))).toBe(true)
+    expect(await exists(join(unpackedRoot, 'vendor', 'audio-capture', 'x64-darwin'))).toBe(true)
+    expect(await exists(join(unpackedRoot, 'vendor', 'ripgrep', 'x64-linux'))).toBe(false)
+    expect(await exists(join(unpackedRoot, 'vendor', 'audio-capture', 'x64-win32'))).toBe(false)
+    expect(await exists(join(unpackedRoot, 'cli.js'))).toBe(false)
+    expect(await exists(join(unpackedRoot, 'resvg.wasm'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- fix the after-pack hook to look inside macOS app bundles under .app/Contents/Resources
- prune non-target claude-agent-sdk ripgrep and audio-capture binaries before signing
- keep cli.js and wasm cleanup in the same hook
- add a regression test that exercises the real mac app bundle layout

## Verification
- pnpm exec eslint scripts/after-pack.js scripts/after-pack.test.ts
- pnpm test:run scripts/after-pack.test.ts
- pnpm test:run
- pnpm typecheck
- pnpm build