### PR TITLE
ci: notarize mac artifacts explicitly in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,64 @@ jobs:
       - name: Package for macOS
         env:
           DEBUG: electron-builder,electron-notarize*
+          CI_MANUAL_NOTARIZE: 'true'
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm exec electron-builder --mac --${{ matrix.arch }} --publish never
+
+      - name: Resolve mac artifacts
+        id: mac-artifacts
+        run: |
+          APP_PATH="$(find dist -maxdepth 2 -type d -name '20x.app' | head -n 1)"
+          ZIP_PATH="$(find dist -maxdepth 1 -type f -name '20x-*-${{ matrix.arch }}.zip' | head -n 1)"
+          DMG_PATH="$(find dist -maxdepth 1 -type f -name '20x-*-${{ matrix.arch }}.dmg' | head -n 1)"
+
+          test -n "$APP_PATH"
+          test -f "$ZIP_PATH"
+          test -f "$DMG_PATH"
+
+          echo "app_path=$APP_PATH" >> "$GITHUB_OUTPUT"
+          echo "zip_path=$ZIP_PATH" >> "$GITHUB_OUTPUT"
+          echo "dmg_path=$DMG_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect packaged outputs
+        run: |
+          ls -lah dist
+          ls -lah "${{ steps.mac-artifacts.outputs.app_path }}"
+          echo "ZIP: ${{ steps.mac-artifacts.outputs.zip_path }}"
+          echo "DMG: ${{ steps.mac-artifacts.outputs.dmg_path }}"
+
+      - name: Notarize mac ZIP and staple app
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          xcrun notarytool submit "${{ steps.mac-artifacts.outputs.zip_path }}" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple "${{ steps.mac-artifacts.outputs.app_path }}"
+          xcrun stapler validate "${{ steps.mac-artifacts.outputs.app_path }}"
+          spctl --assess --type execute --verbose=4 "${{ steps.mac-artifacts.outputs.app_path }}"
+
+      - name: Notarize and staple mac DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          xcrun notarytool submit "${{ steps.mac-artifacts.outputs.dmg_path }}" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple "${{ steps.mac-artifacts.outputs.dmg_path }}"
+          xcrun stapler validate "${{ steps.mac-artifacts.outputs.dmg_path }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/scripts/notarize-config.js
+++ b/scripts/notarize-config.js
@@ -10,6 +10,10 @@ function shouldNotarize(context, env = process.env) {
     return { enabled: false, reason: 'not darwin build' }
   }
 
+  if (String(env.CI_MANUAL_NOTARIZE || '').toLowerCase() === 'true') {
+    return { enabled: false, reason: 'CI_MANUAL_NOTARIZE=true' }
+  }
+
   if (String(env.SKIP_NOTARIZE || '').toLowerCase() === 'true') {
     return { enabled: false, reason: 'SKIP_NOTARIZE=true' }
   }

--- a/scripts/notarize-config.test.ts
+++ b/scripts/notarize-config.test.ts
@@ -42,6 +42,16 @@ describe('notarize-config', () => {
     expect(result).toEqual({ enabled: false, reason: 'SKIP_NOTARIZE=true' })
   })
 
+  it('skips builder-managed notarization when CI manual notarization is enabled', () => {
+    const result = shouldNotarize(createContext('darwin'), {
+      CI_MANUAL_NOTARIZE: 'true',
+      APPLE_ID: 'dev@company.com',
+      APPLE_APP_SPECIFIC_PASSWORD: 'xxxx-xxxx-xxxx-xxxx',
+      APPLE_TEAM_ID: 'ABCD123456'
+    })
+    expect(result).toEqual({ enabled: false, reason: 'CI_MANUAL_NOTARIZE=true' })
+  })
+
   it('skips notarization on non-mac platforms', () => {
     const result = shouldNotarize(createContext('win32'), {
       APPLE_ID: 'dev@company.com',

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -8,6 +8,11 @@ const { notarize } = require('@electron/notarize')
 const { shouldNotarize, getNotarizeOptions } = require('./notarize-config')
 
 async function notarizeApp(context) {
+  const productFilename = context.packager?.appInfo?.productFilename || 'app'
+  console.log(
+    `[notarize] appOutDir=${context.appOutDir} productFilename=${productFilename} platform=${context.electronPlatformName}`
+  )
+
   const decision = shouldNotarize(context, process.env)
   if (!decision.enabled) {
     console.log(`[notarize] Skipping notarization: ${decision.reason}`)


### PR DESCRIPTION
## Summary
- skip the builder-managed notarization hook in CI while keeping local notarization intact
- notarize the generated mac zip and dmg explicitly with notarytool after packaging
- add CI diagnostics and a tested control flag for the manual notarization path

## Test plan
- pnpm --dir 20x test:run scripts/notarize-config.test.ts
- pnpm --dir 20x test:run
- pnpm --dir 20x typecheck
- pnpm --dir 20x build