### PR TITLE
fix: export plain electron-builder ci config

### DIFF
--- a/scripts/electron-builder-ci-mac-config-helper.js
+++ b/scripts/electron-builder-ci-mac-config-helper.js
@@ -1,0 +1,13 @@
+const packageJson = require('../package.json')
+
+function getCiMacBuildConfig(baseBuild = packageJson.build) {
+  return {
+    ...baseBuild,
+    // CI notarizes packaged artifacts explicitly in the workflow.
+    afterSign: undefined
+  }
+}
+
+module.exports = {
+  getCiMacBuildConfig
+}

--- a/scripts/electron-builder-ci-mac-config.js
+++ b/scripts/electron-builder-ci-mac-config.js
@@ -1,12 +1,3 @@
-const packageJson = require('../package.json')
-
-function getCiMacBuildConfig(baseBuild = packageJson.build) {
-  return {
-    ...baseBuild,
-    // CI notarizes packaged artifacts explicitly in the workflow.
-    afterSign: undefined
-  }
-}
+const { getCiMacBuildConfig } = require('./electron-builder-ci-mac-config-helper')
 
 module.exports = getCiMacBuildConfig()
-module.exports.getCiMacBuildConfig = getCiMacBuildConfig

--- a/scripts/electron-builder-ci-mac-config.test.ts
+++ b/scripts/electron-builder-ci-mac-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import packageJson from '../package.json'
-import { getCiMacBuildConfig } from './electron-builder-ci-mac-config'
+import { getCiMacBuildConfig } from './electron-builder-ci-mac-config-helper'
 
 describe('electron-builder-ci-mac-config', () => {
   it('removes afterSign from the base electron-builder config', () => {


### PR DESCRIPTION
Summary:
- fix the CI mac electron-builder config so the file exports only a plain config object
- move the helper function into a separate helper module to avoid schema validation failure
- keep the existing regression test pointed at the helper

Root cause:
- v0.0.54 failed because electron-builder loaded scripts/electron-builder-ci-mac-config.js as a config object and rejected the extra top-level getCiMacBuildConfig property

Testing:
- pnpm --dir 20x test:run scripts/electron-builder-ci-mac-config.test.ts scripts/notarize-config.test.ts
- pnpm --dir 20x typecheck
- pre-commit hook also ran lint, typecheck, build, and the full test suite