### PR TITLE
ci: scale down mac release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - arch: x64
-            runner: macos-15-large
+            runner: macos-15-intel
           - arch: arm64
             runner: macos-14
 


### PR DESCRIPTION
Summary:
- switch the mac x64 release job from macos-15-large to the standard macos-15-intel runner
- keep the arm64 mac job on macos-14 unchanged

Why:
- the release flow is working now and the large runner is no longer justified
- this is the smallest cost reduction that avoids touching the proven notarization/signing path

Testing:
- pre-commit hook ran lint, typecheck, build, and the full test suite before push