### PR TITLE
ci: disable builder notarization in mac release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,6 @@ jobs:
           DEBUG: electron-builder,electron-notarize*
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm exec electron-builder --config ./scripts/electron-builder-ci-mac-config.js --mac --${{ matrix.arch }} --publish never
 
       - name: Resolve mac artifacts

--- a/scripts/electron-builder-ci-mac-config-helper.js
+++ b/scripts/electron-builder-ci-mac-config-helper.js
@@ -3,6 +3,11 @@ const packageJson = require('../package.json')
 function getCiMacBuildConfig(baseBuild = packageJson.build) {
   return {
     ...baseBuild,
+    mac: {
+      ...baseBuild.mac,
+      // CI uses explicit notarytool steps after packaging instead of builder-managed notarization.
+      notarize: false
+    },
     // CI notarizes packaged artifacts explicitly in the workflow.
     afterSign: undefined
   }

--- a/scripts/electron-builder-ci-mac-config.test.ts
+++ b/scripts/electron-builder-ci-mac-config.test.ts
@@ -8,7 +8,10 @@ describe('electron-builder-ci-mac-config', () => {
 
     expect(config.afterSign).toBeUndefined()
     expect(config.afterPack).toBe('./scripts/after-pack.js')
-    expect(config.mac).toEqual(packageJson.build.mac)
+    expect(config.mac).toEqual({
+      ...packageJson.build.mac,
+      notarize: false
+    })
     expect(config.win).toEqual(packageJson.build.win)
     expect(config.linux).toEqual(packageJson.build.linux)
   })


### PR DESCRIPTION
Summary:
- disable builder-managed mac notarization in the CI electron-builder config by setting mac.notarize to false
- remove APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID from the Package for macOS step
- keep Apple notarization credentials only in the explicit notarytool steps after packaging

Why:
- v0.0.55 still failed inside electron-builder's built-in electron-notarize codesign precheck even after removing the custom afterSign hook path
- local manual notarytool notarization already proved the explicit post-package flow works

Testing:
- pnpm --dir 20x test:run scripts/electron-builder-ci-mac-config.test.ts scripts/notarize-config.test.ts
- pnpm --dir 20x typecheck
- pre-commit hook also ran lint, typecheck, build, and the full test suite