### PR TITLE
feat: browser panel with agent-browser integration for canvas

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,9 +2,9 @@ name: Verify
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/canvas-browser-integration]
   push:
-    branches: [main]
+    branches: [main, feat/canvas-browser-integration]
 
 jobs:
   verify:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -163,12 +163,22 @@ function createWindow(): void {
   // This guards against agent-browser or CDP accidentally targeting the main
   // window instead of a webview panel — without this, the entire app UI gets
   // replaced by whatever URL was opened.
-  mainWindow.webContents.on('will-navigate', (event, url) => {
+  //
+  // We use BOTH will-navigate (catches user-initiated navigations) AND
+  // did-start-navigation (catches programmatic navigations via CDP Page.navigate,
+  // webContents.loadURL, etc. that bypass will-navigate).
+  const blockNonAppNavigation = (event: Electron.Event, url: string) => {
     const appOrigins = ['http://localhost:', 'file://']
     const isAppUrl = appOrigins.some((origin) => url.startsWith(origin))
     if (!isAppUrl) {
       console.warn(`[Main] Blocked navigation of main window to: ${url}`)
       event.preventDefault()
+    }
+  }
+  mainWindow.webContents.on('will-navigate', blockNonAppNavigation)
+  mainWindow.webContents.on('did-start-navigation', (event, url, _isInPlace, isMainFrame) => {
+    if (isMainFrame) {
+      blockNonAppNavigation(event, url)
     }
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -159,6 +159,19 @@ function createWindow(): void {
     return { action: 'deny' }
   })
 
+  // SAFETY: Prevent the main window from ever navigating away from the app.
+  // This guards against agent-browser or CDP accidentally targeting the main
+  // window instead of a webview panel — without this, the entire app UI gets
+  // replaced by whatever URL was opened.
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    const appOrigins = ['http://localhost:', 'file://']
+    const isAppUrl = appOrigins.some((origin) => url.startsWith(origin))
+    if (!isAppUrl) {
+      console.warn(`[Main] Blocked navigation of main window to: ${url}`)
+      event.preventDefault()
+    }
+  })
+
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -651,6 +651,9 @@ app.whenReady().then(async () => {
         // Wire state sync into agent manager so agent run events are recorded
         agentManager.setEnterpriseStateSync(enterpriseStateSyncInstance)
 
+        // Wire enterprise auth into agent manager so it can inject JWT into MCP Dev Server requests
+        agentManager.setEnterpriseAuth(enterpriseAuth)
+
         syncManager.setEnterpriseConnection(apiClient, enterpriseSyncMgr, session.userId, enterpriseStateSyncInstance)
 
         console.log('[Main] Enterprise connection restored on startup (with heartbeat)')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -177,23 +177,39 @@ function createWindow(): void {
   // Layer 2: Network-level interception via webRequest API.
   // This is the DEFINITIVE guard — CDP Page.navigate bypasses will-navigate
   // and did-start-navigation events, but it CANNOT bypass network-level blocking.
-  // We block any main-frame navigation of the main window to non-app URLs.
+  //
+  // IMPORTANT: We use webContents.fromId() to verify the request comes from the
+  // main window specifically. We cannot rely on webContentsId alone because
+  // webviews share the same session and their requests also go through this handler.
+  // We must NOT block webview navigations — only the main BrowserWindow.
   const mainWcId = mainWindow.webContents.id
   mainWindow.webContents.session.webRequest.onBeforeRequest(
     { urls: ['*://*/*'] },
     (details, callback) => {
-      // Only block main-frame navigations of the main window to non-app URLs.
-      // Sub-resources (scripts, images, XHR) and webview requests pass through.
-      if (
-        details.webContentsId === mainWcId &&
-        details.resourceType === 'mainFrame'
-      ) {
-        const isAppUrl =
-          details.url.startsWith('http://localhost:') || details.url.startsWith('file://')
-        if (!isAppUrl) {
-          console.warn(`[Main] Network-level block: main window navigation to: ${details.url}`)
-          callback({ cancel: true })
-          return
+      // Only block main-frame navigations of the main BrowserWindow to non-app URLs.
+      // Webview navigations must pass through — they are the browser panels.
+      if (details.resourceType === 'mainFrame') {
+        // Check if this request is from the main window (not a webview)
+        const isMainWindow = details.webContentsId === mainWcId
+        // Fallback: if webContentsId is missing/unreliable, check if the requesting
+        // webContents is a BrowserWindow (not a webview guest)
+        let isMainWindowFallback = false
+        if (details.webContentsId != null && details.webContentsId !== mainWcId) {
+          // Different webContentsId — this is a webview, let it through
+          isMainWindowFallback = false
+        } else if (details.webContentsId == null) {
+          // webContentsId missing — be safe, don't block (might be a webview)
+          isMainWindowFallback = false
+        }
+
+        if (isMainWindow || isMainWindowFallback) {
+          const isAppUrl =
+            details.url.startsWith('http://localhost:') || details.url.startsWith('file://')
+          if (!isAppUrl) {
+            console.warn(`[Main] Network-level block: main window navigation to: ${details.url} (wcId=${details.webContentsId}, mainWcId=${mainWcId})`)
+            callback({ cancel: true })
+            return
+          }
         }
       }
       callback({})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -161,10 +161,9 @@ function createWindow(): void {
 
   // SAFETY: Prevent the main window from ever navigating away from the app.
   // This guards against agent-browser or CDP accidentally targeting the main
-  // window instead of a webview panel — without this, the entire app UI gets
-  // replaced by whatever URL was opened.
+  // window instead of a webview panel.
   //
-  // Layer 1: will-navigate (catches user-initiated navigations)
+  // Layer 1: will-navigate (catches user-initiated navigations — NOT CDP)
   mainWindow.webContents.on('will-navigate', (event, url) => {
     const appOrigins = ['http://localhost:', 'file://']
     const isAppUrl = appOrigins.some((origin) => url.startsWith(origin))
@@ -174,47 +173,26 @@ function createWindow(): void {
     }
   })
 
-  // Layer 2: Network-level interception via webRequest API.
-  // This is the DEFINITIVE guard — CDP Page.navigate bypasses will-navigate
-  // and did-start-navigation events, but it CANNOT bypass network-level blocking.
-  //
-  // IMPORTANT: We use webContents.fromId() to verify the request comes from the
-  // main window specifically. We cannot rely on webContentsId alone because
-  // webviews share the same session and their requests also go through this handler.
-  // We must NOT block webview navigations — only the main BrowserWindow.
-  const mainWcId = mainWindow.webContents.id
-  mainWindow.webContents.session.webRequest.onBeforeRequest(
-    { urls: ['*://*/*'] },
-    (details, callback) => {
-      // Only block main-frame navigations of the main BrowserWindow to non-app URLs.
-      // Webview navigations must pass through — they are the browser panels.
-      if (details.resourceType === 'mainFrame') {
-        // Check if this request is from the main window (not a webview)
-        const isMainWindow = details.webContentsId === mainWcId
-        // Fallback: if webContentsId is missing/unreliable, check if the requesting
-        // webContents is a BrowserWindow (not a webview guest)
-        let isMainWindowFallback = false
-        if (details.webContentsId != null && details.webContentsId !== mainWcId) {
-          // Different webContentsId — this is a webview, let it through
-          isMainWindowFallback = false
-        } else if (details.webContentsId == null) {
-          // webContentsId missing — be safe, don't block (might be a webview)
-          isMainWindowFallback = false
-        }
-
-        if (isMainWindow || isMainWindowFallback) {
-          const isAppUrl =
-            details.url.startsWith('http://localhost:') || details.url.startsWith('file://')
-          if (!isAppUrl) {
-            console.warn(`[Main] Network-level block: main window navigation to: ${details.url} (wcId=${details.webContentsId}, mainWcId=${mainWcId})`)
-            callback({ cancel: true })
-            return
-          }
-        }
+  // Layer 2: Recovery — if CDP Page.navigate bypasses will-navigate and the main
+  // window ends up on a non-app URL, detect it and reload the app immediately.
+  // This is a safety net, not prevention — the window briefly shows the wrong page
+  // then snaps back to the app.
+  const appUrl = is.dev && process.env['ELECTRON_RENDERER_URL']
+    ? process.env['ELECTRON_RENDERER_URL']
+    : null // file:// URL set after loadFile
+  const mw = mainWindow // capture non-null reference for closure
+  mw.webContents.on('did-navigate', (_event, url) => {
+    const appOrigins = ['http://localhost:', 'file://']
+    const isAppUrl = appOrigins.some((origin) => url.startsWith(origin))
+    if (!isAppUrl) {
+      console.warn(`[Main] Main window navigated to non-app URL: ${url} — recovering...`)
+      if (appUrl) {
+        mw.loadURL(appUrl)
+      } else {
+        mw.loadFile(join(__dirname, '../renderer/index.html'))
       }
-      callback({})
     }
-  )
+  })
 
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -105,7 +105,8 @@ function createWindow(): void {
       preload: join(__dirname, '../preload/index.js'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false
+      sandbox: false,
+      webviewTag: true
     }
   })
 
@@ -541,6 +542,12 @@ protocol.registerSchemesAsPrivileged([
 
 // Initialize crash logger as early as possible
 initCrashLogger()
+
+// Enable Chrome DevTools Protocol (CDP) on a fixed port so that agent-browser
+// (and other CDP clients) can connect to webview tabs embedded in the canvas.
+// Port 0 lets Chromium pick a free port; we read it back via the /json endpoint.
+const CDP_PORT = 19222
+app.commandLine.appendSwitch('remote-debugging-port', String(CDP_PORT))
 
 // Ignore EPIPE errors from broken stdout/stderr pipes (e.g. when piped through head/tail)
 process.stdout?.on?.('error', (err: NodeJS.ErrnoException) => { if (err.code !== 'EPIPE') throw err })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -164,23 +164,41 @@ function createWindow(): void {
   // window instead of a webview panel — without this, the entire app UI gets
   // replaced by whatever URL was opened.
   //
-  // We use BOTH will-navigate (catches user-initiated navigations) AND
-  // did-start-navigation (catches programmatic navigations via CDP Page.navigate,
-  // webContents.loadURL, etc. that bypass will-navigate).
-  const blockNonAppNavigation = (event: Electron.Event, url: string) => {
+  // Layer 1: will-navigate (catches user-initiated navigations)
+  mainWindow.webContents.on('will-navigate', (event, url) => {
     const appOrigins = ['http://localhost:', 'file://']
     const isAppUrl = appOrigins.some((origin) => url.startsWith(origin))
     if (!isAppUrl) {
       console.warn(`[Main] Blocked navigation of main window to: ${url}`)
       event.preventDefault()
     }
-  }
-  mainWindow.webContents.on('will-navigate', blockNonAppNavigation)
-  mainWindow.webContents.on('did-start-navigation', (event, url, _isInPlace, isMainFrame) => {
-    if (isMainFrame) {
-      blockNonAppNavigation(event, url)
-    }
   })
+
+  // Layer 2: Network-level interception via webRequest API.
+  // This is the DEFINITIVE guard — CDP Page.navigate bypasses will-navigate
+  // and did-start-navigation events, but it CANNOT bypass network-level blocking.
+  // We block any main-frame navigation of the main window to non-app URLs.
+  const mainWcId = mainWindow.webContents.id
+  mainWindow.webContents.session.webRequest.onBeforeRequest(
+    { urls: ['*://*/*'] },
+    (details, callback) => {
+      // Only block main-frame navigations of the main window to non-app URLs.
+      // Sub-resources (scripts, images, XHR) and webview requests pass through.
+      if (
+        details.webContentsId === mainWcId &&
+        details.resourceType === 'mainFrame'
+      ) {
+        const isAppUrl =
+          details.url.startsWith('http://localhost:') || details.url.startsWith('file://')
+        if (!isAppUrl) {
+          console.warn(`[Main] Network-level block: main window navigation to: ${details.url}`)
+          callback({ cancel: true })
+          return
+        }
+      }
+      callback({})
+    }
+  )
 
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 
 vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
@@ -7,10 +7,31 @@ vi.mock('electron', () => ({
   Notification: vi.fn().mockImplementation(() => ({ show: vi.fn() }))
 }))
 
+const { mockChildKill, mockSpawn } = vi.hoisted(() => {
+  const kill = vi.fn()
+  const spawn = vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    stdin: { writable: true, write: vi.fn() },
+    on: vi.fn(),
+    kill,
+    pid: 4242
+  }))
+  return { mockChildKill: kill, mockSpawn: spawn }
+})
+
+vi.mock('child_process', () => ({
+  spawn: mockSpawn
+}))
+
 import { ipcMain } from 'electron'
 import { registerIpcHandlers } from './ipc-handlers'
 
 describe('registerIpcHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('registers the expected number of IPC handlers', () => {
     const db = {} as unknown as Parameters<typeof registerIpcHandlers>[0]
     const agentManager = {} as unknown as Parameters<typeof registerIpcHandlers>[1]
@@ -36,5 +57,33 @@ describe('registerIpcHandlers', () => {
     expect(channels).toContain('skills:getAll')
     expect(channels).toContain('taskSource:sync')
     expect(channels).toContain('plugin:list')
+  })
+
+  it('terminal:kill ignores stale expectedPid and only kills matching process', async () => {
+    const db = {} as unknown as Parameters<typeof registerIpcHandlers>[0]
+    const agentManager = {} as unknown as Parameters<typeof registerIpcHandlers>[1]
+    const githubManager = {} as unknown as Parameters<typeof registerIpcHandlers>[2]
+    const worktreeManager = {} as unknown as Parameters<typeof registerIpcHandlers>[3]
+    const syncManager = {} as unknown as Parameters<typeof registerIpcHandlers>[4]
+    const pluginRegistry = {} as unknown as Parameters<typeof registerIpcHandlers>[5]
+
+    registerIpcHandlers(db, agentManager, githubManager, worktreeManager, syncManager, pluginRegistry)
+
+    const handleCalls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls as [string, (...args: unknown[]) => unknown][]
+    const createHandler = handleCalls.find((call) => call[0] === 'terminal:create')?.[1]
+    const killHandler = handleCalls.find((call) => call[0] === 'terminal:kill')?.[1]
+
+    expect(createHandler).toBeDefined()
+    expect(killHandler).toBeDefined()
+
+    const sender = { isDestroyed: () => false, send: vi.fn() }
+    await createHandler?.({ sender }, { id: 'panel-1', cols: 80, rows: 24 })
+
+    await killHandler?.({}, { id: 'panel-1', expectedPid: 9999 })
+    expect(mockChildKill).not.toHaveBeenCalled()
+
+    await killHandler?.({}, { id: 'panel-1', expectedPid: 4242 })
+    expect(mockChildKill).toHaveBeenCalledTimes(1)
+    expect(mockChildKill).toHaveBeenCalledWith('SIGTERM')
   })
 })

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1377,4 +1377,11 @@ else:
       terminals.delete(id)
     }
   })
+
+  // ── Browser CDP ─────────────────────────────────────────
+  // Returns the CDP (Chrome DevTools Protocol) port that agent-browser
+  // can use to connect to webview tabs on the canvas.
+  ipcMain.handle('browser:getCdpPort', () => {
+    return { port: 19222 }
+  })
 }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1361,7 +1361,8 @@ else:
       }
     })
 
-    child.on('exit', () => {
+    child.on('exit', (code, signal) => {
+      console.log(`[Terminal] PTY exited id=${id} code=${code} signal=${signal}`)
       terminals.delete(id)
       if (!sender.isDestroyed()) {
         sender.send('terminal:exit', { id })
@@ -1397,7 +1398,13 @@ else:
   })
 
   ipcMain.handle('terminal:write', (_, { id, data }: { id: string; data: string }) => {
-    terminals.get(id)?.write(data)
+    const term = terminals.get(id)
+    if (!term) {
+      console.log(`[Terminal] write to dead terminal id=${id}`)
+      return { alive: false }
+    }
+    term.write(data)
+    return { alive: true }
   })
 
   ipcMain.handle('terminal:resize', (_event, { id, cols, rows }: { id: string; cols: number; rows: number }) => {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1381,6 +1381,13 @@ else:
   }
 
   ipcMain.handle('terminal:create', async (event, { id, cols, rows, cwd }: { id: string; cols: number; rows: number; cwd?: string }) => {
+    // Kill any existing terminal with the same ID (e.g. respawn after exit)
+    const existing = terminals.get(id)
+    if (existing) {
+      try { existing.kill() } catch { /* ignore */ }
+      terminals.delete(id)
+    }
+
     const shellPath = resolveShell()
     console.log(`[Terminal] Creating terminal id=${id} shell=${shellPath} cols=${cols} rows=${rows} cwd=${cwd || '(default)'}`)
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1208,12 +1208,15 @@ export function registerIpcHandlers(
   // (which requires native module rebuild for Electron) and avoids macOS
   // `script` command (which fails with piped stdio).
 
+  /** Max lines to keep in terminal output buffer for agent log queries */
+  const TERMINAL_BUFFER_MAX_LINES = 500
+
   interface TerminalHandle {
     write: (data: string) => void
     kill: () => void
     pid: number
-    /** The child shell PID (inside the Python PTY fork) — used for cwd lookup */
-    shellPid?: number
+    /** Circular buffer of recent terminal output lines */
+    outputBuffer: string[]
   }
 
   const terminals = new Map<string, TerminalHandle>()
@@ -1324,16 +1327,37 @@ else:
       env: { ...process.env } as Record<string, string>,
     })
 
+    const outputBuffer: string[] = []
+
+    /** Append raw PTY output to the line buffer, stripping ANSI escape codes */
+    const appendToBuffer = (raw: string) => {
+      // Strip ANSI escape sequences for clean log output
+      // eslint-disable-next-line no-control-regex
+      const clean = raw.replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?(\x07|\x1b\\)|\x1b[()][A-Z0-9]|\r/g, '')
+      const lines = clean.split('\n')
+      for (const line of lines) {
+        if (line.trim()) outputBuffer.push(line)
+      }
+      // Trim to max buffer size
+      while (outputBuffer.length > TERMINAL_BUFFER_MAX_LINES) {
+        outputBuffer.shift()
+      }
+    }
+
     child.stdout?.on('data', (data: Buffer) => {
+      const str = data.toString()
+      appendToBuffer(str)
       if (!sender.isDestroyed()) {
-        sender.send('terminal:data', { id, data: data.toString() })
+        sender.send('terminal:data', { id, data: str })
       }
     })
 
     child.stderr?.on('data', (data: Buffer) => {
+      const str = data.toString()
+      appendToBuffer(str)
       // Forward stderr too (e.g. shell startup errors)
       if (!sender.isDestroyed()) {
-        sender.send('terminal:data', { id, data: data.toString() })
+        sender.send('terminal:data', { id, data: str })
       }
     })
 
@@ -1352,6 +1376,7 @@ else:
         try { child.kill('SIGTERM') } catch { /* ignore */ }
       },
       pid: child.pid || 0,
+      outputBuffer,
     }
   }
 
@@ -1371,6 +1396,15 @@ else:
   ipcMain.handle('terminal:resize', (_event, { id, cols, rows }: { id: string; cols: number; rows: number }) => {
     // Resize not supported without node-pty — COLUMNS/LINES set at creation
     void id; void cols; void rows
+  })
+
+  /** Get the last N lines from a terminal's output buffer */
+  ipcMain.handle('terminal:getBuffer', (_, { id, lines }: { id: string; lines?: number }) => {
+    const term = terminals.get(id)
+    if (!term) return { lines: [] }
+    const maxLines = Math.min(lines || 200, TERMINAL_BUFFER_MAX_LINES)
+    const buf = term.outputBuffer.slice(-maxLines)
+    return { lines: buf }
   })
 
   ipcMain.handle('terminal:kill', (_, { id }: { id: string }) => {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1416,4 +1416,18 @@ else:
       return { targetId: null }
     }
   })
+
+  // Returns all webview CDP targets. Called from the renderer to resolve
+  // CDP target IDs without CORS issues (renderer can't fetch localhost:19222).
+  ipcMain.handle('browser:getCdpTargets', async () => {
+    try {
+      const res = await fetch('http://localhost:19222/json/list')
+      const targets = (await res.json()) as Array<{ id: string; url: string; type: string; title: string }>
+      return targets
+        .filter((t) => t.type === 'webview')
+        .map((t) => ({ id: t.id, url: t.url, title: t.title }))
+    } catch {
+      return []
+    }
+  })
 }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1388,14 +1388,30 @@ else:
   // Returns the CDP target ID for a webview given its webContentsId.
   // This allows the renderer to store the target ID on the panel data,
   // so agent-browser can connect directly via ws://localhost:19222/devtools/page/<targetId>
-  ipcMain.handle('browser:getTargetId', (_event, webContentsId: number) => {
+  ipcMain.handle('browser:getTargetId', async (_event, webContentsId: number) => {
     try {
       const wc = webContents.fromId(webContentsId)
       if (!wc) return { targetId: null }
-      // devToolsTargetId is the CDP TargetID (a UUID string)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const targetId = (wc as any).devToolsTargetId
-      return { targetId: targetId || null }
+
+      // Use the debugger API to get the CDP target info
+      try {
+        wc.debugger.attach('1.3')
+        const { targetInfo } = await wc.debugger.sendCommand('Target.getTargetInfo')
+        const targetId = targetInfo?.targetId || null
+        wc.debugger.detach()
+        return { targetId }
+      } catch {
+        try { wc.debugger.detach() } catch { /* already detached */ }
+        // Fallback: query CDP /json/list and match by URL
+        const wcUrl = wc.getURL()
+        if (!wcUrl) return { targetId: null }
+        const res = await fetch(`http://localhost:19222/json/list`)
+        const targets = await res.json()
+        const match = targets.find((t: { url: string; type: string }) =>
+          t.type === 'webview' && t.url === wcUrl
+        )
+        return { targetId: match?.id || null }
+      }
     } catch {
       return { targetId: null }
     }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1212,6 +1212,8 @@ export function registerIpcHandlers(
     write: (data: string) => void
     kill: () => void
     pid: number
+    /** The child shell PID (inside the Python PTY fork) — used for cwd lookup */
+    shellPid?: number
   }
 
   const terminals = new Map<string, TerminalHandle>()
@@ -1233,7 +1235,7 @@ export function registerIpcHandlers(
    */
   function createPythonPty(
     id: string, shellPath: string, cols: number, rows: number,
-    sender: Electron.WebContents
+    sender: Electron.WebContents, cwd?: string
   ): TerminalHandle {
     const { spawn } = childProcess
 
@@ -1315,9 +1317,10 @@ else:
         os.waitpid(pid, 0)
 `
 
+    const initialCwd = cwd || process.env.HOME || process.cwd()
     const child = spawn('python3', ['-u', '-c', pythonScript, shellPath, String(cols || 80), String(rows || 24)], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      cwd: process.env.HOME || process.cwd(),
+      cwd: initialCwd,
       env: { ...process.env } as Record<string, string>,
     })
 
@@ -1352,11 +1355,11 @@ else:
     }
   }
 
-  ipcMain.handle('terminal:create', async (event, { id, cols, rows }: { id: string; cols: number; rows: number }) => {
+  ipcMain.handle('terminal:create', async (event, { id, cols, rows, cwd }: { id: string; cols: number; rows: number; cwd?: string }) => {
     const shellPath = resolveShell()
-    console.log(`[Terminal] Creating terminal id=${id} shell=${shellPath} cols=${cols} rows=${rows}`)
+    console.log(`[Terminal] Creating terminal id=${id} shell=${shellPath} cols=${cols} rows=${rows} cwd=${cwd || '(default)'}`)
 
-    const handle = createPythonPty(id, shellPath, cols, rows, event.sender)
+    const handle = createPythonPty(id, shellPath, cols, rows, event.sender, cwd)
     terminals.set(id, handle)
     return { pid: handle.pid }
   })
@@ -1375,6 +1378,76 @@ else:
     if (term) {
       term.kill()
       terminals.delete(id)
+    }
+  })
+
+  /**
+   * Get the current working directory of a terminal's shell process.
+   * The PTY is a Python process that forks a shell child. We need the shell's
+   * cwd, not Python's. Strategy:
+   *   1. Find child PIDs of the Python process via `pgrep -P <pid>`
+   *   2. Get the cwd of the deepest child (most recently forked = active shell)
+   *   3. Use `lsof -p <childPid> -a -d cwd -Fn` for the cwd lookup
+   */
+  ipcMain.handle('terminal:getCwd', async (_, { id }: { id: string }) => {
+    const term = terminals.get(id)
+    if (!term) return { cwd: null }
+
+    try {
+      const { execSync } = childProcess
+      const pythonPid = term.pid
+
+      // Find child PIDs of the Python process (the forked shell)
+      let targetPid = pythonPid
+      try {
+        const children = execSync(`pgrep -P ${pythonPid} 2>/dev/null || true`, {
+          encoding: 'utf-8',
+          timeout: 2000,
+        }).trim()
+        if (children) {
+          // Get the last child (deepest descendant = active process)
+          const childPids = children.split('\n').map((s) => parseInt(s.trim(), 10)).filter(Boolean)
+          if (childPids.length > 0) {
+            // Walk down — find children of children to get the deepest active shell
+            let deepest = childPids[childPids.length - 1]
+            for (let i = 0; i < 5; i++) { // max 5 levels deep
+              const grandchildren = execSync(`pgrep -P ${deepest} 2>/dev/null || true`, {
+                encoding: 'utf-8',
+                timeout: 1000,
+              }).trim()
+              if (!grandchildren) break
+              const gcPids = grandchildren.split('\n').map((s) => parseInt(s.trim(), 10)).filter(Boolean)
+              if (gcPids.length === 0) break
+              deepest = gcPids[gcPids.length - 1]
+            }
+            targetPid = deepest
+          }
+        }
+      } catch { /* ignore pgrep failures */ }
+
+      // Get cwd of the target process
+      const output = execSync(`lsof -p ${targetPid} -a -d cwd -Fn 2>/dev/null || true`, {
+        encoding: 'utf-8',
+        timeout: 2000,
+      })
+      const lines = output.split('\n')
+      const cwdLine = lines.find((l) => l.startsWith('n/'))
+      if (cwdLine) {
+        return { cwd: cwdLine.slice(1) }
+      }
+
+      // Fallback: try /proc on Linux
+      if (process.platform === 'linux') {
+        const linkTarget = execSync(`readlink /proc/${targetPid}/cwd 2>/dev/null || true`, {
+          encoding: 'utf-8',
+          timeout: 2000,
+        }).trim()
+        if (linkTarget) return { cwd: linkTarget }
+      }
+
+      return { cwd: null }
+    } catch {
+      return { cwd: null }
     }
   })
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1423,9 +1423,17 @@ else:
     try {
       const res = await fetch('http://localhost:19222/json/list')
       const targets = (await res.json()) as Array<{ id: string; url: string; type: string; title: string }>
-      return targets
-        .filter((t) => t.type === 'webview')
-        .map((t) => ({ id: t.id, url: t.url, title: t.title }))
+      // agent-browser's `tab` command shows only page + webview targets (not iframes,
+      // service workers, etc.) and assigns t1, t2, t3... indices in list order.
+      // We replicate that filtering so the renderer can compute the exact tab ID.
+      const tabTargets = targets.filter((t) => t.type === 'page' || t.type === 'webview')
+      return tabTargets.map((t, i) => ({
+        id: t.id,
+        url: t.url,
+        title: t.title,
+        type: t.type,
+        tabId: `t${i + 1}`,
+      }))
     } catch {
       return []
     }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1362,10 +1362,16 @@ else:
     })
 
     child.on('exit', (code, signal) => {
-      console.log(`[Terminal] PTY exited id=${id} code=${code} signal=${signal}`)
-      terminals.delete(id)
-      if (!sender.isDestroyed()) {
-        sender.send('terminal:exit', { id })
+      console.log(`[Terminal] PTY exited id=${id} code=${code} signal=${signal} pid=${child.pid}`)
+      // Only clean up if this handle is still the active one for this id.
+      // When terminal:create replaces an existing PTY, the old one's exit
+      // handler fires asynchronously and must NOT delete the new handle.
+      const current = terminals.get(id)
+      if (current && current.pid === (child.pid || 0)) {
+        terminals.delete(id)
+        if (!sender.isDestroyed()) {
+          sender.send('terminal:exit', { id })
+        }
       }
     })
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1424,9 +1424,16 @@ else:
       const res = await fetch('http://localhost:19222/json/list')
       const targets = (await res.json()) as Array<{ id: string; url: string; type: string; title: string }>
       // agent-browser's `tab` command shows only page + webview targets (not iframes,
-      // service workers, etc.) and assigns t1, t2, t3... indices in list order.
-      // We replicate that filtering so the renderer can compute the exact tab ID.
-      const tabTargets = targets.filter((t) => t.type === 'page' || t.type === 'webview')
+      // service workers, etc.) and sorts them: pages first, then webviews.
+      // We replicate that ordering so the renderer can compute the exact tab ID.
+      const tabTargets = targets
+        .filter((t) => t.type === 'page' || t.type === 'webview')
+        .sort((a, b) => {
+          // page before webview (matches agent-browser ordering)
+          if (a.type === 'page' && b.type !== 'page') return -1
+          if (a.type !== 'page' && b.type === 'page') return 1
+          return 0
+        })
       return tabTargets.map((t, i) => ({
         id: t.id,
         url: t.url,

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1427,9 +1427,11 @@ else:
     return { lines: buf }
   })
 
-  ipcMain.handle('terminal:kill', (_, { id }: { id: string }) => {
+  ipcMain.handle('terminal:kill', (_, { id, expectedPid }: { id: string; expectedPid?: number }) => {
     const term = terminals.get(id)
     if (term) {
+      // Ignore stale cleanup calls from an older terminal instance.
+      if (expectedPid !== undefined && term.pid !== expectedPid) return
       term.kill()
       terminals.delete(id)
     }
@@ -1443,9 +1445,10 @@ else:
    *   2. Get the cwd of the deepest child (most recently forked = active shell)
    *   3. Use `lsof -p <childPid> -a -d cwd -Fn` for the cwd lookup
    */
-  ipcMain.handle('terminal:getCwd', async (_, { id }: { id: string }) => {
+  ipcMain.handle('terminal:getCwd', async (_, { id, expectedPid }: { id: string; expectedPid?: number }) => {
     const term = terminals.get(id)
     if (!term) return { cwd: null }
+    if (expectedPid !== undefined && term.pid !== expectedPid) return { cwd: null }
 
     try {
       const { execSync } = childProcess

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, shell, Notification, app, session } from 'electron'
+import { ipcMain, dialog, shell, Notification, app, session, webContents } from 'electron'
 import * as childProcess from 'child_process'
 import { copyFileSync, existsSync, unlinkSync, readdirSync, statSync, readFileSync } from 'fs'
 import { join, basename, extname } from 'path'
@@ -1383,5 +1383,21 @@ else:
   // can use to connect to webview tabs on the canvas.
   ipcMain.handle('browser:getCdpPort', () => {
     return { port: 19222 }
+  })
+
+  // Returns the CDP target ID for a webview given its webContentsId.
+  // This allows the renderer to store the target ID on the panel data,
+  // so agent-browser can connect directly via ws://localhost:19222/devtools/page/<targetId>
+  ipcMain.handle('browser:getTargetId', (_event, webContentsId: number) => {
+    try {
+      const wc = webContents.fromId(webContentsId)
+      if (!wc) return { targetId: null }
+      // devToolsTargetId is the CDP TargetID (a UUID string)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const targetId = (wc as any).devToolsTargetId
+      return { targetId: targetId || null }
+    } catch {
+      return { targetId: null }
+    }
   })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -420,6 +420,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('terminal:kill', { id }),
     getCwd: (id: string): Promise<{ cwd: string | null }> =>
       ipcRenderer.invoke('terminal:getCwd', { id }),
+    getBuffer: (id: string, lines?: number): Promise<{ lines: string[] }> =>
+      ipcRenderer.invoke('terminal:getBuffer', { id, lines }),
     onData: (callback: (data: { id: string; data: string }) => void): (() => void) => {
       const handler = (_: unknown, d: { id: string; data: string }): void => callback(d)
       ipcRenderer.on('terminal:data', handler)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -428,5 +428,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('terminal:exit', handler)
       return () => ipcRenderer.removeListener('terminal:exit', handler)
     }
+  },
+  browser: {
+    getCdpPort: (): Promise<{ port: number }> =>
+      ipcRenderer.invoke('browser:getCdpPort')
   }
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -431,6 +431,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   browser: {
     getCdpPort: (): Promise<{ port: number }> =>
-      ipcRenderer.invoke('browser:getCdpPort')
+      ipcRenderer.invoke('browser:getCdpPort'),
+    getTargetId: (webContentsId: number): Promise<{ targetId: string | null }> =>
+      ipcRenderer.invoke('browser:getTargetId', webContentsId)
   }
 })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -416,10 +416,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('terminal:write', { id, data }),
     resize: (id: string, cols: number, rows: number): Promise<void> =>
       ipcRenderer.invoke('terminal:resize', { id, cols, rows }),
-    kill: (id: string): Promise<void> =>
-      ipcRenderer.invoke('terminal:kill', { id }),
-    getCwd: (id: string): Promise<{ cwd: string | null }> =>
-      ipcRenderer.invoke('terminal:getCwd', { id }),
+    kill: (id: string, expectedPid?: number): Promise<void> =>
+      ipcRenderer.invoke('terminal:kill', { id, expectedPid }),
+    getCwd: (id: string, expectedPid?: number): Promise<{ cwd: string | null }> =>
+      ipcRenderer.invoke('terminal:getCwd', { id, expectedPid }),
     getBuffer: (id: string, lines?: number): Promise<{ lines: string[] }> =>
       ipcRenderer.invoke('terminal:getBuffer', { id, lines }),
     onData: (callback: (data: { id: string; data: string }) => void): (() => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -410,14 +410,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getPathForFile: (file: File): string => webUtils.getPathForFile(file)
   },
   terminal: {
-    create: (id: string, cols: number, rows: number): Promise<{ pid: number }> =>
-      ipcRenderer.invoke('terminal:create', { id, cols, rows }),
+    create: (id: string, cols: number, rows: number, cwd?: string): Promise<{ pid: number }> =>
+      ipcRenderer.invoke('terminal:create', { id, cols, rows, cwd }),
     write: (id: string, data: string): Promise<void> =>
       ipcRenderer.invoke('terminal:write', { id, data }),
     resize: (id: string, cols: number, rows: number): Promise<void> =>
       ipcRenderer.invoke('terminal:resize', { id, cols, rows }),
     kill: (id: string): Promise<void> =>
       ipcRenderer.invoke('terminal:kill', { id }),
+    getCwd: (id: string): Promise<{ cwd: string | null }> =>
+      ipcRenderer.invoke('terminal:getCwd', { id }),
     onData: (callback: (data: { id: string; data: string }) => void): (() => void) => {
       const handler = (_: unknown, d: { id: string; data: string }): void => callback(d)
       ipcRenderer.on('terminal:data', handler)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -433,6 +433,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getCdpPort: (): Promise<{ port: number }> =>
       ipcRenderer.invoke('browser:getCdpPort'),
     getTargetId: (webContentsId: number): Promise<{ targetId: string | null }> =>
-      ipcRenderer.invoke('browser:getTargetId', webContentsId)
+      ipcRenderer.invoke('browser:getTargetId', webContentsId),
+    getCdpTargets: (): Promise<Array<{ id: string; url: string; title: string }>> =>
+      ipcRenderer.invoke('browser:getCdpTargets')
   }
 })

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -35,7 +35,10 @@ export function BrowserPanelContent({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const webviewRef = useRef<any>(null)
 
-  const [currentUrl, setCurrentUrl] = useState(initialUrl || '')
+  // initialSrc is set once and never changed — prevents the webview from
+  // reloading when React re-renders.  All subsequent navigations go through
+  // webviewRef.current.loadURL() which doesn't touch this ref.
+  const initialSrc = useRef(initialUrl || '')
   const [inputValue, setInputValue] = useState(initialUrl || '')
   const [isLoading, setIsLoading] = useState(false)
   const [canGoBack, setCanGoBack] = useState(false)
@@ -90,8 +93,7 @@ export function BrowserPanelContent({
       setCanGoForward(wv.canGoForward())
     }
     const onNavigate = (e: { url: string }) => {
-      // Update local state immediately (fast UI)
-      setCurrentUrl(e.url)
+      // Only update the URL bar text — never feed back into <webview src>
       setInputValue(e.url)
       // Debounce store update to avoid flooding zustand on SPA navigations
       if (pendingUrlUpdate.current) clearTimeout(pendingUrlUpdate.current)
@@ -135,12 +137,15 @@ export function BrowserPanelContent({
         finalUrl = `https://www.google.com/search?q=${encodeURIComponent(finalUrl)}`
       }
     }
-    setCurrentUrl(finalUrl)
     setInputValue(finalUrl)
     setIsSetup(false)
+    // Navigate via loadURL — never set the src attribute reactively
     const wv = webviewRef.current
     if (wv) {
       wv.loadURL(finalUrl)
+    } else {
+      // Webview not mounted yet — set initial src for first render
+      initialSrc.current = finalUrl
     }
   }, [])
 
@@ -219,7 +224,7 @@ export function BrowserPanelContent({
       <div className="flex-1 min-h-0">
         <webview
           ref={webviewRef as any}
-          src={currentUrl}
+          src={initialSrc.current}
           className="w-full h-full"
           /* @ts-expect-error — Electron webview attributes not typed in JSX */
           allowpopups="true"

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -1,327 +1,298 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import {
   Globe,
   RefreshCw,
-  Play,
-  Wifi,
-  WifiOff,
-  Monitor,
+  ArrowLeft,
+  ArrowRight,
   Loader2,
+  Zap,
 } from 'lucide-react'
-import { useBrowserStore, type BrowserSession } from '@/stores/browser-store'
+import { useCanvasStore } from '@/stores/canvas-store'
 
 interface BrowserPanelContentProps {
   panelId: string
+  /** Initial URL to load */
+  url?: string
   sessionName?: string
   streamPort?: number
 }
 
+/** CDP port exposed by the Electron app for agent-browser to connect to */
+const CDP_PORT = 19222
+
 /**
- * Canvas panel content for agent-browser sessions.
+ * Canvas panel with a real Electron <webview> — a fully interactive browser.
  *
- * Shows one of three states:
- * 1. Setup — user enters session name / starts browser
- * 2. Connecting — trying to connect to agent-browser WebSocket stream
- * 3. Live — shows dashboard viewport iframe + live status bar with tabs/URL
- *
- * The agent-browser dashboard on localhost:4848 provides a ready-made viewport.
- * We embed it and overlay a status bar showing real-time info from the WebSocket stream.
+ * The agent can control this browser via CDP (connecting to the webview's
+ * debugger port), and the user sees + interacts with the same page live
+ * on the canvas.
  */
 export function BrowserPanelContent({
   panelId,
-  sessionName: initialSessionName,
-  streamPort: initialStreamPort,
+  url: initialUrl,
 }: BrowserPanelContentProps) {
-  const createSession = useBrowserStore((s) => s.createSession)
-  const connectStream = useBrowserStore((s) => s.connectStream)
-  const sessions = useBrowserStore((s) => s.sessions)
+  const updatePanel = useCanvasStore((s) => s.updatePanel)
+  const edges = useCanvasStore((s) => s.edges)
+  const panels = useCanvasStore((s) => s.panels)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const webviewRef = useRef<any>(null)
 
-  const [sessionName, setSessionName] = useState(initialSessionName || '')
-  const [port, setPort] = useState(initialStreamPort?.toString() || '')
-  const [isSetup, setIsSetup] = useState(!initialSessionName && !initialStreamPort)
-  const [dashboardUrl, setDashboardUrl] = useState<string | null>(null)
-  const [iframeKey, setIframeKey] = useState(0)
-  const [isStarting, setIsStarting] = useState(false)
-  const [startError, setStartError] = useState<string | null>(null)
+  const [currentUrl, setCurrentUrl] = useState(initialUrl || '')
+  const [inputValue, setInputValue] = useState(initialUrl || '')
+  const [isLoading, setIsLoading] = useState(false)
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
+  const [isSetup, setIsSetup] = useState(!initialUrl)
 
-  const session = sessions.get(sessionName)
+  // ── Check if this browser is connected to a task via an edge ──
+  const connectedTaskName = useMemo(() => {
+    const browserEdges = edges.filter(
+      (e) =>
+        e.edgeType === 'browser' &&
+        (e.fromPanelId === panelId || e.toPanelId === panelId)
+    )
+    if (browserEdges.length === 0) return null
+    // Find the connected task panel
+    for (const edge of browserEdges) {
+      const otherId = edge.fromPanelId === panelId ? edge.toPanelId : edge.fromPanelId
+      const otherPanel = panels.find((p) => p.id === otherId)
+      if (otherPanel?.type === 'task') return otherPanel.title
+    }
+    return 'Agent'
+  }, [edges, panels, panelId])
 
-  // Auto-connect if we have initial props
+  // ── Webview event wiring ──────────────────────────────────
   useEffect(() => {
-    if (initialSessionName && initialStreamPort) {
-      const existing = useBrowserStore.getState().sessions.get(initialSessionName)
-      if (!existing) {
-        createSession(initialSessionName, panelId)
-      }
-      connectStream(initialSessionName, initialStreamPort)
-      setDashboardUrl('http://localhost:4848')
-      setSessionName(initialSessionName)
-      setIsSetup(false)
+    const wv = webviewRef.current
+    if (!wv) return
+
+    const onStartLoading = () => setIsLoading(true)
+    const onStopLoading = () => {
+      setIsLoading(false)
+      setCanGoBack(wv.canGoBack())
+      setCanGoForward(wv.canGoForward())
     }
-  }, [initialSessionName, initialStreamPort, panelId, createSession, connectStream])
-
-  const handleStartBrowser = useCallback(async () => {
-    const name = sessionName.trim() || 'default'
-    const streamPort = port.trim() ? parseInt(port.trim(), 10) : undefined
-
-    setIsStarting(true)
-    setStartError(null)
-
-    try {
-      // Create session in store
-      createSession(name, panelId)
-
-      // Try to start the agent-browser dashboard if not running
-      // The dashboard serves the viewport at localhost:4848
-      setDashboardUrl('http://localhost:4848')
-
-      // If a specific stream port was provided, connect to the stream
-      if (streamPort) {
-        connectStream(name, streamPort)
-      }
-
-      setSessionName(name)
-      setIsSetup(false)
-    } catch (err) {
-      setStartError(err instanceof Error ? err.message : 'Failed to start browser')
-    } finally {
-      setIsStarting(false)
+    const onNavigate = (e: { url: string }) => {
+      setCurrentUrl(e.url)
+      setInputValue(e.url)
+      updatePanel(panelId, { url: e.url })
     }
-  }, [sessionName, port, panelId, createSession, connectStream])
+    const onTitleUpdate = (e: { title: string }) => {
+      updatePanel(panelId, { title: e.title || 'Browser' })
+    }
 
-  const handleRefresh = useCallback(() => {
-    setIframeKey((k) => k + 1)
+    wv.addEventListener('did-start-loading', onStartLoading)
+    wv.addEventListener('did-stop-loading', onStopLoading)
+    wv.addEventListener('did-navigate', onNavigate)
+    wv.addEventListener('did-navigate-in-page', onNavigate as any)
+    wv.addEventListener('page-title-updated', onTitleUpdate)
+
+    return () => {
+      wv.removeEventListener('did-start-loading', onStartLoading)
+      wv.removeEventListener('did-stop-loading', onStopLoading)
+      wv.removeEventListener('did-navigate', onNavigate)
+      wv.removeEventListener('did-navigate-in-page', onNavigate as any)
+      wv.removeEventListener('page-title-updated', onTitleUpdate)
+    }
+  }, [panelId, updatePanel, isSetup])
+
+  // ── Navigation handlers ───────────────────────────────────
+  const navigate = useCallback((url: string) => {
+    let finalUrl = url.trim()
+    if (!finalUrl) return
+    if (!/^https?:\/\//i.test(finalUrl)) {
+      // Check if it looks like a URL or a search query
+      if (/^[\w-]+\.[\w]{2,}/.test(finalUrl)) {
+        finalUrl = 'https://' + finalUrl
+      } else {
+        finalUrl = `https://www.google.com/search?q=${encodeURIComponent(finalUrl)}`
+      }
+    }
+    setCurrentUrl(finalUrl)
+    setInputValue(finalUrl)
+    setIsSetup(false)
+    const wv = webviewRef.current
+    if (wv) {
+      wv.loadURL(finalUrl)
+    }
   }, [])
 
-  // Setup screen
+  const handleSubmit = useCallback((e: React.FormEvent) => {
+    e.preventDefault()
+    navigate(inputValue)
+  }, [inputValue, navigate])
+
+  const handleBack = useCallback(() => {
+    webviewRef.current?.goBack()
+  }, [])
+
+  const handleForward = useCallback(() => {
+    webviewRef.current?.goForward()
+  }, [])
+
+  const handleRefresh = useCallback(() => {
+    webviewRef.current?.reload()
+  }, [])
+
+  // ── Setup screen ──────────────────────────────────────────
   if (isSetup) {
-    return <BrowserSetupView
-      sessionName={sessionName}
-      port={port}
-      isStarting={isStarting}
-      startError={startError}
-      onSessionNameChange={setSessionName}
-      onPortChange={setPort}
-      onStart={handleStartBrowser}
-    />
-  }
-
-  // Live browser view
-  return (
-    <div className="flex flex-col h-full min-h-0">
-      {/* Status bar */}
-      <BrowserStatusBar
-        session={session}
-        sessionName={sessionName}
-        onRefresh={handleRefresh}
-      />
-
-      {/* Dashboard viewport iframe */}
-      {dashboardUrl ? (
-        <div className="flex-1 min-h-0 relative">
-          <iframe
-            key={iframeKey}
-            src={dashboardUrl}
-            className="w-full h-full border-0"
-            title={`Browser: ${sessionName}`}
-            allow="clipboard-read; clipboard-write"
-          />
-          {/* Subtle overlay when not connected */}
-          {session && !session.connected && (
-            <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
-              <div className="text-center space-y-2">
-                <WifiOff className="h-6 w-6 mx-auto text-orange-400/60" />
-                <p className="text-xs text-muted-foreground/60">
-                  Waiting for agent-browser stream...
-                </p>
-                <p className="text-[10px] text-muted-foreground/40">
-                  Run: agent-browser stream enable
-                </p>
+    return (
+      <div className="flex flex-col h-full min-h-0">
+        <BrowserUrlBar
+          inputValue={inputValue}
+          isLoading={false}
+          canGoBack={false}
+          canGoForward={false}
+          onInputChange={setInputValue}
+          onSubmit={handleSubmit}
+          onBack={handleBack}
+          onForward={handleForward}
+          onRefresh={handleRefresh}
+          connectedTaskName={connectedTaskName}
+          autoFocus
+        />
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center space-y-3 px-6">
+            <div className="w-14 h-14 mx-auto rounded-2xl bg-orange-500/10 flex items-center justify-center">
+              <Globe className="h-7 w-7 text-orange-400/60" />
+            </div>
+            <div>
+              <div className="text-sm font-medium text-foreground/70 mb-1">Browser</div>
+              <div className="text-[11px] text-muted-foreground/40 leading-relaxed max-w-[240px]">
+                Type a URL or search query above. This is a real browser —
+                the agent can control it and you can interact with it.
+              </div>
+              <div className="mt-3 text-[10px] text-muted-foreground/30 font-mono">
+                CDP port {CDP_PORT}
               </div>
             </div>
-          )}
-        </div>
-      ) : (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center space-y-2 px-6">
-            <Monitor className="h-10 w-10 mx-auto text-orange-400/15" />
-            <div className="text-xs text-muted-foreground/40">
-              Dashboard not available
-            </div>
           </div>
         </div>
-      )}
-    </div>
-  )
-}
+      </div>
+    )
+  }
 
-// ── Setup View ────────────────────────────────────────────────
-
-function BrowserSetupView({
-  sessionName,
-  port,
-  isStarting,
-  startError,
-  onSessionNameChange,
-  onPortChange,
-  onStart,
-}: {
-  sessionName: string
-  port: string
-  isStarting: boolean
-  startError: string | null
-  onSessionNameChange: (v: string) => void
-  onPortChange: (v: string) => void
-  onStart: () => void
-}) {
+  // ── Live browser ──────────────────────────────────────────
   return (
-    <div className="flex flex-col h-full items-center justify-center p-6">
-      <div className="w-full max-w-[280px] space-y-4">
-        <div className="text-center space-y-2">
-          <div className="w-12 h-12 mx-auto rounded-xl bg-orange-500/10 flex items-center justify-center">
-            <Globe className="h-6 w-6 text-orange-400" />
-          </div>
-          <h3 className="text-sm font-medium text-foreground">Agent Browser</h3>
-          <p className="text-[11px] text-muted-foreground/50 leading-relaxed">
-            Connect to an agent-browser session to see live browser activity on the canvas.
-          </p>
-        </div>
+    <div className="flex flex-col h-full min-h-0">
+      <BrowserUrlBar
+        inputValue={inputValue}
+        isLoading={isLoading}
+        canGoBack={canGoBack}
+        canGoForward={canGoForward}
+        onInputChange={setInputValue}
+        onSubmit={handleSubmit}
+        onBack={handleBack}
+        onForward={handleForward}
+        onRefresh={handleRefresh}
+        connectedTaskName={connectedTaskName}
+      />
 
-        <form
-          onSubmit={(e) => { e.preventDefault(); onStart() }}
-          className="space-y-3"
-        >
-          <div className="space-y-1">
-            <label className="text-[10px] text-muted-foreground/40 uppercase tracking-wider">
-              Session Name
-            </label>
-            <input
-              type="text"
-              value={sessionName}
-              onChange={(e) => onSessionNameChange(e.target.value)}
-              placeholder="default"
-              className="w-full text-xs bg-[#0d1117] border border-border/30 rounded-lg px-3 py-2 text-foreground placeholder:text-muted-foreground/25 focus:outline-none focus:border-orange-500/50"
-            />
-          </div>
-
-          <div className="space-y-1">
-            <label className="text-[10px] text-muted-foreground/40 uppercase tracking-wider">
-              Stream Port (optional)
-            </label>
-            <input
-              type="text"
-              value={port}
-              onChange={(e) => onPortChange(e.target.value)}
-              placeholder="Auto-detect from agent-browser"
-              className="w-full text-xs bg-[#0d1117] border border-border/30 rounded-lg px-3 py-2 text-foreground placeholder:text-muted-foreground/25 focus:outline-none focus:border-orange-500/50"
-            />
-          </div>
-
-          {startError && (
-            <p className="text-[11px] text-red-400/80">{startError}</p>
-          )}
-
-          <button
-            type="submit"
-            disabled={isStarting}
-            className="w-full flex items-center justify-center gap-2 text-xs font-medium bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded-lg px-3 py-2.5 transition-colors disabled:opacity-50"
-          >
-            {isStarting ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Play className="h-3.5 w-3.5" />
-            )}
-            {isStarting ? 'Connecting...' : 'Connect to Browser'}
-          </button>
-        </form>
-
-        <div className="text-center">
-          <p className="text-[10px] text-muted-foreground/30 leading-relaxed">
-            First run:{' '}
-            <code className="text-orange-400/50 bg-orange-400/5 px-1 py-0.5 rounded">
-              agent-browser --headed open &lt;url&gt;
-            </code>
-            <br />
-            then:{' '}
-            <code className="text-orange-400/50 bg-orange-400/5 px-1 py-0.5 rounded">
-              agent-browser stream enable
-            </code>
-          </p>
-        </div>
+      {/* Webview — real browser */}
+      <div className="flex-1 min-h-0">
+        <webview
+          ref={webviewRef as any}
+          src={currentUrl}
+          className="w-full h-full"
+          /* @ts-expect-error — Electron webview attributes not typed in JSX */
+          allowpopups="true"
+          style={{ display: 'flex', flex: 1, width: '100%', height: '100%' }}
+        />
       </div>
     </div>
   )
 }
 
-// ── Status Bar ────────────────────────────────────────────────
+// ── URL Bar component ─────────────────────────────────────────
 
-function BrowserStatusBar({
-  session,
-  sessionName,
+function BrowserUrlBar({
+  inputValue,
+  isLoading,
+  canGoBack,
+  canGoForward,
+  onInputChange,
+  onSubmit,
+  onBack,
+  onForward,
   onRefresh,
+  connectedTaskName,
+  autoFocus,
 }: {
-  session: BrowserSession | undefined
-  sessionName: string
+  inputValue: string
+  isLoading: boolean
+  canGoBack: boolean
+  canGoForward: boolean
+  onInputChange: (v: string) => void
+  onSubmit: (e: React.FormEvent) => void
+  onBack: () => void
+  onForward: () => void
   onRefresh: () => void
+  connectedTaskName?: string | null
+  autoFocus?: boolean
 }) {
-  const activeTab = session?.tabs.find((t) => t.active)
-  const displayUrl = session?.currentUrl || activeTab?.url || null
-
   return (
-    <div className="flex items-center gap-2 px-2 py-1.5 bg-[#0d1117]/60 border-b border-border/20 flex-shrink-0">
-      {/* Connection indicator */}
-      <div className="flex items-center gap-1.5 flex-shrink-0">
-        {session?.connected ? (
-          <div className="relative">
-            <Wifi className="h-3 w-3 text-green-400" />
-            <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 bg-green-400 rounded-full animate-pulse" />
-          </div>
-        ) : (
-          <WifiOff className="h-3 w-3 text-muted-foreground/30" />
-        )}
-        <span className="text-[10px] text-muted-foreground/40 font-mono">
-          {sessionName}
-        </span>
-      </div>
-
-      {/* Divider */}
-      <div className="w-px h-3 bg-border/20" />
-
-      {/* URL display */}
-      <div className="flex-1 min-w-0">
-        {displayUrl ? (
-          <span className="text-[11px] text-muted-foreground/50 truncate block font-mono">
-            {displayUrl}
-          </span>
-        ) : (
-          <span className="text-[10px] text-muted-foreground/25 italic">
-            No page loaded
-          </span>
-        )}
-      </div>
-
-      {/* Action indicator */}
-      {session?.lastCommand && (
-        <span className="text-[9px] text-orange-400/50 bg-orange-400/5 px-1.5 py-0.5 rounded flex-shrink-0">
-          {session.lastCommand}
-        </span>
-      )}
-
-      {/* Tab count */}
-      {session && session.tabs.length > 1 && (
-        <span className="text-[9px] text-muted-foreground/30 flex-shrink-0">
-          {session.tabs.length} tabs
-        </span>
-      )}
-
-      {/* Refresh */}
+    <form
+      onSubmit={onSubmit}
+      className="flex items-center gap-1.5 px-2 py-1.5 bg-[#0d1117]/60 border-b border-border/20 flex-shrink-0"
+    >
+      {/* Nav buttons */}
       <button
-        onClick={onRefresh}
-        className="text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors flex-shrink-0"
-        title="Refresh dashboard"
+        type="button"
+        onClick={onBack}
+        disabled={!canGoBack}
+        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
+        title="Back"
       >
-        <RefreshCw className="h-3 w-3" />
+        <ArrowLeft className="h-3 w-3" />
       </button>
-    </div>
+      <button
+        type="button"
+        onClick={onForward}
+        disabled={!canGoForward}
+        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
+        title="Forward"
+      >
+        <ArrowRight className="h-3 w-3" />
+      </button>
+      <button
+        type="button"
+        onClick={onRefresh}
+        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+        title="Refresh"
+      >
+        {isLoading ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : (
+          <RefreshCw className="h-3 w-3" />
+        )}
+      </button>
+
+      {/* URL input */}
+      <div className="flex-1 flex items-center gap-1.5 bg-[#1a2030] rounded-md px-2 py-1 border border-border/20 focus-within:border-orange-500/30 transition-colors">
+        <Globe className="h-3 w-3 text-muted-foreground/30 flex-shrink-0" />
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => onInputChange(e.target.value)}
+          placeholder="Search or enter URL"
+          autoFocus={autoFocus}
+          className="flex-1 text-[11px] bg-transparent text-foreground placeholder:text-muted-foreground/25 focus:outline-none font-mono"
+          onFocus={(e) => e.target.select()}
+        />
+      </div>
+
+      {/* Agent connection indicator */}
+      {connectedTaskName && (
+        <div
+          className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-orange-500/10 border border-orange-500/20 flex-shrink-0"
+          title={`Connected to "${connectedTaskName}" — agent can control this browser via CDP port ${CDP_PORT}`}
+        >
+          <Zap className="h-2.5 w-2.5 text-orange-400" />
+          <span className="text-[9px] font-medium text-orange-400/80 whitespace-nowrap">
+            CDP
+          </span>
+        </div>
+      )}
+    </form>
   )
 }

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -89,6 +89,7 @@ export function BrowserPanelContent({
       try {
         // First try via IPC (uses debugger API or CDP match in main process)
         const wcId = wv.getWebContentsId?.()
+        console.log(`[BrowserPanel:${panelId}] webContentsId=${wcId}, url=${wv.getURL?.()?.slice(0, 60)}`)
         if (wcId) {
           // Store webContentsId on panel for reliable CDP target resolution
           updatePanel(panelId, { webContentsId: wcId })

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -77,6 +77,34 @@ export function BrowserPanelContent({
     return unsub
   }, [panelId])
 
+  // ── Resolve CDP target ID once the webview is ready ──────
+  // The webview exposes getWebContentsId() which we send to main process
+  // to get the CDP target ID — stored on the panel for agent-browser to use.
+  const cdpTargetResolved = useRef(false)
+  useEffect(() => {
+    const wv = webviewRef.current
+    if (!wv || cdpTargetResolved.current) return
+
+    const resolveTargetId = async () => {
+      try {
+        const wcId = wv.getWebContentsId?.()
+        if (!wcId) return
+        const { targetId } = await window.electronAPI.browser.getTargetId(wcId)
+        if (targetId) {
+          cdpTargetResolved.current = true
+          updatePanel(panelId, { cdpTargetId: targetId })
+        }
+      } catch {
+        // Silently ignore — webview may not be ready yet
+      }
+    }
+
+    wv.addEventListener('dom-ready', resolveTargetId)
+    // Also try immediately in case it's already loaded
+    resolveTargetId()
+    return () => wv.removeEventListener('dom-ready', resolveTargetId)
+  }, [panelId, updatePanel, isSetup])
+
   // ── Webview event wiring ──────────────────────────────────
   // Debounce store updates to avoid re-render storms from SPA sites (e.g. Google Maps)
   const pendingUrlUpdate = useRef<ReturnType<typeof setTimeout> | null>(null)

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -87,22 +87,40 @@ export function BrowserPanelContent({
 
     const resolveTargetId = async () => {
       try {
+        // First try via IPC (uses debugger API or CDP match in main process)
         const wcId = wv.getWebContentsId?.()
-        if (!wcId) return
-        const { targetId } = await window.electronAPI.browser.getTargetId(wcId)
-        if (targetId) {
+        if (wcId) {
+          const result = await window.electronAPI.browser.getTargetId(wcId)
+          if (result.targetId) {
+            cdpTargetResolved.current = true
+            updatePanel(panelId, { cdpTargetId: result.targetId })
+            return
+          }
+        }
+
+        // Fallback: query CDP /json/list directly and match by webview URL
+        const wvUrl = wv.getURL?.()
+        if (!wvUrl) return
+        const res = await fetch(`http://localhost:${CDP_PORT}/json/list`)
+        const targets = (await res.json()) as Array<{ id: string; url: string; type: string }>
+        const match = targets.find((t) => t.type === 'webview' && t.url === wvUrl)
+        if (match) {
           cdpTargetResolved.current = true
-          updatePanel(panelId, { cdpTargetId: targetId })
+          updatePanel(panelId, { cdpTargetId: match.id })
         }
       } catch {
         // Silently ignore — webview may not be ready yet
       }
     }
 
+    wv.addEventListener('did-navigate', resolveTargetId)
     wv.addEventListener('dom-ready', resolveTargetId)
     // Also try immediately in case it's already loaded
     resolveTargetId()
-    return () => wv.removeEventListener('dom-ready', resolveTargetId)
+    return () => {
+      wv.removeEventListener('did-navigate', resolveTargetId)
+      wv.removeEventListener('dom-ready', resolveTargetId)
+    }
   }, [panelId, updatePanel, isSetup])
 
   // ── Webview event wiring ──────────────────────────────────

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -38,12 +38,12 @@ export function BrowserPanelContent({
   // initialSrc is set once and never changed — prevents the webview from
   // reloading when React re-renders.  All subsequent navigations go through
   // webviewRef.current.loadURL() which doesn't touch this ref.
-  const initialSrc = useRef(initialUrl || '')
-  const [inputValue, setInputValue] = useState(initialUrl || '')
+  const DEFAULT_URL = 'https://www.google.com'
+  const initialSrc = useRef(initialUrl || DEFAULT_URL)
+  const [inputValue, setInputValue] = useState(initialUrl || DEFAULT_URL)
   const [isLoading, setIsLoading] = useState(false)
   const [canGoBack, setCanGoBack] = useState(false)
   const [canGoForward, setCanGoForward] = useState(false)
-  const [isSetup, setIsSetup] = useState(!initialUrl)
 
   // ── Check if this browser is connected to a task via an edge ──
   // Uses imperative reads + subscribe to avoid re-rendering on every panel move
@@ -121,7 +121,7 @@ export function BrowserPanelContent({
       wv.removeEventListener('did-navigate', resolveTargetId)
       wv.removeEventListener('dom-ready', resolveTargetId)
     }
-  }, [panelId, updatePanel, isSetup])
+  }, [panelId, updatePanel])
 
   // ── Webview event wiring ──────────────────────────────────
   // Debounce store updates to avoid re-render storms from SPA sites (e.g. Google Maps)
@@ -177,7 +177,7 @@ export function BrowserPanelContent({
       if (pendingUrlUpdate.current) clearTimeout(pendingUrlUpdate.current)
       if (pendingTitleUpdate.current) clearTimeout(pendingTitleUpdate.current)
     }
-  }, [panelId, updatePanel, isSetup])
+  }, [panelId, updatePanel])
 
   // ── Navigation handlers ───────────────────────────────────
   const navigate = useCallback((url: string) => {
@@ -192,7 +192,6 @@ export function BrowserPanelContent({
       }
     }
     setInputValue(finalUrl)
-    setIsSetup(false)
     // Navigate via loadURL — never set the src attribute reactively
     const wv = webviewRef.current
     if (wv) {
@@ -219,44 +218,6 @@ export function BrowserPanelContent({
   const handleRefresh = useCallback(() => {
     webviewRef.current?.reload()
   }, [])
-
-  // ── Setup screen ──────────────────────────────────────────
-  if (isSetup) {
-    return (
-      <div className="flex flex-col h-full min-h-0">
-        <BrowserUrlBar
-          inputValue={inputValue}
-          isLoading={false}
-          canGoBack={false}
-          canGoForward={false}
-          onInputChange={setInputValue}
-          onSubmit={handleSubmit}
-          onBack={handleBack}
-          onForward={handleForward}
-          onRefresh={handleRefresh}
-          connectedTaskName={connectedTaskName}
-          autoFocus
-        />
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center space-y-3 px-6">
-            <div className="w-14 h-14 mx-auto rounded-2xl bg-orange-500/10 flex items-center justify-center">
-              <Globe className="h-7 w-7 text-orange-400/60" />
-            </div>
-            <div>
-              <div className="text-sm font-medium text-foreground/70 mb-1">Browser</div>
-              <div className="text-[11px] text-muted-foreground/40 leading-relaxed max-w-[240px]">
-                Type a URL or search query above. This is a real browser —
-                the agent can control it and you can interact with it.
-              </div>
-              <div className="mt-3 text-[10px] text-muted-foreground/30 font-mono">
-                CDP port {CDP_PORT}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    )
-  }
 
   // ── Live browser ──────────────────────────────────────────
   return (

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -90,10 +90,12 @@ export function BrowserPanelContent({
         // First try via IPC (uses debugger API or CDP match in main process)
         const wcId = wv.getWebContentsId?.()
         if (wcId) {
+          // Store webContentsId on panel for reliable CDP target resolution
+          updatePanel(panelId, { webContentsId: wcId })
           const result = await window.electronAPI.browser.getTargetId(wcId)
           if (result.targetId) {
             cdpTargetResolved.current = true
-            updatePanel(panelId, { cdpTargetId: result.targetId })
+            updatePanel(panelId, { cdpTargetId: result.targetId, webContentsId: wcId })
             return
           }
         }

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   Globe,
   RefreshCw,
@@ -32,8 +32,6 @@ export function BrowserPanelContent({
   url: initialUrl,
 }: BrowserPanelContentProps) {
   const updatePanel = useCanvasStore((s) => s.updatePanel)
-  const edges = useCanvasStore((s) => s.edges)
-  const panels = useCanvasStore((s) => s.panels)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const webviewRef = useRef<any>(null)
 
@@ -45,23 +43,42 @@ export function BrowserPanelContent({
   const [isSetup, setIsSetup] = useState(!initialUrl)
 
   // ── Check if this browser is connected to a task via an edge ──
-  const connectedTaskName = useMemo(() => {
-    const browserEdges = edges.filter(
-      (e) =>
-        e.edgeType === 'browser' &&
-        (e.fromPanelId === panelId || e.toPanelId === panelId)
-    )
-    if (browserEdges.length === 0) return null
-    // Find the connected task panel
-    for (const edge of browserEdges) {
-      const otherId = edge.fromPanelId === panelId ? edge.toPanelId : edge.fromPanelId
-      const otherPanel = panels.find((p) => p.id === otherId)
-      if (otherPanel?.type === 'task') return otherPanel.title
+  // Uses imperative reads + subscribe to avoid re-rendering on every panel move
+  const [connectedTaskName, setConnectedTaskName] = useState<string | null>(null)
+
+  useEffect(() => {
+    function computeConnectedTask(): string | null {
+      const { edges, panels } = useCanvasStore.getState()
+      const browserEdges = edges.filter(
+        (e) =>
+          e.edgeType === 'browser' &&
+          (e.fromPanelId === panelId || e.toPanelId === panelId)
+      )
+      if (browserEdges.length === 0) return null
+      for (const edge of browserEdges) {
+        const otherId = edge.fromPanelId === panelId ? edge.toPanelId : edge.fromPanelId
+        const otherPanel = panels.find((p) => p.id === otherId)
+        if (otherPanel?.type === 'task') return otherPanel.title
+      }
+      return 'Agent'
     }
-    return 'Agent'
-  }, [edges, panels, panelId])
+
+    setConnectedTaskName(computeConnectedTask())
+
+    // Only re-compute when edges change, not on every panel position change
+    const unsub = useCanvasStore.subscribe((state, prevState) => {
+      if (state.edges !== prevState.edges) {
+        setConnectedTaskName(computeConnectedTask())
+      }
+    })
+    return unsub
+  }, [panelId])
 
   // ── Webview event wiring ──────────────────────────────────
+  // Debounce store updates to avoid re-render storms from SPA sites (e.g. Google Maps)
+  const pendingUrlUpdate = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingTitleUpdate = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   useEffect(() => {
     const wv = webviewRef.current
     if (!wv) return
@@ -73,12 +90,20 @@ export function BrowserPanelContent({
       setCanGoForward(wv.canGoForward())
     }
     const onNavigate = (e: { url: string }) => {
+      // Update local state immediately (fast UI)
       setCurrentUrl(e.url)
       setInputValue(e.url)
-      updatePanel(panelId, { url: e.url })
+      // Debounce store update to avoid flooding zustand on SPA navigations
+      if (pendingUrlUpdate.current) clearTimeout(pendingUrlUpdate.current)
+      pendingUrlUpdate.current = setTimeout(() => {
+        updatePanel(panelId, { url: e.url })
+      }, 500)
     }
     const onTitleUpdate = (e: { title: string }) => {
-      updatePanel(panelId, { title: e.title || 'Browser' })
+      if (pendingTitleUpdate.current) clearTimeout(pendingTitleUpdate.current)
+      pendingTitleUpdate.current = setTimeout(() => {
+        updatePanel(panelId, { title: e.title || 'Browser' })
+      }, 500)
     }
 
     wv.addEventListener('did-start-loading', onStartLoading)
@@ -93,6 +118,8 @@ export function BrowserPanelContent({
       wv.removeEventListener('did-navigate', onNavigate)
       wv.removeEventListener('did-navigate-in-page', onNavigate as any)
       wv.removeEventListener('page-title-updated', onTitleUpdate)
+      if (pendingUrlUpdate.current) clearTimeout(pendingUrlUpdate.current)
+      if (pendingTitleUpdate.current) clearTimeout(pendingTitleUpdate.current)
     }
   }, [panelId, updatePanel, isSetup])
 

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -1,0 +1,327 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  Globe,
+  RefreshCw,
+  Play,
+  Wifi,
+  WifiOff,
+  Monitor,
+  Loader2,
+} from 'lucide-react'
+import { useBrowserStore, type BrowserSession } from '@/stores/browser-store'
+
+interface BrowserPanelContentProps {
+  panelId: string
+  sessionName?: string
+  streamPort?: number
+}
+
+/**
+ * Canvas panel content for agent-browser sessions.
+ *
+ * Shows one of three states:
+ * 1. Setup — user enters session name / starts browser
+ * 2. Connecting — trying to connect to agent-browser WebSocket stream
+ * 3. Live — shows dashboard viewport iframe + live status bar with tabs/URL
+ *
+ * The agent-browser dashboard on localhost:4848 provides a ready-made viewport.
+ * We embed it and overlay a status bar showing real-time info from the WebSocket stream.
+ */
+export function BrowserPanelContent({
+  panelId,
+  sessionName: initialSessionName,
+  streamPort: initialStreamPort,
+}: BrowserPanelContentProps) {
+  const createSession = useBrowserStore((s) => s.createSession)
+  const connectStream = useBrowserStore((s) => s.connectStream)
+  const sessions = useBrowserStore((s) => s.sessions)
+
+  const [sessionName, setSessionName] = useState(initialSessionName || '')
+  const [port, setPort] = useState(initialStreamPort?.toString() || '')
+  const [isSetup, setIsSetup] = useState(!initialSessionName && !initialStreamPort)
+  const [dashboardUrl, setDashboardUrl] = useState<string | null>(null)
+  const [iframeKey, setIframeKey] = useState(0)
+  const [isStarting, setIsStarting] = useState(false)
+  const [startError, setStartError] = useState<string | null>(null)
+
+  const session = sessions.get(sessionName)
+
+  // Auto-connect if we have initial props
+  useEffect(() => {
+    if (initialSessionName && initialStreamPort) {
+      const existing = useBrowserStore.getState().sessions.get(initialSessionName)
+      if (!existing) {
+        createSession(initialSessionName, panelId)
+      }
+      connectStream(initialSessionName, initialStreamPort)
+      setDashboardUrl('http://localhost:4848')
+      setSessionName(initialSessionName)
+      setIsSetup(false)
+    }
+  }, [initialSessionName, initialStreamPort, panelId, createSession, connectStream])
+
+  const handleStartBrowser = useCallback(async () => {
+    const name = sessionName.trim() || 'default'
+    const streamPort = port.trim() ? parseInt(port.trim(), 10) : undefined
+
+    setIsStarting(true)
+    setStartError(null)
+
+    try {
+      // Create session in store
+      createSession(name, panelId)
+
+      // Try to start the agent-browser dashboard if not running
+      // The dashboard serves the viewport at localhost:4848
+      setDashboardUrl('http://localhost:4848')
+
+      // If a specific stream port was provided, connect to the stream
+      if (streamPort) {
+        connectStream(name, streamPort)
+      }
+
+      setSessionName(name)
+      setIsSetup(false)
+    } catch (err) {
+      setStartError(err instanceof Error ? err.message : 'Failed to start browser')
+    } finally {
+      setIsStarting(false)
+    }
+  }, [sessionName, port, panelId, createSession, connectStream])
+
+  const handleRefresh = useCallback(() => {
+    setIframeKey((k) => k + 1)
+  }, [])
+
+  // Setup screen
+  if (isSetup) {
+    return <BrowserSetupView
+      sessionName={sessionName}
+      port={port}
+      isStarting={isStarting}
+      startError={startError}
+      onSessionNameChange={setSessionName}
+      onPortChange={setPort}
+      onStart={handleStartBrowser}
+    />
+  }
+
+  // Live browser view
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Status bar */}
+      <BrowserStatusBar
+        session={session}
+        sessionName={sessionName}
+        onRefresh={handleRefresh}
+      />
+
+      {/* Dashboard viewport iframe */}
+      {dashboardUrl ? (
+        <div className="flex-1 min-h-0 relative">
+          <iframe
+            key={iframeKey}
+            src={dashboardUrl}
+            className="w-full h-full border-0"
+            title={`Browser: ${sessionName}`}
+            allow="clipboard-read; clipboard-write"
+          />
+          {/* Subtle overlay when not connected */}
+          {session && !session.connected && (
+            <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
+              <div className="text-center space-y-2">
+                <WifiOff className="h-6 w-6 mx-auto text-orange-400/60" />
+                <p className="text-xs text-muted-foreground/60">
+                  Waiting for agent-browser stream...
+                </p>
+                <p className="text-[10px] text-muted-foreground/40">
+                  Run: agent-browser stream enable
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center space-y-2 px-6">
+            <Monitor className="h-10 w-10 mx-auto text-orange-400/15" />
+            <div className="text-xs text-muted-foreground/40">
+              Dashboard not available
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Setup View ────────────────────────────────────────────────
+
+function BrowserSetupView({
+  sessionName,
+  port,
+  isStarting,
+  startError,
+  onSessionNameChange,
+  onPortChange,
+  onStart,
+}: {
+  sessionName: string
+  port: string
+  isStarting: boolean
+  startError: string | null
+  onSessionNameChange: (v: string) => void
+  onPortChange: (v: string) => void
+  onStart: () => void
+}) {
+  return (
+    <div className="flex flex-col h-full items-center justify-center p-6">
+      <div className="w-full max-w-[280px] space-y-4">
+        <div className="text-center space-y-2">
+          <div className="w-12 h-12 mx-auto rounded-xl bg-orange-500/10 flex items-center justify-center">
+            <Globe className="h-6 w-6 text-orange-400" />
+          </div>
+          <h3 className="text-sm font-medium text-foreground">Agent Browser</h3>
+          <p className="text-[11px] text-muted-foreground/50 leading-relaxed">
+            Connect to an agent-browser session to see live browser activity on the canvas.
+          </p>
+        </div>
+
+        <form
+          onSubmit={(e) => { e.preventDefault(); onStart() }}
+          className="space-y-3"
+        >
+          <div className="space-y-1">
+            <label className="text-[10px] text-muted-foreground/40 uppercase tracking-wider">
+              Session Name
+            </label>
+            <input
+              type="text"
+              value={sessionName}
+              onChange={(e) => onSessionNameChange(e.target.value)}
+              placeholder="default"
+              className="w-full text-xs bg-[#0d1117] border border-border/30 rounded-lg px-3 py-2 text-foreground placeholder:text-muted-foreground/25 focus:outline-none focus:border-orange-500/50"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-[10px] text-muted-foreground/40 uppercase tracking-wider">
+              Stream Port (optional)
+            </label>
+            <input
+              type="text"
+              value={port}
+              onChange={(e) => onPortChange(e.target.value)}
+              placeholder="Auto-detect from agent-browser"
+              className="w-full text-xs bg-[#0d1117] border border-border/30 rounded-lg px-3 py-2 text-foreground placeholder:text-muted-foreground/25 focus:outline-none focus:border-orange-500/50"
+            />
+          </div>
+
+          {startError && (
+            <p className="text-[11px] text-red-400/80">{startError}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isStarting}
+            className="w-full flex items-center justify-center gap-2 text-xs font-medium bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded-lg px-3 py-2.5 transition-colors disabled:opacity-50"
+          >
+            {isStarting ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Play className="h-3.5 w-3.5" />
+            )}
+            {isStarting ? 'Connecting...' : 'Connect to Browser'}
+          </button>
+        </form>
+
+        <div className="text-center">
+          <p className="text-[10px] text-muted-foreground/30 leading-relaxed">
+            First run:{' '}
+            <code className="text-orange-400/50 bg-orange-400/5 px-1 py-0.5 rounded">
+              agent-browser --headed open &lt;url&gt;
+            </code>
+            <br />
+            then:{' '}
+            <code className="text-orange-400/50 bg-orange-400/5 px-1 py-0.5 rounded">
+              agent-browser stream enable
+            </code>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Status Bar ────────────────────────────────────────────────
+
+function BrowserStatusBar({
+  session,
+  sessionName,
+  onRefresh,
+}: {
+  session: BrowserSession | undefined
+  sessionName: string
+  onRefresh: () => void
+}) {
+  const activeTab = session?.tabs.find((t) => t.active)
+  const displayUrl = session?.currentUrl || activeTab?.url || null
+
+  return (
+    <div className="flex items-center gap-2 px-2 py-1.5 bg-[#0d1117]/60 border-b border-border/20 flex-shrink-0">
+      {/* Connection indicator */}
+      <div className="flex items-center gap-1.5 flex-shrink-0">
+        {session?.connected ? (
+          <div className="relative">
+            <Wifi className="h-3 w-3 text-green-400" />
+            <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 bg-green-400 rounded-full animate-pulse" />
+          </div>
+        ) : (
+          <WifiOff className="h-3 w-3 text-muted-foreground/30" />
+        )}
+        <span className="text-[10px] text-muted-foreground/40 font-mono">
+          {sessionName}
+        </span>
+      </div>
+
+      {/* Divider */}
+      <div className="w-px h-3 bg-border/20" />
+
+      {/* URL display */}
+      <div className="flex-1 min-w-0">
+        {displayUrl ? (
+          <span className="text-[11px] text-muted-foreground/50 truncate block font-mono">
+            {displayUrl}
+          </span>
+        ) : (
+          <span className="text-[10px] text-muted-foreground/25 italic">
+            No page loaded
+          </span>
+        )}
+      </div>
+
+      {/* Action indicator */}
+      {session?.lastCommand && (
+        <span className="text-[9px] text-orange-400/50 bg-orange-400/5 px-1.5 py-0.5 rounded flex-shrink-0">
+          {session.lastCommand}
+        </span>
+      )}
+
+      {/* Tab count */}
+      {session && session.tabs.length > 1 && (
+        <span className="text-[9px] text-muted-foreground/30 flex-shrink-0">
+          {session.tabs.length} tabs
+        </span>
+      )}
+
+      {/* Refresh */}
+      <button
+        onClick={onRefresh}
+        className="text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors flex-shrink-0"
+        title="Refresh dashboard"
+      >
+        <RefreshCw className="h-3 w-3" />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -98,12 +98,11 @@ export function BrowserPanelContent({
           }
         }
 
-        // Fallback: query CDP /json/list directly and match by webview URL
+        // Fallback: query CDP targets via IPC (avoids CORS) and match by webview URL
         const wvUrl = wv.getURL?.()
         if (!wvUrl) return
-        const res = await fetch(`http://localhost:${CDP_PORT}/json/list`)
-        const targets = (await res.json()) as Array<{ id: string; url: string; type: string }>
-        const match = targets.find((t) => t.type === 'webview' && t.url === wvUrl)
+        const targets = await window.electronAPI.browser.getCdpTargets()
+        const match = targets.find((t) => t.url === wvUrl)
         if (match) {
           cdpTargetResolved.current = true
           updatePanel(panelId, { cdpTargetId: match.id })

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -154,11 +154,18 @@ export function BrowserPanelContent({
       }, 500)
     }
 
+    // Prevent webview from going fullscreen — it covers the entire app
+    const onEnterFullScreen = () => {
+      // Immediately exit fullscreen by pressing Escape in the webview
+      wv.executeJavaScript('document.exitFullscreen?.().catch(()=>{})').catch(() => {})
+    }
+
     wv.addEventListener('did-start-loading', onStartLoading)
     wv.addEventListener('did-stop-loading', onStopLoading)
     wv.addEventListener('did-navigate', onNavigate)
     wv.addEventListener('did-navigate-in-page', onNavigate as any)
     wv.addEventListener('page-title-updated', onTitleUpdate)
+    wv.addEventListener('enter-html-full-screen', onEnterFullScreen)
 
     return () => {
       wv.removeEventListener('did-start-loading', onStartLoading)
@@ -166,6 +173,7 @@ export function BrowserPanelContent({
       wv.removeEventListener('did-navigate', onNavigate)
       wv.removeEventListener('did-navigate-in-page', onNavigate as any)
       wv.removeEventListener('page-title-updated', onTitleUpdate)
+      wv.removeEventListener('enter-html-full-screen', onEnterFullScreen)
       if (pendingUrlUpdate.current) clearTimeout(pendingUrlUpdate.current)
       if (pendingTitleUpdate.current) clearTimeout(pendingTitleUpdate.current)
     }

--- a/src/renderer/src/components/canvas/CanvasConnections.tsx
+++ b/src/renderer/src/components/canvas/CanvasConnections.tsx
@@ -83,7 +83,11 @@ export function CanvasConnections({
         const toAnchor = getAnchor(to, fromCenter.x, fromCenter.y)
         const path = makePath(fromAnchor, toAnchor)
 
-        return { id: edge.id, edge, fromAnchor, toAnchor, path }
+        // For browser edges, find the browser panel's title to show on the label
+        const browserPanel = from.type === 'browser' ? from : to.type === 'browser' ? to : null
+        const browserTitle = browserPanel?.title || ''
+
+        return { id: edge.id, edge, fromAnchor, toAnchor, path, browserTitle }
       })
       .filter(Boolean) as Array<{
       id: string
@@ -91,6 +95,7 @@ export function CanvasConnections({
       fromAnchor: { x: number; y: number; dir: string }
       toAnchor: { x: number; y: number; dir: string }
       path: string
+      browserTitle: string
     }>
   }, [edges, panelMap])
 
@@ -159,6 +164,7 @@ export function CanvasConnections({
             {isBrowser && (
               <EdgeLabel
                 path={edge.path}
+                label={edge.browserTitle || 'Browser'}
                 onDelete={() => removeEdge(edge.id)}
               />
             )}
@@ -212,9 +218,11 @@ export function CanvasConnections({
 
 function EdgeLabel({
   path,
+  label,
   onDelete,
 }: {
   path: string
+  label: string
   onDelete: () => void
 }) {
   // Approximate midpoint from the path's start and end
@@ -226,9 +234,10 @@ function EdgeLabel({
   const mx = (x1 + x2) / 2
   const my = (y1 + y2) / 2
 
-  // Show a ⚡ icon + "CDP :19222" label — indicates active agent-browser access
-  const label = '⚡ CDP :19222'
-  const pillW = 76
+  // Truncate long titles, show with lightning icon
+  const truncated = label.length > 16 ? label.slice(0, 15) + '\u2026' : label
+  const displayLabel = `\u26A1 ${truncated}`
+  const pillW = Math.max(60, displayLabel.length * 6 + 16)
   const pillH = 18
 
   return (
@@ -255,7 +264,7 @@ function EdgeLabel({
         fontFamily="system-ui, sans-serif"
         fontWeight="500"
       >
-        {label}
+        {displayLabel}
       </text>
     </g>
   )

--- a/src/renderer/src/components/canvas/CanvasConnections.tsx
+++ b/src/renderer/src/components/canvas/CanvasConnections.tsx
@@ -14,6 +14,7 @@ export function CanvasConnections({
   const panels = useCanvasStore((s) => s.panels)
   const edges = useCanvasStore((s) => s.edges)
   const connectingFromId = useCanvasStore((s) => s.connectingFromId)
+  const proximityEdge = useCanvasStore((s) => s.proximityEdge)
   const removeEdge = useCanvasStore((s) => s.removeEdge)
 
   const panelMap = useMemo(() => {
@@ -110,7 +111,22 @@ export function CanvasConnections({
     return { fromAnchor, path: makePath(fromAnchor, toAnchor) }
   }, [connectingFromId, mouseCanvasPos, panelMap])
 
-  if (edgeData.length === 0 && !pendingPath) return null
+  // Proximity edge preview (glowing edge during drag)
+  const proximityPath = useMemo(() => {
+    if (!proximityEdge) return null
+    const from = panelMap.get(proximityEdge.fromId)
+    const to = panelMap.get(proximityEdge.toId)
+    if (!from || !to) return null
+
+    const toCenter = { x: to.x + to.width / 2, y: to.y + to.height / 2 }
+    const fromCenter = { x: from.x + from.width / 2, y: from.y + from.height / 2 }
+    const fromAnchor = getAnchor(from, toCenter.x, toCenter.y)
+    const toAnchor = getAnchor(to, fromCenter.x, fromCenter.y)
+    const path = makePath(fromAnchor, toAnchor)
+    return { fromAnchor, toAnchor, path }
+  }, [proximityEdge, panelMap])
+
+  if (edgeData.length === 0 && !pendingPath && !proximityPath) return null
 
   return (
     <svg
@@ -208,6 +224,45 @@ export function CanvasConnections({
               strokeWidth="1.5"
             />
           )}
+        </>
+      )}
+
+      {/* Proximity edge preview — glowing orange dashed line during drag */}
+      {proximityPath && (
+        <>
+          {/* Glow layer */}
+          <path
+            d={proximityPath.path}
+            fill="none"
+            stroke="rgba(249,115,22,0.3)"
+            strokeWidth="8"
+            strokeLinecap="round"
+            className="animate-pulse"
+          />
+          {/* Main dashed line */}
+          <path
+            d={proximityPath.path}
+            fill="none"
+            stroke="rgba(249,115,22,0.7)"
+            strokeWidth="2"
+            strokeDasharray="8 4"
+            strokeLinecap="round"
+          />
+          {/* Anchor dots */}
+          <circle
+            cx={proximityPath.fromAnchor.x}
+            cy={proximityPath.fromAnchor.y}
+            r="4"
+            fill="rgba(249,115,22,0.8)"
+            className="animate-pulse"
+          />
+          <circle
+            cx={proximityPath.toAnchor.x}
+            cy={proximityPath.toAnchor.y}
+            r="4"
+            fill="rgba(249,115,22,0.8)"
+            className="animate-pulse"
+          />
         </>
       )}
     </svg>

--- a/src/renderer/src/components/canvas/CanvasConnections.tsx
+++ b/src/renderer/src/components/canvas/CanvasConnections.tsx
@@ -226,16 +226,21 @@ function EdgeLabel({
   const mx = (x1 + x2) / 2
   const my = (y1 + y2) / 2
 
+  // Show a ⚡ icon + "CDP :19222" label — indicates active agent-browser access
+  const label = '⚡ CDP :19222'
+  const pillW = 76
+  const pillH = 18
+
   return (
     <g
       className="pointer-events-auto cursor-pointer"
       onClick={(e) => { e.stopPropagation(); onDelete() }}
     >
       <rect
-        x={mx - 28}
-        y={my - 9}
-        width="56"
-        height="18"
+        x={mx - pillW / 2}
+        y={my - pillH / 2}
+        width={pillW}
+        height={pillH}
         rx="9"
         fill="#1c1208"
         stroke="rgba(249,115,22,0.3)"
@@ -250,7 +255,7 @@ function EdgeLabel({
         fontFamily="system-ui, sans-serif"
         fontWeight="500"
       >
-        Browser
+        {label}
       </text>
     </g>
   )

--- a/src/renderer/src/components/canvas/CanvasConnections.tsx
+++ b/src/renderer/src/components/canvas/CanvasConnections.tsx
@@ -1,13 +1,10 @@
 import { useMemo } from 'react'
 import { useCanvasStore, type CanvasPanelData, type CanvasEdge } from '@/stores/canvas-store'
-import { X } from 'lucide-react'
 
 /**
- * Renders SVG connection lines between panels.
- * Also renders the in-progress connection line when drawing a new edge.
- *
- * Browser edges get a distinct animated style (pulsing orange gradient)
- * so it's visually clear that an agent has browser access.
+ * Renders smooth bezier connection curves between panels.
+ * Follows Figma/React Flow best practice: clean curves, small anchor dots,
+ * subtle color distinction for typed edges (browser = orange, default = indigo).
  */
 export function CanvasConnections({
   mouseCanvasPos,
@@ -25,277 +22,243 @@ export function CanvasConnections({
     return map
   }, [panels])
 
-  // Calculate edge lines with center-to-center positioning
-  const edgeLines = useMemo(() => {
+  /**
+   * Find the best connection anchor point on a panel edge
+   * given a target point — connects from the nearest edge midpoint.
+   */
+  const getAnchor = (panel: CanvasPanelData, targetX: number, targetY: number) => {
+    const cx = panel.x + panel.width / 2
+    const cy = panel.y + panel.height / 2
+    const dx = targetX - cx
+    const dy = targetY - cy
+
+    // Pick the edge that faces the target
+    if (Math.abs(dx) / panel.width > Math.abs(dy) / panel.height) {
+      // Horizontal — left or right edge
+      return dx > 0
+        ? { x: panel.x + panel.width, y: cy, dir: 'right' as const }
+        : { x: panel.x, y: cy, dir: 'left' as const }
+    } else {
+      // Vertical — top or bottom edge
+      return dy > 0
+        ? { x: cx, y: panel.y + panel.height, dir: 'down' as const }
+        : { x: cx, y: panel.y, dir: 'up' as const }
+    }
+  }
+
+  /** Build a smooth cubic bezier path between two anchored points */
+  const makePath = (
+    from: { x: number; y: number; dir: string },
+    to: { x: number; y: number; dir: string }
+  ) => {
+    const dist = Math.hypot(to.x - from.x, to.y - from.y)
+    const offset = Math.min(80, dist * 0.4)
+
+    const cp = (anchor: { x: number; y: number; dir: string }, sign: number) => {
+      switch (anchor.dir) {
+        case 'right': return { x: anchor.x + offset * sign, y: anchor.y }
+        case 'left':  return { x: anchor.x - offset * sign, y: anchor.y }
+        case 'down':  return { x: anchor.x, y: anchor.y + offset * sign }
+        case 'up':    return { x: anchor.x, y: anchor.y - offset * sign }
+        default:      return { x: anchor.x + offset * sign, y: anchor.y }
+      }
+    }
+
+    const c1 = cp(from, 1)
+    const c2 = cp(to, 1)
+    return `M ${from.x} ${from.y} C ${c1.x} ${c1.y}, ${c2.x} ${c2.y}, ${to.x} ${to.y}`
+  }
+
+  // Calculate edge data
+  const edgeData = useMemo(() => {
     return edges
       .map((edge) => {
         const from = panelMap.get(edge.fromPanelId)
         const to = panelMap.get(edge.toPanelId)
         if (!from || !to) return null
-        return {
-          id: edge.id,
-          x1: from.x + from.width / 2,
-          y1: from.y + from.height / 2,
-          x2: to.x + to.width / 2,
-          y2: to.y + to.height / 2,
-          edge,
-        }
+
+        const toCenter = { x: to.x + to.width / 2, y: to.y + to.height / 2 }
+        const fromCenter = { x: from.x + from.width / 2, y: from.y + from.height / 2 }
+        const fromAnchor = getAnchor(from, toCenter.x, toCenter.y)
+        const toAnchor = getAnchor(to, fromCenter.x, fromCenter.y)
+        const path = makePath(fromAnchor, toAnchor)
+
+        return { id: edge.id, edge, fromAnchor, toAnchor, path }
       })
       .filter(Boolean) as Array<{
       id: string
-      x1: number
-      y1: number
-      x2: number
-      y2: number
       edge: CanvasEdge
+      fromAnchor: { x: number; y: number; dir: string }
+      toAnchor: { x: number; y: number; dir: string }
+      path: string
     }>
   }, [edges, panelMap])
 
-  // In-progress connection line
-  const connectingFrom = connectingFromId ? panelMap.get(connectingFromId) : null
-  const pendingLine =
-    connectingFrom && mouseCanvasPos
-      ? {
-          x1: connectingFrom.x + connectingFrom.width / 2,
-          y1: connectingFrom.y + connectingFrom.height / 2,
-          x2: mouseCanvasPos.x,
-          y2: mouseCanvasPos.y,
-        }
-      : null
+  // Pending connection line
+  const pendingPath = useMemo(() => {
+    if (!connectingFromId || !mouseCanvasPos) return null
+    const from = panelMap.get(connectingFromId)
+    if (!from) return null
 
-  if (edgeLines.length === 0 && !pendingLine) return null
+    const fromAnchor = getAnchor(from, mouseCanvasPos.x, mouseCanvasPos.y)
+    const toAnchor = { ...mouseCanvasPos, dir: fromAnchor.dir === 'right' ? 'left' : fromAnchor.dir === 'left' ? 'right' : fromAnchor.dir === 'down' ? 'up' : 'down' }
+    return { fromAnchor, path: makePath(fromAnchor, toAnchor) }
+  }, [connectingFromId, mouseCanvasPos, panelMap])
+
+  if (edgeData.length === 0 && !pendingPath) return null
 
   return (
     <svg
       className="absolute inset-0 pointer-events-none"
       style={{ overflow: 'visible', zIndex: 0 }}
     >
-      <defs>
-        {/* Default edge arrow */}
-        <marker
-          id="canvas-arrow"
-          markerWidth="8"
-          markerHeight="6"
-          refX="8"
-          refY="3"
-          orient="auto"
-        >
-          <path d="M0,0 L8,3 L0,6" fill="none" stroke="rgba(99,102,241,0.5)" strokeWidth="1" />
-        </marker>
-        <marker
-          id="canvas-arrow-pending"
-          markerWidth="8"
-          markerHeight="6"
-          refX="8"
-          refY="3"
-          orient="auto"
-        >
-          <path d="M0,0 L8,3 L0,6" fill="none" stroke="rgba(99,102,241,0.3)" strokeWidth="1" />
-        </marker>
-
-        {/* Browser edge arrow — orange */}
-        <marker
-          id="canvas-arrow-browser"
-          markerWidth="10"
-          markerHeight="8"
-          refX="10"
-          refY="4"
-          orient="auto"
-        >
-          <path d="M0,0 L10,4 L0,8" fill="none" stroke="rgba(249,115,22,0.7)" strokeWidth="1.5" />
-        </marker>
-
-        {/* Browser edge glow gradient */}
-        <linearGradient id="browser-edge-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
-          <stop offset="0%" stopColor="rgba(249,115,22,0.6)" />
-          <stop offset="50%" stopColor="rgba(251,146,60,0.8)" />
-          <stop offset="100%" stopColor="rgba(249,115,22,0.6)" />
-        </linearGradient>
-
-        {/* Pulsing glow filter for browser edges */}
-        <filter id="browser-glow" x="-20%" y="-20%" width="140%" height="140%">
-          <feGaussianBlur stdDeviation="3" result="blur" />
-          <feMerge>
-            <feMergeNode in="blur" />
-            <feMergeNode in="SourceGraphic" />
-          </feMerge>
-        </filter>
-      </defs>
-
-      {/* CSS animation for browser edge pulse */}
-      <style>{`
-        @keyframes browserEdgePulse {
-          0%, 100% { opacity: 0.4; stroke-dashoffset: 0; }
-          50% { opacity: 0.8; }
-        }
-        @keyframes browserEdgeDash {
-          to { stroke-dashoffset: -20; }
-        }
-        .browser-edge-line {
-          animation: browserEdgePulse 2s ease-in-out infinite, browserEdgeDash 1s linear infinite;
-        }
-        .browser-edge-glow {
-          animation: browserEdgePulse 2s ease-in-out infinite;
-        }
-      `}</style>
-
       {/* Existing edges */}
-      {edgeLines.map((line) => {
-        const isBrowser = line.edge.edgeType === 'browser'
+      {edgeData.map((edge) => {
+        const isBrowser = edge.edge.edgeType === 'browser'
+        const colorFaded = isBrowser ? 'rgba(249,115,22,0.5)' : 'rgba(99,102,241,0.45)'
+        const colorDot = isBrowser ? 'rgba(249,115,22,0.8)' : 'rgba(99,102,241,0.7)'
+
         return (
-          <g key={line.id}>
-            {/* Invisible wider line for easier click target */}
-            <line
-              x1={line.x1}
-              y1={line.y1}
-              x2={line.x2}
-              y2={line.y2}
+          <g key={edge.id}>
+            {/* Invisible wider path for click target */}
+            <path
+              d={edge.path}
+              fill="none"
               stroke="transparent"
               strokeWidth="14"
               className="pointer-events-auto cursor-pointer"
-              onClick={() => removeEdge(line.id)}
+              onClick={() => removeEdge(edge.id)}
             />
 
-            {isBrowser ? (
-              <>
-                {/* Browser edge — glow layer */}
-                <line
-                  x1={line.x1}
-                  y1={line.y1}
-                  x2={line.x2}
-                  y2={line.y2}
-                  stroke="rgba(249,115,22,0.15)"
-                  strokeWidth="6"
-                  strokeLinecap="round"
-                  className="browser-edge-glow"
-                  filter="url(#browser-glow)"
-                />
-                {/* Browser edge — main line */}
-                <line
-                  x1={line.x1}
-                  y1={line.y1}
-                  x2={line.x2}
-                  y2={line.y2}
-                  stroke="url(#browser-edge-gradient)"
-                  strokeWidth="2"
-                  strokeDasharray="8 4"
-                  strokeLinecap="round"
-                  markerEnd="url(#canvas-arrow-browser)"
-                  className="browser-edge-line"
-                />
-                {/* Browser icon at midpoint */}
-                <BrowserEdgeIcon
-                  x={(line.x1 + line.x2) / 2}
-                  y={(line.y1 + line.y2) / 2}
-                  onDelete={() => removeEdge(line.id)}
-                />
-              </>
-            ) : (
-              <>
-                {/* Default edge — visible line */}
-                <line
-                  x1={line.x1}
-                  y1={line.y1}
-                  x2={line.x2}
-                  y2={line.y2}
-                  stroke="rgba(99,102,241,0.35)"
-                  strokeWidth="1.5"
-                  strokeDasharray="6 4"
-                  markerEnd="url(#canvas-arrow)"
-                />
-                {/* Delete button at midpoint */}
-                <EdgeDeleteButton
-                  x={(line.x1 + line.x2) / 2}
-                  y={(line.y1 + line.y2) / 2}
-                  onDelete={() => removeEdge(line.id)}
-                />
-              </>
+            {/* Visible bezier curve */}
+            <path
+              d={edge.path}
+              fill="none"
+              stroke={colorFaded}
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+
+            {/* Source anchor dot */}
+            <circle
+              cx={edge.fromAnchor.x}
+              cy={edge.fromAnchor.y}
+              r="3"
+              fill={colorDot}
+            />
+
+            {/* Target anchor dot */}
+            <circle
+              cx={edge.toAnchor.x}
+              cy={edge.toAnchor.y}
+              r="3"
+              fill={colorDot}
+            />
+
+            {/* Midpoint label for browser edges */}
+            {isBrowser && (
+              <EdgeLabel
+                path={edge.path}
+                onDelete={() => removeEdge(edge.id)}
+              />
+            )}
+
+            {/* Delete on hover for default edges */}
+            {!isBrowser && (
+              <EdgeDeleteDot
+                x={(edge.fromAnchor.x + edge.toAnchor.x) / 2}
+                y={(edge.fromAnchor.y + edge.toAnchor.y) / 2}
+                onDelete={() => removeEdge(edge.id)}
+              />
             )}
           </g>
         )
       })}
 
       {/* Pending connection line */}
-      {pendingLine && (
-        <line
-          x1={pendingLine.x1}
-          y1={pendingLine.y1}
-          x2={pendingLine.x2}
-          y2={pendingLine.y2}
-          stroke="rgba(99,102,241,0.3)"
-          strokeWidth="1.5"
-          strokeDasharray="4 4"
-          markerEnd="url(#canvas-arrow-pending)"
-        />
+      {pendingPath && (
+        <>
+          <path
+            d={pendingPath.path}
+            fill="none"
+            stroke="rgba(99,102,241,0.3)"
+            strokeWidth="2"
+            strokeDasharray="6 4"
+            strokeLinecap="round"
+          />
+          <circle
+            cx={pendingPath.fromAnchor.x}
+            cy={pendingPath.fromAnchor.y}
+            r="3"
+            fill="rgba(99,102,241,0.5)"
+          />
+          {mouseCanvasPos && (
+            <circle
+              cx={mouseCanvasPos.x}
+              cy={mouseCanvasPos.y}
+              r="4"
+              fill="none"
+              stroke="rgba(99,102,241,0.4)"
+              strokeWidth="1.5"
+            />
+          )}
+        </>
       )}
     </svg>
   )
 }
 
-// ── Browser edge icon (globe at midpoint) ─────────────────────
+// ── Browser edge label (small "Browser" pill at midpoint) ─────
 
-function BrowserEdgeIcon({
-  x,
-  y,
+function EdgeLabel({
+  path,
   onDelete,
 }: {
-  x: number
-  y: number
+  path: string
   onDelete: () => void
 }) {
+  // Approximate midpoint from the path's start and end
+  const match = path.match(/M ([\d.-]+) ([\d.-]+) C [\d.-]+[\s,]+[\d.-]+[\s,]+([\d.-]+)[\s,]+([\d.-]+)[\s,]+([\d.-]+)[\s,]+([\d.-]+)/)
+  if (!match) return null
+
+  const x1 = parseFloat(match[1]), y1 = parseFloat(match[2])
+  const x2 = parseFloat(match[5]), y2 = parseFloat(match[6])
+  const mx = (x1 + x2) / 2
+  const my = (y1 + y2) / 2
+
   return (
     <g
       className="pointer-events-auto cursor-pointer"
-      onClick={(e) => {
-        e.stopPropagation()
-        onDelete()
-      }}
+      onClick={(e) => { e.stopPropagation(); onDelete() }}
     >
-      {/* Background circle with glow */}
-      <circle
-        cx={x}
-        cy={y}
-        r="12"
-        fill="#1a1208"
-        stroke="rgba(249,115,22,0.4)"
-        strokeWidth="1.5"
-        className="browser-edge-glow"
+      <rect
+        x={mx - 28}
+        y={my - 9}
+        width="56"
+        height="18"
+        rx="9"
+        fill="#1c1208"
+        stroke="rgba(249,115,22,0.3)"
+        strokeWidth="1"
       />
-      {/* Globe icon */}
-      <foreignObject x={x - 7} y={y - 7} width="14" height="14">
-        <div className="flex items-center justify-center w-full h-full">
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="rgba(249,115,22,0.8)"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="12" cy="12" r="10" />
-            <path d="M2 12h20" />
-            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-          </svg>
-        </div>
-      </foreignObject>
-      {/* Hover: show X */}
-      <g className="opacity-0 hover:opacity-100 transition-opacity">
-        <circle cx={x + 8} cy={y - 8} r="5" fill="#161b22" stroke="rgba(239,68,68,0.5)" strokeWidth="1" />
-        <foreignObject x={x + 5} y={y - 11} width="6" height="6">
-          <div className="flex items-center justify-center w-full h-full">
-            <X className="h-2 w-2 text-red-400" />
-          </div>
-        </foreignObject>
-      </g>
+      <text
+        x={mx}
+        y={my + 4}
+        textAnchor="middle"
+        fill="rgba(249,115,22,0.7)"
+        fontSize="9"
+        fontFamily="system-ui, sans-serif"
+        fontWeight="500"
+      >
+        Browser
+      </text>
     </g>
   )
 }
 
-// ── Default edge delete button ────────────────────────────────
+// ── Delete dot for default edges (appears on hover) ───────────
 
-function EdgeDeleteButton({
+function EdgeDeleteDot({
   x,
   y,
   onDelete,
@@ -307,17 +270,11 @@ function EdgeDeleteButton({
   return (
     <g
       className="pointer-events-auto cursor-pointer opacity-0 hover:opacity-100 transition-opacity"
-      onClick={(e) => {
-        e.stopPropagation()
-        onDelete()
-      }}
+      onClick={(e) => { e.stopPropagation(); onDelete() }}
     >
-      <circle cx={x} cy={y} r="8" fill="#161b22" stroke="rgba(99,102,241,0.3)" strokeWidth="1" />
-      <foreignObject x={x - 5} y={y - 5} width="10" height="10">
-        <div className="flex items-center justify-center w-full h-full">
-          <X className="h-2.5 w-2.5 text-red-400" />
-        </div>
-      </foreignObject>
+      <circle cx={x} cy={y} r="7" fill="#161b22" stroke="rgba(99,102,241,0.3)" strokeWidth="1" />
+      <line x1={x - 2.5} y1={y - 2.5} x2={x + 2.5} y2={y + 2.5} stroke="rgba(239,68,68,0.7)" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1={x + 2.5} y1={y - 2.5} x2={x - 2.5} y2={y + 2.5} stroke="rgba(239,68,68,0.7)" strokeWidth="1.5" strokeLinecap="round" />
     </g>
   )
 }

--- a/src/renderer/src/components/canvas/CanvasConnections.tsx
+++ b/src/renderer/src/components/canvas/CanvasConnections.tsx
@@ -84,11 +84,7 @@ export function CanvasConnections({
         const toAnchor = getAnchor(to, fromCenter.x, fromCenter.y)
         const path = makePath(fromAnchor, toAnchor)
 
-        // For browser edges, find the browser panel's title to show on the label
-        const browserPanel = from.type === 'browser' ? from : to.type === 'browser' ? to : null
-        const browserTitle = browserPanel?.title || ''
-
-        return { id: edge.id, edge, fromAnchor, toAnchor, path, browserTitle }
+        return { id: edge.id, edge, fromAnchor, toAnchor, path }
       })
       .filter(Boolean) as Array<{
       id: string
@@ -96,7 +92,6 @@ export function CanvasConnections({
       fromAnchor: { x: number; y: number; dir: string }
       toAnchor: { x: number; y: number; dir: string }
       path: string
-      browserTitle: string
     }>
   }, [edges, panelMap])
 
@@ -135,9 +130,13 @@ export function CanvasConnections({
     >
       {/* Existing edges */}
       {edgeData.map((edge) => {
-        const isBrowser = edge.edge.edgeType === 'browser'
-        const colorFaded = isBrowser ? 'rgba(249,115,22,0.5)' : 'rgba(99,102,241,0.45)'
-        const colorDot = isBrowser ? 'rgba(249,115,22,0.8)' : 'rgba(99,102,241,0.7)'
+        const edgeType = edge.edge.edgeType
+        const colorFaded = edgeType === 'browser' ? 'rgba(249,115,22,0.5)'
+          : edgeType === 'terminal' ? 'rgba(34,197,94,0.5)'
+          : 'rgba(99,102,241,0.45)'
+        const colorDot = edgeType === 'browser' ? 'rgba(249,115,22,0.8)'
+          : edgeType === 'terminal' ? 'rgba(34,197,94,0.8)'
+          : 'rgba(99,102,241,0.7)'
 
         return (
           <g key={edge.id}>
@@ -176,23 +175,12 @@ export function CanvasConnections({
               fill={colorDot}
             />
 
-            {/* Midpoint label for browser edges */}
-            {isBrowser && (
-              <EdgeLabel
-                path={edge.path}
-                label={edge.browserTitle || 'Browser'}
-                onDelete={() => removeEdge(edge.id)}
-              />
-            )}
-
-            {/* Delete on hover for default edges */}
-            {!isBrowser && (
-              <EdgeDeleteDot
-                x={(edge.fromAnchor.x + edge.toAnchor.x) / 2}
-                y={(edge.fromAnchor.y + edge.toAnchor.y) / 2}
-                onDelete={() => removeEdge(edge.id)}
-              />
-            )}
+            {/* Delete dot on hover (midpoint) */}
+            <EdgeDeleteDot
+              x={(edge.fromAnchor.x + edge.toAnchor.x) / 2}
+              y={(edge.fromAnchor.y + edge.toAnchor.y) / 2}
+              onDelete={() => removeEdge(edge.id)}
+            />
           </g>
         )
       })}
@@ -269,63 +257,7 @@ export function CanvasConnections({
   )
 }
 
-// ── Browser edge label (small "Browser" pill at midpoint) ─────
-
-function EdgeLabel({
-  path,
-  label,
-  onDelete,
-}: {
-  path: string
-  label: string
-  onDelete: () => void
-}) {
-  // Approximate midpoint from the path's start and end
-  const match = path.match(/M ([\d.-]+) ([\d.-]+) C [\d.-]+[\s,]+[\d.-]+[\s,]+([\d.-]+)[\s,]+([\d.-]+)[\s,]+([\d.-]+)[\s,]+([\d.-]+)/)
-  if (!match) return null
-
-  const x1 = parseFloat(match[1]), y1 = parseFloat(match[2])
-  const x2 = parseFloat(match[5]), y2 = parseFloat(match[6])
-  const mx = (x1 + x2) / 2
-  const my = (y1 + y2) / 2
-
-  // Truncate long titles, show with lightning icon
-  const truncated = label.length > 16 ? label.slice(0, 15) + '\u2026' : label
-  const displayLabel = `\u26A1 ${truncated}`
-  const pillW = Math.max(60, displayLabel.length * 6 + 16)
-  const pillH = 18
-
-  return (
-    <g
-      className="pointer-events-auto cursor-pointer"
-      onClick={(e) => { e.stopPropagation(); onDelete() }}
-    >
-      <rect
-        x={mx - pillW / 2}
-        y={my - pillH / 2}
-        width={pillW}
-        height={pillH}
-        rx="9"
-        fill="#1c1208"
-        stroke="rgba(249,115,22,0.3)"
-        strokeWidth="1"
-      />
-      <text
-        x={mx}
-        y={my + 4}
-        textAnchor="middle"
-        fill="rgba(249,115,22,0.7)"
-        fontSize="9"
-        fontFamily="system-ui, sans-serif"
-        fontWeight="500"
-      >
-        {displayLabel}
-      </text>
-    </g>
-  )
-}
-
-// ── Delete dot for default edges (appears on hover) ───────────
+// ── Delete dot for edges (appears on hover) ─────────────────
 
 function EdgeDeleteDot({
   x,

--- a/src/renderer/src/components/canvas/CanvasConnections.tsx
+++ b/src/renderer/src/components/canvas/CanvasConnections.tsx
@@ -5,6 +5,9 @@ import { X } from 'lucide-react'
 /**
  * Renders SVG connection lines between panels.
  * Also renders the in-progress connection line when drawing a new edge.
+ *
+ * Browser edges get a distinct animated style (pulsing orange gradient)
+ * so it's visually clear that an agent has browser access.
  */
 export function CanvasConnections({
   mouseCanvasPos,
@@ -68,6 +71,7 @@ export function CanvasConnections({
       style={{ overflow: 'visible', zIndex: 0 }}
     >
       <defs>
+        {/* Default edge arrow */}
         <marker
           id="canvas-arrow"
           markerWidth="8"
@@ -88,41 +92,128 @@ export function CanvasConnections({
         >
           <path d="M0,0 L8,3 L0,6" fill="none" stroke="rgba(99,102,241,0.3)" strokeWidth="1" />
         </marker>
+
+        {/* Browser edge arrow — orange */}
+        <marker
+          id="canvas-arrow-browser"
+          markerWidth="10"
+          markerHeight="8"
+          refX="10"
+          refY="4"
+          orient="auto"
+        >
+          <path d="M0,0 L10,4 L0,8" fill="none" stroke="rgba(249,115,22,0.7)" strokeWidth="1.5" />
+        </marker>
+
+        {/* Browser edge glow gradient */}
+        <linearGradient id="browser-edge-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stopColor="rgba(249,115,22,0.6)" />
+          <stop offset="50%" stopColor="rgba(251,146,60,0.8)" />
+          <stop offset="100%" stopColor="rgba(249,115,22,0.6)" />
+        </linearGradient>
+
+        {/* Pulsing glow filter for browser edges */}
+        <filter id="browser-glow" x="-20%" y="-20%" width="140%" height="140%">
+          <feGaussianBlur stdDeviation="3" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
       </defs>
 
+      {/* CSS animation for browser edge pulse */}
+      <style>{`
+        @keyframes browserEdgePulse {
+          0%, 100% { opacity: 0.4; stroke-dashoffset: 0; }
+          50% { opacity: 0.8; }
+        }
+        @keyframes browserEdgeDash {
+          to { stroke-dashoffset: -20; }
+        }
+        .browser-edge-line {
+          animation: browserEdgePulse 2s ease-in-out infinite, browserEdgeDash 1s linear infinite;
+        }
+        .browser-edge-glow {
+          animation: browserEdgePulse 2s ease-in-out infinite;
+        }
+      `}</style>
+
       {/* Existing edges */}
-      {edgeLines.map((line) => (
-        <g key={line.id}>
-          {/* Invisible wider line for easier click target */}
-          <line
-            x1={line.x1}
-            y1={line.y1}
-            x2={line.x2}
-            y2={line.y2}
-            stroke="transparent"
-            strokeWidth="12"
-            className="pointer-events-auto cursor-pointer"
-            onClick={() => removeEdge(line.id)}
-          />
-          {/* Visible line */}
-          <line
-            x1={line.x1}
-            y1={line.y1}
-            x2={line.x2}
-            y2={line.y2}
-            stroke="rgba(99,102,241,0.35)"
-            strokeWidth="1.5"
-            strokeDasharray="6 4"
-            markerEnd="url(#canvas-arrow)"
-          />
-          {/* Delete button at midpoint */}
-          <EdgeDeleteButton
-            x={(line.x1 + line.x2) / 2}
-            y={(line.y1 + line.y2) / 2}
-            onDelete={() => removeEdge(line.id)}
-          />
-        </g>
-      ))}
+      {edgeLines.map((line) => {
+        const isBrowser = line.edge.edgeType === 'browser'
+        return (
+          <g key={line.id}>
+            {/* Invisible wider line for easier click target */}
+            <line
+              x1={line.x1}
+              y1={line.y1}
+              x2={line.x2}
+              y2={line.y2}
+              stroke="transparent"
+              strokeWidth="14"
+              className="pointer-events-auto cursor-pointer"
+              onClick={() => removeEdge(line.id)}
+            />
+
+            {isBrowser ? (
+              <>
+                {/* Browser edge — glow layer */}
+                <line
+                  x1={line.x1}
+                  y1={line.y1}
+                  x2={line.x2}
+                  y2={line.y2}
+                  stroke="rgba(249,115,22,0.15)"
+                  strokeWidth="6"
+                  strokeLinecap="round"
+                  className="browser-edge-glow"
+                  filter="url(#browser-glow)"
+                />
+                {/* Browser edge — main line */}
+                <line
+                  x1={line.x1}
+                  y1={line.y1}
+                  x2={line.x2}
+                  y2={line.y2}
+                  stroke="url(#browser-edge-gradient)"
+                  strokeWidth="2"
+                  strokeDasharray="8 4"
+                  strokeLinecap="round"
+                  markerEnd="url(#canvas-arrow-browser)"
+                  className="browser-edge-line"
+                />
+                {/* Browser icon at midpoint */}
+                <BrowserEdgeIcon
+                  x={(line.x1 + line.x2) / 2}
+                  y={(line.y1 + line.y2) / 2}
+                  onDelete={() => removeEdge(line.id)}
+                />
+              </>
+            ) : (
+              <>
+                {/* Default edge — visible line */}
+                <line
+                  x1={line.x1}
+                  y1={line.y1}
+                  x2={line.x2}
+                  y2={line.y2}
+                  stroke="rgba(99,102,241,0.35)"
+                  strokeWidth="1.5"
+                  strokeDasharray="6 4"
+                  markerEnd="url(#canvas-arrow)"
+                />
+                {/* Delete button at midpoint */}
+                <EdgeDeleteButton
+                  x={(line.x1 + line.x2) / 2}
+                  y={(line.y1 + line.y2) / 2}
+                  onDelete={() => removeEdge(line.id)}
+                />
+              </>
+            )}
+          </g>
+        )
+      })}
 
       {/* Pending connection line */}
       {pendingLine && (
@@ -140,6 +231,69 @@ export function CanvasConnections({
     </svg>
   )
 }
+
+// ── Browser edge icon (globe at midpoint) ─────────────────────
+
+function BrowserEdgeIcon({
+  x,
+  y,
+  onDelete,
+}: {
+  x: number
+  y: number
+  onDelete: () => void
+}) {
+  return (
+    <g
+      className="pointer-events-auto cursor-pointer"
+      onClick={(e) => {
+        e.stopPropagation()
+        onDelete()
+      }}
+    >
+      {/* Background circle with glow */}
+      <circle
+        cx={x}
+        cy={y}
+        r="12"
+        fill="#1a1208"
+        stroke="rgba(249,115,22,0.4)"
+        strokeWidth="1.5"
+        className="browser-edge-glow"
+      />
+      {/* Globe icon */}
+      <foreignObject x={x - 7} y={y - 7} width="14" height="14">
+        <div className="flex items-center justify-center w-full h-full">
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="rgba(249,115,22,0.8)"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M2 12h20" />
+            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+          </svg>
+        </div>
+      </foreignObject>
+      {/* Hover: show X */}
+      <g className="opacity-0 hover:opacity-100 transition-opacity">
+        <circle cx={x + 8} cy={y - 8} r="5" fill="#161b22" stroke="rgba(239,68,68,0.5)" strokeWidth="1" />
+        <foreignObject x={x + 5} y={y - 11} width="6" height="6">
+          <div className="flex items-center justify-center w-full h-full">
+            <X className="h-2 w-2 text-red-400" />
+          </div>
+        </foreignObject>
+      </g>
+    </g>
+  )
+}
+
+// ── Default edge delete button ────────────────────────────────
 
 function EdgeDeleteButton({
   x,

--- a/src/renderer/src/components/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/src/components/canvas/CanvasContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react'
-import { CheckSquare, MessageSquare, Monitor, AppWindow, X } from 'lucide-react'
+import { CheckSquare, MessageSquare, Monitor, AppWindow, Globe, X } from 'lucide-react'
 import { useTaskStore } from '@/stores/task-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useDashboardStore } from '@/stores/dashboard-store'
@@ -106,6 +106,16 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
       </div>
 
       <div className="py-1 max-h-[400px] overflow-y-auto custom-scrollbar">
+        {/* Browser section — always available */}
+        <MenuSection title="Browser">
+          <MenuItem
+            icon={<Globe className="h-3.5 w-3.5 text-orange-400" />}
+            label="Agent Browser"
+            sublabel="Connect to agent-browser session"
+            onClick={() => handleAddPanel('browser', 'Agent Browser')}
+          />
+        </MenuSection>
+
         {/* Applications section */}
         {applications.length > 0 && (
           <MenuSection title="Applications">

--- a/src/renderer/src/components/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/src/components/canvas/CanvasContextMenu.tsx
@@ -50,7 +50,7 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
   }, [onClose])
 
   const handleAddPanel = useCallback(
-    (type: CanvasPanelType, title: string, refId?: string) => {
+    (type: CanvasPanelType, title: string, refId?: string, url?: string) => {
       // Don't add duplicate task/transcript/app panels for the same refId
       if (refId && (type === 'task' || type === 'transcript' || type === 'app')) {
         const exists = panels.some((p) => p.type === type && p.refId === refId)
@@ -66,6 +66,7 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
         type,
         title,
         refId,
+        url,
         x: position.canvasX + offset,
         y: position.canvasY + offset,
         width: DEFAULT_PANEL_WIDTH,
@@ -112,7 +113,7 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
             icon={<Globe className="h-3.5 w-3.5 text-orange-400" />}
             label="Agent Browser"
             sublabel="Browser controlled by agent via CDP"
-            onClick={() => handleAddPanel('browser', 'Agent Browser')}
+            onClick={() => handleAddPanel('browser', 'Agent Browser', undefined, 'https://www.google.com')}
           />
           <MenuItem
             icon={<TerminalSquare className="h-3.5 w-3.5 text-amber-400" />}

--- a/src/renderer/src/components/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/src/components/canvas/CanvasContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react'
-import { CheckSquare, MessageSquare, Monitor, AppWindow, Globe, X } from 'lucide-react'
+import { CheckSquare, MessageSquare, Monitor, AppWindow, Globe, TerminalSquare, X } from 'lucide-react'
 import { useTaskStore } from '@/stores/task-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useDashboardStore } from '@/stores/dashboard-store'
@@ -106,13 +106,19 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
       </div>
 
       <div className="py-1 max-h-[400px] overflow-y-auto custom-scrollbar">
-        {/* Browser section — always available */}
-        <MenuSection title="Browser">
+        {/* Browser & Terminal — always available */}
+        <MenuSection title="Tools">
           <MenuItem
             icon={<Globe className="h-3.5 w-3.5 text-orange-400" />}
             label="Agent Browser"
-            sublabel="Connect to agent-browser session"
+            sublabel="Browser controlled by agent via CDP"
             onClick={() => handleAddPanel('browser', 'Agent Browser')}
+          />
+          <MenuItem
+            icon={<TerminalSquare className="h-3.5 w-3.5 text-amber-400" />}
+            label="Terminal"
+            sublabel="Interactive shell session"
+            onClick={() => handleAddPanel('terminal', 'Terminal')}
           />
         </MenuSection>
 

--- a/src/renderer/src/components/canvas/CanvasMinimap.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.tsx
@@ -1,0 +1,299 @@
+import { useCallback, useRef, useState, useMemo } from 'react'
+import { useCanvasStore, type CanvasPanelData, MIN_ZOOM, MAX_ZOOM } from '@/stores/canvas-store'
+import { Minus, Plus, Maximize2, ChevronDown, ChevronUp } from 'lucide-react'
+
+// ── Constants ─────────────────────────────────────────────
+const MINIMAP_W = 180
+const MINIMAP_H = 120
+const MINIMAP_PAD = 12 // padding inside the minimap
+
+// Panel type → color mapping
+const PANEL_COLORS: Record<string, string> = {
+  task: 'rgba(99,102,241,0.7)',     // indigo
+  browser: 'rgba(249,115,22,0.7)',  // orange
+  terminal: 'rgba(34,197,94,0.7)',  // green
+  app: 'rgba(168,85,247,0.7)',      // purple
+  transcript: 'rgba(59,130,246,0.6)', // blue
+  webpage: 'rgba(236,72,153,0.6)',  // pink
+  placeholder: 'rgba(107,114,128,0.4)', // gray
+}
+
+/**
+ * CanvasMinimap — a small overview map in the bottom-right corner.
+ *
+ * Shows all panels as colored rectangles, the current viewport as a
+ * semi-transparent rectangle, and supports:
+ * - Click to navigate to a location
+ * - Drag the viewport rectangle to pan
+ * - Zoom controls (+/-)
+ * - Fit-to-content button
+ * - Collapsible
+ */
+export function CanvasMinimap({
+  containerWidth,
+  containerHeight,
+}: {
+  containerWidth: number
+  containerHeight: number
+}) {
+  const panels = useCanvasStore((s) => s.panels)
+  const viewport = useCanvasStore((s) => s.viewport)
+  const edges = useCanvasStore((s) => s.edges)
+  const setViewport = useCanvasStore((s) => s.setViewport)
+  const zoomTo = useCanvasStore((s) => s.zoomTo)
+  const fitToContent = useCanvasStore((s) => s.fitToContent)
+
+  const [collapsed, setCollapsed] = useState(false)
+  const [isDragging, setIsDragging] = useState(false)
+  const svgRef = useRef<SVGSVGElement>(null)
+
+  // ── Compute bounding box of all panels ──────────────────
+  const bounds = useMemo(() => {
+    if (panels.length === 0) {
+      return { minX: 0, minY: 0, maxX: 1000, maxY: 800 }
+    }
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const p of panels) {
+      minX = Math.min(minX, p.x)
+      minY = Math.min(minY, p.y)
+      maxX = Math.max(maxX, p.x + p.width)
+      maxY = Math.max(maxY, p.y + p.height)
+    }
+    // Also include the viewport visible area so it never clips out
+    const vpLeft = -viewport.x / viewport.zoom
+    const vpTop = -viewport.y / viewport.zoom
+    const vpRight = vpLeft + containerWidth / viewport.zoom
+    const vpBottom = vpTop + containerHeight / viewport.zoom
+    minX = Math.min(minX, vpLeft)
+    minY = Math.min(minY, vpTop)
+    maxX = Math.max(maxX, vpRight)
+    maxY = Math.max(maxY, vpBottom)
+
+    // Add padding
+    const pad = 100
+    return { minX: minX - pad, minY: minY - pad, maxX: maxX + pad, maxY: maxY + pad }
+  }, [panels, viewport, containerWidth, containerHeight])
+
+  // ── Scale factor: canvas space → minimap space ──────────
+  const canvasW = bounds.maxX - bounds.minX
+  const canvasH = bounds.maxY - bounds.minY
+  const innerW = MINIMAP_W - MINIMAP_PAD * 2
+  const innerH = MINIMAP_H - MINIMAP_PAD * 2
+  const scale = Math.min(innerW / canvasW, innerH / canvasH)
+
+  // Transform canvas coord → minimap coord
+  const toMiniX = (cx: number) => MINIMAP_PAD + (cx - bounds.minX) * scale
+  const toMiniY = (cy: number) => MINIMAP_PAD + (cy - bounds.minY) * scale
+
+  // ── Viewport rectangle in minimap ──────────────────────
+  const vpLeft = -viewport.x / viewport.zoom
+  const vpTop = -viewport.y / viewport.zoom
+  const vpW = containerWidth / viewport.zoom
+  const vpH = containerHeight / viewport.zoom
+  const vpRect = {
+    x: toMiniX(vpLeft),
+    y: toMiniY(vpTop),
+    w: vpW * scale,
+    h: vpH * scale,
+  }
+
+  // ── Click/drag on minimap → pan canvas ──────────────────
+  const panToMinimapPoint = useCallback(
+    (clientX: number, clientY: number) => {
+      const svg = svgRef.current
+      if (!svg) return
+      const rect = svg.getBoundingClientRect()
+      const mx = clientX - rect.left
+      const my = clientY - rect.top
+
+      // Convert minimap coord → canvas coord
+      const canvasX = (mx - MINIMAP_PAD) / scale + bounds.minX
+      const canvasY = (my - MINIMAP_PAD) / scale + bounds.minY
+
+      // Center the viewport on this point
+      const newVpX = -(canvasX * viewport.zoom - containerWidth / 2)
+      const newVpY = -(canvasY * viewport.zoom - containerHeight / 2)
+      setViewport({ x: newVpX, y: newVpY })
+    },
+    [scale, bounds, viewport.zoom, containerWidth, containerHeight, setViewport]
+  )
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setIsDragging(true)
+      panToMinimapPoint(e.clientX, e.clientY)
+    },
+    [panToMinimapPoint]
+  )
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isDragging) return
+      panToMinimapPoint(e.clientX, e.clientY)
+    },
+    [isDragging, panToMinimapPoint]
+  )
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false)
+  }, [])
+
+  // ── Edge lines in minimap ─────────────────────────────
+  const panelMap = useMemo(() => {
+    const map = new Map<string, CanvasPanelData>()
+    for (const p of panels) map.set(p.id, p)
+    return map
+  }, [panels])
+
+  const zoomPercent = Math.round(viewport.zoom * 100)
+
+  if (panels.length === 0) return null
+
+  return (
+    <div
+      className="absolute bottom-4 right-4 z-10 select-none"
+      style={{ pointerEvents: 'auto' }}
+    >
+      {/* Header bar — always visible */}
+      <div
+        className="flex items-center justify-between px-2 py-1 bg-[#1a2030]/95 backdrop-blur-sm border border-border/40 rounded-t-lg cursor-pointer"
+        style={{ width: MINIMAP_W, borderBottom: collapsed ? undefined : 'none', borderRadius: collapsed ? '8px' : undefined }}
+        onClick={() => setCollapsed((c) => !c)}
+      >
+        <span className="text-[10px] font-medium text-muted-foreground/60 uppercase tracking-wider">
+          Map
+        </span>
+        <div className="flex items-center gap-1">
+          <span className="text-[10px] text-muted-foreground/40 tabular-nums">
+            {zoomPercent}%
+          </span>
+          {collapsed ? (
+            <ChevronUp className="h-3 w-3 text-muted-foreground/40" />
+          ) : (
+            <ChevronDown className="h-3 w-3 text-muted-foreground/40" />
+          )}
+        </div>
+      </div>
+
+      {/* Minimap body */}
+      {!collapsed && (
+        <div
+          className="bg-[#0d1117]/95 backdrop-blur-sm border border-border/40 border-t-0 rounded-b-lg overflow-hidden"
+          style={{ width: MINIMAP_W }}
+        >
+          {/* SVG minimap */}
+          <svg
+            ref={svgRef}
+            width={MINIMAP_W}
+            height={MINIMAP_H}
+            className="cursor-crosshair"
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseUp}
+          >
+            {/* Edge lines */}
+            {edges.map((edge) => {
+              const from = panelMap.get(edge.fromPanelId)
+              const to = panelMap.get(edge.toPanelId)
+              if (!from || !to) return null
+              const isBrowser = edge.edgeType === 'browser'
+              return (
+                <line
+                  key={edge.id}
+                  x1={toMiniX(from.x + from.width / 2)}
+                  y1={toMiniY(from.y + from.height / 2)}
+                  x2={toMiniX(to.x + to.width / 2)}
+                  y2={toMiniY(to.y + to.height / 2)}
+                  stroke={isBrowser ? 'rgba(249,115,22,0.4)' : 'rgba(99,102,241,0.3)'}
+                  strokeWidth="1"
+                />
+              )
+            })}
+
+            {/* Panel rectangles */}
+            {panels.map((p) => {
+              const color = PANEL_COLORS[p.type] || 'rgba(148,163,184,0.5)'
+              const px = toMiniX(p.x)
+              const py = toMiniY(p.y)
+              const pw = Math.max(3, p.width * scale)
+              const ph = Math.max(2, p.height * scale)
+              return (
+                <rect
+                  key={p.id}
+                  x={px}
+                  y={py}
+                  width={pw}
+                  height={ph}
+                  rx="1"
+                  fill={color}
+                  stroke="rgba(255,255,255,0.1)"
+                  strokeWidth="0.5"
+                />
+              )
+            })}
+
+            {/* Viewport rectangle */}
+            <rect
+              x={vpRect.x}
+              y={vpRect.y}
+              width={Math.max(4, vpRect.w)}
+              height={Math.max(3, vpRect.h)}
+              rx="1"
+              fill="rgba(255,255,255,0.06)"
+              stroke="rgba(255,255,255,0.3)"
+              strokeWidth="1"
+              className="pointer-events-none"
+            />
+          </svg>
+
+          {/* Zoom controls bar */}
+          <div className="flex items-center justify-between px-1.5 py-1 border-t border-border/20">
+            <button
+              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+              onClick={(e) => { e.stopPropagation(); zoomTo(viewport.zoom / 1.2) }}
+              title="Zoom out (Ctrl+-)"
+            >
+              <Minus className="h-3 w-3" />
+            </button>
+
+            {/* Zoom slider */}
+            <input
+              type="range"
+              min={MIN_ZOOM * 100}
+              max={MAX_ZOOM * 100}
+              value={viewport.zoom * 100}
+              onChange={(e) => {
+                e.stopPropagation()
+                zoomTo(Number(e.target.value) / 100)
+              }}
+              className="flex-1 mx-1.5 h-1 accent-indigo-500 cursor-pointer"
+              style={{ opacity: 0.5 }}
+              title={`Zoom: ${zoomPercent}%`}
+            />
+
+            <button
+              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+              onClick={(e) => { e.stopPropagation(); zoomTo(viewport.zoom * 1.2) }}
+              title="Zoom in (Ctrl+=)"
+            >
+              <Plus className="h-3 w-3" />
+            </button>
+
+            <div className="w-px h-3 bg-border/20 mx-0.5" />
+
+            <button
+              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+              onClick={(e) => { e.stopPropagation(); fitToContent(containerWidth, containerHeight) }}
+              title="Fit all panels"
+            >
+              <Maximize2 className="h-3 w-3" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/canvas/CanvasMinimap.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.tsx
@@ -199,7 +199,9 @@ export function CanvasMinimap({
               const from = panelMap.get(edge.fromPanelId)
               const to = panelMap.get(edge.toPanelId)
               if (!from || !to) return null
-              const isBrowser = edge.edgeType === 'browser'
+              const edgeColor = edge.edgeType === 'browser' ? 'rgba(249,115,22,0.4)'
+                : edge.edgeType === 'terminal' ? 'rgba(34,197,94,0.4)'
+                : 'rgba(99,102,241,0.3)'
               return (
                 <line
                   key={edge.id}
@@ -207,7 +209,7 @@ export function CanvasMinimap({
                   y1={toMiniY(from.y + from.height / 2)}
                   x2={toMiniX(to.x + to.width / 2)}
                   y2={toMiniY(to.y + to.height / 2)}
-                  stroke={isBrowser ? 'rgba(249,115,22,0.4)' : 'rgba(99,102,241,0.3)'}
+                  stroke={edgeColor}
                   strokeWidth="1"
                 />
               )

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -416,7 +416,7 @@ const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, 
     return <TerminalPanelContent terminalId={id} />
   }
   if (type === 'browser') {
-    return <BrowserPanelContent panelId={id} sessionName={browserSessionId} streamPort={streamPort} />
+    return <BrowserPanelContent panelId={id} url={url} sessionName={browserSessionId} streamPort={streamPort} />
   }
   return (
     <div className="flex items-center justify-center h-full text-muted-foreground/50 text-xs">

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -34,7 +34,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   const focusPanel = useCanvasStore((s) => s.focusPanel)
   const setDraggingPanelId = useCanvasStore((s) => s.setDraggingPanelId)
   const setSnapGuides = useCanvasStore((s) => s.setSnapGuides)
-  const connectingFromId = useCanvasStore((s) => s.connectingFromId)
+  // Read connectingFromId imperatively to avoid re-rendering ALL panels when it changes.
+  // Only the connect button click handlers need it — not the render path.
   const setConnectingFromId = useCanvasStore((s) => s.setConnectingFromId)
   const addEdge = useCanvasStore((s) => s.addEdge)
 
@@ -141,39 +142,54 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   }, [isResizing, panel.id, panel.minWidth, panel.minHeight, zoom, updatePanel])
 
   // ── Connect (edge drawing) ─────────────────────────────────
-  const isConnecting = connectingFromId === panel.id
-  const isConnectTarget = !!connectingFromId && connectingFromId !== panel.id
+  // Local state tracks whether THIS panel initiated connecting — avoids global subscription
+  const [isConnectingLocal, setIsConnectingLocal] = useState(false)
 
   const handleStartConnect = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
       setConnectingFromId(panel.id)
+      setIsConnectingLocal(true)
     },
     [setConnectingFromId, panel.id]
   )
 
-  // When this panel is clicked while another panel is in "connecting" mode,
-  // complete the edge. Auto-detect browser edge type.
-  const handleClickWhileConnecting = useCallback(() => {
-    if (connectingFromId && connectingFromId !== panel.id) {
-      const fromPanel = useCanvasStore.getState().panels.find((p) => p.id === connectingFromId)
-      const isBrowserEdge =
-        panel.type === 'browser' || fromPanel?.type === 'browser'
-      addEdge(connectingFromId, panel.id, isBrowserEdge ? 'browser' : undefined)
+  const handleCancelConnect = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
       setConnectingFromId(null)
-    }
-  }, [connectingFromId, panel.id, panel.type, addEdge, setConnectingFromId])
+      setIsConnectingLocal(false)
+    },
+    [setConnectingFromId]
+  )
+
+  // Sync local state when store clears connectingFromId (Escape, background click, or edge completed)
+  useEffect(() => {
+    if (!isConnectingLocal) return
+    const unsub = useCanvasStore.subscribe((s) => {
+      if (s.connectingFromId !== panel.id) {
+        setIsConnectingLocal(false)
+      }
+    })
+    return unsub
+  }, [isConnectingLocal, panel.id])
 
   // ── Click handling ────────────────────────────────────────
   const handleMouseDown = useCallback(
     () => {
-      if (isConnectTarget) {
-        handleClickWhileConnecting()
+      // Read connecting state imperatively — no subscription cost
+      const connectingFrom = useCanvasStore.getState().connectingFromId
+      if (connectingFrom && connectingFrom !== panel.id) {
+        // Complete the edge
+        const fromPanel = useCanvasStore.getState().panels.find((p) => p.id === connectingFrom)
+        const isBrowserEdge = panel.type === 'browser' || fromPanel?.type === 'browser'
+        addEdge(connectingFrom, panel.id, isBrowserEdge ? 'browser' : undefined)
+        setConnectingFromId(null)
         return
       }
       bringToFront(panel.id)
     },
-    [bringToFront, panel.id, isConnectTarget, handleClickWhileConnecting]
+    [bringToFront, panel.id, panel.type, addEdge, setConnectingFromId]
   )
 
   // ── Focus (zoom-to-fit this panel) ────────────────────────
@@ -223,11 +239,9 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       ref={panelRef}
       data-canvas-panel="true"
       onMouseDown={handleMouseDown}
-      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col overflow-hidden select-none transition-all duration-150 ${cfg.border} ${
+      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col overflow-hidden select-none transition-shadow duration-150 ${cfg.border} ${
         isDragging ? 'shadow-indigo-500/10 ring-1 ring-indigo-500/30' : ''
-      } ${isConnecting ? 'ring-2 ring-orange-500/50 shadow-orange-500/10' : ''} ${
-        isConnectTarget ? 'ring-2 ring-indigo-400/50 shadow-indigo-500/10 cursor-crosshair' : ''
-      }`}
+      } ${isConnectingLocal ? 'ring-2 ring-orange-500/50' : ''}`}
       style={{
         left: panel.x,
         top: panel.y,
@@ -278,17 +292,17 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         )}
 
         {/* Panel actions — visible on hover (or always when connecting) */}
-        <div className={`flex items-center gap-0.5 transition-opacity duration-150 ${isConnecting ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
+        <div className={`flex items-center gap-0.5 transition-opacity duration-150 ${isConnectingLocal ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
           {/* Connect / link to another panel */}
           <button
             onMouseDown={(e) => e.stopPropagation()}
-            onClick={isConnecting ? () => setConnectingFromId(null) : handleStartConnect}
+            onClick={isConnectingLocal ? handleCancelConnect : handleStartConnect}
             className={`h-5 w-5 rounded flex items-center justify-center transition-colors ${
-              isConnecting
+              isConnectingLocal
                 ? 'bg-orange-500/20 text-orange-400 ring-1 ring-orange-500/40'
                 : 'hover:bg-white/10 text-muted-foreground/50 hover:text-muted-foreground'
             }`}
-            title={isConnecting ? 'Cancel connecting (click another panel to connect)' : 'Connect to another panel'}
+            title={isConnectingLocal ? 'Cancel connecting (click another panel to connect)' : 'Connect to another panel'}
           >
             <Link2 className="h-3 w-3" />
           </button>

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -4,7 +4,7 @@ import {
   calculateSnap,
   type CanvasPanelData,
 } from '@/stores/canvas-store'
-import { X, Focus, Maximize2, Minimize2, PanelLeft, PanelRight, Columns2 } from 'lucide-react'
+import { X, Focus, Maximize2, Minimize2, PanelLeft, PanelRight, Columns2, Link2 } from 'lucide-react'
 import type { TaskWorkspaceLayout } from '@/components/tasks/TaskWorkspace'
 import { TaskPanelContent } from './TaskPanelContent'
 import { TranscriptPanelContent } from './TranscriptPanelContent'
@@ -34,6 +34,9 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   const focusPanel = useCanvasStore((s) => s.focusPanel)
   const setDraggingPanelId = useCanvasStore((s) => s.setDraggingPanelId)
   const setSnapGuides = useCanvasStore((s) => s.setSnapGuides)
+  const connectingFromId = useCanvasStore((s) => s.connectingFromId)
+  const setConnectingFromId = useCanvasStore((s) => s.setConnectingFromId)
+  const addEdge = useCanvasStore((s) => s.addEdge)
 
   const panelRef = useRef<HTMLDivElement>(null)
   const [isDragging, setIsDragging] = useState(false)
@@ -137,12 +140,40 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     }
   }, [isResizing, panel.id, panel.minWidth, panel.minHeight, zoom, updatePanel])
 
+  // ── Connect (edge drawing) ─────────────────────────────────
+  const isConnecting = connectingFromId === panel.id
+  const isConnectTarget = !!connectingFromId && connectingFromId !== panel.id
+
+  const handleStartConnect = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      setConnectingFromId(panel.id)
+    },
+    [setConnectingFromId, panel.id]
+  )
+
+  // When this panel is clicked while another panel is in "connecting" mode,
+  // complete the edge. Auto-detect browser edge type.
+  const handleClickWhileConnecting = useCallback(() => {
+    if (connectingFromId && connectingFromId !== panel.id) {
+      const fromPanel = useCanvasStore.getState().panels.find((p) => p.id === connectingFromId)
+      const isBrowserEdge =
+        panel.type === 'browser' || fromPanel?.type === 'browser'
+      addEdge(connectingFromId, panel.id, isBrowserEdge ? 'browser' : undefined)
+      setConnectingFromId(null)
+    }
+  }, [connectingFromId, panel.id, panel.type, addEdge, setConnectingFromId])
+
   // ── Click handling ────────────────────────────────────────
   const handleMouseDown = useCallback(
     () => {
+      if (isConnectTarget) {
+        handleClickWhileConnecting()
+        return
+      }
       bringToFront(panel.id)
     },
-    [bringToFront, panel.id]
+    [bringToFront, panel.id, isConnectTarget, handleClickWhileConnecting]
   )
 
   // ── Focus (zoom-to-fit this panel) ────────────────────────
@@ -192,8 +223,10 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       ref={panelRef}
       data-canvas-panel="true"
       onMouseDown={handleMouseDown}
-      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col overflow-hidden select-none transition-shadow duration-150 ${cfg.border} ${
+      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col overflow-hidden select-none transition-all duration-150 ${cfg.border} ${
         isDragging ? 'shadow-indigo-500/10 ring-1 ring-indigo-500/30' : ''
+      } ${isConnecting ? 'ring-2 ring-orange-500/50 shadow-orange-500/10' : ''} ${
+        isConnectTarget ? 'ring-2 ring-indigo-400/50 shadow-indigo-500/10 cursor-crosshair' : ''
       }`}
       style={{
         left: panel.x,
@@ -244,8 +277,22 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
           </div>
         )}
 
-        {/* Panel actions — visible on hover */}
-        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+        {/* Panel actions — visible on hover (or always when connecting) */}
+        <div className={`flex items-center gap-0.5 transition-opacity duration-150 ${isConnecting ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
+          {/* Connect / link to another panel */}
+          <button
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={isConnecting ? () => setConnectingFromId(null) : handleStartConnect}
+            className={`h-5 w-5 rounded flex items-center justify-center transition-colors ${
+              isConnecting
+                ? 'bg-orange-500/20 text-orange-400 ring-1 ring-orange-500/40'
+                : 'hover:bg-white/10 text-muted-foreground/50 hover:text-muted-foreground'
+            }`}
+            title={isConnecting ? 'Cancel connecting (click another panel to connect)' : 'Connect to another panel'}
+          >
+            <Link2 className="h-3 w-3" />
+          </button>
+
           {/* Focus / zoom-to-fit button */}
           <button
             onMouseDown={(e) => e.stopPropagation()}

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -110,7 +110,13 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
             (e.fromPanelId === prox.toId && e.toPanelId === prox.fromId)
         )
         if (!alreadyExists) {
-          addEdge(prox.fromId, prox.toId, 'browser')
+          // Determine edge type from the panel types
+          const allPanels = useCanvasStore.getState().panels
+          const fromP = allPanels.find((p) => p.id === prox.fromId)
+          const toP = allPanels.find((p) => p.id === prox.toId)
+          const isBrowser = fromP?.type === 'browser' || toP?.type === 'browser'
+          const isTerminal = fromP?.type === 'terminal' || toP?.type === 'terminal'
+          addEdge(prox.fromId, prox.toId, isBrowser ? 'browser' : isTerminal ? 'terminal' : undefined)
         }
         useCanvasStore.getState().setProximityEdge(null)
       }
@@ -211,7 +217,9 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         // Complete the edge
         const fromPanel = useCanvasStore.getState().panels.find((p) => p.id === connectingFrom)
         const isBrowserEdge = panel.type === 'browser' || fromPanel?.type === 'browser'
-        addEdge(connectingFrom, panel.id, isBrowserEdge ? 'browser' : undefined)
+        const isTerminalEdge = panel.type === 'terminal' || fromPanel?.type === 'terminal'
+        const edgeType = isBrowserEdge ? 'browser' : isTerminalEdge ? 'terminal' : undefined
+        addEdge(connectingFrom, panel.id, edgeType)
         setConnectingFromId(null)
         return
       }
@@ -250,6 +258,26 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     },
     []
   )
+
+  // ── Side handle auto-hide after 20s of panel inactivity ──────
+  const [sideHandleVisible, setSideHandleVisible] = useState(false)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handlePanelMouseEnter = useCallback(() => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+    setSideHandleVisible(true)
+    hideTimerRef.current = setTimeout(() => setSideHandleVisible(false), 20_000)
+  }, [])
+
+  const handlePanelMouseLeave = useCallback(() => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+    setSideHandleVisible(false)
+  }, [])
+
+  // Clean up timer on unmount
+  useEffect(() => {
+    return () => { if (hideTimerRef.current) clearTimeout(hideTimerRef.current) }
+  }, [])
 
   // ── Proximity glow — this panel is a target of auto-connect proximity ──
   const [isProximityTarget, setIsProximityTarget] = useState(false)
@@ -320,6 +348,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       ref={panelRef}
       data-canvas-panel="true"
       onMouseDown={handleMouseDown}
+      onMouseEnter={handlePanelMouseEnter}
+      onMouseLeave={handlePanelMouseLeave}
       className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col select-none transition-shadow duration-150 group/panel ${cfg.border} ${
         isDragging ? 'shadow-indigo-500/10 ring-1 ring-indigo-500/30' : ''
       } ${isConnectingLocal ? 'ring-2 ring-orange-500/50' : ''} ${
@@ -471,7 +501,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       {/* Side handle — React Flow style, for task panels: click to create browser, drag to connect */}
       {panel.type === 'task' && !isCollapsed && !isDragging && (
         <div
-          className="absolute opacity-0 group-hover/panel:opacity-100 transition-opacity duration-200"
+          className={`absolute transition-opacity duration-200 ${sideHandleVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
           style={{
             right: -18,
             top: '50%',

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -11,6 +11,7 @@ import { TranscriptPanelContent } from './TranscriptPanelContent'
 import { AppPanelContent } from './AppPanelContent'
 import { WebPagePanelContent } from './WebPagePanelContent'
 import { TerminalPanelContent } from './TerminalPanelContent'
+import { BrowserPanelContent } from './BrowserPanelContent'
 
 interface CanvasPanelProps {
   panel: CanvasPanelData
@@ -182,6 +183,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     app: { label: 'App', color: 'bg-green-500/20 text-green-400', border: 'border-green-500/40' },
     webpage: { label: 'Web', color: 'bg-cyan-500/20 text-cyan-400', border: 'border-cyan-500/40' },
     terminal: { label: 'Terminal', color: 'bg-amber-500/20 text-amber-400', border: 'border-amber-500/50' },
+    browser: { label: 'Browser', color: 'bg-orange-500/20 text-orange-400', border: 'border-orange-500/40' },
   }
   const cfg = TYPE_CONFIG[panel.type] ?? { label: 'Panel', color: 'bg-muted/30 text-muted-foreground', border: 'border-border/50' }
 
@@ -283,7 +285,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       {/* Content area */}
       {!isCollapsed && (
         <div
-          className={`flex-1 overflow-hidden min-h-0 ${panel.type === 'task' || panel.type === 'transcript' || panel.type === 'webpage' || panel.type === 'terminal' || (panel.type === 'app' && panel.refId) ? '' : 'p-3 overflow-auto'}`}
+          className={`flex-1 overflow-hidden min-h-0 ${panel.type === 'task' || panel.type === 'transcript' || panel.type === 'webpage' || panel.type === 'terminal' || panel.type === 'browser' || (panel.type === 'app' && panel.refId) ? '' : 'p-3 overflow-auto'}`}
           style={frozen ? { visibility: 'hidden' } : undefined}
         >
           <MemoizedPanelContent
@@ -293,6 +295,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
             url={panel.url}
             title={panel.title}
             taskLayout={taskLayout}
+            browserSessionId={panel.browserSessionId}
+            streamPort={panel.streamPort}
           />
         </div>
       )}
@@ -330,9 +334,11 @@ interface PanelContentProps {
   url?: string
   title: string
   taskLayout?: TaskWorkspaceLayout
+  browserSessionId?: string
+  streamPort?: number
 }
 
-const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, title, taskLayout }: PanelContentProps) {
+const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, title, taskLayout, browserSessionId, streamPort }: PanelContentProps) {
   if (type === 'task' && refId) {
     return <TaskPanelContent taskId={refId} panelLayout={taskLayout} />
   }
@@ -347,6 +353,9 @@ const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, 
   }
   if (type === 'terminal') {
     return <TerminalPanelContent terminalId={id} />
+  }
+  if (type === 'browser') {
+    return <BrowserPanelContent panelId={id} sessionName={browserSessionId} streamPort={streamPort} />
   }
   return (
     <div className="flex items-center justify-center h-full text-muted-foreground/50 text-xs">

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -18,6 +18,10 @@ interface CanvasPanelProps {
   zoom: number
   /** When true, the panel is off-viewport — heavy content (iframes, terminals) is hidden */
   frozen?: boolean
+  /** 0-based index of this panel in the panels array */
+  panelIndex?: number
+  /** When true, show the panel index number as an overlay badge */
+  showIndex?: boolean
 }
 
 /**
@@ -27,7 +31,7 @@ interface CanvasPanelProps {
  * Memoized so that only the panel whose data changed re-renders — prevents
  * iframes/terminals from being remounted when a *different* panel moves.
  */
-export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = false }: CanvasPanelProps) {
+export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = false, panelIndex, showIndex = false }: CanvasPanelProps) {
   const bringToFront = useCanvasStore((s) => s.bringToFront)
   const updatePanel = useCanvasStore((s) => s.updatePanel)
   const removePanel = useCanvasStore((s) => s.removePanel)
@@ -378,6 +382,20 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
             <path d="M 3 3 L 8 3 L 8 5 L 5 5 L 5 8 L 3 8 Z" fill="currentColor" />
             <path d="M 0 6 L 2 6 L 2 8 L 0 8 Z" fill="currentColor" />
           </svg>
+        </div>
+      )}
+
+      {/* Panel index badge — shown when Ctrl/Cmd is held */}
+      {showIndex && panelIndex !== undefined && panelIndex < 9 && (
+        <div
+          className="absolute inset-0 flex items-center justify-center pointer-events-none z-50"
+          style={{ background: 'rgba(0,0,0,0.5)', borderRadius: 'inherit' }}
+        >
+          <div className="flex items-center justify-center w-16 h-16 rounded-2xl bg-indigo-500/90 shadow-2xl shadow-indigo-500/40 border border-indigo-400/50">
+            <span className="text-3xl font-bold text-white tabular-nums">
+              {panelIndex + 1}
+            </span>
+          </div>
         </div>
       )}
     </div>

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -2,9 +2,12 @@ import { useCallback, useRef, useState, useEffect, memo } from 'react'
 import {
   useCanvasStore,
   calculateSnap,
+  detectProximityEdge,
+  DEFAULT_PANEL_WIDTH,
+  DEFAULT_PANEL_HEIGHT,
   type CanvasPanelData,
 } from '@/stores/canvas-store'
-import { X, Focus, Maximize2, Minimize2, PanelLeft, PanelRight, Columns2, Link2 } from 'lucide-react'
+import { X, Focus, Maximize2, Minimize2, PanelLeft, PanelRight, Columns2, Link2, Globe } from 'lucide-react'
 import type { TaskWorkspaceLayout } from '@/components/tasks/TaskWorkspace'
 import { TaskPanelContent } from './TaskPanelContent'
 import { TranscriptPanelContent } from './TranscriptPanelContent'
@@ -80,7 +83,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       const newY = dragStart.current.panelY + dy
 
       // Read panels imperatively — avoids reactive subscription that re-renders all panels
-      const otherPanels = useCanvasStore.getState().panels.filter((p) => p.id !== panel.id)
+      const { panels: allPanels, edges } = useCanvasStore.getState()
+      const otherPanels = allPanels.filter((p) => p.id !== panel.id)
       const { x: snappedX, y: snappedY, guides } = calculateSnap(
         { x: newX, y: newY, width: panel.width, height: panel.height },
         otherPanels
@@ -88,9 +92,29 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
 
       updatePanel(panel.id, { x: snappedX, y: snappedY })
       setSnapGuides(guides)
+
+      // Auto-connect proximity detection (browser ↔ task)
+      const draggedWithPos = { ...panel, x: snappedX, y: snappedY }
+      const prox = detectProximityEdge(draggedWithPos, otherPanels, edges)
+      useCanvasStore.getState().setProximityEdge(prox)
     }
 
     const handleUp = () => {
+      // If there's a proximity edge, auto-connect on drop
+      const prox = useCanvasStore.getState().proximityEdge
+      if (prox) {
+        const { edges } = useCanvasStore.getState()
+        const alreadyExists = edges.some(
+          (e) =>
+            (e.fromPanelId === prox.fromId && e.toPanelId === prox.toId) ||
+            (e.fromPanelId === prox.toId && e.toPanelId === prox.fromId)
+        )
+        if (!alreadyExists) {
+          addEdge(prox.fromId, prox.toId, 'browser')
+        }
+        useCanvasStore.getState().setProximityEdge(null)
+      }
+
       setIsDragging(false)
       setDraggingPanelId(null)
       setSnapGuides([])
@@ -227,6 +251,59 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     []
   )
 
+  // ── Proximity glow — this panel is a target of auto-connect proximity ──
+  const [isProximityTarget, setIsProximityTarget] = useState(false)
+  useEffect(() => {
+    const unsub = useCanvasStore.subscribe((s, prev) => {
+      if (s.proximityEdge !== prev.proximityEdge) {
+        const isTarget = s.proximityEdge
+          ? (s.proximityEdge.fromId === panel.id || s.proximityEdge.toId === panel.id) &&
+            s.draggingPanelId !== panel.id
+          : false
+        setIsProximityTarget(isTarget)
+      }
+    })
+    return unsub
+  }, [panel.id])
+
+  // ── Create connected browser panel (from side handle click) ──
+  const handleCreateBrowser = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+      // Place new browser panel to the right of this panel with a gap
+      const gap = 40
+      const newX = panel.x + panel.width + gap
+      const newY = panel.y
+      const addPanel = useCanvasStore.getState().addPanel
+      const newId = addPanel({
+        type: 'browser',
+        title: 'Browser',
+        x: newX,
+        y: newY,
+        width: DEFAULT_PANEL_WIDTH,
+        height: DEFAULT_PANEL_HEIGHT,
+      })
+      // Auto-connect with browser edge
+      if (newId) {
+        addEdge(panel.id, newId, 'browser')
+      }
+    },
+    [panel.id, panel.x, panel.y, panel.width, addEdge]
+  )
+
+  // ── Start connecting from side handle (drag) ──
+  const handleSideHandleDrag = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+      // Enter connection mode — the user drags to an existing browser panel
+      setConnectingFromId(panel.id)
+      setIsConnectingLocal(true)
+    },
+    [setConnectingFromId, panel.id]
+  )
+
   // ── Panel type styling ────────────────────────────────────
   const TYPE_CONFIG: Record<string, { label: string; color: string; border: string }> = {
     task: { label: 'Task', color: 'bg-blue-500/20 text-blue-400', border: 'border-blue-500/40' },
@@ -243,9 +320,11 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       ref={panelRef}
       data-canvas-panel="true"
       onMouseDown={handleMouseDown}
-      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col overflow-hidden select-none transition-shadow duration-150 ${cfg.border} ${
+      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col select-none transition-shadow duration-150 group/panel ${cfg.border} ${
         isDragging ? 'shadow-indigo-500/10 ring-1 ring-indigo-500/30' : ''
-      } ${isConnectingLocal ? 'ring-2 ring-orange-500/50' : ''}`}
+      } ${isConnectingLocal ? 'ring-2 ring-orange-500/50' : ''} ${
+        isProximityTarget ? 'ring-2 ring-orange-500/60 shadow-orange-500/20 shadow-2xl' : ''
+      }`}
       style={{
         left: panel.x,
         top: panel.y,
@@ -256,6 +335,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         minHeight: isCollapsed ? undefined : (panel.minHeight ?? 150),
       }}
     >
+      {/* Inner wrapper — clips content within rounded corners */}
+      <div className="flex flex-col flex-1 min-h-0 overflow-hidden rounded-[11px]">
       {/* Title bar — drag handle */}
       <div
         className="flex items-center gap-2 px-3 py-2 border-b border-border/40 bg-[#141a26] flex-shrink-0 cursor-grab active:cursor-grabbing group"
@@ -366,6 +447,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         </div>
       )}
 
+      </div>{/* end inner wrapper */}
+
       {/* Resize handle (bottom-right corner) */}
       {!isCollapsed && (
         <div
@@ -382,6 +465,49 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
             <path d="M 3 3 L 8 3 L 8 5 L 5 5 L 5 8 L 3 8 Z" fill="currentColor" />
             <path d="M 0 6 L 2 6 L 2 8 L 0 8 Z" fill="currentColor" />
           </svg>
+        </div>
+      )}
+
+      {/* Side handle — React Flow style, for task panels: click to create browser, drag to connect */}
+      {panel.type === 'task' && !isCollapsed && !isDragging && (
+        <div
+          className="absolute opacity-0 group-hover/panel:opacity-100 transition-opacity duration-200"
+          style={{
+            right: -18,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            zIndex: 10,
+          }}
+        >
+          <button
+            onMouseDown={(e) => {
+              e.stopPropagation()
+              const startX = e.clientX
+              const startY = e.clientY
+              let moved = false
+
+              const onMove = (me: MouseEvent) => {
+                if (Math.abs(me.clientX - startX) > 5 || Math.abs(me.clientY - startY) > 5) {
+                  moved = true
+                  handleSideHandleDrag(e)
+                  window.removeEventListener('mousemove', onMove)
+                }
+              }
+              const onUp = () => {
+                window.removeEventListener('mousemove', onMove)
+                window.removeEventListener('mouseup', onUp)
+                if (!moved) {
+                  handleCreateBrowser(e)
+                }
+              }
+              window.addEventListener('mousemove', onMove)
+              window.addEventListener('mouseup', onUp)
+            }}
+            className="flex items-center justify-center w-8 h-8 rounded-full bg-orange-500/20 border border-orange-500/40 hover:bg-orange-500/30 hover:border-orange-500/60 hover:scale-110 transition-all duration-150 cursor-pointer shadow-lg shadow-orange-500/10"
+            title="Click to add browser · Drag to connect to existing browser"
+          >
+            <Globe className="h-3.5 w-3.5 text-orange-400" />
+          </button>
         </div>
       )}
 

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -557,7 +557,7 @@ const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, 
     return <WebPagePanelContent panelId={id} url={url} title={title} />
   }
   if (type === 'terminal') {
-    return <TerminalPanelContent terminalId={id} />
+    return <TerminalPanelContent terminalId={id} cwd={url} />
   }
   if (type === 'browser') {
     return <BrowserPanelContent panelId={id} url={url} sessionName={browserSessionId} streamPort={streamPort} />

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -7,7 +7,7 @@ import {
   DEFAULT_PANEL_HEIGHT,
   type CanvasPanelData,
 } from '@/stores/canvas-store'
-import { X, Focus, Maximize2, Minimize2, PanelLeft, PanelRight, Columns2, Link2, Globe } from 'lucide-react'
+import { X, Focus, Maximize2, Minimize2, PanelLeft, PanelRight, Columns2, Globe } from 'lucide-react'
 import type { TaskWorkspaceLayout } from '@/components/tasks/TaskWorkspace'
 import { TaskPanelContent } from './TaskPanelContent'
 import { TranscriptPanelContent } from './TranscriptPanelContent'
@@ -178,24 +178,6 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   // ── Connect (edge drawing) ─────────────────────────────────
   // Local state tracks whether THIS panel initiated connecting — avoids global subscription
   const [isConnectingLocal, setIsConnectingLocal] = useState(false)
-
-  const handleStartConnect = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation()
-      setConnectingFromId(panel.id)
-      setIsConnectingLocal(true)
-    },
-    [setConnectingFromId, panel.id]
-  )
-
-  const handleCancelConnect = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation()
-      setConnectingFromId(null)
-      setIsConnectingLocal(false)
-    },
-    [setConnectingFromId]
-  )
 
   // Sync local state when store clears connectingFromId (Escape, background click, or edge completed)
   useEffect(() => {
@@ -406,22 +388,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
           </div>
         )}
 
-        {/* Panel actions — visible on hover (or always when connecting) */}
-        <div className={`flex items-center gap-0.5 transition-opacity duration-150 ${isConnectingLocal ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
-          {/* Connect / link to another panel */}
-          <button
-            onMouseDown={(e) => e.stopPropagation()}
-            onClick={isConnectingLocal ? handleCancelConnect : handleStartConnect}
-            className={`h-5 w-5 rounded flex items-center justify-center transition-colors ${
-              isConnectingLocal
-                ? 'bg-orange-500/20 text-orange-400 ring-1 ring-orange-500/40'
-                : 'hover:bg-white/10 text-muted-foreground/50 hover:text-muted-foreground'
-            }`}
-            title={isConnectingLocal ? 'Cancel connecting (click another panel to connect)' : 'Connect to another panel'}
-          >
-            <Link2 className="h-3 w-3" />
-          </button>
-
+        {/* Panel actions — visible on hover */}
+        <div className={`flex items-center gap-0.5 transition-opacity duration-150 opacity-0 group-hover:opacity-100`}>
           {/* Focus / zoom-to-fit button */}
           <button
             onMouseDown={(e) => e.stopPropagation()}

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -361,13 +361,19 @@ export function InfiniteCanvas() {
   // ── Keyboard shortcuts ───────────────────────────────────
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Ignore shortcuts when typing in an input/textarea
+      // Ignore shortcuts when typing in an input/textarea or xterm terminal
       const tag = (e.target as HTMLElement)?.tagName?.toLowerCase()
-      const isInputFocused = tag === 'input' || tag === 'textarea' || (e.target as HTMLElement)?.isContentEditable
+      const isXtermFocused = !!(e.target as HTMLElement)?.closest('.xterm')
+      const isInputFocused = tag === 'input' || tag === 'textarea' || (e.target as HTMLElement)?.isContentEditable || isXtermFocused
 
       // Track Ctrl held state — shows panel index badges (Ctrl only, not Cmd)
       if (e.key === 'Control' && !e.repeat) {
         setCtrlHeld(true)
+      }
+      // Clear stale ctrlHeld if Ctrl was released while OS had focus
+      // (e.g. after Ctrl+Cmd+Shift+3 screenshot, OS swallows the keyup)
+      if (!e.ctrlKey && e.key !== 'Control') {
+        setCtrlHeld(false)
       }
 
       if (e.code === 'Space' && !e.repeat && !isInputFocused) {

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -6,6 +6,7 @@ import { useTaskStore } from '@/stores/task-store'
 import { CanvasPanel } from './CanvasPanel'
 import { CanvasConnections } from './CanvasConnections'
 import { CanvasContextMenu } from './CanvasContextMenu'
+import { CanvasMinimap } from './CanvasMinimap'
 import { Move, ZoomIn, ZoomOut, RotateCcw, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 
@@ -351,10 +352,17 @@ export function InfiniteCanvas() {
     [viewport]
   )
 
+  // ── Focused panel tracking (for Tab cycling) ─────────────
+  const [focusedPanelIndex, setFocusedPanelIndex] = useState(-1)
+
   // ── Keyboard shortcuts ───────────────────────────────────
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.code === 'Space' && !e.repeat) {
+      // Ignore shortcuts when typing in an input/textarea
+      const tag = (e.target as HTMLElement)?.tagName?.toLowerCase()
+      const isInputFocused = tag === 'input' || tag === 'textarea' || (e.target as HTMLElement)?.isContentEditable
+
+      if (e.code === 'Space' && !e.repeat && !isInputFocused) {
         setSpaceHeld(true)
       }
       if (e.code === 'Equal' && (e.ctrlKey || e.metaKey)) {
@@ -369,6 +377,43 @@ export function InfiniteCanvas() {
         e.preventDefault()
         resetViewport()
       }
+
+      // Ctrl/Cmd + 1-9: focus panel by index
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey) {
+        const digitMatch = e.code.match(/^Digit([1-9])$/)
+        if (digitMatch) {
+          const idx = parseInt(digitMatch[1], 10) - 1
+          const currentPanels = useCanvasStore.getState().panels
+          if (idx < currentPanels.length) {
+            e.preventDefault()
+            const container = containerRef.current
+            if (container) {
+              const rect = container.getBoundingClientRect()
+              useCanvasStore.getState().focusPanel(currentPanels[idx].id, rect.width, rect.height)
+              setFocusedPanelIndex(idx)
+            }
+          }
+        }
+      }
+
+      // Tab / Shift+Tab: cycle through panels
+      if (e.code === 'Tab' && !isInputFocused && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault()
+        const currentPanels = useCanvasStore.getState().panels
+        if (currentPanels.length === 0) return
+
+        const next = e.shiftKey
+          ? (focusedPanelIndex <= 0 ? currentPanels.length - 1 : focusedPanelIndex - 1)
+          : (focusedPanelIndex >= currentPanels.length - 1 ? 0 : focusedPanelIndex + 1)
+
+        setFocusedPanelIndex(next)
+        const container = containerRef.current
+        if (container) {
+          const rect = container.getBoundingClientRect()
+          useCanvasStore.getState().focusPanel(currentPanels[next].id, rect.width, rect.height)
+        }
+      }
+
       // Escape: cancel connecting or close context menu
       if (e.code === 'Escape') {
         const { connectingFromId: cid } = useCanvasStore.getState()
@@ -390,7 +435,7 @@ export function InfiniteCanvas() {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
     }
-  }, [viewport.zoom, zoomTo, resetViewport])
+  }, [viewport.zoom, zoomTo, resetViewport, focusedPanelIndex])
 
   const zoomPercent = Math.round(viewport.zoom * 100)
 
@@ -518,6 +563,12 @@ export function InfiniteCanvas() {
           {Math.round(-viewport.y / viewport.zoom)}
         </span>
       </div>
+
+      {/* ── Minimap (bottom-right) ── */}
+      <CanvasMinimap
+        containerWidth={containerSize.width}
+        containerHeight={containerSize.height}
+      />
 
       {/* ── Empty state ── */}
       {panels.length === 0 && (

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -355,12 +355,20 @@ export function InfiniteCanvas() {
   // ── Focused panel tracking (for Tab cycling) ─────────────
   const [focusedPanelIndex, setFocusedPanelIndex] = useState(-1)
 
+  // ── Ctrl-held state (shows panel index badges) ──────────
+  const [ctrlHeld, setCtrlHeld] = useState(false)
+
   // ── Keyboard shortcuts ───────────────────────────────────
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Ignore shortcuts when typing in an input/textarea
       const tag = (e.target as HTMLElement)?.tagName?.toLowerCase()
       const isInputFocused = tag === 'input' || tag === 'textarea' || (e.target as HTMLElement)?.isContentEditable
+
+      // Track Ctrl/Cmd held state — shows panel index badges
+      if ((e.key === 'Control' || e.key === 'Meta') && !e.repeat) {
+        setCtrlHeld(true)
+      }
 
       if (e.code === 'Space' && !e.repeat && !isInputFocused) {
         setSpaceHeld(true)
@@ -428,12 +436,22 @@ export function InfiniteCanvas() {
       if (e.code === 'Space') {
         setSpaceHeld(false)
       }
+      if (e.key === 'Control' || e.key === 'Meta') {
+        setCtrlHeld(false)
+      }
+    }
+    // Also clear on window blur (Ctrl+Tab to another window)
+    const handleBlur = () => {
+      setCtrlHeld(false)
+      setSpaceHeld(false)
     }
     window.addEventListener('keydown', handleKeyDown)
     window.addEventListener('keyup', handleKeyUp)
+    window.addEventListener('blur', handleBlur)
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', handleBlur)
     }
   }, [viewport.zoom, zoomTo, resetViewport, focusedPanelIndex])
 
@@ -483,12 +501,14 @@ export function InfiniteCanvas() {
           <CanvasConnections mouseCanvasPos={mouseCanvasPos} />
 
           {/* Render panels — off-viewport panels are frozen (content hidden) */}
-          {panels.map((panel) => (
+          {panels.map((panel, index) => (
             <CanvasPanel
               key={panel.id}
               panel={panel}
               zoom={viewport.zoom}
               frozen={!visiblePanelIds.has(panel.id)}
+              panelIndex={index}
+              showIndex={ctrlHeld}
             />
           ))}
         </div>

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -365,8 +365,8 @@ export function InfiniteCanvas() {
       const tag = (e.target as HTMLElement)?.tagName?.toLowerCase()
       const isInputFocused = tag === 'input' || tag === 'textarea' || (e.target as HTMLElement)?.isContentEditable
 
-      // Track Ctrl/Cmd held state — shows panel index badges
-      if ((e.key === 'Control' || e.key === 'Meta') && !e.repeat) {
+      // Track Ctrl held state — shows panel index badges (Ctrl only, not Cmd)
+      if (e.key === 'Control' && !e.repeat) {
         setCtrlHeld(true)
       }
 
@@ -436,7 +436,7 @@ export function InfiniteCanvas() {
       if (e.code === 'Space') {
         setSpaceHeld(false)
       }
-      if (e.key === 'Control' || e.key === 'Meta') {
+      if (e.key === 'Control') {
         setCtrlHeld(false)
       }
     }

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -487,35 +487,36 @@ export function InfiniteCanvas() {
         </Button>
       </div>
 
-      {/* ── HUD: Add + Viewport info ── */}
-      <div className="absolute top-3 right-3 flex items-center gap-2 z-10 select-none">
+      {/* ── HUD: Add button (top-left, primary CTA) ── */}
+      <div className="absolute top-3 left-3 z-10">
         <Button
-          variant="ghost"
           size="sm"
-          className="h-7 w-7 p-0 bg-[#1a2030]/90 backdrop-blur-sm border border-border/40 hover:border-border/60"
-          onClick={() => {
+          className="h-8 px-3 bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm text-xs gap-1.5"
+          onClick={(e) => {
+            const btn = e.currentTarget.getBoundingClientRect()
             const rect = containerRef.current?.getBoundingClientRect()
             if (!rect) return
-            const cx = rect.left + rect.width / 2
-            const cy = rect.top + rect.height / 2
             setContextMenu({
-              clientX: cx,
-              clientY: cy,
-              canvasX: (cx - rect.left - viewport.x) / viewport.zoom,
-              canvasY: (cy - rect.top - viewport.y) / viewport.zoom,
+              clientX: btn.left,
+              clientY: btn.bottom + 4,
+              canvasX: (btn.left - rect.left - viewport.x) / viewport.zoom,
+              canvasY: (btn.bottom + 4 - rect.top - viewport.y) / viewport.zoom,
             })
           }}
           title="Add to canvas"
         >
           <Plus className="h-3.5 w-3.5" />
+          <span>Add</span>
         </Button>
-        <div className="flex items-center gap-2 text-[10px] text-muted-foreground/40">
-          <Move className="h-3 w-3" />
-          <span className="tabular-nums">
-            {Math.round(-viewport.x / viewport.zoom)},{' '}
-            {Math.round(-viewport.y / viewport.zoom)}
-          </span>
-        </div>
+      </div>
+
+      {/* ── HUD: Viewport info (top-right) ── */}
+      <div className="absolute top-3 right-3 flex items-center gap-2 text-[10px] text-muted-foreground/40 z-10 select-none">
+        <Move className="h-3 w-3" />
+        <span className="tabular-nums">
+          {Math.round(-viewport.x / viewport.zoom)},{' '}
+          {Math.round(-viewport.y / viewport.zoom)}
+        </span>
       </div>
 
       {/* ── Empty state ── */}

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -379,21 +379,21 @@ export function InfiniteCanvas() {
       if (e.code === 'Space' && !e.repeat && !isInputFocused) {
         setSpaceHeld(true)
       }
-      if (e.code === 'Equal' && (e.ctrlKey || e.metaKey)) {
+      if (e.code === 'Equal' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
         zoomTo(viewport.zoom * 1.2)
       }
-      if (e.code === 'Minus' && (e.ctrlKey || e.metaKey)) {
+      if (e.code === 'Minus' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
         zoomTo(viewport.zoom / 1.2)
       }
-      if (e.code === 'Digit0' && (e.ctrlKey || e.metaKey)) {
+      if (e.code === 'Digit0' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
         resetViewport()
       }
 
       // Ctrl/Cmd + 1-9: focus panel by index
-      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey) {
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && !isInputFocused) {
         const digitMatch = e.code.match(/^Digit([1-9])$/)
         if (digitMatch) {
           const idx = parseInt(digitMatch[1], 10) - 1

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -6,7 +6,7 @@ import { useTaskStore } from '@/stores/task-store'
 import { CanvasPanel } from './CanvasPanel'
 import { CanvasConnections } from './CanvasConnections'
 import { CanvasContextMenu } from './CanvasContextMenu'
-import { Move, ZoomIn, ZoomOut, RotateCcw, Plus, Globe, TerminalSquare, X } from 'lucide-react'
+import { Move, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 
 /**
@@ -106,10 +106,6 @@ export function InfiniteCanvas() {
   const connectingFromId = useCanvasStore((s) => s.connectingFromId)
   const setConnectingFromId = useCanvasStore((s) => s.setConnectingFromId)
   const [mouseCanvasPos, setMouseCanvasPos] = useState<{ x: number; y: number } | null>(null)
-
-  // Add panel dropdown state
-  const [showAddMenu, setShowAddMenu] = useState(false)
-  const addMenuRef = useRef<HTMLDivElement>(null)
 
   // Track container size for viewport visibility culling
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
@@ -355,48 +351,6 @@ export function InfiniteCanvas() {
     [viewport]
   )
 
-  // ── Add panel helpers ────────────────────────────────────
-  const addPanelAtCenter = useCallback(
-    (type: 'webpage' | 'terminal', title: string) => {
-      const container = containerRef.current
-      const rect = container?.getBoundingClientRect()
-      const vp = useCanvasStore.getState().viewport
-      const currentPanels = useCanvasStore.getState().panels
-      const centerX = rect
-        ? (rect.width / 2 - vp.x) / vp.zoom - DEFAULT_PANEL_WIDTH / 2
-        : 0
-      const centerY = rect
-        ? (rect.height / 2 - vp.y) / vp.zoom - DEFAULT_PANEL_HEIGHT / 2
-        : 0
-      const offset = (currentPanels.length % 5) * 30
-      addPanel({
-        type,
-        title,
-        x: centerX + offset,
-        y: centerY + offset,
-        width: DEFAULT_PANEL_WIDTH,
-        height: DEFAULT_PANEL_HEIGHT,
-      })
-      setShowAddMenu(false)
-    },
-    [addPanel]
-  )
-
-  // Close add menu on outside click
-  useEffect(() => {
-    if (!showAddMenu) return
-    const handleClick = (e: MouseEvent) => {
-      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
-        setShowAddMenu(false)
-      }
-    }
-    const timer = setTimeout(() => document.addEventListener('mousedown', handleClick), 0)
-    return () => {
-      clearTimeout(timer)
-      document.removeEventListener('mousedown', handleClick)
-    }
-  }, [showAddMenu])
-
   // ── Keyboard shortcuts ───────────────────────────────────
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -530,63 +484,6 @@ export function InfiniteCanvas() {
           title="Reset view (Ctrl+0)"
         >
           <RotateCcw className="h-3.5 w-3.5" />
-        </Button>
-      </div>
-
-      {/* ── HUD: Add Panel button ── */}
-      <div ref={addMenuRef} className="absolute bottom-4 right-4 z-10">
-        {showAddMenu && (
-          <div className="absolute bottom-full right-0 mb-2 w-56 bg-[#1a2030]/95 backdrop-blur-sm border border-border/40 rounded-xl shadow-2xl overflow-hidden animate-in fade-in slide-in-from-bottom-2 duration-150">
-            <div className="flex items-center justify-between px-3 py-2 border-b border-border/20">
-              <span className="text-[11px] font-medium text-muted-foreground/70">Add Panel</span>
-              <button
-                onClick={() => setShowAddMenu(false)}
-                className="text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-            <div className="py-1">
-              <button
-                onClick={() => addPanelAtCenter('webpage', 'Web Page')}
-                className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-white/5 transition-colors group"
-              >
-                <Globe className="h-4 w-4 text-cyan-400 flex-shrink-0" />
-                <div>
-                  <div className="text-[12px] text-foreground/80 group-hover:text-foreground transition-colors">
-                    Web Page
-                  </div>
-                  <div className="text-[10px] text-muted-foreground/40">
-                    Embed any website
-                  </div>
-                </div>
-              </button>
-              <button
-                onClick={() => addPanelAtCenter('terminal', 'Terminal')}
-                className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-white/5 transition-colors group"
-              >
-                <TerminalSquare className="h-4 w-4 text-amber-400 flex-shrink-0" />
-                <div>
-                  <div className="text-[12px] text-foreground/80 group-hover:text-foreground transition-colors">
-                    Terminal
-                  </div>
-                  <div className="text-[10px] text-muted-foreground/40">
-                    Interactive shell session
-                  </div>
-                </div>
-              </button>
-            </div>
-          </div>
-        )}
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-8 px-3 bg-[#1a2030]/90 backdrop-blur-sm border border-border/40 hover:border-border/60 text-xs gap-1.5"
-          onClick={() => setShowAddMenu(!showAddMenu)}
-          title="Add panel"
-        >
-          <Plus className="h-3.5 w-3.5" />
-          <span>Add Panel</span>
         </Button>
       </div>
 

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -102,6 +102,11 @@ export function InfiniteCanvas() {
     canvasY: number
   } | null>(null)
 
+  // Connection drawing state
+  const connectingFromId = useCanvasStore((s) => s.connectingFromId)
+  const setConnectingFromId = useCanvasStore((s) => s.setConnectingFromId)
+  const [mouseCanvasPos, setMouseCanvasPos] = useState<{ x: number; y: number } | null>(null)
+
   // Add panel dropdown state
   const [showAddMenu, setShowAddMenu] = useState(false)
   const addMenuRef = useRef<HTMLDivElement>(null)
@@ -275,6 +280,18 @@ export function InfiniteCanvas() {
         return
       }
 
+      // Cancel connection drawing on background click
+      const { connectingFromId: cid } = useCanvasStore.getState()
+      if (cid && e.button === 0) {
+        const target = e.target as HTMLElement
+        const isBackground = target === containerRef.current || target.dataset?.canvasBg === 'true'
+        if (isBackground) {
+          setConnectingFromId(null)
+          setMouseCanvasPos(null)
+          return
+        }
+      }
+
       const isMiddle = e.button === 1
       const isLeftOnCanvas =
         e.button === 0 &&
@@ -293,6 +310,19 @@ export function InfiniteCanvas() {
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
+      // Track mouse position in canvas space for connection line rendering
+      if (connectingFromId) {
+        const container = containerRef.current
+        if (container) {
+          const rect = container.getBoundingClientRect()
+          const vp = useCanvasStore.getState().viewport
+          setMouseCanvasPos({
+            x: (e.clientX - rect.left - vp.x) / vp.zoom,
+            y: (e.clientY - rect.top - vp.y) / vp.zoom,
+          })
+        }
+      }
+
       if (!isPanning) return
       const dx = e.clientX - panStartRef.current.x
       const dy = e.clientY - panStartRef.current.y
@@ -385,8 +415,13 @@ export function InfiniteCanvas() {
         e.preventDefault()
         resetViewport()
       }
-      // Escape: close context menu
+      // Escape: cancel connecting or close context menu
       if (e.code === 'Escape') {
+        const { connectingFromId: cid } = useCanvasStore.getState()
+        if (cid) {
+          setConnectingFromId(null)
+          setMouseCanvasPos(null)
+        }
         setContextMenu(null)
       }
     }
@@ -446,7 +481,7 @@ export function InfiniteCanvas() {
           <SnapGuides guides={snapGuides} containerRef={containerRef} viewport={viewport} />
 
           {/* Connection lines */}
-          <CanvasConnections mouseCanvasPos={null} />
+          <CanvasConnections mouseCanvasPos={mouseCanvasPos} />
 
           {/* Render panels — off-viewport panels are frozen (content hidden) */}
           {panels.map((panel) => (

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -6,7 +6,7 @@ import { useTaskStore } from '@/stores/task-store'
 import { CanvasPanel } from './CanvasPanel'
 import { CanvasConnections } from './CanvasConnections'
 import { CanvasContextMenu } from './CanvasContextMenu'
-import { Move, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react'
+import { Move, ZoomIn, ZoomOut, RotateCcw, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 
 /**
@@ -487,13 +487,35 @@ export function InfiniteCanvas() {
         </Button>
       </div>
 
-      {/* ── HUD: Viewport info ── */}
-      <div className="absolute top-3 right-3 flex items-center gap-2 text-[10px] text-muted-foreground/40 z-10 select-none">
-        <Move className="h-3 w-3" />
-        <span className="tabular-nums">
-          {Math.round(-viewport.x / viewport.zoom)},{' '}
-          {Math.round(-viewport.y / viewport.zoom)}
-        </span>
+      {/* ── HUD: Add + Viewport info ── */}
+      <div className="absolute top-3 right-3 flex items-center gap-2 z-10 select-none">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 bg-[#1a2030]/90 backdrop-blur-sm border border-border/40 hover:border-border/60"
+          onClick={() => {
+            const rect = containerRef.current?.getBoundingClientRect()
+            if (!rect) return
+            const cx = rect.left + rect.width / 2
+            const cy = rect.top + rect.height / 2
+            setContextMenu({
+              clientX: cx,
+              clientY: cy,
+              canvasX: (cx - rect.left - viewport.x) / viewport.zoom,
+              canvasY: (cy - rect.top - viewport.y) / viewport.zoom,
+            })
+          }}
+          title="Add to canvas"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+        <div className="flex items-center gap-2 text-[10px] text-muted-foreground/40">
+          <Move className="h-3 w-3" />
+          <span className="tabular-nums">
+            {Math.round(-viewport.x / viewport.zoom)},{' '}
+            {Math.round(-viewport.y / viewport.zoom)}
+          </span>
+        </div>
       </div>
 
       {/* ── Empty state ── */}

--- a/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+const terminalCreate = vi.fn()
+const terminalWrite = vi.fn()
+const terminalResize = vi.fn()
+const terminalKill = vi.fn()
+const terminalGetCwd = vi.fn()
+const terminalOnData = vi.fn(() => vi.fn())
+const terminalOnExit = vi.fn(() => vi.fn())
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    cols = 80
+    rows = 24
+    textarea = document.createElement('textarea')
+    loadAddon() {}
+    open() {}
+    focus() {}
+    clear() {}
+    write() {}
+    dispose() {}
+    onData() {
+      return { dispose: vi.fn() }
+    }
+    onKey() {
+      return { dispose: vi.fn() }
+    }
+  },
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class {},
+}))
+
+import { TerminalPanelContent } from './TerminalPanelContent'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('TerminalPanelContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    terminalWrite.mockResolvedValue(undefined)
+    terminalResize.mockResolvedValue(undefined)
+    terminalKill.mockResolvedValue(undefined)
+
+    Object.defineProperty(window, 'electronAPI', {
+      value: {
+        ...(window.electronAPI ?? {}),
+        terminal: {
+          create: terminalCreate,
+          write: terminalWrite,
+          resize: terminalResize,
+          kill: terminalKill,
+          getCwd: terminalGetCwd,
+          getBuffer: vi.fn(),
+          onData: terminalOnData,
+          onExit: terminalOnExit,
+        },
+      },
+      configurable: true,
+      writable: true,
+    })
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        disconnect() {}
+      }
+    )
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 640,
+      height: 480,
+      top: 0,
+      left: 0,
+      right: 640,
+      bottom: 480,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('kills only the PTY instance that owned the cleanup', async () => {
+    const firstCwd = deferred<{ cwd: string | null }>()
+    const secondCwd = deferred<{ cwd: string | null }>()
+
+    terminalCreate.mockResolvedValueOnce({ pid: 111 }).mockResolvedValueOnce({ pid: 222 })
+    terminalGetCwd.mockImplementationOnce(() => firstCwd.promise).mockImplementationOnce(() => secondCwd.promise)
+
+    const first = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(1)
+    })
+
+    first.unmount()
+
+    const second = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(2)
+    })
+
+    expect(terminalGetCwd).toHaveBeenNthCalledWith(1, 'panel-1', 111)
+
+    firstCwd.resolve({ cwd: '/tmp/one' })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 111)
+    })
+
+    second.unmount()
+    expect(terminalGetCwd).toHaveBeenNthCalledWith(2, 'panel-1', 222)
+
+    secondCwd.resolve({ cwd: '/tmp/two' })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 222)
+    })
+  })
+
+  it('kills a PTY that resolves after its component instance already unmounted', async () => {
+    const firstCreate = deferred<{ pid: number }>()
+    const secondCwd = deferred<{ cwd: string | null }>()
+
+    terminalCreate
+      .mockImplementationOnce(() => firstCreate.promise)
+      .mockResolvedValueOnce({ pid: 222 })
+    terminalGetCwd.mockImplementationOnce(() => secondCwd.promise)
+
+    const first = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(1)
+    })
+
+    first.unmount()
+
+    const second = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(2)
+    })
+
+    firstCreate.resolve({ pid: 111 })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 111)
+    })
+
+    expect(terminalGetCwd).not.toHaveBeenCalled()
+
+    second.unmount()
+    expect(terminalGetCwd).toHaveBeenNthCalledWith(1, 'panel-1', 222)
+
+    secondCwd.resolve({ cwd: '/tmp/two' })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 222)
+    })
+  })
+})

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -116,24 +116,8 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
 
       console.log(`[Terminal:${terminalId}] PTY created, setting up listeners`)
 
-      let respawning = false
-
       const inputDispose = term.onData((data) => {
-        window.electronAPI.terminal.write(terminalId, data).then((result: { alive?: boolean } | void) => {
-          if (result && 'alive' in result && !result.alive && !respawning) {
-            // PTY is dead but we didn't get an exit event — auto-respawn
-            console.log(`[Terminal:${terminalId}] PTY dead on write, auto-respawning`)
-            respawning = true
-            window.electronAPI.terminal.create(
-              terminalId, term.cols, term.rows, cwdRef.current
-            ).then(() => {
-              respawning = false
-              term.focus()
-            }).catch(() => {
-              respawning = false
-            })
-          }
-        })
+        window.electronAPI.terminal.write(terminalId, data)
       })
 
       const removeDataListener = window.electronAPI.terminal.onData(({ id, data }) => {

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -129,6 +129,9 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
         removeExitListener,
       ]
 
+      // Focus the terminal so it can receive keyboard input
+      term.focus()
+
       setIsReady(true)
     } catch (err) {
       console.error('Failed to create terminal:', err)
@@ -229,10 +232,25 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     )
   }
 
+  // Focus the terminal when the container is clicked
+  const handleClick = useCallback(() => {
+    xtermRef.current?.focus()
+  }, [])
+
+  // Prevent keyboard events from bubbling up to InfiniteCanvas shortcuts
+  // xterm.js renders into a <canvas>, which isn't an input/textarea,
+  // so InfiniteCanvas's keyboard handler would intercept keystrokes.
+  const stopKeyboardPropagation = useCallback((e: React.KeyboardEvent) => {
+    e.stopPropagation()
+  }, [])
+
   return (
     <div
       ref={containerRef}
       className="h-full w-full"
+      onClick={handleClick}
+      onKeyDown={stopKeyboardPropagation}
+      onKeyUp={stopKeyboardPropagation}
       style={{
         background: '#141a26',
         // Minimum dimensions prevent xterm's internal canvas renderer from

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -2,10 +2,13 @@ import { useEffect, useRef, useCallback, useState } from 'react'
 import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
+import { useCanvasStore } from '@/stores/canvas-store'
 import '@xterm/xterm/css/xterm.css'
 
 interface TerminalPanelContentProps {
   terminalId: string
+  /** Initial working directory — restored from persisted panel state */
+  cwd?: string
 }
 
 /**
@@ -21,7 +24,7 @@ interface TerminalPanelContentProps {
  *      sees truly-zero values even during layout shifts.
  *   3. Every fit() call is wrapped in try-catch.
  */
-export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) {
+export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
@@ -97,7 +100,8 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
       await window.electronAPI.terminal.create(
         terminalId,
         term.cols,
-        term.rows
+        term.rows,
+        cwd
       )
 
       const inputDispose = term.onData((data) => {
@@ -127,7 +131,7 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
       console.error('Failed to create terminal:', err)
       setError(err instanceof Error ? err.message : 'Failed to create terminal')
     }
-  }, [terminalId])
+  }, [terminalId, cwd])
 
   // Use ResizeObserver to detect when the container first gets real
   // dimensions, then initialize xterm. This is the primary guard
@@ -173,12 +177,19 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
     return () => {
       observer.disconnect()
 
+      // Capture cwd before killing the terminal — persists across restarts
+      window.electronAPI.terminal.getCwd(terminalId).then(({ cwd: currentCwd }) => {
+        if (currentCwd) {
+          useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
+        }
+      }).catch(() => {}).finally(() => {
+        // Kill PTY after cwd capture attempt
+        window.electronAPI.terminal.kill(terminalId).catch(() => {})
+      })
+
       // Cleanup listeners
       for (const fn of cleanupRef.current) fn()
       cleanupRef.current = []
-
-      // Kill PTY
-      window.electronAPI.terminal.kill(terminalId).catch(() => {})
 
       // Dispose xterm
       xtermRef.current?.dispose()
@@ -187,6 +198,20 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
       initCalledRef.current = false
     }
   }, [initTerminal, terminalId, isReady])
+
+  // ── Periodically capture cwd so it persists on crash/force-quit ──
+  useEffect(() => {
+    if (!isReady) return
+    const interval = setInterval(async () => {
+      try {
+        const { cwd: currentCwd } = await window.electronAPI.terminal.getCwd(terminalId)
+        if (currentCwd) {
+          useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
+        }
+      } catch { /* ignore */ }
+    }, 10_000) // every 10 seconds
+    return () => clearInterval(interval)
+  }, [isReady, terminalId])
 
   if (error) {
     return (

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -116,9 +116,24 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
 
       console.log(`[Terminal:${terminalId}] PTY created, setting up listeners`)
 
+      let respawning = false
+
       const inputDispose = term.onData((data) => {
-        console.log(`[Terminal:${terminalId}] onData fired, sending to PTY`, { dataLen: data.length })
-        window.electronAPI.terminal.write(terminalId, data)
+        window.electronAPI.terminal.write(terminalId, data).then((result: { alive?: boolean } | void) => {
+          if (result && 'alive' in result && !result.alive && !respawning) {
+            // PTY is dead but we didn't get an exit event — auto-respawn
+            console.log(`[Terminal:${terminalId}] PTY dead on write, auto-respawning`)
+            respawning = true
+            window.electronAPI.terminal.create(
+              terminalId, term.cols, term.rows, cwdRef.current
+            ).then(() => {
+              respawning = false
+              term.focus()
+            }).catch(() => {
+              respawning = false
+            })
+          }
+        })
       })
 
       const removeDataListener = window.electronAPI.terminal.onData(({ id, data }) => {

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -33,6 +33,9 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   const cleanupRef = useRef<(() => void)[]>([])
   const initCalledRef = useRef(false)
 
+  // Store cwd in a ref — only used at init time, never triggers re-init
+  const cwdRef = useRef(cwd)
+
   const initTerminal = useCallback(async () => {
     if (!containerRef.current || xtermRef.current || initCalledRef.current) return
 
@@ -101,7 +104,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
         terminalId,
         term.cols,
         term.rows,
-        cwd
+        cwdRef.current // read from ref, not prop — stable reference
       )
 
       const inputDispose = term.onData((data) => {
@@ -131,7 +134,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       console.error('Failed to create terminal:', err)
       setError(err instanceof Error ? err.message : 'Failed to create terminal')
     }
-  }, [terminalId, cwd])
+  }, [terminalId]) // cwd intentionally NOT a dep — read from cwdRef at init
 
   // Use ResizeObserver to detect when the container first gets real
   // dimensions, then initialize xterm. This is the primary guard
@@ -200,6 +203,8 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   }, [initTerminal, terminalId, isReady])
 
   // ── Periodically capture cwd so it persists on crash/force-quit ──
+  // Uses direct IPC + store update — does NOT change any props that would
+  // trigger re-initialization of the terminal.
   useEffect(() => {
     if (!isReady) return
     const interval = setInterval(async () => {
@@ -209,7 +214,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
           useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
         }
       } catch { /* ignore */ }
-    }, 10_000) // every 10 seconds
+    }, 30_000) // every 30 seconds (less aggressive)
     return () => clearInterval(interval)
   }, [isReady, terminalId])
 

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -38,12 +38,18 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   const cwdRef = useRef(cwd)
 
   const initTerminal = useCallback(async () => {
+    console.log(`[Terminal:${terminalId}] initTerminal called`, {
+      hasContainer: !!containerRef.current,
+      hasXterm: !!xtermRef.current,
+      initCalled: initCalledRef.current,
+    })
     if (!containerRef.current || xtermRef.current || initCalledRef.current) return
 
     // Wait until the container actually has dimensions.
     // During canvas viewport changes or panel open animations the container
     // may still be 0×0 when this runs.
     const rect = containerRef.current.getBoundingClientRect()
+    console.log(`[Terminal:${terminalId}] container rect`, { w: rect.width, h: rect.height })
     if (rect.width < 10 || rect.height < 10) return
 
     initCalledRef.current = true
@@ -108,7 +114,10 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
         cwdRef.current // read from ref, not prop — stable reference
       )
 
+      console.log(`[Terminal:${terminalId}] PTY created, setting up listeners`)
+
       const inputDispose = term.onData((data) => {
+        console.log(`[Terminal:${terminalId}] onData fired, sending to PTY`, { dataLen: data.length })
         window.electronAPI.terminal.write(terminalId, data)
       })
 
@@ -154,7 +163,12 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       ]
 
       // Focus the terminal so it can receive keyboard input
+      console.log(`[Terminal:${terminalId}] calling term.focus(), textarea exists:`, !!term.textarea)
       term.focus()
+      // Verify focus actually took
+      setTimeout(() => {
+        console.log(`[Terminal:${terminalId}] after focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
+      }, 100)
 
       isReadyRef.current = true
       setIsReady(true)
@@ -260,8 +274,12 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
 
   // Focus the terminal when the container is clicked
   const handleClick = useCallback(() => {
+    console.log(`[Terminal:${terminalId}] container clicked, focusing. hasXterm:`, !!xtermRef.current, 'textarea:', !!xtermRef.current?.textarea)
     xtermRef.current?.focus()
-  }, [])
+    setTimeout(() => {
+      console.log(`[Terminal:${terminalId}] after click-focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
+    }, 50)
+  }, [terminalId])
 
   return (
     <div

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -32,6 +32,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   const [error, setError] = useState<string | null>(null)
   const cleanupRef = useRef<(() => void)[]>([])
   const initCalledRef = useRef(false)
+  const isReadyRef = useRef(false)
 
   // Store cwd in a ref — only used at init time, never triggers re-init
   const cwdRef = useRef(cwd)
@@ -155,6 +156,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       // Focus the terminal so it can receive keyboard input
       term.focus()
 
+      isReadyRef.current = true
       setIsReady(true)
     } catch (err) {
       console.error('Failed to create terminal:', err)
@@ -185,7 +187,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       if (width < 10 || height < 10) return // still too small — skip
       try {
         fitAddonRef.current.fit()
-        if (xtermRef.current && isReady) {
+        if (xtermRef.current && isReadyRef.current) {
           window.electronAPI.terminal.resize(
             terminalId,
             xtermRef.current.cols,
@@ -225,8 +227,9 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       xtermRef.current = null
       fitAddonRef.current = null
       initCalledRef.current = false
+      isReadyRef.current = false
     }
-  }, [initTerminal, terminalId, isReady])
+  }, [initTerminal, terminalId])
 
   // ── Periodically capture cwd so it persists on crash/force-quit ──
   // Uses direct IPC + store update — does NOT change any props that would

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -33,6 +33,8 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   const cleanupRef = useRef<(() => void)[]>([])
   const initCalledRef = useRef(false)
   const isReadyRef = useRef(false)
+  const activePidRef = useRef<number | null>(null)
+  const isMountedRef = useRef(true)
 
   // Store cwd in a ref — only used at init time, never triggers re-init
   const cwdRef = useRef(cwd)
@@ -107,12 +109,21 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     if (!xtermRef.current) return
 
     try {
-      await window.electronAPI.terminal.create(
+      const { pid } = await window.electronAPI.terminal.create(
         terminalId,
         term.cols,
         term.rows,
         cwdRef.current // read from ref, not prop — stable reference
       )
+
+      // StrictMode / fast remount can unmount this instance before create() resolves.
+      // In that case, kill only the PTY we just created and let the live instance continue.
+      if (!isMountedRef.current || xtermRef.current !== term) {
+        await window.electronAPI.terminal.kill(terminalId, pid).catch(() => {})
+        return
+      }
+
+      activePidRef.current = pid
 
       console.log(`[Terminal:${terminalId}] PTY created, setting up listeners`)
 
@@ -145,7 +156,8 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
             term.cols,
             term.rows,
             cwdRef.current
-          ).then(() => {
+          ).then(({ pid }) => {
+            activePidRef.current = pid
             term.focus()
           }).catch(() => {
             processExited = true
@@ -183,6 +195,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   // zero-size container.
   useEffect(() => {
     if (!containerRef.current) return
+    isMountedRef.current = true
 
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0]
@@ -220,16 +233,20 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
 
     return () => {
       observer.disconnect()
+      const expectedPid = activePidRef.current ?? undefined
+      isMountedRef.current = false
 
-      // Capture cwd before killing the terminal — persists across restarts
-      window.electronAPI.terminal.getCwd(terminalId).then(({ cwd: currentCwd }) => {
-        if (currentCwd) {
-          useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
-        }
-      }).catch(() => {}).finally(() => {
-        // Kill PTY after cwd capture attempt
-        window.electronAPI.terminal.kill(terminalId).catch(() => {})
-      })
+      if (expectedPid !== undefined) {
+        // Capture cwd before killing the terminal — persists across restarts.
+        // Skip ID-only cleanup when this instance never acquired a PTY pid.
+        window.electronAPI.terminal.getCwd(terminalId, expectedPid).then(({ cwd: currentCwd }) => {
+          if (currentCwd) {
+            useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
+          }
+        }).catch(() => {}).finally(() => {
+          window.electronAPI.terminal.kill(terminalId, expectedPid).catch(() => {})
+        })
+      }
 
       // Cleanup listeners
       for (const fn of cleanupRef.current) fn()
@@ -241,6 +258,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       fitAddonRef.current = null
       initCalledRef.current = false
       isReadyRef.current = false
+      activePidRef.current = null
     }
   }, [initTerminal, terminalId])
 
@@ -251,7 +269,8 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     if (!isReady) return
     const interval = setInterval(async () => {
       try {
-        const { cwd: currentCwd } = await window.electronAPI.terminal.getCwd(terminalId)
+        const expectedPid = activePidRef.current ?? undefined
+        const { cwd: currentCwd } = await window.electronAPI.terminal.getCwd(terminalId, expectedPid)
         if (currentCwd) {
           useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
         }

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -117,14 +117,37 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
         }
       })
 
+      let processExited = false
+
       const removeExitListener = window.electronAPI.terminal.onExit(({ id }) => {
         if (id === terminalId) {
-          term.write('\r\n\x1b[90m[Process exited]\x1b[0m\r\n')
+          processExited = true
+          term.write('\r\n\x1b[90m[Process exited — press Enter to restart]\x1b[0m\r\n')
+        }
+      })
+
+      // Respawn the shell when the user presses Enter after exit
+      const respawnDispose = term.onKey(({ domEvent }) => {
+        if (processExited && domEvent.key === 'Enter') {
+          processExited = false
+          term.clear()
+          window.electronAPI.terminal.create(
+            terminalId,
+            term.cols,
+            term.rows,
+            cwdRef.current
+          ).then(() => {
+            term.focus()
+          }).catch(() => {
+            processExited = true
+            term.write('\r\n\x1b[90m[Failed to restart shell]\x1b[0m\r\n')
+          })
         }
       })
 
       cleanupRef.current = [
         () => inputDispose.dispose(),
+        () => respawnDispose.dispose(),
         removeDataListener,
         removeExitListener,
       ]

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -237,20 +237,11 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     xtermRef.current?.focus()
   }, [])
 
-  // Prevent keyboard events from bubbling up to InfiniteCanvas shortcuts
-  // xterm.js renders into a <canvas>, which isn't an input/textarea,
-  // so InfiniteCanvas's keyboard handler would intercept keystrokes.
-  const stopKeyboardPropagation = useCallback((e: React.KeyboardEvent) => {
-    e.stopPropagation()
-  }, [])
-
   return (
     <div
       ref={containerRef}
-      className="h-full w-full"
+      className="h-full w-full xterm-container"
       onClick={handleClick}
-      onKeyDown={stopKeyboardPropagation}
-      onKeyUp={stopKeyboardPropagation}
       style={{
         background: '#141a26',
         // Minimum dimensions prevent xterm's internal canvas renderer from

--- a/src/renderer/src/stores/browser-store.ts
+++ b/src/renderer/src/stores/browser-store.ts
@@ -1,0 +1,176 @@
+import { create } from 'zustand'
+
+// ── Browser session types ────────────────────────────────────
+
+export interface BrowserTab {
+  tabId: string
+  title: string
+  url: string
+  active: boolean
+}
+
+export interface BrowserSession {
+  sessionName: string
+  /** WebSocket streaming port (auto-assigned by agent-browser) */
+  streamPort: number | null
+  /** CDP WebSocket URL */
+  cdpUrl: string | null
+  /** Whether streaming is active */
+  connected: boolean
+  /** Whether the browser is screencasting */
+  screencasting: boolean
+  /** Current viewport dimensions */
+  viewportWidth: number
+  viewportHeight: number
+  /** Open tabs */
+  tabs: BrowserTab[]
+  /** Current URL */
+  currentUrl: string | null
+  /** Latest command being executed */
+  lastCommand: string | null
+  /** WebSocket instance (transient — not persisted) */
+  ws: WebSocket | null
+  /** Associated canvas panel ID */
+  panelId: string | null
+  /** Associated task panel ID (for auto-edge creation) */
+  linkedTaskPanelId: string | null
+}
+
+interface BrowserStoreState {
+  sessions: Map<string, BrowserSession>
+
+  // Actions
+  createSession: (sessionName: string, panelId: string, linkedTaskPanelId?: string) => BrowserSession
+  removeSession: (sessionName: string) => void
+  updateSession: (sessionName: string, updates: Partial<BrowserSession>) => void
+  getSession: (sessionName: string) => BrowserSession | undefined
+
+  // WebSocket stream connection
+  connectStream: (sessionName: string, port: number) => void
+  disconnectStream: (sessionName: string) => void
+}
+
+export const useBrowserStore = create<BrowserStoreState>((set, get) => ({
+  sessions: new Map(),
+
+  createSession: (sessionName, panelId, linkedTaskPanelId) => {
+    const session: BrowserSession = {
+      sessionName,
+      streamPort: null,
+      cdpUrl: null,
+      connected: false,
+      screencasting: false,
+      viewportWidth: 1280,
+      viewportHeight: 720,
+      tabs: [],
+      currentUrl: null,
+      lastCommand: null,
+      ws: null,
+      panelId,
+      linkedTaskPanelId: linkedTaskPanelId ?? null,
+    }
+    set((s) => {
+      const next = new Map(s.sessions)
+      next.set(sessionName, session)
+      return { sessions: next }
+    })
+    return session
+  },
+
+  removeSession: (sessionName) => {
+    const session = get().sessions.get(sessionName)
+    if (session?.ws) {
+      session.ws.close()
+    }
+    set((s) => {
+      const next = new Map(s.sessions)
+      next.delete(sessionName)
+      return { sessions: next }
+    })
+  },
+
+  updateSession: (sessionName, updates) => {
+    set((s) => {
+      const existing = s.sessions.get(sessionName)
+      if (!existing) return s
+      const next = new Map(s.sessions)
+      next.set(sessionName, { ...existing, ...updates })
+      return { sessions: next }
+    })
+  },
+
+  getSession: (sessionName) => {
+    return get().sessions.get(sessionName)
+  },
+
+  connectStream: (sessionName, port) => {
+    const { sessions, updateSession } = get()
+    const session = sessions.get(sessionName)
+    if (!session) return
+
+    // Close existing connection
+    if (session.ws) {
+      session.ws.close()
+    }
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`)
+
+    ws.onopen = () => {
+      updateSession(sessionName, { connected: true, streamPort: port })
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const text = typeof event.data === 'string' ? event.data : new TextDecoder().decode(event.data)
+        const msg = JSON.parse(text)
+
+        switch (msg.type) {
+          case 'status':
+            updateSession(sessionName, {
+              connected: msg.connected,
+              screencasting: msg.screencasting,
+              viewportWidth: msg.viewportWidth,
+              viewportHeight: msg.viewportHeight,
+            })
+            break
+          case 'tabs':
+            updateSession(sessionName, {
+              tabs: msg.tabs?.map((t: BrowserTab) => ({
+                tabId: t.tabId,
+                title: t.title,
+                url: t.url,
+                active: t.active,
+              })) ?? [],
+            })
+            break
+          case 'url':
+            updateSession(sessionName, { currentUrl: msg.url })
+            break
+          case 'command':
+            updateSession(sessionName, { lastCommand: msg.action || msg.params?.action || null })
+            break
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+
+    ws.onclose = () => {
+      updateSession(sessionName, { connected: false, screencasting: false })
+    }
+
+    ws.onerror = () => {
+      updateSession(sessionName, { connected: false })
+    }
+
+    updateSession(sessionName, { ws, streamPort: port })
+  },
+
+  disconnectStream: (sessionName) => {
+    const session = get().sessions.get(sessionName)
+    if (session?.ws) {
+      session.ws.close()
+      get().updateSession(sessionName, { ws: null, connected: false })
+    }
+  },
+}))

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -94,6 +94,9 @@ interface CanvasState {
   // Connection drawing state (transient)
   connectingFromId: string | null
 
+  // Auto-connect proximity state (transient, shown during drag)
+  proximityEdge: { fromId: string; toId: string } | null
+
   // Persistence
   isLoaded: boolean
   loadCanvas: () => Promise<void>
@@ -123,6 +126,7 @@ interface CanvasState {
   removeEdge: (id: string) => void
   removeEdgesForPanel: (panelId: string) => void
   setConnectingFromId: (id: string | null) => void
+  setProximityEdge: (edge: { fromId: string; toId: string } | null) => void
   clearEdges: () => void
 }
 
@@ -149,6 +153,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   draggingPanelId: null,
   snapGuides: [],
   connectingFromId: null,
+  proximityEdge: null,
   isLoaded: false,
 
   loadCanvas: async () => {
@@ -374,6 +379,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   },
 
   setConnectingFromId: (id) => set({ connectingFromId: id }),
+  setProximityEdge: (edge) => set({ proximityEdge: edge }),
 
   clearEdges: () => {
     set({ edges: [] })
@@ -457,6 +463,71 @@ export function calculateSnap(
   if (guideY) guides.push(guideY)
 
   return { x: bestDx < threshold ? snapX : x, y: bestDy < threshold ? snapY : y, guides }
+}
+
+// ── Auto-connect proximity detection ─────────────────────────
+
+/** Distance threshold (canvas px) for auto-connect proximity */
+export const PROXIMITY_THRESHOLD = 80
+
+/**
+ * Check if a dragged panel is close enough to a compatible panel for auto-connect.
+ * Returns { fromId, toId } of the browser↔task pair, or null.
+ * Only browser↔task pairings trigger proximity (not browser↔browser, etc.).
+ */
+export function detectProximityEdge(
+  draggedPanel: CanvasPanelData,
+  otherPanels: CanvasPanelData[],
+  existingEdges: CanvasEdge[]
+): { fromId: string; toId: string } | null {
+  // Only browser or task panels participate in auto-connect
+  if (draggedPanel.type !== 'browser' && draggedPanel.type !== 'task') return null
+
+  const compatibleType = draggedPanel.type === 'browser' ? 'task' : 'browser'
+  const dCx = draggedPanel.x + draggedPanel.width / 2
+  const dCy = draggedPanel.y + draggedPanel.height / 2
+
+  let bestDist = Infinity
+  let bestPanel: CanvasPanelData | null = null
+
+  for (const p of otherPanels) {
+    if (p.type !== compatibleType) continue
+    // Skip if already connected
+    const alreadyConnected = existingEdges.some(
+      (e) =>
+        (e.fromPanelId === draggedPanel.id && e.toPanelId === p.id) ||
+        (e.fromPanelId === p.id && e.toPanelId === draggedPanel.id)
+    )
+    if (alreadyConnected) continue
+
+    // Distance between panel edges (not centers) — more intuitive
+    const pRight = p.x + p.width
+    const pBottom = p.y + p.height
+    const dRight = draggedPanel.x + draggedPanel.width
+    const dBottom = draggedPanel.y + draggedPanel.height
+
+    // Gap between nearest edges
+    const gapX = Math.max(0, Math.max(p.x - dRight, draggedPanel.x - pRight))
+    const gapY = Math.max(0, Math.max(p.y - dBottom, draggedPanel.y - pBottom))
+    const dist = Math.sqrt(gapX * gapX + gapY * gapY)
+
+    // Also check overlapping panels (dist would be 0)
+    const effectiveDist = dist === 0
+      ? Math.hypot(dCx - (p.x + p.width / 2), dCy - (p.y + p.height / 2)) * 0.1
+      : dist
+
+    if (effectiveDist < PROXIMITY_THRESHOLD && effectiveDist < bestDist) {
+      bestDist = effectiveDist
+      bestPanel = p
+    }
+  }
+
+  if (!bestPanel) return null
+
+  // Always put task first, browser second for consistent edge direction
+  return draggedPanel.type === 'task'
+    ? { fromId: draggedPanel.id, toId: bestPanel.id }
+    : { fromId: bestPanel.id, toId: draggedPanel.id }
 }
 
 // ── Browser↔Task edge notification ──────────────────────────

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -470,26 +470,44 @@ function notifyAgentOfBrowserConnection(
   Promise.all([
     import('./agent-store'),
     import('@/lib/ipc-client'),
-  ]).then(([{ useAgentStore }, { agentSessionApi }]) => {
+  ]).then(async ([{ useAgentStore }, { agentSessionApi }]) => {
     const session = useAgentStore.getState().getSession(taskPanel.refId!)
     if (!session?.sessionId) return
 
     const browserUrl = browserPanel.url || '(no URL loaded yet)'
+
+    // Resolve the actual tab ID by matching the webview's URL against CDP targets
+    let tabHint = 'agent-browser tab              # list tabs to find the right one'
+    try {
+      const res = await fetch(`http://localhost:${CDP_PORT}/json/list`)
+      const targets = (await res.json()) as Array<{ id: string; title: string; url: string; type: string }>
+      // Match by URL prefix (webview URLs may have extra params)
+      const browserUrlBase = (browserPanel.url || '').split('?')[0].split('#')[0]
+      const match = browserUrlBase
+        ? targets.find((t) => t.url.startsWith(browserUrlBase) && t.type === 'page')
+        : null
+      if (match) {
+        // agent-browser uses t1, t2, ... based on the target list order
+        const pageTargets = targets.filter((t) => t.type === 'page')
+        const idx = pageTargets.findIndex((t) => t.id === match.id)
+        if (idx >= 0) {
+          tabHint = `agent-browser tab t${idx + 1}           # "${match.title}" — ${browserUrl}`
+        }
+      }
+    } catch {
+      // CDP query failed — fall back to generic hint
+    }
+
     agentSessionApi.send(
       session.sessionId,
       `[System] A browser panel has been connected to your task on the canvas. You now have access to control it.\n\n` +
-      `The browser webview appears as an "iframe" CDP target (not a tab). To connect:\n\n` +
-      `  # Find the webview's WebSocket URL\n` +
-      `  curl -s http://localhost:${CDP_PORT}/json/list | python3 -c "\n` +
-      `  import json, sys\n` +
-      `  targets = json.load(sys.stdin)\n` +
-      `  for t in targets:\n` +
-      `      if t.get('parentId'):\n` +
-      `          print(t['webSocketDebuggerUrl'])\n` +
-      `  "\n\n` +
-      `  # Connect using the WebSocket URL from above\n` +
-      `  agent-browser --cdp <ws-url> open ${browserUrl}\n` +
-      `  agent-browser snapshot -i\n\n` +
+      `To connect:\n` +
+      `  agent-browser connect ${CDP_PORT}\n` +
+      `  ${tabHint}\n` +
+      `  agent-browser snapshot -i      # get interactive elements\n\n` +
+      `Important: if commands stop working, kill stale daemons first:\n` +
+      `  pkill -f agent-browser; sleep 1\n` +
+      `  agent-browser connect ${CDP_PORT}\n\n` +
       `The user can see everything you do in the browser in real time on the canvas.`,
       taskPanel.refId!,
       session.agentId

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -478,10 +478,18 @@ function notifyAgentOfBrowserConnection(
     agentSessionApi.send(
       session.sessionId,
       `[System] A browser panel has been connected to your task on the canvas. You now have access to control it.\n\n` +
-      `To use it:\n` +
-      `  agent-browser connect ${CDP_PORT}\n` +
-      `  agent-browser tab                # find the tab showing: ${browserUrl}\n` +
-      `  agent-browser snapshot -i         # get interactive elements\n\n` +
+      `The browser webview appears as an "iframe" CDP target (not a tab). To connect:\n\n` +
+      `  # Find the webview's WebSocket URL\n` +
+      `  curl -s http://localhost:${CDP_PORT}/json/list | python3 -c "\n` +
+      `  import json, sys\n` +
+      `  targets = json.load(sys.stdin)\n` +
+      `  for t in targets:\n` +
+      `      if t.get('parentId'):\n` +
+      `          print(t['webSocketDebuggerUrl'])\n` +
+      `  "\n\n` +
+      `  # Connect using the WebSocket URL from above\n` +
+      `  agent-browser --cdp <ws-url> open ${browserUrl}\n` +
+      `  agent-browser snapshot -i\n\n` +
       `The user can see everything you do in the browser in real time on the canvas.`,
       taskPanel.refId!,
       session.agentId

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -472,12 +472,49 @@ function notifyAgentOfBrowserConnection(
   // and matching the browser panel's URL. This is done at notification time
   // so it always picks up the latest target, even if cdpTargetId wasn't stored yet.
   const resolveAndNotify = async () => {
-    const [{ useAgentStore }, { agentSessionApi }] = await Promise.all([
+    const [{ useAgentStore }, { agentSessionApi }, { useTaskStore }] = await Promise.all([
       import('./agent-store'),
       import('@/lib/ipc-client'),
+      import('./task-store'),
     ])
 
-    const session = useAgentStore.getState().getSession(taskPanel.refId!)
+    const taskId = taskPanel.refId!
+    let session = useAgentStore.getState().getSession(taskId)
+
+    // If no active session, auto-start or resume the task
+    if (!session?.sessionId) {
+      const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
+      if (!task?.agent_id) return // No agent assigned — can't start
+
+      const initSession = useAgentStore.getState().initSession
+      try {
+        if (task.session_id) {
+          // Resume existing session
+          useAgentStore.getState().clearMessageDedup(taskId)
+          initSession(taskId, '', task.agent_id)
+          const result = await agentSessionApi.resume(task.agent_id, taskId, task.session_id)
+          if (result.ended) {
+            // Session ended — start fresh
+            initSession(taskId, '', task.agent_id)
+            const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
+            initSession(taskId, sessionId, task.agent_id)
+          } else {
+            initSession(taskId, result.sessionId, task.agent_id)
+          }
+        } else {
+          // Start new session
+          initSession(taskId, '', task.agent_id)
+          const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
+          initSession(taskId, sessionId, task.agent_id)
+        }
+        // Re-fetch the session after start/resume
+        session = useAgentStore.getState().getSession(taskId)
+      } catch (err) {
+        console.error('[Canvas] Failed to auto-start/resume task for browser connection:', err)
+        return
+      }
+    }
+
     if (!session?.sessionId) return
 
     const browserTitle = browserPanel.title || 'Browser'

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -524,19 +524,28 @@ function notifyAgentOfBrowserConnection(
     const browserTitle = browserPanel.title || 'Browser'
     const browserUrl = browserPanel.url || ''
 
-    // Resolve the CDP target ID — ONLY use webview targets, never the main app window.
-    let cdpTargetId = browserPanel.cdpTargetId || null
-    if (!cdpTargetId) {
-      try {
-        const res = await fetch(`http://localhost:${CDP_PORT}/json/list`)
-        const targets = (await res.json()) as Array<{ id: string; url: string; type: string }>
-        // Only match webview targets — never "page" (which is the main app)
-        const match = browserUrl
-          ? targets.find((t) => t.type === 'webview' && t.url.startsWith(browserUrl.split('?')[0].split('#')[0]))
+    // ALWAYS resolve the CDP target ID fresh from /json/list.
+    // Stored cdpTargetId goes stale on every app restart (CDP reassigns IDs).
+    // We verify it still exists, and fall back to URL matching if not.
+    let cdpTargetId: string | null = null
+    try {
+      const res = await fetch(`http://localhost:${CDP_PORT}/json/list`)
+      const targets = (await res.json()) as Array<{ id: string; url: string; type: string }>
+      const webviews = targets.filter((t) => t.type === 'webview')
+
+      // 1. Check if the stored target ID is still valid
+      const storedId = browserPanel.cdpTargetId
+      if (storedId && webviews.some((t) => t.id === storedId)) {
+        cdpTargetId = storedId
+      } else {
+        // 2. Match by URL
+        const urlBase = browserUrl.split('?')[0].split('#')[0]
+        const match = urlBase
+          ? webviews.find((t) => t.url.startsWith(urlBase))
           : null
-        cdpTargetId = match?.id || targets.find((t) => t.type === 'webview')?.id || null
-      } catch { /* CDP query failed */ }
-    }
+        cdpTargetId = match?.id || (webviews.length === 1 ? webviews[0].id : null)
+      }
+    } catch { /* CDP query failed */ }
 
     // SAFETY: Only send connection instructions when we have a confirmed webview target.
     // Without it, agent-browser would default to the main app window and break the UI.

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -207,7 +207,11 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 
   zoomAtPoint: (delta, clientX, clientY, containerRect) => {
     const { viewport } = get()
-    const factor = delta > 0 ? 0.9 : 1.1
+    // Scale zoom factor by delta magnitude for smooth trackpad pinch-to-zoom.
+    // Mac trackpads send small deltas (~2-4px) per event; mice send larger (~100px).
+    // Clamp the intensity so it never exceeds a ~15% step per event.
+    const intensity = Math.min(Math.abs(delta) / 100, 0.15)
+    const factor = delta > 0 ? 1 - intensity : 1 + intensity
     const newZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, viewport.zoom * factor))
 
     const pointX = (clientX - containerRect.left - viewport.x) / viewport.zoom

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -524,14 +524,12 @@ function notifyAgentOfBrowserConnection(
     const browserTitle = browserPanel.title || 'Browser'
     const browserUrl = browserPanel.url || ''
 
-    // ALWAYS resolve the CDP target ID fresh from /json/list.
+    // ALWAYS resolve the CDP target ID fresh via IPC (main process queries
+    // localhost:19222/json/list — no CORS issues unlike renderer fetch).
     // Stored cdpTargetId goes stale on every app restart (CDP reassigns IDs).
-    // We verify it still exists, and fall back to URL matching if not.
     let cdpTargetId: string | null = null
     try {
-      const res = await fetch(`http://localhost:${CDP_PORT}/json/list`)
-      const targets = (await res.json()) as Array<{ id: string; url: string; type: string }>
-      const webviews = targets.filter((t) => t.type === 'webview')
+      const webviews = await window.electronAPI.browser.getCdpTargets()
 
       // 1. Check if the stored target ID is still valid
       const storedId = browserPanel.cdpTargetId
@@ -546,7 +544,7 @@ function notifyAgentOfBrowserConnection(
         // 3. No URL — pick first available webview
         cdpTargetId = webviews[0]?.id || null
       }
-    } catch { /* CDP query failed */ }
+    } catch { /* IPC query failed */ }
 
     // SAFETY: Only send connection instructions when we have a confirmed webview target.
     // Without it, agent-browser would default to the main app window and break the UI.

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -37,7 +37,7 @@ export interface CanvasPanelData {
 
 // ── Connections / Edges ───────────────────────────────────
 
-export type CanvasEdgeType = 'default' | 'browser'
+export type CanvasEdgeType = 'default' | 'browser' | 'terminal'
 
 export interface CanvasEdge {
   id: string
@@ -356,9 +356,12 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     }))
     scheduleSave()
 
-    // ── Notify agent when a browser edge connects browser↔task ──
+    // ── Notify agent when a browser/terminal edge connects to a task ──
     if (edgeType === 'browser') {
       notifyAgentOfBrowserConnection(panels, fromPanelId, toPanelId)
+    }
+    if (edgeType === 'terminal') {
+      notifyAgentOfTerminalConnection(panels, fromPanelId, toPanelId)
     }
 
     return id
@@ -480,10 +483,12 @@ export function detectProximityEdge(
   otherPanels: CanvasPanelData[],
   existingEdges: CanvasEdge[]
 ): { fromId: string; toId: string } | null {
-  // Only browser or task panels participate in auto-connect
-  if (draggedPanel.type !== 'browser' && draggedPanel.type !== 'task') return null
+  // Only browser, terminal, or task panels participate in auto-connect
+  if (draggedPanel.type !== 'browser' && draggedPanel.type !== 'terminal' && draggedPanel.type !== 'task') return null
 
-  const compatibleType = draggedPanel.type === 'browser' ? 'task' : 'browser'
+  // Task connects to browser or terminal; browser/terminal connect to task
+  const compatibleTypes: CanvasPanelType[] =
+    draggedPanel.type === 'task' ? ['browser', 'terminal'] : ['task']
   const dCx = draggedPanel.x + draggedPanel.width / 2
   const dCy = draggedPanel.y + draggedPanel.height / 2
 
@@ -491,7 +496,7 @@ export function detectProximityEdge(
   let bestPanel: CanvasPanelData | null = null
 
   for (const p of otherPanels) {
-    if (p.type !== compatibleType) continue
+    if (!compatibleTypes.includes(p.type)) continue
     // Skip if already connected
     const alreadyConnected = existingEdges.some(
       (e) =>
@@ -706,6 +711,91 @@ function notifyAgentOfBrowserConnection(
       taskPanel.refId!,
       session.agentId
     ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
+  }
+
+  resolveAndNotify().catch(() => {
+    // Silently ignore — can happen in test environments
+  })
+}
+
+// ── Terminal↔Task edge notification ──────────────────────────
+
+function notifyAgentOfTerminalConnection(
+  panels: CanvasPanelData[],
+  fromPanelId: string,
+  toPanelId: string
+) {
+  const fromPanel = panels.find((p) => p.id === fromPanelId)
+  const toPanel = panels.find((p) => p.id === toPanelId)
+  const taskPanel = fromPanel?.type === 'task' ? fromPanel : toPanel?.type === 'task' ? toPanel : null
+  const terminalPanel = fromPanel?.type === 'terminal' ? fromPanel : toPanel?.type === 'terminal' ? toPanel : null
+
+  if (!taskPanel?.refId || !terminalPanel) return
+
+  const resolveAndNotify = async () => {
+    const [{ useAgentStore }, { agentSessionApi }, { useTaskStore }] = await Promise.all([
+      import('./agent-store'),
+      import('@/lib/ipc-client'),
+      import('./task-store'),
+    ])
+
+    const taskId = taskPanel.refId!
+    let session = useAgentStore.getState().getSession(taskId)
+
+    // If no active session, auto-start or resume the task
+    if (!session?.sessionId) {
+      const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
+      if (!task?.agent_id) return
+
+      const initSession = useAgentStore.getState().initSession
+      try {
+        if (task.session_id) {
+          useAgentStore.getState().clearMessageDedup(taskId)
+          initSession(taskId, '', task.agent_id)
+          const result = await agentSessionApi.resume(task.agent_id, taskId, task.session_id)
+          if (result.ended) {
+            initSession(taskId, '', task.agent_id)
+            const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
+            initSession(taskId, sessionId, task.agent_id)
+          } else {
+            initSession(taskId, result.sessionId, task.agent_id)
+          }
+        } else {
+          initSession(taskId, '', task.agent_id)
+          const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
+          initSession(taskId, sessionId, task.agent_id)
+        }
+        session = useAgentStore.getState().getSession(taskId)
+      } catch (err) {
+        console.error('[TerminalEdge] Failed to auto-start/resume task:', err)
+        return
+      }
+    }
+
+    if (!session?.sessionId) return
+
+    // Get the current terminal buffer to include as initial context
+    const terminalId = terminalPanel.id
+    let bufferPreview = ''
+    try {
+      const { lines } = await window.electronAPI.terminal.getBuffer(terminalId, 50)
+      if (lines.length > 0) {
+        bufferPreview = `\n\nCurrent terminal output (last ${lines.length} lines):\n\`\`\`\n${lines.join('\n')}\n\`\`\``
+      }
+    } catch { /* ignore */ }
+
+    agentSessionApi.send(
+      session.sessionId,
+      `[System] A terminal panel "${terminalPanel.title}" has been connected to your task on the canvas.\n\n` +
+      `You can read the terminal's output log at any time by running:\n` +
+      `  read_terminal_log\n\n` +
+      `This is a read-only view — you cannot type into this terminal.\n` +
+      `The terminal panel ID is: ${terminalId}\n` +
+      `Use your own Bash tool for running commands. Use the terminal log to observe output from processes the user is running.` +
+      bufferPreview,
+      taskPanel.refId!,
+      session.agentId
+    ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of terminal connection:', err))
   }
 
   resolveAndNotify().catch(() => {

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -566,15 +566,18 @@ function notifyAgentOfBrowserConnection(
     agentSessionApi.send(
       session.sessionId,
       `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas. You now have access to control it.\n\n` +
+      `CRITICAL: You MUST include --cdp flag on EVERY agent-browser command. Without it, agent-browser targets the main app window and breaks the UI.\n\n` +
       `To connect:\n` +
-      `  agent-browser --cdp "${wsUrl}" open about:blank\n` +
-      `  # Direct connection to "${browserTitle}" webview\n` +
-      `  agent-browser snapshot -i      # get interactive elements\n\n` +
+      `  agent-browser --cdp "${wsUrl}" open about:blank\n\n` +
+      `For ALL subsequent commands, always include --cdp:\n` +
+      `  agent-browser --cdp "${wsUrl}" snapshot -i\n` +
+      `  agent-browser --cdp "${wsUrl}" click <ref>\n` +
+      `  agent-browser --cdp "${wsUrl}" type <ref> "text"\n` +
+      `  agent-browser --cdp "${wsUrl}" open <url>\n\n` +
       `If commands stop working, kill stale daemons first:\n` +
       `  pkill -f agent-browser; sleep 1\n` +
       `  agent-browser --cdp "${wsUrl}" open about:blank\n\n` +
-      `IMPORTANT: Do NOT use "agent-browser connect" or "agent-browser open" without --cdp flag — ` +
-      `that would navigate the main application window.\n\n` +
+      `NEVER use agent-browser without --cdp "${wsUrl}" — every single command needs it.\n\n` +
       `The user can see everything you do in the browser in real time on the canvas.`,
       taskPanel.refId!,
       session.agentId

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -472,12 +472,19 @@ function notifyAgentOfBrowserConnection(
   const taskPanel = fromPanel?.type === 'task' ? fromPanel : toPanel?.type === 'task' ? toPanel : null
   const browserPanel = fromPanel?.type === 'browser' ? fromPanel : toPanel?.type === 'browser' ? toPanel : null
 
+  // Read fresh panel data from store — the `panels` parameter is a snapshot from
+  // edge creation and may have stale webContentsId from localStorage persistence.
+  const freshBrowserPanel = browserPanel
+    ? useCanvasStore.getState().panels.find((p) => p.id === browserPanel.id) || browserPanel
+    : browserPanel
+
   console.log('[BrowserEdge] notifyAgentOfBrowserConnection called', {
     fromPanelId, toPanelId,
     fromType: fromPanel?.type, toType: toPanel?.type,
-    taskRefId: taskPanel?.refId, browserPanelId: browserPanel?.id,
-    browserUrl: browserPanel?.url, browserTitle: browserPanel?.title,
-    browserCdpTargetId: browserPanel?.cdpTargetId,
+    taskRefId: taskPanel?.refId, browserPanelId: freshBrowserPanel?.id,
+    browserUrl: freshBrowserPanel?.url, browserTitle: freshBrowserPanel?.title,
+    browserCdpTargetId: freshBrowserPanel?.cdpTargetId,
+    browserWebContentsId: freshBrowserPanel?.webContentsId,
   })
 
   if (!taskPanel?.refId || !browserPanel) {
@@ -536,8 +543,10 @@ function notifyAgentOfBrowserConnection(
       return
     }
 
-    const browserTitle = browserPanel.title || 'Browser'
-    const browserUrl = browserPanel.url || ''
+    // Re-read fresh panel data — webContentsId may have been updated since edge creation
+    const bp = useCanvasStore.getState().panels.find((p) => p.id === browserPanel.id) || browserPanel
+    const browserTitle = bp.title || 'Browser'
+    const browserUrl = bp.url || ''
 
     // Resolve which agent-browser tab ID (t1, t2, t3...) corresponds to this
     // browser panel's webview. Uses webContentsId for reliable direct lookup.
@@ -549,16 +558,16 @@ function notifyAgentOfBrowserConnection(
         allTargets: allTargets.map((t) => ({ tabId: t.tabId, type: t.type, url: t.url?.slice(0, 60) })),
         webviewsCount: webviews.length,
         browserUrl,
-        webContentsId: browserPanel.webContentsId,
+        webContentsId: bp.webContentsId,
       })
       if (webviews.length === 0) return null
 
       let match: typeof webviews[0] | null = null
 
       // 1. Best: use webContentsId → getTargetId for exact CDP target, then find its tabId
-      if (!match && browserPanel.webContentsId) {
+      if (!match && bp.webContentsId) {
         try {
-          const result = await window.electronAPI.browser.getTargetId(browserPanel.webContentsId)
+          const result = await window.electronAPI.browser.getTargetId(bp.webContentsId)
           if (result.targetId) {
             match = allTargets.find((t) => t.id === result.targetId) || null
             if (match) console.log('[BrowserEdge] matched by webContentsId→getTargetId', match.tabId)

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -23,6 +23,8 @@ export interface CanvasPanelData {
   streamPort?: number
   /** CDP target ID for this webview — used to connect agent-browser directly */
   cdpTargetId?: string
+  /** Electron webContentsId for this webview — used to resolve CDP target via IPC */
+  webContentsId?: number
   title: string
   x: number
   y: number
@@ -538,30 +540,40 @@ function notifyAgentOfBrowserConnection(
     const browserUrl = browserPanel.url || ''
 
     // Resolve which agent-browser tab ID (t1, t2, t3...) corresponds to this
-    // browser panel's webview. Retry a few times since webview may not be in CDP yet.
+    // browser panel's webview. Uses webContentsId for reliable direct lookup.
     let tabId: string | null = null
     const resolveTab = async (attempt: number): Promise<string | null> => {
       const allTargets = await window.electronAPI.browser.getCdpTargets()
       const webviews = allTargets.filter((t) => t.type === 'webview')
       console.log(`[BrowserEdge] resolveTab attempt=${attempt}`, {
-        allTargetsCount: allTargets.length,
         allTargets: allTargets.map((t) => ({ tabId: t.tabId, type: t.type, url: t.url?.slice(0, 60) })),
         webviewsCount: webviews.length,
         browserUrl,
-        storedCdpTargetId: browserPanel.cdpTargetId,
+        webContentsId: browserPanel.webContentsId,
       })
       if (webviews.length === 0) return null
 
-      const storedId = browserPanel.cdpTargetId
-      let match = storedId ? webviews.find((t) => t.id === storedId) : null
-      if (match) console.log('[BrowserEdge] matched by stored cdpTargetId', match.tabId)
+      let match: typeof webviews[0] | null = null
 
-      if (!match && browserUrl) {
-        const urlBase = browserUrl.split('?')[0].split('#')[0]
-        match = webviews.find((t) => t.url.startsWith(urlBase)) || webviews[0] || null
-        if (match) console.log('[BrowserEdge] matched by URL or fallback to first webview', { tabId: match.tabId, matchUrl: match.url?.slice(0, 60) })
+      // 1. Best: use webContentsId → getTargetId for exact CDP target, then find its tabId
+      if (!match && browserPanel.webContentsId) {
+        try {
+          const result = await window.electronAPI.browser.getTargetId(browserPanel.webContentsId)
+          if (result.targetId) {
+            match = allTargets.find((t) => t.id === result.targetId) || null
+            if (match) console.log('[BrowserEdge] matched by webContentsId→getTargetId', match.tabId)
+          }
+        } catch { /* debugger API failed */ }
       }
 
+      // 2. Match by URL
+      if (!match && browserUrl) {
+        const urlBase = browserUrl.split('?')[0].split('#')[0]
+        match = webviews.find((t) => t.url.startsWith(urlBase)) || null
+        if (match) console.log('[BrowserEdge] matched by URL', { tabId: match.tabId, matchUrl: match.url?.slice(0, 60) })
+      }
+
+      // 3. Last resort — first available webview
       if (!match) {
         match = webviews[0] || null
         if (match) console.log('[BrowserEdge] fallback to first webview', match.tabId)

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -562,22 +562,24 @@ function notifyAgentOfBrowserConnection(
       return
     }
 
-    const wsUrl = `ws://localhost:${CDP_PORT}/devtools/page/${cdpTargetId}`
     agentSessionApi.send(
       session.sessionId,
       `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas. You now have access to control it.\n\n` +
-      `CRITICAL: You MUST include --cdp flag on EVERY agent-browser command. Without it, agent-browser targets the main app window and breaks the UI.\n\n` +
-      `To connect:\n` +
-      `  agent-browser --cdp "${wsUrl}" open about:blank\n\n` +
-      `For ALL subsequent commands, always include --cdp:\n` +
-      `  agent-browser --cdp "${wsUrl}" snapshot -i\n` +
-      `  agent-browser --cdp "${wsUrl}" click <ref>\n` +
-      `  agent-browser --cdp "${wsUrl}" type <ref> "text"\n` +
-      `  agent-browser --cdp "${wsUrl}" open <url>\n\n` +
-      `If commands stop working, kill stale daemons first:\n` +
-      `  pkill -f agent-browser; sleep 1\n` +
-      `  agent-browser --cdp "${wsUrl}" open about:blank\n\n` +
-      `NEVER use agent-browser without --cdp "${wsUrl}" — every single command needs it.\n\n` +
+      `CRITICAL SETUP — follow these steps exactly:\n\n` +
+      `Step 1: Connect to the Electron app's CDP port:\n` +
+      `  pkill -f agent-browser 2>/dev/null; sleep 1\n` +
+      `  agent-browser connect ${CDP_PORT}\n\n` +
+      `Step 2: List targets and find the webview (NOT the main "page" window):\n` +
+      `  agent-browser tab\n\n` +
+      `Step 3: Switch to the webview target that shows "${browserUrl || browserTitle}":\n` +
+      `  agent-browser tab <index>   # pick the [webview] entry, NOT [page]\n\n` +
+      `Step 4: Now use commands normally:\n` +
+      `  agent-browser open <url>\n` +
+      `  agent-browser snapshot -i\n` +
+      `  agent-browser click <ref>\n\n` +
+      `DANGER: The [page] target at index 0 is the main Electron app window.\n` +
+      `NEVER interact with it — switching to it or navigating it will break the app UI.\n` +
+      `Always use a [webview] target.\n\n` +
       `The user can see everything you do in the browser in real time on the canvas.`,
       taskPanel.refId!,
       session.agentId

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { settingsApi } from '@/lib/ipc-client'
 
 const CANVAS_STORAGE_KEY = 'canvas_state'
+const CDP_PORT = 19222
 let saveTimer: ReturnType<typeof setTimeout> | null = null
 const SAVE_DEBOUNCE_MS = 1000
 
@@ -329,7 +330,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 
   // Edges
   addEdge: (fromPanelId, toPanelId, edgeType) => {
-    const { edges } = get()
+    const { edges, panels } = get()
     const exists = edges.some(
       (e) =>
         (e.fromPanelId === fromPanelId && e.toPanelId === toPanelId) ||
@@ -341,6 +342,12 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
       edges: [...s.edges, { id, fromPanelId, toPanelId, edgeType }]
     }))
     scheduleSave()
+
+    // ── Notify agent when a browser edge connects browser↔task ──
+    if (edgeType === 'browser') {
+      notifyAgentOfBrowserConnection(panels, fromPanelId, toPanelId)
+    }
+
     return id
   },
 
@@ -442,4 +449,44 @@ export function calculateSnap(
   if (guideY) guides.push(guideY)
 
   return { x: bestDx < threshold ? snapX : x, y: bestDy < threshold ? snapY : y, guides }
+}
+
+// ── Browser↔Task edge notification ──────────────────────────
+// Lazy-imports agent-store and ipc-client to avoid circular deps in tests.
+
+function notifyAgentOfBrowserConnection(
+  panels: CanvasPanelData[],
+  fromPanelId: string,
+  toPanelId: string
+) {
+  const fromPanel = panels.find((p) => p.id === fromPanelId)
+  const toPanel = panels.find((p) => p.id === toPanelId)
+  const taskPanel = fromPanel?.type === 'task' ? fromPanel : toPanel?.type === 'task' ? toPanel : null
+  const browserPanel = fromPanel?.type === 'browser' ? fromPanel : toPanel?.type === 'browser' ? toPanel : null
+
+  if (!taskPanel?.refId || !browserPanel) return
+
+  // Lazy imports to avoid pulling agent-store into canvas-store at module level
+  Promise.all([
+    import('./agent-store'),
+    import('@/lib/ipc-client'),
+  ]).then(([{ useAgentStore }, { agentSessionApi }]) => {
+    const session = useAgentStore.getState().getSession(taskPanel.refId!)
+    if (!session?.sessionId) return
+
+    const browserUrl = browserPanel.url || '(no URL loaded yet)'
+    agentSessionApi.send(
+      session.sessionId,
+      `[System] A browser panel has been connected to your task on the canvas. You now have access to control it.\n\n` +
+      `To use it:\n` +
+      `  agent-browser connect ${CDP_PORT}\n` +
+      `  agent-browser tab                # find the tab showing: ${browserUrl}\n` +
+      `  agent-browser snapshot -i         # get interactive elements\n\n` +
+      `The user can see everything you do in the browser in real time on the canvas.`,
+      taskPanel.refId!,
+      session.agentId
+    ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
+  }).catch(() => {
+    // Silently ignore — can happen in test environments
+  })
 }

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -21,6 +21,8 @@ export interface CanvasPanelData {
   browserSessionId?: string
   /** WebSocket streaming port (for browser panels) */
   streamPort?: number
+  /** CDP target ID for this webview — used to connect agent-browser directly */
+  cdpTargetId?: string
   title: string
   x: number
   y: number
@@ -470,44 +472,38 @@ function notifyAgentOfBrowserConnection(
   Promise.all([
     import('./agent-store'),
     import('@/lib/ipc-client'),
-  ]).then(async ([{ useAgentStore }, { agentSessionApi }]) => {
+  ]).then(([{ useAgentStore }, { agentSessionApi }]) => {
     const session = useAgentStore.getState().getSession(taskPanel.refId!)
     if (!session?.sessionId) return
 
-    const browserUrl = browserPanel.url || '(no URL loaded yet)'
+    const cdpTargetId = browserPanel.cdpTargetId
+    const browserTitle = browserPanel.title || 'Browser'
 
-    // Resolve the actual tab ID by matching the webview's URL against CDP targets
-    let tabHint = 'agent-browser tab              # list tabs to find the right one'
-    try {
-      const res = await fetch(`http://localhost:${CDP_PORT}/json/list`)
-      const targets = (await res.json()) as Array<{ id: string; title: string; url: string; type: string }>
-      // Match by URL prefix (webview URLs may have extra params)
-      const browserUrlBase = (browserPanel.url || '').split('?')[0].split('#')[0]
-      const match = browserUrlBase
-        ? targets.find((t) => t.url.startsWith(browserUrlBase) && t.type === 'page')
-        : null
-      if (match) {
-        // agent-browser uses t1, t2, ... based on the target list order
-        const pageTargets = targets.filter((t) => t.type === 'page')
-        const idx = pageTargets.findIndex((t) => t.id === match.id)
-        if (idx >= 0) {
-          tabHint = `agent-browser tab t${idx + 1}           # "${match.title}" — ${browserUrl}`
-        }
-      }
-    } catch {
-      // CDP query failed — fall back to generic hint
+    // If we have the CDP target ID, give the agent a direct WebSocket URL
+    // Otherwise fall back to generic connect + tab instructions
+    let connectSection: string
+    if (cdpTargetId) {
+      connectSection =
+        `  agent-browser --cdp "ws://localhost:${CDP_PORT}/devtools/page/${cdpTargetId}" open about:blank\n` +
+        `  # Direct connection to "${browserTitle}" webview\n`
+    } else {
+      connectSection =
+        `  agent-browser connect ${CDP_PORT}\n` +
+        `  agent-browser tab              # list tabs to find the browser panel\n` +
+        `  agent-browser tab t<N>          # switch to it (not t1 — that's the main app)\n`
     }
 
     agentSessionApi.send(
       session.sessionId,
-      `[System] A browser panel has been connected to your task on the canvas. You now have access to control it.\n\n` +
+      `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas. You now have access to control it.\n\n` +
       `To connect:\n` +
-      `  agent-browser connect ${CDP_PORT}\n` +
-      `  ${tabHint}\n` +
+      connectSection +
       `  agent-browser snapshot -i      # get interactive elements\n\n` +
       `Important: if commands stop working, kill stale daemons first:\n` +
       `  pkill -f agent-browser; sleep 1\n` +
-      `  agent-browser connect ${CDP_PORT}\n\n` +
+      (cdpTargetId
+        ? `  agent-browser --cdp "ws://localhost:${CDP_PORT}/devtools/page/${cdpTargetId}" open about:blank\n\n`
+        : `  agent-browser connect ${CDP_PORT}\n\n`) +
       `The user can see everything you do in the browser in real time on the canvas.`,
       taskPanel.refId!,
       session.agentId

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -527,10 +527,12 @@ function notifyAgentOfBrowserConnection(
     // Resolve which agent-browser tab ID (t1, t2, t3...) corresponds to this
     // browser panel's webview. The IPC handler returns all page+webview targets
     // with pre-computed tabId matching agent-browser's `tab` command output.
+    // Retry a few times since the webview may not be registered in CDP yet.
     let tabId: string | null = null
-    try {
+    const resolveTab = async (): Promise<string | null> => {
       const allTargets = await window.electronAPI.browser.getCdpTargets()
       const webviews = allTargets.filter((t) => t.type === 'webview')
+      if (webviews.length === 0) return null
 
       // 1. Check if the stored target ID is still valid
       const storedId = browserPanel.cdpTargetId
@@ -547,8 +549,15 @@ function notifyAgentOfBrowserConnection(
         match = webviews[0] || null
       }
 
-      if (match) {
-        tabId = match.tabId
+      return match?.tabId || null
+    }
+
+    try {
+      // Try up to 3 times with 1s delay — webview may still be loading in CDP
+      for (let attempt = 0; attempt < 3; attempt++) {
+        tabId = await resolveTab()
+        if (tabId) break
+        await new Promise((r) => setTimeout(r, 1000))
       }
     } catch { /* IPC query failed */ }
 

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -537,13 +537,14 @@ function notifyAgentOfBrowserConnection(
       const storedId = browserPanel.cdpTargetId
       if (storedId && webviews.some((t) => t.id === storedId)) {
         cdpTargetId = storedId
-      } else {
+      } else if (browserUrl) {
         // 2. Match by URL
         const urlBase = browserUrl.split('?')[0].split('#')[0]
-        const match = urlBase
-          ? webviews.find((t) => t.url.startsWith(urlBase))
-          : null
-        cdpTargetId = match?.id || (webviews.length === 1 ? webviews[0].id : null)
+        const match = webviews.find((t) => t.url.startsWith(urlBase))
+        cdpTargetId = match?.id || webviews[0]?.id || null
+      } else {
+        // 3. No URL — pick first available webview
+        cdpTargetId = webviews[0]?.id || null
       }
     } catch { /* CDP query failed */ }
 

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -470,11 +470,19 @@ function notifyAgentOfBrowserConnection(
   const taskPanel = fromPanel?.type === 'task' ? fromPanel : toPanel?.type === 'task' ? toPanel : null
   const browserPanel = fromPanel?.type === 'browser' ? fromPanel : toPanel?.type === 'browser' ? toPanel : null
 
-  if (!taskPanel?.refId || !browserPanel) return
+  console.log('[BrowserEdge] notifyAgentOfBrowserConnection called', {
+    fromPanelId, toPanelId,
+    fromType: fromPanel?.type, toType: toPanel?.type,
+    taskRefId: taskPanel?.refId, browserPanelId: browserPanel?.id,
+    browserUrl: browserPanel?.url, browserTitle: browserPanel?.title,
+    browserCdpTargetId: browserPanel?.cdpTargetId,
+  })
 
-  // Resolve the CDP target ID for this webview by querying /json/list
-  // and matching the browser panel's URL. This is done at notification time
-  // so it always picks up the latest target, even if cdpTargetId wasn't stored yet.
+  if (!taskPanel?.refId || !browserPanel) {
+    console.log('[BrowserEdge] BAIL: no taskPanel.refId or no browserPanel')
+    return
+  }
+
   const resolveAndNotify = async () => {
     const [{ useAgentStore }, { agentSessionApi }, { useTaskStore }] = await Promise.all([
       import('./agent-store'),
@@ -484,21 +492,24 @@ function notifyAgentOfBrowserConnection(
 
     const taskId = taskPanel.refId!
     let session = useAgentStore.getState().getSession(taskId)
+    console.log('[BrowserEdge] session state', { taskId, sessionId: session?.sessionId, agentId: session?.agentId })
 
     // If no active session, auto-start or resume the task
     if (!session?.sessionId) {
       const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
-      if (!task?.agent_id) return // No agent assigned — can't start
+      console.log('[BrowserEdge] no session, looking up task', { taskId, agentId: task?.agent_id, sessionId: task?.session_id })
+      if (!task?.agent_id) {
+        console.log('[BrowserEdge] BAIL: no agent_id on task')
+        return
+      }
 
       const initSession = useAgentStore.getState().initSession
       try {
         if (task.session_id) {
-          // Resume existing session
           useAgentStore.getState().clearMessageDedup(taskId)
           initSession(taskId, '', task.agent_id)
           const result = await agentSessionApi.resume(task.agent_id, taskId, task.session_id)
           if (result.ended) {
-            // Session ended — start fresh
             initSession(taskId, '', task.agent_id)
             const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
             initSession(taskId, sessionId, task.agent_id)
@@ -506,60 +517,71 @@ function notifyAgentOfBrowserConnection(
             initSession(taskId, result.sessionId, task.agent_id)
           }
         } else {
-          // Start new session
           initSession(taskId, '', task.agent_id)
           const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
           initSession(taskId, sessionId, task.agent_id)
         }
-        // Re-fetch the session after start/resume
         session = useAgentStore.getState().getSession(taskId)
+        console.log('[BrowserEdge] session after auto-start', { sessionId: session?.sessionId })
       } catch (err) {
-        console.error('[Canvas] Failed to auto-start/resume task for browser connection:', err)
+        console.error('[BrowserEdge] Failed to auto-start/resume task:', err)
         return
       }
     }
 
-    if (!session?.sessionId) return
+    if (!session?.sessionId) {
+      console.log('[BrowserEdge] BAIL: still no sessionId after auto-start attempt')
+      return
+    }
 
     const browserTitle = browserPanel.title || 'Browser'
     const browserUrl = browserPanel.url || ''
 
     // Resolve which agent-browser tab ID (t1, t2, t3...) corresponds to this
-    // browser panel's webview. The IPC handler returns all page+webview targets
-    // with pre-computed tabId matching agent-browser's `tab` command output.
-    // Retry a few times since the webview may not be registered in CDP yet.
+    // browser panel's webview. Retry a few times since webview may not be in CDP yet.
     let tabId: string | null = null
-    const resolveTab = async (): Promise<string | null> => {
+    const resolveTab = async (attempt: number): Promise<string | null> => {
       const allTargets = await window.electronAPI.browser.getCdpTargets()
       const webviews = allTargets.filter((t) => t.type === 'webview')
+      console.log(`[BrowserEdge] resolveTab attempt=${attempt}`, {
+        allTargetsCount: allTargets.length,
+        allTargets: allTargets.map((t) => ({ tabId: t.tabId, type: t.type, url: t.url?.slice(0, 60) })),
+        webviewsCount: webviews.length,
+        browserUrl,
+        storedCdpTargetId: browserPanel.cdpTargetId,
+      })
       if (webviews.length === 0) return null
 
-      // 1. Check if the stored target ID is still valid
       const storedId = browserPanel.cdpTargetId
       let match = storedId ? webviews.find((t) => t.id === storedId) : null
+      if (match) console.log('[BrowserEdge] matched by stored cdpTargetId', match.tabId)
 
-      // 2. Match by URL
       if (!match && browserUrl) {
         const urlBase = browserUrl.split('?')[0].split('#')[0]
         match = webviews.find((t) => t.url.startsWith(urlBase)) || webviews[0] || null
+        if (match) console.log('[BrowserEdge] matched by URL or fallback to first webview', { tabId: match.tabId, matchUrl: match.url?.slice(0, 60) })
       }
 
-      // 3. No URL — pick first available webview
       if (!match) {
         match = webviews[0] || null
+        if (match) console.log('[BrowserEdge] fallback to first webview', match.tabId)
       }
 
       return match?.tabId || null
     }
 
     try {
-      // Try up to 3 times with 1s delay — webview may still be loading in CDP
       for (let attempt = 0; attempt < 3; attempt++) {
-        tabId = await resolveTab()
+        tabId = await resolveTab(attempt)
         if (tabId) break
+        console.log(`[BrowserEdge] no tab found, retrying in 1s (attempt ${attempt + 1}/3)`)
         await new Promise((r) => setTimeout(r, 1000))
       }
-    } catch { /* IPC query failed */ }
+    } catch (err) {
+      console.error('[BrowserEdge] resolveTab error:', err)
+    }
+
+    console.log('[BrowserEdge] final result', { tabId, browserTitle, browserUrl })
 
     if (!tabId) {
       agentSessionApi.send(

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -7,7 +7,7 @@ const SAVE_DEBOUNCE_MS = 1000
 
 // ── Panel types ────────────────────────────────────────────
 
-export type CanvasPanelType = 'task' | 'transcript' | 'app' | 'webpage' | 'terminal' | 'placeholder'
+export type CanvasPanelType = 'task' | 'transcript' | 'app' | 'webpage' | 'terminal' | 'browser' | 'placeholder'
 
 export interface CanvasPanelData {
   id: string
@@ -16,6 +16,10 @@ export interface CanvasPanelData {
   refId?: string
   /** URL for webpage panels */
   url?: string
+  /** Browser session name (for browser panels) */
+  browserSessionId?: string
+  /** WebSocket streaming port (for browser panels) */
+  streamPort?: number
   title: string
   x: number
   y: number
@@ -28,10 +32,14 @@ export interface CanvasPanelData {
 
 // ── Connections / Edges ───────────────────────────────────
 
+export type CanvasEdgeType = 'default' | 'browser'
+
 export interface CanvasEdge {
   id: string
   fromPanelId: string
   toPanelId: string
+  /** Visual style for the edge — 'browser' gets animated pulsing style */
+  edgeType?: CanvasEdgeType
 }
 
 // ── Snapping helpers ──────────────────────────────────────
@@ -106,7 +114,7 @@ interface CanvasState {
   setSnapGuides: (guides: SnapGuide[]) => void
 
   // Edge / connection actions
-  addEdge: (fromPanelId: string, toPanelId: string) => string
+  addEdge: (fromPanelId: string, toPanelId: string, edgeType?: CanvasEdgeType) => string
   removeEdge: (id: string) => void
   removeEdgesForPanel: (panelId: string) => void
   setConnectingFromId: (id: string | null) => void
@@ -320,7 +328,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   setSnapGuides: (guides) => set({ snapGuides: guides }),
 
   // Edges
-  addEdge: (fromPanelId, toPanelId) => {
+  addEdge: (fromPanelId, toPanelId, edgeType) => {
     const { edges } = get()
     const exists = edges.some(
       (e) =>
@@ -330,7 +338,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     if (exists) return ''
     const id = `edge-${++edgeCounter}-${Date.now()}`
     set((s) => ({
-      edges: [...s.edges, { id, fromPanelId, toPanelId }]
+      edges: [...s.edges, { id, fromPanelId, toPanelId, edgeType }]
     }))
     scheduleSave()
     return id

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -468,19 +468,34 @@ function notifyAgentOfBrowserConnection(
 
   if (!taskPanel?.refId || !browserPanel) return
 
-  // Lazy imports to avoid pulling agent-store into canvas-store at module level
-  Promise.all([
-    import('./agent-store'),
-    import('@/lib/ipc-client'),
-  ]).then(([{ useAgentStore }, { agentSessionApi }]) => {
+  // Resolve the CDP target ID for this webview by querying /json/list
+  // and matching the browser panel's URL. This is done at notification time
+  // so it always picks up the latest target, even if cdpTargetId wasn't stored yet.
+  const resolveAndNotify = async () => {
+    const [{ useAgentStore }, { agentSessionApi }] = await Promise.all([
+      import('./agent-store'),
+      import('@/lib/ipc-client'),
+    ])
+
     const session = useAgentStore.getState().getSession(taskPanel.refId!)
     if (!session?.sessionId) return
 
-    const cdpTargetId = browserPanel.cdpTargetId
     const browserTitle = browserPanel.title || 'Browser'
+    const browserUrl = browserPanel.url || ''
+
+    // Try to resolve the CDP target ID
+    let cdpTargetId = browserPanel.cdpTargetId || null
+    if (!cdpTargetId && browserUrl) {
+      try {
+        const res = await fetch(`http://localhost:${CDP_PORT}/json/list`)
+        const targets = (await res.json()) as Array<{ id: string; url: string; type: string }>
+        const match = targets.find((t) => t.type === 'webview' && t.url.startsWith(browserUrl.split('?')[0].split('#')[0]))
+          || targets.find((t) => t.type === 'webview')
+        if (match) cdpTargetId = match.id
+      } catch { /* CDP query failed — use fallback */ }
+    }
 
     // If we have the CDP target ID, give the agent a direct WebSocket URL
-    // Otherwise fall back to generic connect + tab instructions
     let connectSection: string
     if (cdpTargetId) {
       connectSection =
@@ -508,7 +523,9 @@ function notifyAgentOfBrowserConnection(
       taskPanel.refId!,
       session.agentId
     ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
-  }).catch(() => {
+  }
+
+  resolveAndNotify().catch(() => {
     // Silently ignore — can happen in test environments
   })
 }

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -524,38 +524,42 @@ function notifyAgentOfBrowserConnection(
     const browserTitle = browserPanel.title || 'Browser'
     const browserUrl = browserPanel.url || ''
 
-    // ALWAYS resolve the CDP target ID fresh via IPC (main process queries
-    // localhost:19222/json/list — no CORS issues unlike renderer fetch).
-    // Stored cdpTargetId goes stale on every app restart (CDP reassigns IDs).
-    let cdpTargetId: string | null = null
+    // Resolve which agent-browser tab ID (t1, t2, t3...) corresponds to this
+    // browser panel's webview. The IPC handler returns all page+webview targets
+    // with pre-computed tabId matching agent-browser's `tab` command output.
+    let tabId: string | null = null
     try {
-      const webviews = await window.electronAPI.browser.getCdpTargets()
+      const allTargets = await window.electronAPI.browser.getCdpTargets()
+      const webviews = allTargets.filter((t) => t.type === 'webview')
 
       // 1. Check if the stored target ID is still valid
       const storedId = browserPanel.cdpTargetId
-      if (storedId && webviews.some((t) => t.id === storedId)) {
-        cdpTargetId = storedId
-      } else if (browserUrl) {
-        // 2. Match by URL
+      let match = storedId ? webviews.find((t) => t.id === storedId) : null
+
+      // 2. Match by URL
+      if (!match && browserUrl) {
         const urlBase = browserUrl.split('?')[0].split('#')[0]
-        const match = webviews.find((t) => t.url.startsWith(urlBase))
-        cdpTargetId = match?.id || webviews[0]?.id || null
-      } else {
-        // 3. No URL — pick first available webview
-        cdpTargetId = webviews[0]?.id || null
+        match = webviews.find((t) => t.url.startsWith(urlBase)) || webviews[0] || null
+      }
+
+      // 3. No URL — pick first available webview
+      if (!match) {
+        match = webviews[0] || null
+      }
+
+      if (match) {
+        tabId = match.tabId
       }
     } catch { /* IPC query failed */ }
 
-    // SAFETY: Only send connection instructions when we have a confirmed webview target.
-    // Without it, agent-browser would default to the main app window and break the UI.
-    if (!cdpTargetId) {
+    if (!tabId) {
       agentSessionApi.send(
         session.sessionId,
         `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas.\n\n` +
         `The browser panel is loading. To connect once ready:\n` +
         `  agent-browser connect ${CDP_PORT}\n` +
-        `  agent-browser tab    # find the [webview] target, NOT the [page]\n` +
-        `  agent-browser tab --url "<pattern>"   # switch to it\n\n` +
+        `  agent-browser tab    # find the [webview] target\n` +
+        `  agent-browser tab <tN>   # switch to the webview\n\n` +
         `Then use commands normally (open, snapshot, click, etc.).\n` +
         `Do NOT interact with the [page] target — that is the main app window.`,
         taskPanel.refId!,
@@ -564,21 +568,17 @@ function notifyAgentOfBrowserConnection(
       return
     }
 
-    // Build a URL pattern for tab --url matching (use domain from browser URL)
-    const urlDomain = browserUrl ? new URL(browserUrl).hostname.replace('www.', '') : ''
-    const tabUrlPattern = urlDomain ? `"*${urlDomain}*"` : `"*google*"`
-
     agentSessionApi.send(
       session.sessionId,
       `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas. You now have access to control it.\n\n` +
       `To use the browser, run these commands:\n` +
       `  agent-browser connect ${CDP_PORT}\n` +
-      `  agent-browser tab --url ${tabUrlPattern}\n\n` +
+      `  agent-browser tab ${tabId}\n\n` +
       `Then use commands normally:\n` +
       `  agent-browser open <url>\n` +
       `  agent-browser snapshot -i\n` +
       `  agent-browser click <ref>\n\n` +
-      `IMPORTANT: Do NOT use "agent-browser tab t1" or interact with the [page] target — that is the main app window.\n` +
+      `Do NOT use "agent-browser tab t1" — that is the main app window.\n` +
       `The user can see everything you do in the browser in real time on the canvas.`,
       taskPanel.refId!,
       session.agentId

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -524,42 +524,49 @@ function notifyAgentOfBrowserConnection(
     const browserTitle = browserPanel.title || 'Browser'
     const browserUrl = browserPanel.url || ''
 
-    // Try to resolve the CDP target ID
+    // Resolve the CDP target ID — ONLY use webview targets, never the main app window.
     let cdpTargetId = browserPanel.cdpTargetId || null
-    if (!cdpTargetId && browserUrl) {
+    if (!cdpTargetId) {
       try {
         const res = await fetch(`http://localhost:${CDP_PORT}/json/list`)
         const targets = (await res.json()) as Array<{ id: string; url: string; type: string }>
-        const match = targets.find((t) => t.type === 'webview' && t.url.startsWith(browserUrl.split('?')[0].split('#')[0]))
-          || targets.find((t) => t.type === 'webview')
-        if (match) cdpTargetId = match.id
-      } catch { /* CDP query failed — use fallback */ }
+        // Only match webview targets — never "page" (which is the main app)
+        const match = browserUrl
+          ? targets.find((t) => t.type === 'webview' && t.url.startsWith(browserUrl.split('?')[0].split('#')[0]))
+          : null
+        cdpTargetId = match?.id || targets.find((t) => t.type === 'webview')?.id || null
+      } catch { /* CDP query failed */ }
     }
 
-    // If we have the CDP target ID, give the agent a direct WebSocket URL
-    let connectSection: string
-    if (cdpTargetId) {
-      connectSection =
-        `  agent-browser --cdp "ws://localhost:${CDP_PORT}/devtools/page/${cdpTargetId}" open about:blank\n` +
-        `  # Direct connection to "${browserTitle}" webview\n`
-    } else {
-      connectSection =
-        `  agent-browser connect ${CDP_PORT}\n` +
-        `  agent-browser tab              # list tabs to find the browser panel\n` +
-        `  agent-browser tab t<N>          # switch to it (not t1 — that's the main app)\n`
+    // SAFETY: Only send connection instructions when we have a confirmed webview target.
+    // Without it, agent-browser would default to the main app window and break the UI.
+    if (!cdpTargetId) {
+      agentSessionApi.send(
+        session.sessionId,
+        `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas.\n\n` +
+        `The browser panel is not loaded yet — the user needs to navigate to a URL first.\n` +
+        `Once loaded, you will receive updated connection instructions.\n\n` +
+        `IMPORTANT: Do NOT use "agent-browser connect" or "agent-browser open" — ` +
+        `that would navigate the main application window. Wait for the direct WebSocket URL.`,
+        taskPanel.refId!,
+        session.agentId
+      ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
+      return
     }
 
+    const wsUrl = `ws://localhost:${CDP_PORT}/devtools/page/${cdpTargetId}`
     agentSessionApi.send(
       session.sessionId,
       `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas. You now have access to control it.\n\n` +
       `To connect:\n` +
-      connectSection +
+      `  agent-browser --cdp "${wsUrl}" open about:blank\n` +
+      `  # Direct connection to "${browserTitle}" webview\n` +
       `  agent-browser snapshot -i      # get interactive elements\n\n` +
-      `Important: if commands stop working, kill stale daemons first:\n` +
+      `If commands stop working, kill stale daemons first:\n` +
       `  pkill -f agent-browser; sleep 1\n` +
-      (cdpTargetId
-        ? `  agent-browser --cdp "ws://localhost:${CDP_PORT}/devtools/page/${cdpTargetId}" open about:blank\n\n`
-        : `  agent-browser connect ${CDP_PORT}\n\n`) +
+      `  agent-browser --cdp "${wsUrl}" open about:blank\n\n` +
+      `IMPORTANT: Do NOT use "agent-browser connect" or "agent-browser open" without --cdp flag — ` +
+      `that would navigate the main application window.\n\n` +
       `The user can see everything you do in the browser in real time on the canvas.`,
       taskPanel.refId!,
       session.agentId

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -552,34 +552,33 @@ function notifyAgentOfBrowserConnection(
       agentSessionApi.send(
         session.sessionId,
         `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas.\n\n` +
-        `The browser panel is not loaded yet — the user needs to navigate to a URL first.\n` +
-        `Once loaded, you will receive updated connection instructions.\n\n` +
-        `IMPORTANT: Do NOT use "agent-browser connect" or "agent-browser open" — ` +
-        `that would navigate the main application window. Wait for the direct WebSocket URL.`,
+        `The browser panel is loading. To connect once ready:\n` +
+        `  agent-browser connect ${CDP_PORT}\n` +
+        `  agent-browser tab    # find the [webview] target, NOT the [page]\n` +
+        `  agent-browser tab --url "<pattern>"   # switch to it\n\n` +
+        `Then use commands normally (open, snapshot, click, etc.).\n` +
+        `Do NOT interact with the [page] target — that is the main app window.`,
         taskPanel.refId!,
         session.agentId
       ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
       return
     }
 
+    // Build a URL pattern for tab --url matching (use domain from browser URL)
+    const urlDomain = browserUrl ? new URL(browserUrl).hostname.replace('www.', '') : ''
+    const tabUrlPattern = urlDomain ? `"*${urlDomain}*"` : `"*google*"`
+
     agentSessionApi.send(
       session.sessionId,
       `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas. You now have access to control it.\n\n` +
-      `CRITICAL SETUP — follow these steps exactly:\n\n` +
-      `Step 1: Connect to the Electron app's CDP port:\n` +
-      `  pkill -f agent-browser 2>/dev/null; sleep 1\n` +
-      `  agent-browser connect ${CDP_PORT}\n\n` +
-      `Step 2: List targets and find the webview (NOT the main "page" window):\n` +
-      `  agent-browser tab\n\n` +
-      `Step 3: Switch to the webview target that shows "${browserUrl || browserTitle}":\n` +
-      `  agent-browser tab <index>   # pick the [webview] entry, NOT [page]\n\n` +
-      `Step 4: Now use commands normally:\n` +
+      `To use the browser, run these commands:\n` +
+      `  agent-browser connect ${CDP_PORT}\n` +
+      `  agent-browser tab --url ${tabUrlPattern}\n\n` +
+      `Then use commands normally:\n` +
       `  agent-browser open <url>\n` +
       `  agent-browser snapshot -i\n` +
       `  agent-browser click <ref>\n\n` +
-      `DANGER: The [page] target at index 0 is the main Electron app window.\n` +
-      `NEVER interact with it — switching to it or navigating it will break the app UI.\n` +
-      `Always use a [webview] target.\n\n` +
+      `IMPORTANT: Do NOT use "agent-browser tab t1" or interact with the [page] target — that is the main app window.\n` +
       `The user can see everything you do in the browser in real time on the canvas.`,
       taskPanel.refId!,
       session.agentId

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -367,6 +367,7 @@ interface ElectronAPI {
     resize: (id: string, cols: number, rows: number) => Promise<void>
     kill: (id: string) => Promise<void>
     getCwd: (id: string) => Promise<{ cwd: string | null }>
+    getBuffer: (id: string, lines?: number) => Promise<{ lines: string[] }>
     onData: (callback: (data: { id: string; data: string }) => void) => () => void
     onExit: (callback: (data: { id: string }) => void) => () => void
   }

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -362,10 +362,11 @@ interface ElectronAPI {
     getPathForFile: (file: File) => string
   }
   terminal: {
-    create: (id: string, cols: number, rows: number) => Promise<{ pid: number }>
+    create: (id: string, cols: number, rows: number, cwd?: string) => Promise<{ pid: number }>
     write: (id: string, data: string) => Promise<void>
     resize: (id: string, cols: number, rows: number) => Promise<void>
     kill: (id: string) => Promise<void>
+    getCwd: (id: string) => Promise<{ cwd: string | null }>
     onData: (callback: (data: { id: string; data: string }) => void) => () => void
     onExit: (callback: (data: { id: string }) => void) => () => void
   }

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -384,6 +384,7 @@ interface ElectronAPI {
   onGithubDeviceCode: (callback: (code: string) => void) => () => void
   browser: {
     getCdpPort: () => Promise<{ port: number }>
+    getTargetId: (webContentsId: number) => Promise<{ targetId: string | null }>
   }
   onGitlabDeviceCode: (callback: (code: string) => void) => () => void
   onOAuthCallback: (callback: (event: { code: string; state: string }) => void) => () => void

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -385,7 +385,7 @@ interface ElectronAPI {
   browser: {
     getCdpPort: () => Promise<{ port: number }>
     getTargetId: (webContentsId: number) => Promise<{ targetId: string | null }>
-    getCdpTargets: () => Promise<Array<{ id: string; url: string; title: string }>>
+    getCdpTargets: () => Promise<Array<{ id: string; url: string; title: string; type: string; tabId: string }>>
   }
   onGitlabDeviceCode: (callback: (code: string) => void) => () => void
   onOAuthCallback: (callback: (event: { code: string; state: string }) => void) => () => void

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -385,6 +385,7 @@ interface ElectronAPI {
   browser: {
     getCdpPort: () => Promise<{ port: number }>
     getTargetId: (webContentsId: number) => Promise<{ targetId: string | null }>
+    getCdpTargets: () => Promise<Array<{ id: string; url: string; title: string }>>
   }
   onGitlabDeviceCode: (callback: (code: string) => void) => () => void
   onOAuthCallback: (callback: (event: { code: string; state: string }) => void) => () => void

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -365,8 +365,8 @@ interface ElectronAPI {
     create: (id: string, cols: number, rows: number, cwd?: string) => Promise<{ pid: number }>
     write: (id: string, data: string) => Promise<void>
     resize: (id: string, cols: number, rows: number) => Promise<void>
-    kill: (id: string) => Promise<void>
-    getCwd: (id: string) => Promise<{ cwd: string | null }>
+    kill: (id: string, expectedPid?: number) => Promise<void>
+    getCwd: (id: string, expectedPid?: number) => Promise<{ cwd: string | null }>
     getBuffer: (id: string, lines?: number) => Promise<{ lines: string[] }>
     onData: (callback: (data: { id: string; data: string }) => void) => () => void
     onExit: (callback: (data: { id: string }) => void) => () => void

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -382,6 +382,9 @@ interface ElectronAPI {
   onHeartbeatDisabled: (callback: (event: { taskId: string; reason: string }) => void) => () => void
   onWorktreeProgress: (callback: (event: WorktreeProgressEvent) => void) => () => void
   onGithubDeviceCode: (callback: (code: string) => void) => () => void
+  browser: {
+    getCdpPort: () => Promise<{ port: number }>
+  }
   onGitlabDeviceCode: (callback: (code: string) => void) => () => void
   onOAuthCallback: (callback: (event: { code: string; state: string }) => void) => () => void
 }


### PR DESCRIPTION
## Summary
- Adds a new `browser` panel type to the infinite canvas that connects to [Vercel's agent-browser](https://github.com/vercel-labs/agent-browser) via WebSocket streaming
- Browser panels show the agent-browser dashboard viewport with a real-time status bar (URL, tabs, commands, connection state)
- Connections between task and browser panels use a **distinct pulsing orange animated edge** with a globe icon, making it visually clear when an agent has browser access

## New files
- **`BrowserPanelContent.tsx`** — Setup screen (session name, port) → live dashboard iframe + status bar
- **`browser-store.ts`** — Zustand store for browser sessions: WebSocket stream connection, real-time state updates

## Modified files
- **`canvas-store.ts`** — `browser` panel type, `browserSessionId`/`streamPort` fields, `edgeType` on CanvasEdge
- **`CanvasPanel.tsx`** — Wired BrowserPanelContent + orange badge styling
- **`CanvasConnections.tsx`** — Browser-specific animated edges (pulsing orange gradient, glow filter, globe icon at midpoint)
- **`CanvasContextMenu.tsx`** — "Agent Browser" option in right-click menu

## How it works
1. Right-click canvas → "Agent Browser" → setup screen appears
2. Enter session name + optional stream port → connects to agent-browser WebSocket stream
3. Panel shows dashboard viewport (`localhost:4848`) + live status bar
4. Draw an edge between task panel ↔ browser panel → pulsing orange animated connection

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] All 1215 tests pass (`pnpm test`)
- [x] Lint + typecheck clean (pre-commit hooks)
- [ ] Manual: right-click canvas → add Agent Browser panel → verify setup screen renders
- [ ] Manual: run `agent-browser --headed open example.com && agent-browser stream enable` → connect panel → verify live status
- [ ] Manual: create edge between task panel and browser panel → verify pulsing orange edge with globe icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)