### PR TITLE
fix: add explicit publish config for electron-updater

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,11 @@
   "build": {
     "appId": "com.20x.app",
     "productName": "20x",
+    "publish": {
+      "provider": "github",
+      "owner": "peakflo",
+      "repo": "20x"
+    },
     "directories": {
       "buildResources": "resources"
     },


### PR DESCRIPTION
## Summary
- Add explicit `publish` config to `package.json` build section pointing to `github/peakflo/20x`
- Without this, electron-builder infers the provider from the git remote — which may fail in CI shallow clones, resulting in a broken `app-update.yml` inside the packaged app

## Why this is needed
electron-updater reads `app-update.yml` (embedded in the app at build time) to know where to check for updates. If the `publish` field is missing from the build config, electron-builder tries to infer it from the git remote URL. In GitHub Actions with `actions/checkout@v4` (shallow clone), this inference may produce incorrect results, causing `checkForUpdates()` to hang or fail.

## Test plan
- [ ] After merging + releasing, verify `app-update.yml` inside the packaged app contains `provider: github`, `owner: peakflo`, `repo: 20x`
- [ ] Verify "Check for Updates" resolves (not infinite spinner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)