### PR TITLE
feat: implement auto-update UX

### DIFF
--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -65,12 +65,11 @@ describe('auto-updater', () => {
       expect(events).toContain('error')
     })
 
-    it('should register IPC handlers for updater:check, updater:download, updater:install, updater:getVersion', async () => {
+    it('should register IPC handlers via registerUpdaterIpc', async () => {
       const { ipcMain } = await import('electron')
-      const { initAutoUpdater } = await import('./auto-updater')
-      const mockWindow = { isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } } as any
+      const { registerUpdaterIpc } = await import('./auto-updater')
 
-      initAutoUpdater(mockWindow)
+      registerUpdaterIpc()
 
       const registeredChannels = (ipcMain.handle as any).mock.calls.map((c: any[]) => c[0])
       expect(registeredChannels).toContain('updater:check')

--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -105,6 +105,26 @@ describe('auto-updater', () => {
         currentVersion: '0.0.31'
       }))
     })
+
+    it('should send up-to-date status on 404 errors instead of suppressing', async () => {
+      const { initAutoUpdater } = await import('./auto-updater')
+      const sendMock = vi.fn()
+      const mockWindow = { isDestroyed: vi.fn(() => false), webContents: { send: sendMock } } as any
+
+      initAutoUpdater(mockWindow)
+
+      const errorHandler = mockAutoUpdater.on.mock.calls.find(
+        (c: any[]) => c[0] === 'error'
+      )?.[1]
+
+      expect(errorHandler).toBeDefined()
+      errorHandler(new Error('HttpError: 404 Not Found'))
+
+      expect(sendMock).toHaveBeenCalledWith('updater:status', expect.objectContaining({
+        status: 'up-to-date',
+        currentVersion: '0.0.31'
+      }))
+    })
   })
 
   describe('isUpdateDownloaded', () => {

--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock electron-updater
+const mockAutoUpdater = {
+  autoDownload: false,
+  autoInstallOnAppQuit: false,
+  on: vi.fn(),
+  checkForUpdates: vi.fn(),
+  downloadUpdate: vi.fn(),
+  quitAndInstall: vi.fn()
+}
+
+vi.mock('electron-updater', () => ({
+  autoUpdater: mockAutoUpdater
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/test'),
+    getName: vi.fn(() => '20x'),
+    getVersion: vi.fn(() => '0.0.31'),
+    isPackaged: true
+  },
+  BrowserWindow: vi.fn(),
+  dialog: { showMessageBox: vi.fn() },
+  ipcMain: {
+    handle: vi.fn(),
+    on: vi.fn()
+  }
+}))
+
+describe('auto-updater', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockAutoUpdater.autoDownload = false
+    mockAutoUpdater.autoInstallOnAppQuit = false
+    mockAutoUpdater.on.mockReset()
+    mockAutoUpdater.checkForUpdates.mockReset()
+    mockAutoUpdater.downloadUpdate.mockReset()
+  })
+
+  describe('initAutoUpdater', () => {
+    it('should set autoDownload to true for silent background downloads', async () => {
+      const { initAutoUpdater } = await import('./auto-updater')
+      const mockWindow = { isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } } as any
+
+      initAutoUpdater(mockWindow)
+
+      expect(mockAutoUpdater.autoDownload).toBe(true)
+      expect(mockAutoUpdater.autoInstallOnAppQuit).toBe(false)
+    })
+
+    it('should register all required event listeners', async () => {
+      const { initAutoUpdater } = await import('./auto-updater')
+      const mockWindow = { isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } } as any
+
+      initAutoUpdater(mockWindow)
+
+      const events = mockAutoUpdater.on.mock.calls.map((c: any[]) => c[0])
+      expect(events).toContain('checking-for-update')
+      expect(events).toContain('update-available')
+      expect(events).toContain('update-not-available')
+      expect(events).toContain('download-progress')
+      expect(events).toContain('update-downloaded')
+      expect(events).toContain('error')
+    })
+
+    it('should register IPC handlers for updater:check, updater:download, updater:install, updater:getVersion', async () => {
+      const { ipcMain } = await import('electron')
+      const { initAutoUpdater } = await import('./auto-updater')
+      const mockWindow = { isDestroyed: vi.fn(() => false), webContents: { send: vi.fn() } } as any
+
+      initAutoUpdater(mockWindow)
+
+      const registeredChannels = (ipcMain.handle as any).mock.calls.map((c: any[]) => c[0])
+      expect(registeredChannels).toContain('updater:check')
+      expect(registeredChannels).toContain('updater:download')
+      expect(registeredChannels).toContain('updater:install')
+      expect(registeredChannels).toContain('updater:getVersion')
+    })
+
+    it('should send release notes in update-available event', async () => {
+      const { initAutoUpdater } = await import('./auto-updater')
+      const sendMock = vi.fn()
+      const mockWindow = { isDestroyed: vi.fn(() => false), webContents: { send: sendMock } } as any
+
+      initAutoUpdater(mockWindow)
+
+      // Find and invoke the 'update-available' handler
+      const updateAvailableHandler = mockAutoUpdater.on.mock.calls.find(
+        (c: any[]) => c[0] === 'update-available'
+      )?.[1]
+
+      expect(updateAvailableHandler).toBeDefined()
+      updateAvailableHandler({
+        version: '1.0.0',
+        releaseNotes: '## What\'s new\n- Bug fixes',
+        releaseDate: '2026-04-01'
+      })
+
+      expect(sendMock).toHaveBeenCalledWith('updater:status', expect.objectContaining({
+        status: 'available',
+        version: '1.0.0',
+        releaseNotes: '## What\'s new\n- Bug fixes',
+        releaseDate: '2026-04-01',
+        currentVersion: '0.0.31'
+      }))
+    })
+  })
+
+  describe('isUpdateDownloaded', () => {
+    it('should return false initially', async () => {
+      const { isUpdateDownloaded } = await import('./auto-updater')
+      expect(isUpdateDownloaded()).toBe(false)
+    })
+  })
+
+  describe('getPendingVersion', () => {
+    it('should return null initially', async () => {
+      const { getPendingVersion } = await import('./auto-updater')
+      expect(getPendingVersion()).toBeNull()
+    })
+  })
+})

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -1,29 +1,44 @@
 import { autoUpdater, type UpdateInfo } from 'electron-updater'
-import { BrowserWindow, ipcMain } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain } from 'electron'
 
 let mainWin: BrowserWindow | null = null
+
+/** Version of the latest available update (set when update-available fires) */
+let pendingVersion: string | null = null
+
+/** Whether an update has been downloaded and is ready to install */
+let updateDownloaded = false
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
 export function initAutoUpdater(win: BrowserWindow): void {
   mainWin = win
 
-  // Don't auto-download — let the user decide
-  autoUpdater.autoDownload = false
-  autoUpdater.autoInstallOnAppQuit = true
+  // Silently download in the background so the update is ready when the user quits
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = false // We handle quit-time prompt ourselves
 
   autoUpdater.on('checking-for-update', () => {
     send('updater:status', { status: 'checking' })
   })
 
   autoUpdater.on('update-available', (info: UpdateInfo) => {
+    pendingVersion = info.version
     send('updater:status', {
       status: 'available',
       version: info.version,
-      releaseNotes: typeof info.releaseNotes === 'string' ? info.releaseNotes : ''
+      releaseNotes: typeof info.releaseNotes === 'string'
+        ? info.releaseNotes
+        : Array.isArray(info.releaseNotes)
+          ? info.releaseNotes.map((n) => `## ${n.version}\n${n.note}`).join('\n\n')
+          : '',
+      releaseDate: info.releaseDate ?? '',
+      currentVersion: app.getVersion()
     })
   })
 
   autoUpdater.on('update-not-available', () => {
-    send('updater:status', { status: 'up-to-date' })
+    send('updater:status', { status: 'up-to-date', currentVersion: app.getVersion() })
   })
 
   autoUpdater.on('download-progress', (progress) => {
@@ -34,6 +49,7 @@ export function initAutoUpdater(win: BrowserWindow): void {
   })
 
   autoUpdater.on('update-downloaded', (info: UpdateInfo) => {
+    updateDownloaded = true
     send('updater:status', {
       status: 'downloaded',
       version: info.version
@@ -74,12 +90,36 @@ export function initAutoUpdater(win: BrowserWindow): void {
     autoUpdater.quitAndInstall()
   })
 
+  ipcMain.handle('updater:getVersion', () => {
+    return app.getVersion()
+  })
+
   // Check for updates on startup (after a short delay)
   setTimeout(() => {
     autoUpdater.checkForUpdates().catch(() => {
       // Silently ignore — no releases published yet is fine
     })
   }, 10_000)
+
+  // Re-check once a day (24h interval)
+  setInterval(() => {
+    autoUpdater.checkForUpdates().catch(() => {})
+  }, ONE_DAY_MS)
+}
+
+/**
+ * Whether a downloaded update is ready to install.
+ * Used by the quit-time prompt in index.ts.
+ */
+export function isUpdateDownloaded(): boolean {
+  return updateDownloaded
+}
+
+/**
+ * Get the pending update version (if any).
+ */
+export function getPendingVersion(): string | null {
+  return pendingVersion
 }
 
 function send(channel: string, data: unknown): void {

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -100,8 +100,9 @@ export function initAutoUpdater(win: BrowserWindow): void {
   })
 
   autoUpdater.on('error', (err) => {
-    // Suppress 404 errors — no releases published yet is expected
+    // 404 / no releases published yet → treat as up-to-date so the UI resolves
     if (err.message?.includes('404') || err.message?.includes('Cannot find latest')) {
+      send('updater:status', { status: 'up-to-date', currentVersion: app.getVersion() })
       return
     }
     send('updater:status', {

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -2,6 +2,7 @@ import { autoUpdater, type UpdateInfo } from 'electron-updater'
 import { app, BrowserWindow, ipcMain } from 'electron'
 
 let mainWin: BrowserWindow | null = null
+let updaterActive = false
 
 /** Version of the latest available update (set when update-available fires) */
 let pendingVersion: string | null = null
@@ -11,8 +12,50 @@ let updateDownloaded = false
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
+/**
+ * Register updater IPC handlers. Must be called early (before the renderer
+ * loads) so that `ipcRenderer.invoke('updater:*')` never throws
+ * "No handler registered". Safe to call in dev mode — the handlers simply
+ * return no-op results when the real updater hasn't been started.
+ */
+export function registerUpdaterIpc(): void {
+  ipcMain.handle('updater:check', async () => {
+    if (!updaterActive) return { success: false, error: 'Updater not available in dev mode' }
+    try {
+      const result = await autoUpdater.checkForUpdates()
+      return { success: true, version: result?.updateInfo?.version ?? null }
+    } catch (err) {
+      return { success: false, error: (err as Error).message }
+    }
+  })
+
+  ipcMain.handle('updater:download', async () => {
+    if (!updaterActive) return { success: false, error: 'Updater not available in dev mode' }
+    try {
+      await autoUpdater.downloadUpdate()
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: (err as Error).message }
+    }
+  })
+
+  ipcMain.handle('updater:install', () => {
+    if (!updaterActive) return
+    autoUpdater.quitAndInstall()
+  })
+
+  ipcMain.handle('updater:getVersion', () => {
+    return app.getVersion()
+  })
+}
+
+/**
+ * Start the real auto-updater (production only).
+ * Call registerUpdaterIpc() first so the IPC handlers exist.
+ */
 export function initAutoUpdater(win: BrowserWindow): void {
   mainWin = win
+  updaterActive = true
 
   // Silently download in the background so the update is ready when the user quits
   autoUpdater.autoDownload = true
@@ -65,33 +108,6 @@ export function initAutoUpdater(win: BrowserWindow): void {
       status: 'error',
       error: err.message
     })
-  })
-
-  // IPC handlers
-  ipcMain.handle('updater:check', async () => {
-    try {
-      const result = await autoUpdater.checkForUpdates()
-      return { success: true, version: result?.updateInfo?.version ?? null }
-    } catch (err) {
-      return { success: false, error: (err as Error).message }
-    }
-  })
-
-  ipcMain.handle('updater:download', async () => {
-    try {
-      await autoUpdater.downloadUpdate()
-      return { success: true }
-    } catch (err) {
-      return { success: false, error: (err as Error).message }
-    }
-  })
-
-  ipcMain.handle('updater:install', () => {
-    autoUpdater.quitAndInstall()
-  })
-
-  ipcMain.handle('updater:getVersion', () => {
-    return app.getVersion()
   })
 
   // Check for updates on startup (after a short delay)

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -1,5 +1,5 @@
 import { autoUpdater, type UpdateInfo } from 'electron-updater'
-import { app, BrowserWindow, dialog, ipcMain } from 'electron'
+import { app, BrowserWindow, ipcMain } from 'electron'
 
 let mainWin: BrowserWindow | null = null
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,7 +29,7 @@ import { EnterpriseStateSync } from './enterprise-state-sync'
 import { setTaskApiNotifier, setTranscriptProvider, stopTaskApiServer } from './task-api-server'
 import { startSecretBroker, stopSecretBroker, writeSecretShellWrapper } from './secret-broker'
 import { startMobileApiServer, stopMobileApiServer, broadcastToMobileClients, setMobileApiNotifier } from './mobile-api-server'
-import { initAutoUpdater, isUpdateDownloaded, getPendingVersion } from './auto-updater'
+import { registerUpdaterIpc, initAutoUpdater, isUpdateDownloaded, getPendingVersion } from './auto-updater'
 import { initCrashLogger } from './crash-logger'
 
 let mainWindow: BrowserWindow | null = null
@@ -682,6 +682,9 @@ app.whenReady().then(async () => {
   }
 
   registerIpcHandlers(db, agentManager, githubManager, worktreeManager, syncManager, pluginRegistry, mcpToolCaller, oauthManager, recurrenceScheduler, enterpriseAuth ?? undefined, claudePluginManager, heartbeatScheduler, enterpriseHeartbeatInstance ?? undefined, enterpriseStateSyncInstance ?? undefined, gitlabManager ?? undefined)
+
+  // Register updater IPC handlers (safe in dev mode — returns no-op results)
+  registerUpdaterIpc()
 
   // Build the application menu (includes "Check for Updates…")
   buildAppMenu()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { execFile, execSync } from 'child_process'
 import { readdirSync } from 'fs'
-import { app, BrowserWindow, net, protocol, shell, Tray, Menu, nativeImage } from 'electron'
+import { app, BrowserWindow, dialog, net, protocol, shell, Tray, Menu, nativeImage } from 'electron'
 import { join } from 'path'
 import { pathToFileURL } from 'url'
 import { is } from '@electron-toolkit/utils'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,7 +29,7 @@ import { EnterpriseStateSync } from './enterprise-state-sync'
 import { setTaskApiNotifier, setTranscriptProvider, stopTaskApiServer } from './task-api-server'
 import { startSecretBroker, stopSecretBroker, writeSecretShellWrapper } from './secret-broker'
 import { startMobileApiServer, stopMobileApiServer, broadcastToMobileClients, setMobileApiNotifier } from './mobile-api-server'
-import { initAutoUpdater } from './auto-updater'
+import { initAutoUpdater, isUpdateDownloaded, getPendingVersion } from './auto-updater'
 import { initCrashLogger } from './crash-logger'
 
 let mainWindow: BrowserWindow | null = null
@@ -206,6 +206,95 @@ function createWindow(): void {
       mainWindow.webContents.send(channel, data)
     }
   })
+}
+
+/**
+ * Build and set the application menu.
+ * Adds "Check for Updates…" under the app menu (macOS) or Help menu (Win/Linux).
+ */
+function buildAppMenu(): void {
+  const isMac = process.platform === 'darwin'
+
+  const checkForUpdatesItem: Electron.MenuItemConstructorOptions = {
+    label: 'Check for Updates…',
+    click: () => {
+      mainWindow?.show()
+      mainWindow?.webContents.send('menu:check-for-updates')
+    }
+  }
+
+  const template: Electron.MenuItemConstructorOptions[] = [
+    ...(isMac
+      ? [
+          {
+            label: app.name,
+            submenu: [
+              { role: 'about' as const },
+              { type: 'separator' as const },
+              checkForUpdatesItem,
+              { type: 'separator' as const },
+              { role: 'services' as const },
+              { type: 'separator' as const },
+              { role: 'hide' as const },
+              { role: 'hideOthers' as const },
+              { role: 'unhide' as const },
+              { type: 'separator' as const },
+              { role: 'quit' as const }
+            ]
+          }
+        ]
+      : []),
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' }
+      ]
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' }
+      ]
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        ...(isMac
+          ? [{ type: 'separator' as const }, { role: 'front' as const }]
+          : [{ role: 'close' as const }])
+      ]
+    },
+    {
+      label: 'Help',
+      submenu: [
+        ...(!isMac ? [checkForUpdatesItem, { type: 'separator' as const }] : []),
+        {
+          label: 'View on GitHub',
+          click: () => {
+            shell.openExternal('https://github.com/peakflo/20x')
+          }
+        }
+      ]
+    }
+  ]
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 }
 
 function createTray(): void {
@@ -594,6 +683,9 @@ app.whenReady().then(async () => {
 
   registerIpcHandlers(db, agentManager, githubManager, worktreeManager, syncManager, pluginRegistry, mcpToolCaller, oauthManager, recurrenceScheduler, enterpriseAuth ?? undefined, claudePluginManager, heartbeatScheduler, enterpriseHeartbeatInstance ?? undefined, enterpriseStateSyncInstance ?? undefined, gitlabManager ?? undefined)
 
+  // Build the application menu (includes "Check for Updates…")
+  buildAppMenu()
+
   // Start secret broker and write shell wrapper (awaited so broker is ready before any sessions)
   try {
     const brokerPort = await startSecretBroker(db)
@@ -635,12 +727,34 @@ app.on('window-all-closed', () => {
   }
 })
 
-app.on('before-quit', (event) => {
+app.on('before-quit', async (event) => {
   if (isShuttingDown) {
     return
   }
 
   event.preventDefault()
+
+  // If a downloaded update is ready, offer to install before quitting
+  if (isUpdateDownloaded()) {
+    const version = getPendingVersion()
+    const { response } = await dialog.showMessageBox({
+      type: 'info',
+      title: 'Update Ready',
+      message: `A new version${version ? ` (v${version})` : ''} has been downloaded.`,
+      detail: 'Would you like to install the update and restart, or quit without updating?',
+      buttons: ['Install & Restart', 'Quit Without Updating'],
+      defaultId: 0,
+      cancelId: 1
+    })
+
+    if (response === 0) {
+      // Install & restart — autoUpdater handles the process
+      const { autoUpdater } = await import('electron-updater')
+      autoUpdater.quitAndInstall()
+      return
+    }
+  }
+
   isShuttingDown = true
   isQuitting = true
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -380,10 +380,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('updater:download'),
     install: (): Promise<void> =>
       ipcRenderer.invoke('updater:install'),
-    onStatus: (callback: (data: { status: string; version?: string; percent?: number; error?: string; releaseNotes?: string }) => void): (() => void) => {
-      const handler = (_: unknown, data: { status: string; version?: string; percent?: number; error?: string; releaseNotes?: string }): void => callback(data)
+    onStatus: (callback: (data: { status: string; version?: string; percent?: number; error?: string; releaseNotes?: string; releaseDate?: string; currentVersion?: string }) => void): (() => void) => {
+      const handler = (_: unknown, data: { status: string; version?: string; percent?: number; error?: string; releaseNotes?: string; releaseDate?: string; currentVersion?: string }): void => callback(data)
       ipcRenderer.on('updater:status', handler)
       return () => ipcRenderer.removeListener('updater:status', handler)
+    },
+    getVersion: (): Promise<string> =>
+      ipcRenderer.invoke('updater:getVersion'),
+    onMenuCheckForUpdates: (callback: () => void): (() => void) => {
+      const handler = (): void => callback()
+      ipcRenderer.on('menu:check-for-updates', handler)
+      return () => ipcRenderer.removeListener('menu:check-for-updates', handler)
     }
   },
   agentInstaller: {

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { SettingsWorkspace } from '@/components/settings/SettingsWorkspace'
 import { DashboardWorkspace } from '@/components/dashboard/DashboardWorkspace'
 import { TaskForm, type TaskFormSubmitData } from '@/components/tasks/TaskForm'
 import { DeleteConfirmDialog } from '@/components/tasks/DeleteConfirmDialog'
+import { UpdateDialog } from '@/components/update/UpdateDialog'
 import { Dialog, DialogContent, DialogHeader, DialogBody, DialogTitle } from '@/components/ui/Dialog'
 import { OrchestratorPanel } from '@/components/orchestrator/OrchestratorPanel'
 import { OnboardingWizard, shouldShowOnboarding } from '@/components/onboarding/OnboardingWizard'
@@ -13,7 +14,7 @@ import { useUIStore } from '@/stores/ui-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useAgentAutoStart } from '@/hooks/use-agent-auto-start'
 import { useOverdueNotifications } from '@/hooks/use-overdue-notifications'
-import { attachmentApi, worktreeApi, settingsApi } from '@/lib/ipc-client'
+import { attachmentApi, worktreeApi, settingsApi, updaterApi } from '@/lib/ipc-client'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { isOverdue, isSnoozed } from '@/lib/utils'
 import { useEffect, useState, useCallback } from 'react'
@@ -22,6 +23,7 @@ import type { FileAttachment } from '@/types'
 import { MessageSquare, ExternalLink, LayoutDashboard, CheckSquare, Zap, Settings } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import type { SidebarView } from '@/stores/ui-store'
+import logo20x from '@/assets/logos/20x.svg'
 
 export function AppLayout() {
   const { tasks, allTasks, selectedTask, createTask, updateTask, deleteTask, selectTask } = useTasks()
@@ -42,8 +44,29 @@ export function AppLayout() {
     closeDashboardPreview
   } = useUIStore()
 
+  // ── Update indicator state ──
+  const [updateAvailableVersion, setUpdateAvailableVersion] = useState<string | null>(null)
+  const [updateDialogOpen, setUpdateDialogOpen] = useState(false)
+
   useEffect(() => {
     fetchAgents()
+
+    // Listen for update status events to show the yellow dot
+    const cleanupStatus = updaterApi.onStatus((data) => {
+      if (data.status === 'available' || data.status === 'downloading' || data.status === 'downloaded') {
+        setUpdateAvailableVersion(data.version ?? null)
+      }
+    })
+
+    // Listen for "Check for Updates" from the native application menu
+    const cleanupMenu = updaterApi.onMenuCheckForUpdates(() => {
+      setUpdateDialogOpen(true)
+    })
+
+    return () => {
+      cleanupStatus()
+      cleanupMenu()
+    }
   }, [])
 
   const editingTask = editingTaskId ? tasks.find((t) => t.id === editingTaskId) || selectedTask : undefined
@@ -108,8 +131,23 @@ export function AppLayout() {
 
   return (
     <>
-      {/* ── Top bar: drag region with logo (left) + nav switcher (center-left) + actions (right) ── */}
+      {/* ── Top bar: drag region with logo (left) + nav switcher (center) + actions (right) ── */}
       <div className="drag-region h-12 flex-shrink-0 flex items-center justify-center px-4 border-b border-border/50 windows-titlebar-pad">
+        {/* Logo + update indicator — pinned left */}
+        <div className="no-drag absolute left-4 flex items-center gap-2 macos-titlebar-pad">
+          <div className="relative">
+            <img src={logo20x} className="h-5 w-5" alt="20x" />
+            {updateAvailableVersion && (
+              <button
+                onClick={() => setUpdateDialogOpen(true)}
+                className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-amber-400 ring-2 ring-background cursor-pointer animate-pulse"
+                title={`Update available: v${updateAvailableVersion}`}
+              />
+            )}
+          </div>
+          <span className="text-sm font-semibold text-foreground">20x</span>
+        </div>
+
         {/* View switcher — centered */}
         <div className="no-drag flex rounded-md border border-border bg-muted/30 p-0.5">
           {NAV_ITEMS.map(({ key, label, icon: Icon }) => (
@@ -406,6 +444,9 @@ export function AppLayout() {
           </div>
         </DialogContent>
       </Dialog>
+
+      {/* Update dialog */}
+      <UpdateDialog open={updateDialogOpen} onClose={() => setUpdateDialogOpen(false)} />
 
       {/* Toast */}
       {toast && (

--- a/src/renderer/src/components/update/UpdateDialog.test.tsx
+++ b/src/renderer/src/components/update/UpdateDialog.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { UpdateDialog } from './UpdateDialog'
+
+// Access the mock electronAPI from setup-renderer.ts
+const mockUpdater = window.electronAPI.updater
+
+describe('UpdateDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUpdater.check.mockResolvedValue({ success: true })
+    mockUpdater.getVersion.mockResolvedValue('0.0.31')
+  })
+
+  it('should show checking state when opened', () => {
+    render(<UpdateDialog open={true} onClose={vi.fn()} />)
+    expect(screen.getByText('Checking for updates...')).toBeInTheDocument()
+  })
+
+  it('should call updater.check when opened', () => {
+    render(<UpdateDialog open={true} onClose={vi.fn()} />)
+    expect(mockUpdater.check).toHaveBeenCalled()
+  })
+
+  it('should display current version', async () => {
+    render(<UpdateDialog open={true} onClose={vi.fn()} />)
+    await waitFor(() => {
+      // Radix Dialog may render duplicate nodes; just check at least one exists
+      expect(screen.getAllByText('v0.0.31').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('should show error when check fails (e.g. dev mode)', async () => {
+    mockUpdater.check.mockResolvedValue({ success: false, error: 'Updater not available in dev mode' })
+
+    render(<UpdateDialog open={true} onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Updater not available in dev mode')).toBeInTheDocument()
+    })
+  })
+
+  it('should show up-to-date state via onStatus event', async () => {
+    let statusCallback: ((data: Record<string, unknown>) => void) | null = null
+    mockUpdater.onStatus.mockImplementation((cb: (data: Record<string, unknown>) => void) => {
+      statusCallback = cb
+      return vi.fn()
+    })
+
+    render(<UpdateDialog open={true} onClose={vi.fn()} />)
+
+    // Simulate the main process sending 'up-to-date'
+    statusCallback!({ status: 'up-to-date', currentVersion: '0.0.31' })
+
+    await waitFor(() => {
+      // Radix Dialog may render duplicate nodes
+      expect(screen.getAllByText(/up to date/i).length).toBeGreaterThan(0)
+    })
+  })
+
+  it('should show update available state with version and download button', async () => {
+    let statusCallback: ((data: Record<string, unknown>) => void) | null = null
+    mockUpdater.onStatus.mockImplementation((cb: (data: Record<string, unknown>) => void) => {
+      statusCallback = cb
+      return vi.fn()
+    })
+
+    render(<UpdateDialog open={true} onClose={vi.fn()} />)
+
+    statusCallback!({
+      status: 'available',
+      version: '1.0.0',
+      releaseNotes: '## Bug fixes\n- Fixed crash',
+      releaseDate: '2026-04-17',
+      currentVersion: '0.0.31'
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('v1.0.0')).toBeInTheDocument()
+      expect(screen.getByText('Download Update')).toBeInTheDocument()
+    })
+  })
+
+  it('should show Install & Restart button when downloaded', async () => {
+    let statusCallback: ((data: Record<string, unknown>) => void) | null = null
+    mockUpdater.onStatus.mockImplementation((cb: (data: Record<string, unknown>) => void) => {
+      statusCallback = cb
+      return vi.fn()
+    })
+
+    render(<UpdateDialog open={true} onClose={vi.fn()} />)
+
+    statusCallback!({ status: 'downloaded', version: '1.0.0' })
+
+    await waitFor(() => {
+      expect(screen.getByText('Install & Restart')).toBeInTheDocument()
+    })
+  })
+
+  it('should call onClose when Close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<UpdateDialog open={true} onClose={onClose} />)
+
+    // The Close button is a <button> with variant="outline"
+    const closeButtons = screen.getAllByRole('button', { name: /close/i })
+    fireEvent.click(closeButtons[closeButtons.length - 1])
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/update/UpdateDialog.test.tsx
+++ b/src/renderer/src/components/update/UpdateDialog.test.tsx
@@ -1,9 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { UpdateDialog } from './UpdateDialog'
 
-// Access the mock electronAPI from setup-renderer.ts
-const mockUpdater = window.electronAPI.updater
+// Access the mock electronAPI from setup-renderer.ts — cast to Mock for vi helpers
+const mockUpdater = window.electronAPI.updater as unknown as {
+  check: Mock
+  download: Mock
+  install: Mock
+  getVersion: Mock
+  onStatus: Mock
+  onMenuCheckForUpdates: Mock
+}
 
 describe('UpdateDialog', () => {
   beforeEach(() => {

--- a/src/renderer/src/components/update/UpdateDialog.tsx
+++ b/src/renderer/src/components/update/UpdateDialog.tsx
@@ -1,0 +1,204 @@
+import { useState, useEffect } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogBody, DialogTitle, DialogDescription } from '@/components/ui/Dialog'
+import { Button } from '@/components/ui/Button'
+import { Markdown } from '@/components/ui/Markdown'
+import { updaterApi } from '@/lib/ipc-client'
+import { Download, RotateCw, Loader2, ExternalLink, Check } from 'lucide-react'
+
+interface UpdateDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+interface UpdateState {
+  status: string
+  version: string | null
+  currentVersion: string | null
+  releaseNotes: string
+  releaseDate: string
+  percent: number
+  error: string | null
+}
+
+export function UpdateDialog({ open, onClose }: UpdateDialogProps) {
+  const [state, setState] = useState<UpdateState>({
+    status: 'idle',
+    version: null,
+    currentVersion: null,
+    releaseNotes: '',
+    releaseDate: '',
+    percent: 0,
+    error: null
+  })
+
+  // Load current version on mount
+  useEffect(() => {
+    updaterApi.getVersion().then((v) => {
+      setState((s) => ({ ...s, currentVersion: v }))
+    })
+  }, [])
+
+  // Subscribe to updater status events
+  useEffect(() => {
+    const cleanup = updaterApi.onStatus((data) => {
+      setState((prev) => ({
+        ...prev,
+        status: data.status,
+        version: data.version ?? prev.version,
+        currentVersion: data.currentVersion ?? prev.currentVersion,
+        releaseNotes: data.releaseNotes ?? prev.releaseNotes,
+        releaseDate: data.releaseDate ?? prev.releaseDate,
+        percent: data.percent ?? prev.percent,
+        error: data.error ?? null
+      }))
+    })
+    return cleanup
+  }, [])
+
+  // When opened from menu and no update known yet, trigger a check
+  useEffect(() => {
+    if (open && state.status === 'idle') {
+      setState((s) => ({ ...s, status: 'checking', error: null }))
+      updaterApi.check()
+    }
+  }, [open])
+
+  const handleDownload = async () => {
+    await updaterApi.download()
+  }
+
+  const handleInstall = () => {
+    updaterApi.install()
+  }
+
+  const hasUpdate = state.status === 'available' || state.status === 'downloading' || state.status === 'downloaded'
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{hasUpdate ? 'Update Available' : 'Software Update'}</DialogTitle>
+          <DialogDescription>
+            {state.status === 'checking'
+              ? 'Checking for updates\u2026'
+              : state.status === 'up-to-date'
+                ? 'You\'re up to date!'
+                : hasUpdate
+                  ? 'A new version of 20x is available'
+                  : 'Check for 20x updates'}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody>
+          <div className="space-y-4">
+            {/* Version comparison */}
+            <div className="flex items-center gap-3 text-sm">
+              <span className="text-muted-foreground">Current:</span>
+              <code className="bg-muted px-1.5 py-0.5 rounded text-xs">
+                v{state.currentVersion ?? '?'}
+              </code>
+              {state.version && (
+                <>
+                  <span className="text-muted-foreground">&rarr;</span>
+                  <code className="bg-primary/10 text-primary px-1.5 py-0.5 rounded text-xs font-semibold">
+                    v{state.version}
+                  </code>
+                </>
+              )}
+            </div>
+
+            {/* Checking spinner */}
+            {state.status === 'checking' && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Checking for updates...
+              </div>
+            )}
+
+            {/* Up to date */}
+            {state.status === 'up-to-date' && (
+              <div className="text-sm text-green-400 flex items-center gap-1.5">
+                <Check className="h-4 w-4" />
+                20x is up to date. You&apos;re running the latest version.
+              </div>
+            )}
+
+            {/* Release notes */}
+            {hasUpdate && state.releaseNotes && (
+              <div className="border border-border rounded-lg p-4 max-h-64 overflow-y-auto">
+                <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+                  What&apos;s New
+                </h4>
+                <Markdown size="xs">
+                  {state.releaseNotes}
+                </Markdown>
+              </div>
+            )}
+
+            {/* Link to full release page */}
+            {hasUpdate && state.version && (
+              <a
+                href={`https://github.com/peakflo/20x/releases/tag/v${state.version}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+                onClick={(e) => {
+                  e.preventDefault()
+                  window.electronAPI?.shell?.openExternal(`https://github.com/peakflo/20x/releases/tag/v${state.version}`)
+                }}
+              >
+                <ExternalLink className="h-3 w-3" />
+                View full release on GitHub
+              </a>
+            )}
+
+            {/* Download progress */}
+            {state.status === 'downloading' && (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>Downloading update...</span>
+                  <span>{state.percent}%</span>
+                </div>
+                <div className="h-2 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-primary rounded-full transition-all duration-300"
+                    style={{ width: `${state.percent}%` }}
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* Error message */}
+            {state.error && (
+              <div className="text-sm text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+                {state.error}
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-2 pt-2">
+              {state.status === 'downloaded' ? (
+                <Button onClick={handleInstall} className="flex-1">
+                  <RotateCw className="h-4 w-4 mr-2" />
+                  Install &amp; Restart
+                </Button>
+              ) : state.status === 'available' ? (
+                <Button onClick={handleDownload} className="flex-1">
+                  <Download className="h-4 w-4 mr-2" />
+                  Download Update
+                </Button>
+              ) : state.status === 'downloading' ? (
+                <Button disabled className="flex-1">
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Downloading...
+                </Button>
+              ) : null}
+              <Button variant="outline" onClick={onClose}>
+                {hasUpdate ? 'Later' : 'Close'}
+              </Button>
+            </div>
+          </div>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/update/UpdateDialog.tsx
+++ b/src/renderer/src/components/update/UpdateDialog.tsx
@@ -59,7 +59,16 @@ export function UpdateDialog({ open, onClose }: UpdateDialogProps) {
   useEffect(() => {
     if (open && state.status === 'idle') {
       setState((s) => ({ ...s, status: 'checking', error: null }))
-      updaterApi.check()
+      updaterApi.check().then((result) => {
+        // In dev mode (or if check fails synchronously), the main process
+        // won't fire updater:status events — handle the response directly.
+        if (result && !result.success) {
+          setState((s) => s.status === 'checking'
+            ? { ...s, status: 'error', error: result.error ?? 'Update check failed' }
+            : s
+          )
+        }
+      })
     }
   }, [open])
 

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -241,8 +241,14 @@ export const updaterApi = {
   install: (): Promise<void> => {
     return window.electronAPI?.updater?.install() ?? Promise.resolve()
   },
-  onStatus: (callback: (data: { status: string; version?: string; percent?: number; error?: string }) => void): (() => void) => {
+  getVersion: (): Promise<string> => {
+    return window.electronAPI?.updater?.getVersion() ?? Promise.resolve('?.?.?')
+  },
+  onStatus: (callback: (data: { status: string; version?: string; percent?: number; error?: string; releaseNotes?: string; releaseDate?: string; currentVersion?: string }) => void): (() => void) => {
     return window.electronAPI?.updater?.onStatus(callback) ?? (() => {})
+  },
+  onMenuCheckForUpdates: (callback: () => void): (() => void) => {
+    return window.electronAPI?.updater?.onMenuCheckForUpdates(callback) ?? (() => {})
   }
 }
 

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -81,6 +81,9 @@ html, body, #root {
 .drag-region { -webkit-app-region: drag; }
 .no-drag { -webkit-app-region: no-drag; }
 
+/* ── macOS: push left-pinned elements past the traffic lights (≈ 70px) ── */
+[data-platform="darwin"] .macos-titlebar-pad { margin-left: 56px; }
+
 /* ── Windows: push content left of the title-bar overlay (min/max/close ≈ 140px) ── */
 [data-platform="win32"] .windows-titlebar-pad { padding-right: 150px; }
 /* ── Windows: any top-right header that sits behind the overlay needs right padding too ── */

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -348,7 +348,9 @@ interface ElectronAPI {
     check: () => Promise<{ success: boolean; version?: string; error?: string }>
     download: () => Promise<{ success: boolean; error?: string }>
     install: () => Promise<void>
-    onStatus: (callback: (data: { status: string; version?: string; percent?: number; error?: string; releaseNotes?: string }) => void) => () => void
+    getVersion: () => Promise<string>
+    onStatus: (callback: (data: { status: string; version?: string; percent?: number; error?: string; releaseNotes?: string; releaseDate?: string; currentVersion?: string }) => void) => () => void
+    onMenuCheckForUpdates: (callback: () => void) => () => void
   }
   agentInstaller: {
     detect: () => Promise<Record<string, { installed: boolean; version: string | null }>>

--- a/test/setup-renderer.ts
+++ b/test/setup-renderer.ts
@@ -164,7 +164,15 @@ const mockElectronAPI = {
   }),
   onTasksRefresh: vi.fn((_cb: () => void) => {
     return vi.fn()
-  })
+  }),
+  updater: {
+    check: vi.fn().mockResolvedValue({ success: true }),
+    download: vi.fn().mockResolvedValue({ success: true }),
+    install: vi.fn().mockResolvedValue(undefined),
+    getVersion: vi.fn().mockResolvedValue('0.0.31'),
+    onStatus: vi.fn((_cb: (data: unknown) => void) => vi.fn()),
+    onMenuCheckForUpdates: vi.fn((_cb: () => void) => vi.fn())
+  }
 }
 
 Object.defineProperty(window, 'electronAPI', {


### PR DESCRIPTION
## Summary
- Add auto-update UX: yellow pulsing dot near 20x logo when update available, update dialog with version comparison, release notes, download progress, and install button
- Add native app menu with "Check for Updates..." option (macOS app menu / Win+Linux Help menu)
- Silent background download with quit-time prompt to install & restart
- Once-a-day automatic update check + on-startup check after 10s delay
- Split `registerUpdaterIpc()` from `initAutoUpdater()` so IPC handlers work in dev mode too
- Handle 404/not-found errors from GitHub releases gracefully (show "up to date" instead of infinite spinner)

## Changes
- `src/main/auto-updater.ts` — Core updater module with IPC handlers, event forwarding, daily check
- `src/main/index.ts` — App menu, quit-time update prompt, early IPC registration
- `src/preload/index.ts` — Expose `getVersion` and `onMenuCheckForUpdates` to renderer
- `src/renderer/src/components/update/UpdateDialog.tsx` — Update dialog UI
- `src/renderer/src/components/layout/AppLayout.tsx` — Yellow dot indicator + dialog integration
- `src/renderer/src/lib/ipc-client.ts` — Updater API additions
- `src/renderer/src/types/electron.d.ts` — Type definitions for updater API
- `test/setup-renderer.ts` — Mock updater for renderer tests

## Test plan
- [x] 7 unit tests for `auto-updater.ts` (config, events, IPC handlers, 404 handling)
- [x] 8 unit tests for `UpdateDialog.tsx` (all status states, error handling, user interactions)
- [ ] Manual: verify yellow dot appears when update is available in production build
- [ ] Manual: verify "Check for Updates" menu item opens dialog
- [ ] Manual: verify quit-time prompt appears when update is downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)