### PR TITLE
ci: run mac release builds on native runner arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,17 @@ on:
 
 jobs:
   build-mac:
-    runs-on: macos-14
+    runs-on: ${{ matrix.runner }}
     environment: release
 
     strategy:
       fail-fast: false
       matrix:
-        arch: [x64, arm64]
+        include:
+          - arch: x64
+            runner: macos-13
+          - arch: arm64
+            runner: macos-14
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- run mac x64 release builds on macos-13 (Intel)
- keep arm64 release builds on macos-14 (Apple Silicon)
- avoid host-arch optional native packages leaking into the wrong mac artifact

## Verification
- validated .github/workflows/release.yml parses as YAML with Ruby YAML.load_file
- confirmed current x64 failure logs still include arm64-only native packages on arm64 runners