### PR TITLE
feat: add Claude Opus 4.7 model

### DIFF
--- a/src/renderer/src/types/index.test.ts
+++ b/src/renderer/src/types/index.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { CODEX_MODELS, CodexModel } from './index'
+import { CLAUDE_MODELS, ClaudeModel, CODEX_MODELS, CodexModel } from './index'
+
+describe('CLAUDE_MODELS', () => {
+  it('includes Claude Opus 4.7', () => {
+    expect(CLAUDE_MODELS).toContainEqual({
+      id: ClaudeModel.OPUS_4_7,
+      name: 'Claude Opus 4.7'
+    })
+  })
+})
 
 describe('CODEX_MODELS', () => {
   it('lists GPT-5.4 first as the recommended model', () => {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -41,6 +41,7 @@ export const CODING_AGENTS: { value: CodingAgentType; label: string }[] = [
 ]
 
 export enum ClaudeModel {
+  OPUS_4_7 = 'claude-opus-4-7',
   SONNET_4_6 = 'claude-sonnet-4-6',
   SONNET_4_5 = 'claude-sonnet-4-5',
   OPUS_4_6 = 'claude-opus-4-6',
@@ -51,6 +52,7 @@ export enum ClaudeModel {
 }
 
 export const CLAUDE_MODELS: { id: ClaudeModel; name: string }[] = [
+  { id: ClaudeModel.OPUS_4_7, name: 'Claude Opus 4.7' },
   { id: ClaudeModel.SONNET_4_6, name: 'Claude Sonnet 4.6' },
   { id: ClaudeModel.SONNET_4_5, name: 'Claude Sonnet 4.5' },
   { id: ClaudeModel.OPUS_4_6, name: 'Claude Opus 4.6' },


### PR DESCRIPTION
## Summary
- add `claude-opus-4-7` to the Claude Code model list
- expose Claude Opus 4.7 anywhere the shared Claude model registry is used
- add a unit test covering the new model entry

## Test plan
- [x] pnpm build
- [x] pnpm test:run