### PR TITLE
ci: fully bypass builder afterSign in mac release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - arch: x64
-            runner: macos-13
+            runner: macos-15-large
           - arch: arm64
             runner: macos-14
 
@@ -66,13 +66,12 @@ jobs:
       - name: Package for macOS
         env:
           DEBUG: electron-builder,electron-notarize*
-          CI_MANUAL_NOTARIZE: 'true'
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: pnpm exec electron-builder --mac --${{ matrix.arch }} --publish never
+        run: pnpm exec electron-builder --config ./scripts/electron-builder-ci-mac-config.js --mac --${{ matrix.arch }} --publish never
 
       - name: Resolve mac artifacts
         id: mac-artifacts

--- a/scripts/electron-builder-ci-mac-config.js
+++ b/scripts/electron-builder-ci-mac-config.js
@@ -1,0 +1,12 @@
+const packageJson = require('../package.json')
+
+function getCiMacBuildConfig(baseBuild = packageJson.build) {
+  return {
+    ...baseBuild,
+    // CI notarizes packaged artifacts explicitly in the workflow.
+    afterSign: undefined
+  }
+}
+
+module.exports = getCiMacBuildConfig()
+module.exports.getCiMacBuildConfig = getCiMacBuildConfig

--- a/scripts/electron-builder-ci-mac-config.test.ts
+++ b/scripts/electron-builder-ci-mac-config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import packageJson from '../package.json'
+import { getCiMacBuildConfig } from './electron-builder-ci-mac-config'
+
+describe('electron-builder-ci-mac-config', () => {
+  it('removes afterSign from the base electron-builder config', () => {
+    const config = getCiMacBuildConfig(packageJson.build)
+
+    expect(config.afterSign).toBeUndefined()
+    expect(config.afterPack).toBe('./scripts/after-pack.js')
+    expect(config.mac).toEqual(packageJson.build.mac)
+    expect(config.win).toEqual(packageJson.build.win)
+    expect(config.linux).toEqual(packageJson.build.linux)
+  })
+})


### PR DESCRIPTION
## Summary
- switch the mac release job to a dedicated electron-builder config that omits \
- keep manual notarization in workflow steps after packaging succeeds
- move the x64 mac runner to a supported label and add a regression test for the CI config helper

## Testing
- pnpm --dir 20x test:run scripts/notarize-config.test.ts scripts/electron-builder-ci-mac-config.test.ts
- pnpm --dir 20x typecheck
- pre-commit hook also ran: lint, typecheck, build, full test suite