### PR TITLE
Fix Claude skill learning path in new workspaces

### DIFF
--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -553,6 +553,15 @@ export class AgentManager extends EventEmitter {
       const task = this.db.getTask(taskId)
       const agent = this.db.getAgent(agentId)
       const agentConfig = agent?.config
+      const backendType = (agentConfig?.coding_agent as string) || CodingAgentType.OPENCODE
+      const isClaudeCode = backendType === CodingAgentType.CLAUDE_CODE
+      const skillsDir = isClaudeCode
+        ? join(workspaceDir, '.claude', 'skills')
+        : join(workspaceDir, '.agents', 'skills')
+
+      // Ensure the backend-specific skill root exists even when no DB skills are
+      // pre-assigned. Learning-mode sessions can then create/update skills there.
+      await mkdir(skillsDir, { recursive: true })
 
       // Resolve which skill IDs to use
       let skillIds: string[] | undefined
@@ -572,11 +581,6 @@ export class AgentManager extends EventEmitter {
       // Claude Code agent: .claude/skills/<name>/SKILL.md
       // Other agents: .agents/skills/<name>/SKILL.md
       if (skills.length > 0) {
-        const backendType = (agentConfig?.coding_agent as string) || CodingAgentType.OPENCODE
-        const isClaudeCode = backendType === CodingAgentType.CLAUDE_CODE
-        const skillsDir = isClaudeCode
-          ? join(workspaceDir, '.claude', 'skills')
-          : join(workspaceDir, '.agents', 'skills')
         for (const skill of skills) {
           const dir = join(skillsDir, skill.name)
           await mkdir(dir, { recursive: true })

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -169,7 +169,12 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
     // 2. Build the same feedback prompt as desktop
     const commentPart = comment ? ` Comment: "${comment}".` : ''
     const today = new Date().toISOString().split('T')[0]
-    const prompt = `User rated this session ${rating}/5.${commentPart}\n\nReview the session and update skills in .agents/skills/:\n\n**For skills you used:**\nUpdate the YAML frontmatter:\n- confidence: ${rating >= 4 ? '+0.05 (was helpful)' : rating <= 2 ? '-0.10 (was wrong/outdated)' : 'no change'}\n- uses: increment by 1\n- lastUsed: ${today}\n- tags: add relevant keywords if missing\n\n**If you discovered a new reusable pattern:**\nCreate a new skill file.\n\nUpdate existing skills that were helpful or create new ones for patterns worth reusing.`
+    const feedbackAgent = agents.find((a) => a.id === task.agent_id)
+    const codingAgent = (feedbackAgent?.config as Record<string, unknown> | undefined)?.coding_agent
+    const skillsDir = (codingAgent === 'claude-code' || codingAgent === 'claude_code')
+      ? '.claude/skills'
+      : '.agents/skills'
+    const prompt = `User rated this session ${rating}/5.${commentPart}\n\nReview the session and update skills in ${skillsDir}/:\n\n**For skills you used:**\nUpdate the YAML frontmatter:\n- confidence: ${rating >= 4 ? '+0.05 (was helpful)' : rating <= 2 ? '-0.10 (was wrong/outdated)' : 'no change'}\n- uses: increment by 1\n- lastUsed: ${today}\n- tags: add relevant keywords if missing\n\n**If you discovered a new reusable pattern:**\nCreate a new skill file.\n\nUpdate existing skills that were helpful or create new ones for patterns worth reusing.`
 
     // 3. Resume the session (or start fresh if none) and send feedback prompt
     try {
@@ -193,7 +198,7 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
       // Fallback: complete the task even if learning session fails
       await updateTask(task.id, { status: TaskStatus.Completed })
     }
-  }, [task, session, updateTask, initSession])
+  }, [task, session, updateTask, initSession, agents])
 
   const handleFeedbackSkip = useCallback(async () => {
     if (!task) return

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -462,9 +462,14 @@ export function TaskWorkspace({
     // Build feedback prompt
     const commentPart = comment ? ` Comment: "${comment}".` : ''
     const today = new Date().toISOString().split('T')[0]
+    const feedbackAgent = agents.find((a) => a.id === task.agent_id)
+    const codingAgent = feedbackAgent?.config?.coding_agent
+    const skillsDir = (codingAgent === 'claude-code' || codingAgent === 'claude_code')
+      ? '.claude/skills'
+      : '.agents/skills'
     const prompt = `User rated this session ${rating}/5.${commentPart}
 
-Review the session and update skills in .agents/skills/:
+Review the session and update skills in ${skillsDir}/:
 
 **For skills you used:**
 Update the YAML frontmatter:
@@ -521,7 +526,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
       console.error('Failed to send feedback:', error)
       await taskApi.update(task.id, { status: TaskStatus.ReadyForReview })
     }
-  }, [ensureChatSession, sendMessage, session.sessionId, task?.id])
+  }, [agents, ensureChatSession, sendMessage, session.sessionId, task?.agent_id, task?.id])
 
   const handleFeedbackSkip = useCallback(async () => {
     if (!task?.id) return


### PR DESCRIPTION
## Summary
- create the backend-specific skills root at session startup so learning-mode sessions can write skills immediately
- send Claude Code feedback sessions to .claude/skills instead of .agents/skills
- keep OpenCode and Codex feedback sessions targeting .agents/skills

## Testing
- attempted to run targeted vitest suites, but test execution in this workspace is currently blocked by a missing @electron-toolkit/tsconfig dependency referenced by tsconfig.node.json