### PR TITLE
fix: restore enterprise auth on startup so MCP Dev Server JWT injection works

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -651,6 +651,9 @@ app.whenReady().then(async () => {
         // Wire state sync into agent manager so agent run events are recorded
         agentManager.setEnterpriseStateSync(enterpriseStateSyncInstance)
 
+        // Wire enterprise auth into agent manager so it can inject JWT into MCP Dev Server requests
+        agentManager.setEnterpriseAuth(enterpriseAuth)
+
         syncManager.setEnterpriseConnection(apiClient, enterpriseSyncMgr, session.userId, enterpriseStateSyncInstance)
 
         console.log('[Main] Enterprise connection restored on startup (with heartbeat)')


### PR DESCRIPTION
## Summary

- On app startup, the enterprise session restore path wired up `enterpriseStateSync` into the agent manager but omitted calling `agentManager.setEnterpriseAuth()`.
- This left `this.enterpriseAuth === null` in `buildMcpServersForAdapter`, so the JWT injection block for `[Workflo] MCP Dev Server` was silently skipped and `Authorization` headers remained `{}`.
- The login flow (`ipc-handlers.ts`) already called `setEnterpriseAuth()` correctly — this brings the startup restore path in line.

**Root cause trace:**
1. `index.ts` startup restore → misses `agentManager.setEnterpriseAuth(enterpriseAuth)`
2. Agent session starts → `buildMcpServersForAdapter` → `this.enterpriseAuth` is `null`
3. JWT injection block skipped → `headers: {}` passed to Claude Code
4. `[Workflo] MCP Dev Server` tools fail to load (no auth)

**Verified:** Local MCP Dev Server (`localhost:2000`) correctly authenticates and returns tools when the Bearer JWT/API key is present.

## Test plan

- [ ] Restart the 20x app (without logging out and back in)
- [ ] Start a new agent session
- [ ] Confirm `[Workflo] MCP Dev Server` tools are available (check `--mcp-config` in process args — `headers` should contain `Authorization: Bearer <jwt>`)
- [ ] Confirm logging in fresh still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)