### PR TITLE
fix: prevent enterprise apiRequest execute call with missing tenant/workflow IDs

### DIFF
--- a/src/renderer/src/stores/dashboard-store.test.ts
+++ b/src/renderer/src/stores/dashboard-store.test.ts
@@ -26,6 +26,7 @@ import { enterpriseApi } from '@/lib/ipc-client'
 import { useEnterpriseStore } from '@/stores/enterprise-store'
 
 const mockApiRequest = vi.mocked(enterpriseApi.apiRequest)
+const mockEnableIframeAuth = vi.mocked(enterpriseApi.enableIframeAuth)
 
 const mockApplications: ApplicationItem[] = [
   {
@@ -172,6 +173,38 @@ describe('useDashboardStore', () => {
     expect(state.applicationsError).toBeNull()
     // Verify lowercase triggerType value matching NodeType.APPLICATION_TRIGGER enum
     expect(mockApiRequest).toHaveBeenCalledWith('GET', '/api/workflows?triggerType=application_trigger')
+  })
+
+  it('fetchApplications falls back to id/workspace tenant when workflow fields are missing', async () => {
+    useEnterpriseStore.setState({
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      userEmail: 'test@example.com',
+      userId: 'user-1',
+      currentTenant: { id: 'tenant-fallback', name: 'Fallback Tenant' },
+      availableTenants: null
+    })
+
+    mockApiRequest.mockResolvedValueOnce({
+      workflows: [{
+        id: 'wf-from-id',
+        name: 'Workflow with ID only',
+        description: null,
+        status: 'Active',
+        lastRun: null,
+        runCount: 0,
+        updatedAt: '2026-03-28T10:00:00Z',
+        version: 1
+      }]
+    })
+
+    await useDashboardStore.getState().fetchApplications()
+
+    const state = useDashboardStore.getState()
+    expect(state.applications).toHaveLength(1)
+    expect(state.applications[0].workflowId).toBe('wf-from-id')
+    expect(state.applications[0].tenantId).toBe('tenant-fallback')
   })
 
   it('fetchApplications handles errors', async () => {
@@ -486,6 +519,39 @@ describe('tab management', () => {
     expect(state.expandedView).toBe(true)
 
     await promise
+  })
+
+  it('openApplication does not execute when tenantId is missing', async () => {
+    useDashboardStore.setState({
+      applications: [{
+        workflowId: 'wf-no-tenant',
+        tenantId: '',
+        name: 'No tenant app',
+        description: null,
+        status: 'Active',
+        lastRun: null,
+        runCount: 0,
+        updatedAt: '2026-03-28T10:00:00Z',
+        version: 1
+      }]
+    })
+    useEnterpriseStore.setState({
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      userEmail: 'test@example.com',
+      userId: 'user-1',
+      currentTenant: null,
+      availableTenants: null
+    })
+
+    await useDashboardStore.getState().openApplication('wf-no-tenant')
+
+    expect(mockEnableIframeAuth).not.toHaveBeenCalled()
+    expect(mockApiRequest).not.toHaveBeenCalled()
+    const state = useDashboardStore.getState()
+    expect(state.openTabs).toHaveLength(1)
+    expect(state.openTabs[0].error).toContain('Tenant ID is required')
   })
 
   it('openApplication switches to existing tab by workflowId without creating a duplicate', async () => {

--- a/src/renderer/src/stores/dashboard-store.ts
+++ b/src/renderer/src/stores/dashboard-store.ts
@@ -297,7 +297,8 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       // Must use lowercase 'application_trigger' to match the NodeType enum value in workflow-builder
       const result = await enterpriseApi.apiRequest('GET', '/api/workflows?triggerType=application_trigger') as {
         workflows: Array<{
-          workflowId: string
+          workflowId?: string
+          id?: string
           tenantId?: string
           name: string
           description: string | null
@@ -308,9 +309,10 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
           version: number
         }>
       }
+      const fallbackTenantId = useEnterpriseStore.getState().currentTenant?.id || ''
       const applications: ApplicationItem[] = (result.workflows || []).map((w) => ({
-        workflowId: w.workflowId,
-        tenantId: w.tenantId || '',
+        workflowId: (w.workflowId || w.id || '').trim(),
+        tenantId: (w.tenantId || fallbackTenantId).trim(),
         name: w.name,
         description: w.description,
         status: w.status || 'Draft',
@@ -318,7 +320,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
         runCount: w.runCount || 0,
         updatedAt: w.updatedAt,
         version: w.version
-      }))
+      })).filter((w) => !!w.workflowId)
       set({ applications, applicationsLoading: false })
     } catch (err) {
       if (isAuthError(err)) handleAuthError()
@@ -423,34 +425,44 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   },
 
   openApplication: async (workflowId: string) => {
-    const { openTabs } = get()
-
-    // If already open, just switch to it
-    const existing = openTabs.find((t) => t.workflowId === workflowId)
-    if (existing) {
-      set({ activeTabId: workflowId, expandedView: true })
+    const normalizedWorkflowId = workflowId.trim()
+    if (!normalizedWorkflowId) {
+      console.error('Cannot open application without workflowId')
       return
     }
 
-    const app = get().applications.find((a) => a.workflowId === workflowId)
+    const { openTabs } = get()
+
+    // If already open, just switch to it
+    const existing = openTabs.find((t) => t.workflowId === normalizedWorkflowId)
+    if (existing) {
+      set({ activeTabId: normalizedWorkflowId, expandedView: true })
+      return
+    }
+
+    const app = get().applications.find((a) => a.workflowId === normalizedWorkflowId)
     const tenantId = app?.tenantId || useEnterpriseStore.getState().currentTenant?.id || ''
 
     // Create new tab in executing state
     const newTab: ApplicationTab = {
-      workflowId,
+      workflowId: normalizedWorkflowId,
       url: null,
       executing: true,
       polling: false,
       error: null,
       executionStatus: null
     }
-    set({ openTabs: [...openTabs, newTab], activeTabId: workflowId, expandedView: true })
+    set({ openTabs: [...openTabs, newTab], activeTabId: normalizedWorkflowId, expandedView: true })
 
     try {
+      if (!tenantId) {
+        throw new Error('Tenant ID is required to execute this application. Please select an organization and try again.')
+      }
+
       await enterpriseApi.enableIframeAuth()
 
       const result = await enterpriseApi.apiRequest('POST', '/api/workflows/execute/ui', {
-        workflowId,
+        workflowId: normalizedWorkflowId,
         tenantId,
         input: {
           userId: 'current-user',
@@ -463,12 +475,12 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
         throw new Error('No execution ID returned from server')
       }
 
-      set({ openTabs: updateTab(get().openTabs, workflowId, { executing: false, polling: true }) })
+      set({ openTabs: updateTab(get().openTabs, normalizedWorkflowId, { executing: false, polling: true }) })
 
       // Poll execution until application URL is found
       const poll = async (execId: string) => {
         // Stop polling if tab was closed while we were waiting
-        if (!get().openTabs.find((t) => t.workflowId === workflowId)) return
+        if (!get().openTabs.find((t) => t.workflowId === normalizedWorkflowId)) return
 
         try {
           const execution = await enterpriseApi.apiRequest(
@@ -476,11 +488,11 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
             `/api/workflow-executions/${execId}`
           ) as ExecutionData
 
-          set({ openTabs: updateTab(get().openTabs, workflowId, { executionStatus: execution.status }) })
+          set({ openTabs: updateTab(get().openTabs, normalizedWorkflowId, { executionStatus: execution.status }) })
 
           const url = findApplicationUrl(execution.steps)
           if (url) {
-            set({ openTabs: updateTab(get().openTabs, workflowId, { url, polling: false }) })
+            set({ openTabs: updateTab(get().openTabs, normalizedWorkflowId, { url, polling: false }) })
             return
           }
 
@@ -488,9 +500,9 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
           if (status === 'running' || status === 'pending') {
             setTimeout(() => poll(execId), 2000)
           } else if (status === 'failed') {
-            set({ openTabs: updateTab(get().openTabs, workflowId, { polling: false, error: 'Application execution failed' }) })
+            set({ openTabs: updateTab(get().openTabs, normalizedWorkflowId, { polling: false, error: 'Application execution failed' }) })
           } else {
-            set({ openTabs: updateTab(get().openTabs, workflowId, { polling: false, error: 'No application URL found in execution output' }) })
+            set({ openTabs: updateTab(get().openTabs, normalizedWorkflowId, { polling: false, error: 'No application URL found in execution output' }) })
           }
         } catch (err) {
           const msg = err instanceof Error ? err.message.toLowerCase() : ''
@@ -499,7 +511,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
             setTimeout(() => poll(execId), 3000)
             return
           }
-          set({ openTabs: updateTab(get().openTabs, workflowId, { polling: false, error: 'Failed to check execution status' }) })
+          set({ openTabs: updateTab(get().openTabs, normalizedWorkflowId, { polling: false, error: 'Failed to check execution status' }) })
         }
       }
 
@@ -507,7 +519,7 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     } catch (err) {
       console.error('Failed to open application:', err)
       set({
-        openTabs: updateTab(get().openTabs, workflowId, {
+        openTabs: updateTab(get().openTabs, normalizedWorkflowId, {
           executing: false,
           polling: false,
           error: err instanceof Error ? err.message : 'Failed to execute application'


### PR DESCRIPTION
## Summary
- normalize application workflow payload parsing to support either workflowId or id
- fallback tenantId from current selected tenant when workflow payload omits tenantId
- guard application execution against missing tenant/workflow identifiers before calling /api/workflows/execute/ui
- add dashboard store regression tests for ID fallback and missing-tenant execution guard

## Test Plan
- pnpm --dir 20x exec vitest run --project renderer src/renderer/src/stores/dashboard-store.test.ts
- pnpm --dir 20x run test:run
- pnpm --dir 20x run typecheck
- pnpm --dir 20x run build