### PR TITLE
fix: render HTML release notes and prevent install-restart loop

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -751,7 +751,8 @@ app.on('before-quit', async (event) => {
     })
 
     if (response === 0) {
-      // Install & restart — autoUpdater handles the process
+      // Install & restart — set flag first to prevent before-quit loop
+      isShuttingDown = true
       const { autoUpdater } = await import('electron-updater')
       autoUpdater.quitAndInstall()
       return

--- a/src/renderer/src/components/update/UpdateDialog.tsx
+++ b/src/renderer/src/components/update/UpdateDialog.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogBody, DialogTitle, DialogDescription } from '@/components/ui/Dialog'
 import { Button } from '@/components/ui/Button'
-import { Markdown } from '@/components/ui/Markdown'
 import { updaterApi } from '@/lib/ipc-client'
 import { Download, RotateCw, Loader2, ExternalLink, Check } from 'lucide-react'
 
@@ -131,15 +130,16 @@ export function UpdateDialog({ open, onClose }: UpdateDialogProps) {
               </div>
             )}
 
-            {/* Release notes */}
+            {/* Release notes (may be HTML from GitHub or markdown) */}
             {hasUpdate && state.releaseNotes && (
               <div className="border border-border rounded-lg p-4 max-h-64 overflow-y-auto">
                 <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
                   What&apos;s New
                 </h4>
-                <Markdown size="xs">
-                  {state.releaseNotes}
-                </Markdown>
+                <div
+                  className="text-xs text-foreground prose prose-invert prose-xs max-w-none [&_a]:text-primary [&_a]:underline [&_ul]:list-disc [&_ul]:pl-4 [&_li]:my-0.5"
+                  dangerouslySetInnerHTML={{ __html: state.releaseNotes }}
+                />
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- **HTML release notes**: GitHub's `generate_release_notes` produces HTML, not markdown. Switched from `<Markdown>` to `dangerouslySetInnerHTML` with styled container
- **Install & Restart loop**: `autoUpdater.quitAndInstall()` fires `before-quit` internally, reopening the update dialog infinitely. Fixed by setting `isShuttingDown = true` before calling `quitAndInstall()`

## Test plan
- [x] 15 unit tests pass (7 auto-updater + 8 UpdateDialog)
- [ ] Manual: verify release notes render correctly (headings, lists, links)
- [ ] Manual: verify "Install & Restart" quits and installs without looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)