### PR TITLE
20x: allow attaching files to messages in agent transcript

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -12,6 +12,7 @@ vi.mock('fs', async (importOriginal) => {
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
     copyFileSync: vi.fn(),
+    readFileSync: vi.fn(() => ''),
     existsSync: vi.fn(() => false),
   }
 })
@@ -51,13 +52,14 @@ vi.mock('./secret-broker', () => ({
 }))
 
 import { mkdir as mkdirAsync, writeFile as writeFileAsync } from 'fs/promises'
-import { existsSync, copyFileSync, mkdirSync } from 'fs'
+import { existsSync, copyFileSync, mkdirSync, readFileSync } from 'fs'
 
 const mockedMkdirAsync = vi.mocked(mkdirAsync)
 const mockedWriteFileAsync = vi.mocked(writeFileAsync)
 const mockedExistsSync = vi.mocked(existsSync)
 const mockedCopyFileSync = vi.mocked(copyFileSync)
 const mockedMkdirSync = vi.mocked(mkdirSync)
+const mockedReadFileSync = vi.mocked(readFileSync)
 
 function makeSkillRecord(overrides: Partial<{
   id: string; name: string; description: string; content: string;
@@ -1355,6 +1357,49 @@ describe('syncAttachmentsToWorkspace', () => {
       '/tmp/ws/attachments/exists.txt'
     )
     expect(refs).toEqual(['- attachments/exists.txt'])
+  })
+})
+
+describe('buildMessageWithAttachmentContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('includes attachment references and a bounded preview for small text files', () => {
+    const mgr = new AgentManager(createMockDb({}))
+    const session = { workspaceDir: '/tmp/ws' } as { workspaceDir: string }
+
+    mockedExistsSync.mockImplementation((p: any) => String(p).includes('/tmp/ws/attachments/spec.md'))
+    mockedReadFileSync.mockImplementation(() => 'A'.repeat(1500))
+
+    const result = (mgr as any).buildMessageWithAttachmentContext(
+      session,
+      'Please use attached context',
+      [{ id: 'att-1', filename: 'spec.md', size: 1024, mime_type: 'text/markdown' }]
+    ) as string
+
+    expect(result).toContain('Please use attached context')
+    expect(result).toContain('- attachments/spec.md (text/markdown, 1.0 KB)')
+    expect(result).toContain('Small text previews')
+    expect(result).toContain('...[truncated]')
+    expect(result.length).toBeLessThan(2600)
+  })
+
+  it('caps attachment references and reports omitted items', () => {
+    const mgr = new AgentManager(createMockDb({}))
+    const session = { workspaceDir: '/tmp/ws' } as { workspaceDir: string }
+    const attachments = Array.from({ length: 12 }, (_, i) => ({
+      id: `att-${i + 1}`,
+      filename: `file-${i + 1}.txt`,
+      size: 100,
+      mime_type: 'text/plain'
+    }))
+
+    mockedExistsSync.mockReturnValue(false)
+    const result = (mgr as any).buildMessageWithAttachmentContext(session, 'Use files', attachments) as string
+
+    expect(result).toContain('... and 2 more attachment(s) omitted')
+    expect((result.match(/- attachments\/file-/g) || []).length).toBe(10)
   })
 })
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -60,6 +60,13 @@ interface PollingEntry {
   hasSeenWork?: boolean  // True once we've seen at least one non-IDLE status
 }
 
+interface MessageAttachmentRef {
+  id: string
+  filename: string
+  size: number
+  mime_type: string
+}
+
 export class AgentManager extends EventEmitter {
   private sessions: Map<string, AgentSession> = new Map()
   /** Maps old (temp) session IDs to their re-keyed (real) IDs so that
@@ -482,6 +489,103 @@ export class AgentManager extends EventEmitter {
     const agent = this.db.getAgent(agentId)
     const backendType = (agent?.config?.coding_agent as string) || CodingAgentType.OPENCODE
     return backendType === CodingAgentType.CLAUDE_CODE ? 'CLAUDE.md' : 'AGENTS.md'
+  }
+
+  private formatAttachmentSize(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes <= 0) return 'unknown size'
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+
+  private isTextAttachment(mimeType: string, filename: string): boolean {
+    if (mimeType.startsWith('text/')) return true
+    const lower = filename.toLowerCase()
+    return (
+      lower.endsWith('.md') ||
+      lower.endsWith('.txt') ||
+      lower.endsWith('.json') ||
+      lower.endsWith('.yaml') ||
+      lower.endsWith('.yml') ||
+      lower.endsWith('.xml') ||
+      lower.endsWith('.csv') ||
+      lower.endsWith('.ts') ||
+      lower.endsWith('.tsx') ||
+      lower.endsWith('.js') ||
+      lower.endsWith('.jsx') ||
+      lower.endsWith('.py') ||
+      lower.endsWith('.java') ||
+      lower.endsWith('.go') ||
+      lower.endsWith('.rb') ||
+      lower.endsWith('.rs') ||
+      lower.endsWith('.sql')
+    )
+  }
+
+  private buildMessageWithAttachmentContext(
+    session: AgentSession,
+    message: string,
+    attachments?: MessageAttachmentRef[]
+  ): string {
+    if (!attachments || attachments.length === 0) return message
+
+    const capped = attachments.slice(0, 10)
+    const omittedCount = attachments.length - capped.length
+    const refs = capped.map(
+      (att) => `- attachments/${att.filename} (${att.mime_type || 'application/octet-stream'}, ${this.formatAttachmentSize(att.size)})`
+    )
+
+    const previewBlocks: string[] = []
+    const MAX_PREVIEWS = 3
+    const MAX_PREVIEW_FILE_SIZE = 24 * 1024
+    const MAX_PREVIEW_CHARS = 1200
+    const workspaceDir = session.workspaceDir
+
+    if (workspaceDir) {
+      for (const att of capped) {
+        if (previewBlocks.length >= MAX_PREVIEWS) break
+        if (!this.isTextAttachment(att.mime_type || '', att.filename)) continue
+        if (att.size > MAX_PREVIEW_FILE_SIZE) continue
+
+        const absPath = join(workspaceDir, 'attachments', att.filename)
+        if (!existsSync(absPath)) continue
+
+        try {
+          const text = readFileSync(absPath, 'utf-8')
+          const truncated = text.slice(0, MAX_PREVIEW_CHARS)
+          const suffix = text.length > MAX_PREVIEW_CHARS ? '\n...[truncated]' : ''
+          previewBlocks.push(`### attachments/${att.filename}\n\`\`\`\n${truncated}${suffix}\n\`\`\``)
+        } catch {
+          continue
+        }
+      }
+    }
+
+    let attachmentContext = '\n\nMessage attachments (already available in your workspace):\n'
+    attachmentContext += refs.join('\n')
+    if (omittedCount > 0) {
+      attachmentContext += `\n- ... and ${omittedCount} more attachment(s) omitted to keep context focused`
+    }
+    attachmentContext += '\n\nContext loading guidance:'
+    attachmentContext += '\n- Start with only the listed files relevant to the user request.'
+    attachmentContext += '\n- Do not load full file contents unless necessary.'
+    attachmentContext += '\n- For large/binary files, inspect metadata or selective excerpts first.'
+
+    if (previewBlocks.length > 0) {
+      attachmentContext += '\n\nSmall text previews (use only if relevant):\n'
+      attachmentContext += previewBlocks.join('\n\n')
+    }
+
+    return `${message}${attachmentContext}`
+  }
+
+  private buildDisplayMessage(message: string, attachments?: MessageAttachmentRef[]): string {
+    if (!attachments || attachments.length === 0) return message
+    const capped = attachments.slice(0, 10)
+    const omittedCount = attachments.length - capped.length
+    const refs = capped.map((att) => `- ${att.filename}`)
+    const omitted = omittedCount > 0 ? `\n- ... and ${omittedCount} more` : ''
+    return `${message}\n\nAttached to this message:\n${refs.join('\n')}${omitted}`
   }
 
   /**
@@ -2355,7 +2459,13 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     })
   }
 
-  async sendMessage(sessionId: string, message: string, taskId?: string, agentId?: string): Promise<{ newSessionId?: string }> {
+  async sendMessage(
+    sessionId: string,
+    message: string,
+    taskId?: string,
+    agentId?: string,
+    attachments?: MessageAttachmentRef[]
+  ): Promise<{ newSessionId?: string }> {
     let session = this.sessions.get(sessionId)
 
     // Check redirect map: session ID may have been re-keyed (temp → real)
@@ -2413,7 +2523,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         }
 
         // Send the user's message (fire-and-forget to avoid blocking IPC response)
-        this.doSendAdapterMessage(session, sessionId, message).catch((err) => {
+        this.doSendAdapterMessage(session, sessionId, message, attachments).catch((err) => {
           console.error(`[AgentManager] doSendAdapterMessage failed for session ${sessionId}:`, err)
           this.handleSessionError(sessionId, session!, err)
         })
@@ -2424,7 +2534,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     if (!session) throw new Error(`Session not found: ${sessionId}`)
 
     // Fire-and-forget to avoid blocking IPC response and freezing the renderer
-    this.doSendAdapterMessage(session, sessionId, message).catch((err) => {
+    this.doSendAdapterMessage(session, sessionId, message, attachments).catch((err) => {
       console.error(`[AgentManager] doSendAdapterMessage failed for session ${sessionId}:`, err)
       this.handleSessionError(sessionId, session!, err)
     })
@@ -2446,7 +2556,12 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     })
   }
 
-  private async doSendAdapterMessage(session: AgentSession, sessionId: string, message: string): Promise<void> {
+  private async doSendAdapterMessage(
+    session: AgentSession,
+    sessionId: string,
+    message: string,
+    attachments?: MessageAttachmentRef[]
+  ): Promise<void> {
     if (session.status === 'error') {
       // Check if this is an incompatible session error (non-recoverable)
       if (session.adapter) {
@@ -2490,6 +2605,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       this.enterpriseStateSync.recordAgentRunStarted(currentTask, agent?.name)
     }
 
+    const userFacingMessage = this.buildDisplayMessage(message, attachments)
+
     // Show user's message in UI
     this.sendToRenderer('agent:output', {
       sessionId,
@@ -2498,7 +2615,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       data: {
         id: `user-message-${Date.now()}`,
         role: 'user',
-        content: message,
+        content: userFacingMessage,
         partType: 'text'
       }
     })
@@ -2511,9 +2628,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     )
 
     // Send prompt via adapter
-    const parts: MessagePart[] = [
-      { type: MessagePartType.TEXT, text: message }
-    ]
+    const promptText = this.buildMessageWithAttachmentContext(session, message, attachments)
+    const parts: MessagePart[] = [{ type: MessagePartType.TEXT, text: promptText }]
     await session.adapter.sendPrompt(sessionId, parts, sessionConfig)
 
     // Start polling if not already started (for Claude Code after resume)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -329,10 +329,13 @@ export function registerIpcHandlers(
     return { success: true }
   })
 
-  ipcMain.handle('agentSession:send', async (_, sessionId: string, message: string, taskId?: string, agentId?: string) => {
-    const result = await agentManager.sendMessage(sessionId, message, taskId, agentId)
-    return { success: true, ...result }
-  })
+  ipcMain.handle(
+    'agentSession:send',
+    async (_, sessionId: string, message: string, taskId?: string, agentId?: string, attachments?: Array<{ id: string; filename: string; size: number; mime_type: string }>) => {
+      const result = await agentManager.sendMessage(sessionId, message, taskId, agentId, attachments)
+      return { success: true, ...result }
+    }
+  )
 
   ipcMain.handle('agentSession:approve', async (_, sessionId: string, approved: boolean, message?: string) => {
     await agentManager.respondToPermission(sessionId, approved, message)

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -585,9 +585,14 @@ async function routePost(pathname: string, params: Record<string, unknown>): Pro
   const sendMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/send$/)
   if (sendMatch) {
     const sessionId = sendMatch[1]
-    const { message, taskId, agentId: aid } = params as { message: string; taskId?: string; agentId?: string }
+    const { message, taskId, agentId: aid, attachments } = params as {
+      message: string
+      taskId?: string
+      agentId?: string
+      attachments?: Array<{ id: string; filename: string; size: number; mime_type: string }>
+    }
     if (!message) throw Object.assign(new Error('message is required'), { status: 400 })
-    const result = await agent.sendMessage(sessionId, message, taskId, aid)
+    const result = await agent.sendMessage(sessionId, message, taskId, aid, attachments)
     return { success: true, ...result }
   }
 

--- a/src/mobile/api/client.ts
+++ b/src/mobile/api/client.ts
@@ -90,8 +90,8 @@ export const api = {
       post<{ sessionId: string }>('/api/sessions/start', { agentId, taskId, skipInitialPrompt }),
     resume: (sessionId: string, agentId: string, taskId: string) =>
       post<{ sessionId: string }>(`/api/sessions/${encodeURIComponent(sessionId)}/resume`, { agentId, taskId }),
-    send: (sessionId: string, message: string, taskId?: string, agentId?: string) =>
-      post<{ success: boolean; newSessionId?: string }>(`/api/sessions/${encodeURIComponent(sessionId)}/send`, { message, taskId, agentId }),
+    send: (sessionId: string, message: string, taskId?: string, agentId?: string, attachments?: Array<{ id: string; filename: string; size: number; mime_type: string }>) =>
+      post<{ success: boolean; newSessionId?: string }>(`/api/sessions/${encodeURIComponent(sessionId)}/send`, { message, taskId, agentId, attachments }),
     approve: (sessionId: string, approved: boolean, message?: string) =>
       post<{ success: boolean }>(`/api/sessions/${encodeURIComponent(sessionId)}/approve`, { approved, message }),
     sync: (sessionId: string) =>

--- a/src/mobile/components/ChatInput.test.tsx
+++ b/src/mobile/components/ChatInput.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { ChatInput } from './ChatInput'
+
+describe('ChatInput attachments', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('sends selected attachments with the message', () => {
+    const onSend = vi.fn()
+    const attachments = [{ id: 'att-1', filename: 'spec.md', size: 512, mime_type: 'text/markdown' }]
+
+    render(<ChatInput onSend={onSend} attachments={attachments} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Send a message...'), { target: { value: 'Please review' } })
+    fireEvent.click(screen.getByLabelText('Send message'))
+
+    expect(onSend).toHaveBeenCalledWith('Please review', { attachments })
+  })
+
+  it('removes attachment chip when remove is tapped', () => {
+    const onRemoveAttachment = vi.fn()
+    const attachments = [{ id: 'att-1', filename: 'spec.md', size: 512, mime_type: 'text/markdown' }]
+
+    render(
+      <ChatInput
+        onSend={vi.fn()}
+        attachments={attachments}
+        onRemoveAttachment={onRemoveAttachment}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText('Remove spec.md'))
+
+    expect(onRemoveAttachment).toHaveBeenCalledWith('att-1')
+  })
+})

--- a/src/mobile/components/ChatInput.tsx
+++ b/src/mobile/components/ChatInput.tsx
@@ -1,19 +1,43 @@
 import { useState, useRef } from 'react'
 
-interface ChatInputProps {
-  onSend: (message: string) => void
-  disabled?: boolean
-  placeholder?: string
+export interface ChatInputAttachment {
+  id: string
+  filename: string
+  size: number
+  mime_type: string
 }
 
-export function ChatInput({ onSend, disabled, placeholder = 'Send a message...' }: ChatInputProps) {
+interface ChatInputProps {
+  onSend: (message: string, options?: { attachments?: ChatInputAttachment[] }) => void
+  disabled?: boolean
+  placeholder?: string
+  attachments?: ChatInputAttachment[]
+  onRemoveAttachment?: (attachmentId: string) => void
+  onOpenAttachmentPicker?: () => void
+}
+
+function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function ChatInput({
+  onSend,
+  disabled,
+  placeholder = 'Send a message...',
+  attachments = [],
+  onRemoveAttachment,
+  onOpenAttachmentPicker
+}: ChatInputProps) {
   const [value, setValue] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const handleSend = () => {
     const text = value.trim()
     if (!text || disabled) return
-    onSend(text)
+    onSend(text, attachments.length > 0 ? { attachments } : undefined)
     setValue('')
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto'
@@ -36,26 +60,71 @@ export function ChatInput({ onSend, disabled, placeholder = 'Send a message...' 
   }
 
   return (
-    <div className="flex items-end gap-2 px-3 py-3">
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={(e) => { setValue(e.target.value); autoResize() }}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        disabled={disabled}
-        rows={1}
-        className="flex-1 bg-muted/50 border border-border rounded-lg px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground resize-none overflow-hidden max-h-32 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/30 min-h-[32px] disabled:opacity-40"
-      />
-      <button
-        onClick={handleSend}
-        disabled={disabled || !value.trim()}
-        className="h-[32px] w-[32px] shrink-0 rounded-lg flex items-center justify-center bg-primary text-primary-foreground active:opacity-80 disabled:opacity-30 transition-colors"
-      >
-        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="m22 2-7 20-4-9-9-4z" /><path d="M22 2 11 13" />
-        </svg>
-      </button>
+    <div className="px-3 py-3 space-y-2">
+      {attachments.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {attachments.map((attachment) => (
+            <span
+              key={attachment.id}
+              className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/60 bg-muted/40 px-2 py-1 text-[11px] text-foreground"
+              title={`${attachment.filename} (${formatFileSize(attachment.size)})`}
+            >
+              <svg className="h-3 w-3 shrink-0 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/>
+              </svg>
+              <span className="truncate max-w-[180px]">{attachment.filename}</span>
+              <span className="text-muted-foreground">{formatFileSize(attachment.size)}</span>
+              <button
+                type="button"
+                onClick={() => onRemoveAttachment?.(attachment.id)}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label={`Remove ${attachment.filename}`}
+              >
+                <svg className="h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+                </svg>
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-end gap-2">
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => { setValue(e.target.value); autoResize() }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={1}
+          className="flex-1 bg-muted/50 border border-border rounded-lg px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground resize-none overflow-hidden max-h-32 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/30 min-h-[32px] disabled:opacity-40"
+        />
+        {onOpenAttachmentPicker && (
+          <button
+            type="button"
+            onClick={onOpenAttachmentPicker}
+            disabled={disabled}
+            className="h-[32px] w-[32px] shrink-0 rounded-lg flex items-center justify-center border border-border/50 text-muted-foreground hover:text-foreground active:opacity-80 disabled:opacity-30 transition-colors"
+            title="Attach files"
+            aria-label="Attach files"
+          >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l9.2-9.19a4 4 0 0 1 5.65 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
+            </svg>
+          </button>
+        )}
+        <button
+          onClick={handleSend}
+          disabled={disabled || !value.trim()}
+          className="h-[32px] w-[32px] shrink-0 rounded-lg flex items-center justify-center bg-primary text-primary-foreground active:opacity-80 disabled:opacity-30 transition-colors"
+          aria-label="Send message"
+        >
+          <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="m22 2-7 20-4-9-9-4z" /><path d="M22 2 11 13" />
+          </svg>
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/mobile/pages/ConversationPage.tsx
+++ b/src/mobile/pages/ConversationPage.tsx
@@ -4,7 +4,7 @@ import { useAgentStore, SessionStatus } from '../stores/agent-store'
 import { api } from '../api/client'
 import { useSessionControls } from '../hooks/useSessionControls'
 import { MessageBubble } from '../components/MessageBubble'
-import { ChatInput } from '../components/ChatInput'
+import { ChatInput, type ChatInputAttachment } from '../components/ChatInput'
 import { cn } from '../lib/utils'
 import type { Route } from '../App'
 
@@ -17,6 +17,8 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
   const isAtBottomRef = useRef(true)
   const [todosExpanded, setTodosExpanded] = useState(false)
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
+  const [showAttachmentPicker, setShowAttachmentPicker] = useState(false)
+  const [messageAttachments, setMessageAttachments] = useState<ChatInputAttachment[]>([])
 
   const messages = session?.messages || []
   const lastMessage = messages[messages.length - 1]
@@ -47,6 +49,10 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
 
   // Can the user send input?
   const canSendInput = hasSession && (isWorking || isWaitingApproval || session?.status === SessionStatus.IDLE)
+  const taskAttachments = useMemo(
+    () => (Array.isArray(task?.attachments) ? task.attachments : []) as ChatInputAttachment[],
+    [task?.attachments]
+  )
 
   // Extract latest todos from messages — matches desktop TodoSummary logic
   const latestTodos = useMemo(() => {
@@ -68,7 +74,7 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
 
   // Smart send handler — mirrors desktop TaskWorkspace.handleSend logic
   const handleSend = useCallback(
-    async (message: string) => {
+    async (message: string, options?: { attachments?: ChatInputAttachment[] }) => {
       // Get latest session from store, not from closure, to avoid stale closure bug
       const currentSession = useAgentStore.getState().sessions.get(taskId)
       if (!currentSession?.sessionId) return
@@ -76,11 +82,19 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
         if (isQuestion) {
           await api.sessions.approve(currentSession.sessionId, true, message)
         } else {
-          const result = await api.sessions.send(currentSession.sessionId, message, taskId, currentSession.agentId)
+          const result = await api.sessions.send(
+            currentSession.sessionId,
+            message,
+            taskId,
+            currentSession.agentId,
+            options?.attachments
+          )
           if (result.newSessionId && taskId) {
             initSession(taskId, result.newSessionId, currentSession.agentId)
           }
         }
+        setMessageAttachments([])
+        setShowAttachmentPicker(false)
       } catch (e) {
         console.error('Failed to send message:', e)
       }
@@ -102,6 +116,24 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
     },
     [taskId, activeQuestionId]
   )
+
+  const toggleAttachment = useCallback((attachment: ChatInputAttachment) => {
+    setMessageAttachments((prev) => {
+      const exists = prev.some((att) => att.id === attachment.id)
+      if (exists) return prev.filter((att) => att.id !== attachment.id)
+      return [...prev, attachment]
+    })
+  }, [])
+
+  const removeAttachment = useCallback((attachmentId: string) => {
+    setMessageAttachments((prev) => prev.filter((att) => att.id !== attachmentId))
+  }, [])
+
+  useEffect(() => {
+    // Prune selections when task attachments change
+    const validIds = new Set(taskAttachments.map((att) => att.id))
+    setMessageAttachments((prev) => prev.filter((att) => validIds.has(att.id)))
+  }, [taskAttachments])
 
   // Session controls (shared hook provides double-click protection and rollback)
   const { handleStart: _startSession, handleResume: _resumeSession, handleStop: _stopSession, handleRestart: _restartSession } = useSessionControls(taskId)
@@ -398,10 +430,47 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
 
       {/* Input area — matches desktop transcript panel input */}
       <div className="shrink-0 border-t border-border/50">
+        {showAttachmentPicker && taskAttachments.length > 0 && (
+          <div className="border-b border-border/50 px-3 py-2 max-h-40 overflow-y-auto bg-muted/20">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs text-muted-foreground">Attach files to this message</span>
+              <button
+                type="button"
+                onClick={() => setShowAttachmentPicker(false)}
+                className="text-xs text-muted-foreground hover:text-foreground"
+              >
+                Done
+              </button>
+            </div>
+            <div className="space-y-1">
+              {taskAttachments.map((attachment) => {
+                const checked = messageAttachments.some((att) => att.id === attachment.id)
+                return (
+                  <button
+                    key={attachment.id}
+                    type="button"
+                    onClick={() => toggleAttachment(attachment)}
+                    className={cn(
+                      'w-full text-left rounded-md px-2 py-1.5 border text-xs transition-colors',
+                      checked
+                        ? 'border-primary/40 bg-primary/10 text-foreground'
+                        : 'border-border/50 text-muted-foreground hover:text-foreground hover:bg-white/5'
+                    )}
+                  >
+                    {attachment.filename}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
         <ChatInput
           onSend={handleSend}
           disabled={!canSendInput}
           placeholder={placeholder}
+          attachments={messageAttachments}
+          onRemoveAttachment={removeAttachment}
+          onOpenAttachmentPicker={taskAttachments.length > 0 ? () => setShowAttachmentPicker((prev) => !prev) : undefined}
         />
       </div>
     </div>

--- a/src/mobile/stores/task-store.ts
+++ b/src/mobile/stores/task-store.ts
@@ -6,6 +6,14 @@ import type { TaskStatus } from '@shared/constants'
 // Re-export for convenience
 export type { TaskStatus }
 
+export interface TaskAttachment {
+  id: string
+  filename: string
+  size: number
+  mime_type: string
+  added_at: string
+}
+
 export interface Task {
   id: string
   title: string
@@ -16,7 +24,7 @@ export interface Task {
   assignee: string
   due_date: string | null
   labels: string[]
-  attachments: unknown[]
+  attachments: TaskAttachment[]
   repos: string[]
   output_fields: unknown[]
   agent_id: string | null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -97,8 +97,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('agentSession:abort', sessionId),
     stop: (sessionId: string): Promise<{ success: boolean }> =>
       ipcRenderer.invoke('agentSession:stop', sessionId),
-    send: (sessionId: string, message: string, taskId?: string, agentId?: string): Promise<{ success: boolean; newSessionId?: string }> =>
-      ipcRenderer.invoke('agentSession:send', sessionId, message, taskId, agentId),
+    send: (sessionId: string, message: string, taskId?: string, agentId?: string, attachments?: Array<{ id: string; filename: string; size: number; mime_type: string }>): Promise<{ success: boolean; newSessionId?: string }> =>
+      ipcRenderer.invoke('agentSession:send', sessionId, message, taskId, agentId, attachments),
     approve: (sessionId: string, approved: boolean, message?: string): Promise<{ success: boolean }> =>
       ipcRenderer.invoke('agentSession:approve', sessionId, approved, message),
     syncSkills: (sessionId: string): Promise<{ created: string[]; updated: string[]; unchanged: string[] }> =>

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { AgentTranscriptPanel } from './AgentTranscriptPanel'
+import { SessionStatus } from '@/stores/agent-store'
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: () => ({
+    getTotalSize: () => 0,
+    getVirtualItems: () => [],
+    scrollToIndex: vi.fn(),
+    measureElement: vi.fn()
+  })
+}))
+
+describe('AgentTranscriptPanel drag and drop attachments', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('adds dropped files as pending attachments and sends them with the message', async () => {
+    const onSend = vi.fn()
+    const onAddAttachmentPaths = vi.fn().mockResolvedValue([
+      {
+        id: 'att-1',
+        filename: 'spec.md',
+        size: 512,
+        mime_type: 'text/markdown'
+      }
+    ])
+
+    Object.assign(window, {
+      electronAPI: {
+        ...window.electronAPI,
+        webUtils: {
+          ...window.electronAPI?.webUtils,
+          getPathForFile: vi.fn(() => '/tmp/spec.md')
+        }
+      }
+    })
+
+    render(
+      <AgentTranscriptPanel
+        messages={[]}
+        status={SessionStatus.IDLE}
+        onStop={() => undefined}
+        onSend={onSend}
+        onAddAttachmentPaths={onAddAttachmentPaths}
+      />
+    )
+
+    const composer = screen.getByTestId('transcript-composer')
+    const file = new File(['spec'], 'spec.md', { type: 'text/markdown' })
+
+    fireEvent.drop(composer, {
+      dataTransfer: {
+        files: [file],
+        types: ['Files']
+      }
+    })
+
+    await waitFor(() => {
+      expect(onAddAttachmentPaths).toHaveBeenCalledWith(['/tmp/spec.md'])
+    })
+    expect(await screen.findByText('spec.md')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Send a message... (Shift+Enter for new line)'), {
+      target: { value: 'Please use this file' }
+    })
+    fireEvent.click(screen.getByLabelText('Send message'))
+
+    expect(onSend).toHaveBeenCalledWith('Please use this file', {
+      attachments: [
+        {
+          id: 'att-1',
+          filename: 'spec.md',
+          size: 512,
+          mime_type: 'text/markdown'
+        }
+      ]
+    })
+  })
+})

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -91,6 +91,7 @@ interface AgentTranscriptPanelProps {
   onRestart?: () => void
   onSend?: (message: string, options?: { attachments?: ComposerAttachment[] }) => void
   onPickAttachments?: () => Promise<ComposerAttachment[]>
+  onAddAttachmentPaths?: (filePaths: string[]) => Promise<ComposerAttachment[]>
   className?: string
   /** Transient system status (e.g. 'Compacting conversation history…') */
   systemStatus?: string | null
@@ -515,11 +516,34 @@ function formatAttachmentSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-export function AgentTranscriptPanel({ title = 'Agent transcript', messages, status, onStop, onRestart, onSend, onPickAttachments, className, systemStatus }: AgentTranscriptPanelProps) {
+function mergeAttachments(current: ComposerAttachment[], added: ComposerAttachment[]): ComposerAttachment[] {
+  const seen = new Set(current.map((attachment) => attachment.id))
+  const merged = [...current]
+  for (const item of added) {
+    if (seen.has(item.id)) continue
+    seen.add(item.id)
+    merged.push(item)
+  }
+  return merged
+}
+
+export function AgentTranscriptPanel({
+  title = 'Agent transcript',
+  messages,
+  status,
+  onStop,
+  onRestart,
+  onSend,
+  onPickAttachments,
+  onAddAttachmentPaths,
+  className,
+  systemStatus
+}: AgentTranscriptPanelProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const [viewMode, setViewMode] = useState<ViewMode>(ViewMode.MARKDOWN)
   const [pendingAttachments, setPendingAttachments] = useState<ComposerAttachment[]>([])
+  const [isDragOverComposer, setIsDragOverComposer] = useState(false)
 
   // Find the latest todowrite message to show as a pinned summary
   const latestTodos = useMemo(() => {
@@ -634,20 +658,47 @@ export function AgentTranscriptPanel({ title = 'Agent transcript', messages, sta
     if (!onPickAttachments) return
     const picked = await onPickAttachments()
     if (!picked.length) return
-    setPendingAttachments((prev) => {
-      const seen = new Set(prev.map((a) => a.id))
-      const merged = [...prev]
-      for (const item of picked) {
-        if (seen.has(item.id)) continue
-        seen.add(item.id)
-        merged.push(item)
-      }
-      return merged
-    })
+    setPendingAttachments((prev) => mergeAttachments(prev, picked))
+  }
+
+  const handleAddAttachmentPaths = async (filePaths: string[]) => {
+    if (!onAddAttachmentPaths || filePaths.length === 0) return
+    const added = await onAddAttachmentPaths(filePaths)
+    if (!added.length) return
+    setPendingAttachments((prev) => mergeAttachments(prev, added))
   }
 
   const handleRemoveAttachment = (id: string) => {
     setPendingAttachments((prev) => prev.filter((att) => att.id !== id))
+  }
+
+  const handleComposerDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!onAddAttachmentPaths || !Array.from(e.dataTransfer.types).includes('Files')) return
+    e.preventDefault()
+    e.stopPropagation()
+    e.dataTransfer.dropEffect = 'copy'
+    setIsDragOverComposer(true)
+  }
+
+  const handleComposerDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!onAddAttachmentPaths) return
+    e.preventDefault()
+    e.stopPropagation()
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return
+    setIsDragOverComposer(false)
+  }
+
+  const handleComposerDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+    if (!onAddAttachmentPaths) return
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOverComposer(false)
+
+    const filePaths = Array.from(e.dataTransfer.files)
+      .map((file) => window.electronAPI.webUtils.getPathForFile(file))
+      .filter(Boolean)
+
+    await handleAddAttachmentPaths(filePaths)
   }
 
   return (
@@ -791,7 +842,19 @@ export function AgentTranscriptPanel({ title = 'Agent transcript', messages, sta
       {/* Input + Footer */}
       <div className="border-t border-border shrink-0">
         {onSend && (
-          <div className="px-4 py-3 space-y-2.5">
+          <div
+            data-testid="transcript-composer"
+            className={`relative px-4 py-3 space-y-2.5 transition-colors ${isDragOverComposer ? 'bg-primary/5' : ''}`}
+            onDragOver={handleComposerDragOver}
+            onDragEnter={handleComposerDragOver}
+            onDragLeave={handleComposerDragLeave}
+            onDrop={handleComposerDrop}
+          >
+            {isDragOverComposer && (
+              <div className="pointer-events-none absolute inset-2 z-10 flex items-center justify-center rounded-xl border border-dashed border-primary/40 bg-background/90">
+                <span className="text-xs font-medium text-primary">Drop files to attach them to this message</span>
+              </div>
+            )}
             {pendingAttachments.length > 0 && (
               <div className="flex flex-wrap gap-1.5">
                 {pendingAttachments.map((attachment) => (
@@ -816,20 +879,20 @@ export function AgentTranscriptPanel({ title = 'Agent transcript', messages, sta
               </div>
             )}
             <div className="flex items-end gap-2">
-            <textarea
-              ref={inputRef}
-              rows={1}
-              placeholder="Send a message... (Shift+Enter for new line)"
-              className="flex-1 bg-muted/50 border border-border rounded-lg px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/30 resize-none overflow-hidden max-h-32 min-h-[32px]"
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) {
-                  e.preventDefault()
-                  handleSend()
-                }
-              }}
-              onInput={autoResize}
-            />
-            {onPickAttachments && (
+              <textarea
+                ref={inputRef}
+                rows={1}
+                placeholder="Send a message... (Shift+Enter for new line)"
+                className="flex-1 bg-muted/50 border border-border rounded-lg px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/30 resize-none overflow-hidden max-h-32 min-h-[32px]"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault()
+                    handleSend()
+                  }
+                }}
+                onInput={autoResize}
+              />
+              {onPickAttachments && (
               <Button
                 type="button"
                 variant="ghost"
@@ -837,14 +900,15 @@ export function AgentTranscriptPanel({ title = 'Agent transcript', messages, sta
                 onClick={handleAddAttachments}
                 className="h-[32px] w-[32px] shrink-0 rounded-lg"
                 title="Attach files"
+                aria-label="Attach files"
               >
                 <Paperclip className="h-4 w-4" />
               </Button>
             )}
-            <Button variant="default" size="icon" onClick={handleSend} className="h-[32px] w-[32px] shrink-0 rounded-lg">
-              <Send className="h-4 w-4" />
-            </Button>
-          </div>
+              <Button variant="default" size="icon" onClick={handleSend} className="h-[32px] w-[32px] shrink-0 rounded-lg" aria-label="Send message">
+                <Send className="h-4 w-4" />
+              </Button>
+            </div>
           </div>
         )}
       </div>

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState, useMemo, useCallback } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { StopCircle, Loader2, Terminal, Send, ChevronRight, ChevronDown, Wrench, AlertTriangle, CheckCircle2, Circle, Clock, RotateCcw, Code2, Eye, ListTodo, FileText, ArrowDown } from 'lucide-react'
+import { StopCircle, Loader2, Terminal, Send, ChevronRight, ChevronDown, Wrench, AlertTriangle, CheckCircle2, Circle, Clock, RotateCcw, Code2, Eye, ListTodo, FileText, ArrowDown, Paperclip, X } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Markdown } from '@/components/ui/Markdown'
 import type { AgentMessage } from '@/hooks/use-agent-session'
@@ -89,10 +89,18 @@ interface AgentTranscriptPanelProps {
   status: SessionStatus
   onStop: () => void
   onRestart?: () => void
-  onSend?: (message: string) => void
+  onSend?: (message: string, options?: { attachments?: ComposerAttachment[] }) => void
+  onPickAttachments?: () => Promise<ComposerAttachment[]>
   className?: string
   /** Transient system status (e.g. 'Compacting conversation history…') */
   systemStatus?: string | null
+}
+
+export interface ComposerAttachment {
+  id: string
+  filename: string
+  size: number
+  mime_type: string
 }
 
 function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessage; onAnswer?: (answer: string) => void; canAnswer: boolean }) {
@@ -500,10 +508,18 @@ function TodoSummary({ todos }: { todos: NonNullable<AgentMessage['tool']>['todo
   )
 }
 
-export function AgentTranscriptPanel({ title = 'Agent transcript', messages, status, onStop, onRestart, onSend, className, systemStatus }: AgentTranscriptPanelProps) {
+function formatAttachmentSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '—'
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function AgentTranscriptPanel({ title = 'Agent transcript', messages, status, onStop, onRestart, onSend, onPickAttachments, className, systemStatus }: AgentTranscriptPanelProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const [viewMode, setViewMode] = useState<ViewMode>(ViewMode.MARKDOWN)
+  const [pendingAttachments, setPendingAttachments] = useState<ComposerAttachment[]>([])
 
   // Find the latest todowrite message to show as a pinned summary
   const latestTodos = useMemo(() => {
@@ -606,11 +622,32 @@ export function AgentTranscriptPanel({ title = 'Agent transcript', messages, sta
   const handleSend = () => {
     const value = inputRef.current?.value.trim()
     if (value && onSend) {
-      onSend(value)
+      onSend(value, pendingAttachments.length > 0 ? { attachments: pendingAttachments } : undefined)
       inputRef.current!.value = ''
       // Reset textarea height back to single row
       inputRef.current!.style.height = 'auto'
+      setPendingAttachments([])
     }
+  }
+
+  const handleAddAttachments = async () => {
+    if (!onPickAttachments) return
+    const picked = await onPickAttachments()
+    if (!picked.length) return
+    setPendingAttachments((prev) => {
+      const seen = new Set(prev.map((a) => a.id))
+      const merged = [...prev]
+      for (const item of picked) {
+        if (seen.has(item.id)) continue
+        seen.add(item.id)
+        merged.push(item)
+      }
+      return merged
+    })
+  }
+
+  const handleRemoveAttachment = (id: string) => {
+    setPendingAttachments((prev) => prev.filter((att) => att.id !== id))
   }
 
   return (
@@ -754,7 +791,31 @@ export function AgentTranscriptPanel({ title = 'Agent transcript', messages, sta
       {/* Input + Footer */}
       <div className="border-t border-border shrink-0">
         {onSend && (
-          <div className="flex items-end gap-2 px-4 py-3">
+          <div className="px-4 py-3 space-y-2.5">
+            {pendingAttachments.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {pendingAttachments.map((attachment) => (
+                  <span
+                    key={attachment.id}
+                    className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/60 bg-muted/40 px-2 py-1 text-[11px] text-foreground"
+                    title={`${attachment.filename} (${formatAttachmentSize(attachment.size)})`}
+                  >
+                    <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />
+                    <span className="truncate max-w-[220px]">{attachment.filename}</span>
+                    <span className="text-muted-foreground">{formatAttachmentSize(attachment.size)}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveAttachment(attachment.id)}
+                      className="text-muted-foreground hover:text-foreground"
+                      aria-label={`Remove ${attachment.filename}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="flex items-end gap-2">
             <textarea
               ref={inputRef}
               rows={1}
@@ -768,9 +829,22 @@ export function AgentTranscriptPanel({ title = 'Agent transcript', messages, sta
               }}
               onInput={autoResize}
             />
+            {onPickAttachments && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={handleAddAttachments}
+                className="h-[32px] w-[32px] shrink-0 rounded-lg"
+                title="Attach files"
+              >
+                <Paperclip className="h-4 w-4" />
+              </Button>
+            )}
             <Button variant="default" size="icon" onClick={handleSend} className="h-[32px] w-[32px] shrink-0 rounded-lg">
               <Send className="h-4 w-4" />
             </Button>
+          </div>
           </div>
         )}
       </div>

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -337,7 +337,7 @@ describe('TaskWorkspace – stale triage session cleanup', () => {
     })
 
     await waitFor(() => {
-      expect(window.electronAPI.agentSession.send).toHaveBeenCalledWith('resumed-session-1', 'approved', taskId, agentId)
+      expect(window.electronAPI.agentSession.send).toHaveBeenCalledWith('resumed-session-1', 'approved', taskId, agentId, undefined)
     })
   })
 })

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -424,11 +424,8 @@ export function TaskWorkspace({
     [approve, ensureChatSession, sendMessage, session.messages]
   )
 
-  const handlePickAttachments = useCallback(async () => {
-    if (!task?.id) return []
-    const filePaths = await attachmentApi.pick()
-    if (!filePaths.length) return []
-
+  const handleAddAttachmentPaths = useCallback(async (filePaths: string[]) => {
+    if (!task?.id || filePaths.length === 0) return []
     const saved = await Promise.all(filePaths.map((fp) => attachmentApi.save(task.id, fp)))
     const merged = [...task.attachments]
     const seen = new Set(merged.map((a) => a.id))
@@ -440,6 +437,13 @@ export function TaskWorkspace({
     onUpdateAttachments(merged)
     return saved
   }, [onUpdateAttachments, task?.attachments, task?.id])
+
+  const handlePickAttachments = useCallback(async () => {
+    if (!task?.id) return []
+    const filePaths = await attachmentApi.pick()
+    if (!filePaths.length) return []
+    return handleAddAttachmentPaths(filePaths)
+  }, [handleAddAttachmentPaths, task?.id])
 
   // ── Feedback orchestration ──────────────────────────────────
 
@@ -701,6 +705,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
               onRestart={handleStartFreshSession}
               onSend={handleSend}
               onPickAttachments={handlePickAttachments}
+              onAddAttachmentPaths={handleAddAttachmentPaths}
               className="h-full"
             />
           </div>

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -16,7 +16,7 @@ import { useAgentSession } from '@/hooks/use-agent-session'
 import { useAgentStore, SessionStatus } from '@/stores/agent-store'
 import { useSettingsStore, type GitProvider } from '@/stores/settings-store'
 import { useTaskStore } from '@/stores/task-store'
-import { taskApi, worktreeApi, taskSourceApi, onAgentIncompatibleSession, onWorktreeProgress } from '@/lib/ipc-client'
+import { taskApi, worktreeApi, taskSourceApi, onAgentIncompatibleSession, onWorktreeProgress, attachmentApi } from '@/lib/ipc-client'
 import { useEffect, useCallback, useRef, useState, useMemo } from 'react'
 import { TaskStatus } from '@/types'
 import type { WorkfloTask, FileAttachment, OutputField, Agent, UpdateAgentDTO, CreateAgentDTO } from '@/types'
@@ -401,7 +401,7 @@ export function TaskWorkspace({
   }, [fetchTasks, resume, start, task?.agent_id, task?.id, task?.session_id])
 
   const handleSend = useCallback(
-    async (message: string) => {
+    async (message: string, options?: { attachments?: Array<{ id: string; filename: string; size: number; mime_type: string }> }) => {
       // Route unresolved question responses through approve(), even if status lags.
       let questionIndex = -1
       for (let i = session.messages.length - 1; i >= 0; i--) {
@@ -419,10 +419,27 @@ export function TaskWorkspace({
 
       const readySessionId = await ensureChatSession()
       if (!readySessionId) return
-      await sendMessage(message)
+      await sendMessage(message, options)
     },
     [approve, ensureChatSession, sendMessage, session.messages]
   )
+
+  const handlePickAttachments = useCallback(async () => {
+    if (!task?.id) return []
+    const filePaths = await attachmentApi.pick()
+    if (!filePaths.length) return []
+
+    const saved = await Promise.all(filePaths.map((fp) => attachmentApi.save(task.id, fp)))
+    const merged = [...task.attachments]
+    const seen = new Set(merged.map((a) => a.id))
+    for (const attachment of saved) {
+      if (seen.has(attachment.id)) continue
+      seen.add(attachment.id)
+      merged.push(attachment)
+    }
+    onUpdateAttachments(merged)
+    return saved
+  }, [onUpdateAttachments, task?.attachments, task?.id])
 
   // ── Feedback orchestration ──────────────────────────────────
 
@@ -683,6 +700,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
               onStop={handleAbort}
               onRestart={handleStartFreshSession}
               onSend={handleSend}
+              onPickAttachments={handlePickAttachments}
               className="h-full"
             />
           </div>

--- a/src/renderer/src/hooks/use-agent-session.test.tsx
+++ b/src/renderer/src/hooks/use-agent-session.test.tsx
@@ -137,7 +137,20 @@ describe('useAgentSession', () => {
         await result.current.sendMessage('Hello agent')
       })
 
-      expect(mockElectronAPI.agentSession.send).toHaveBeenCalledWith('sess-1', 'Hello agent', 'task-1', 'agent-1')
+      expect(mockElectronAPI.agentSession.send).toHaveBeenCalledWith('sess-1', 'Hello agent', 'task-1', 'agent-1', undefined)
+    })
+
+    it('sends message attachments when provided', async () => {
+      useAgentStore.getState().initSession('task-1', 'sess-1', 'agent-1')
+
+      const { result } = renderHook(() => useAgentSession('task-1'))
+      const attachments = [{ id: 'a-1', filename: 'notes.md', size: 128, mime_type: 'text/markdown' }]
+
+      await act(async () => {
+        await result.current.sendMessage('Use this file', { attachments })
+      })
+
+      expect(mockElectronAPI.agentSession.send).toHaveBeenCalledWith('sess-1', 'Use this file', 'task-1', 'agent-1', attachments)
     })
 
     it('throws when no active session', async () => {
@@ -171,7 +184,7 @@ describe('useAgentSession', () => {
       })
 
       // Should use the NEW sessionId from store, not the old one from closure
-      expect(mockElectronAPI.agentSession.send).toHaveBeenCalledWith('sess-2-new', 'After resume', 'task-1', 'agent-1')
+      expect(mockElectronAPI.agentSession.send).toHaveBeenCalledWith('sess-2-new', 'After resume', 'task-1', 'agent-1', undefined)
     })
   })
 

--- a/src/renderer/src/hooks/use-agent-session.ts
+++ b/src/renderer/src/hooks/use-agent-session.ts
@@ -14,6 +14,15 @@ export interface AgentSessionState {
   systemStatus?: string | null
 }
 
+export interface SendMessageOptions {
+  attachments?: Array<{
+    id: string
+    filename: string
+    size: number
+    mime_type: string
+  }>
+}
+
 const EMPTY_SESSION: AgentSessionState = {
   sessionId: null,
   status: SessionStatus.IDLE,
@@ -85,11 +94,11 @@ export function useAgentSession(taskId: string | undefined) {
   }, [taskId, endSession])
 
   const sendMessage = useCallback(
-    async (message: string) => {
+    async (message: string, options?: SendMessageOptions) => {
       // Get latest session from store, not from closure
       const currentSession = useAgentStore.getState().sessions.get(taskId!)
       if (!currentSession?.sessionId) throw new Error('No active session')
-      const result = await agentSessionApi.send(currentSession.sessionId, message, taskId, currentSession.agentId)
+      const result = await agentSessionApi.send(currentSession.sessionId, message, taskId, currentSession.agentId, options?.attachments)
       // Session was recreated on the main process — update renderer store
       if (result.newSessionId && taskId) {
         initSession(taskId, result.newSessionId, currentSession.agentId)

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -1,5 +1,5 @@
 import type { WorkfloTask, CreateTaskDTO, UpdateTaskDTO, FileAttachment, Agent, CreateAgentDTO, UpdateAgentDTO, McpServer, CreateMcpServerDTO, UpdateMcpServerDTO, Skill, CreateSkillDTO, UpdateSkillDTO, Secret, CreateSecretDTO, UpdateSecretDTO, TaskSource, CreateTaskSourceDTO, UpdateTaskSourceDTO, SyncResult, PluginMeta, ConfigFieldSchema, ConfigFieldOption, PluginAction, ActionResult, SourceUser, ReassignResult, MarketplaceSource, InstalledPlugin, DiscoverablePlugin, MarketplaceCatalog, PluginResources } from '@/types'
-import type { AgentOutputEvent, AgentOutputBatchEvent, AgentStatusEvent, AgentApprovalRequest, GhCliStatus, GlabCliStatus, GitHubRepo, GitHubCollaborator, WorktreeProgressEvent, McpTestResult, SkillSyncResult, DepsStatus } from '@/types/electron'
+import type { AgentOutputEvent, AgentOutputBatchEvent, AgentStatusEvent, AgentApprovalRequest, GhCliStatus, GlabCliStatus, GitHubRepo, GitHubCollaborator, WorktreeProgressEvent, McpTestResult, SkillSyncResult, DepsStatus, AgentMessageAttachment } from '@/types/electron'
 
 export const taskApi = {
   getAll: (): Promise<WorkfloTask[]> => {
@@ -116,8 +116,8 @@ export const agentSessionApi = {
     return window.electronAPI.agentSession.stop(sessionId)
   },
 
-  send: (sessionId: string, message: string, taskId?: string, agentId?: string): Promise<{ success: boolean; newSessionId?: string }> => {
-    return window.electronAPI.agentSession.send(sessionId, message, taskId, agentId)
+  send: (sessionId: string, message: string, taskId?: string, agentId?: string, attachments?: AgentMessageAttachment[]): Promise<{ success: boolean; newSessionId?: string }> => {
+    return window.electronAPI.agentSession.send(sessionId, message, taskId, agentId, attachments)
   },
 
   approve: (sessionId: string, approved: boolean, message?: string): Promise<{ success: boolean }> => {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -42,6 +42,13 @@ export interface AgentSessionSuccessResult {
   success: boolean
 }
 
+export interface AgentMessageAttachment {
+  id: string
+  filename: string
+  size: number
+  mime_type: string
+}
+
 export interface AgentOutputEvent {
   sessionId: string
   taskId?: string
@@ -186,7 +193,7 @@ interface ElectronAPI {
     resume: (agentId: string, taskId: string, ocSessionId: string) => Promise<AgentSessionStartResult>
     abort: (sessionId: string) => Promise<AgentSessionSuccessResult>
     stop: (sessionId: string) => Promise<AgentSessionSuccessResult>
-    send: (sessionId: string, message: string, taskId?: string, agentId?: string) => Promise<AgentSessionSuccessResult & { newSessionId?: string }>
+    send: (sessionId: string, message: string, taskId?: string, agentId?: string, attachments?: AgentMessageAttachment[]) => Promise<AgentSessionSuccessResult & { newSessionId?: string }>
     approve: (sessionId: string, approved: boolean, message?: string) => Promise<AgentSessionSuccessResult>
     syncSkills: (sessionId: string) => Promise<SkillSyncResult>
     syncSkillsForTask: (taskId: string) => Promise<SkillSyncResult>


### PR DESCRIPTION
## Summary
- add per-message file attachments in desktop and mobile transcript composers
- pass attachment metadata through renderer/mobile API, IPC, and agent manager send paths
- include bounded attachment context in prompts (file refs + small text previews only) to avoid context bloat

## Testing
- ELECTRON_RUN_AS_NODE=1 electron ./node_modules/vitest/vitest.mjs run src/renderer/src/hooks/use-agent-session.test.tsx src/renderer/src/components/tasks/TaskWorkspace.test.tsx src/mobile/components/ChatInput.test.tsx src/main/agent-manager.test.ts
- pnpm test:run
- pnpm typecheck