### PR TITLE
feat: implement auto-update UX

### DIFF
--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -105,6 +105,26 @@ describe('auto-updater', () => {
         currentVersion: '0.0.31'
       }))
     })
+
+    it('should send up-to-date status on 404 errors instead of suppressing', async () => {
+      const { initAutoUpdater } = await import('./auto-updater')
+      const sendMock = vi.fn()
+      const mockWindow = { isDestroyed: vi.fn(() => false), webContents: { send: sendMock } } as any
+
+      initAutoUpdater(mockWindow)
+
+      const errorHandler = mockAutoUpdater.on.mock.calls.find(
+        (c: any[]) => c[0] === 'error'
+      )?.[1]
+
+      expect(errorHandler).toBeDefined()
+      errorHandler(new Error('HttpError: 404 Not Found'))
+
+      expect(sendMock).toHaveBeenCalledWith('updater:status', expect.objectContaining({
+        status: 'up-to-date',
+        currentVersion: '0.0.31'
+      }))
+    })
   })
 
   describe('isUpdateDownloaded', () => {

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -100,8 +100,9 @@ export function initAutoUpdater(win: BrowserWindow): void {
   })
 
   autoUpdater.on('error', (err) => {
-    // Suppress 404 errors — no releases published yet is expected
+    // 404 / no releases published yet → treat as up-to-date so the UI resolves
     if (err.message?.includes('404') || err.message?.includes('Cannot find latest')) {
+      send('updater:status', { status: 'up-to-date', currentVersion: app.getVersion() })
       return
     }
     send('updater:status', {


### PR DESCRIPTION
## Summary
- Add auto-update UX: yellow pulsing dot near 20x logo when update available, update dialog with version comparison, release notes, download progress, and install button
- Add native app menu with "Check for Updates..." option (macOS app menu / Win+Linux Help menu)
- Silent background download with quit-time prompt to install & restart
- Once-a-day automatic update check + on-startup check after 10s delay
- Split `registerUpdaterIpc()` from `initAutoUpdater()` so IPC handlers work in dev mode
- Handle 404/not-found errors from GitHub releases gracefully (show "up to date" instead of infinite spinner)

## Test plan
- [x] 7 unit tests for `auto-updater.ts` (config, events, IPC handlers, 404 handling)
- [x] 8 unit tests for `UpdateDialog.tsx` (all status states, error handling, user interactions)
- [ ] Manual: verify yellow dot appears when update is available in production build
- [ ] Manual: verify "Check for Updates" menu item opens dialog
- [ ] Manual: verify quit-time prompt appears when update is downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)