### PR TITLE
fix(canvas): prevent stale terminal cleanup from killing new PTY

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,9 +2,9 @@ name: Verify
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/canvas-browser-integration]
   push:
-    branches: [main]
+    branches: [main, feat/canvas-browser-integration]
 
 jobs:
   verify:

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 
 vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
@@ -7,10 +7,31 @@ vi.mock('electron', () => ({
   Notification: vi.fn().mockImplementation(() => ({ show: vi.fn() }))
 }))
 
+const { mockChildKill, mockSpawn } = vi.hoisted(() => {
+  const kill = vi.fn()
+  const spawn = vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    stdin: { writable: true, write: vi.fn() },
+    on: vi.fn(),
+    kill,
+    pid: 4242
+  }))
+  return { mockChildKill: kill, mockSpawn: spawn }
+})
+
+vi.mock('child_process', () => ({
+  spawn: mockSpawn
+}))
+
 import { ipcMain } from 'electron'
 import { registerIpcHandlers } from './ipc-handlers'
 
 describe('registerIpcHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('registers the expected number of IPC handlers', () => {
     const db = {} as unknown as Parameters<typeof registerIpcHandlers>[0]
     const agentManager = {} as unknown as Parameters<typeof registerIpcHandlers>[1]
@@ -36,5 +57,33 @@ describe('registerIpcHandlers', () => {
     expect(channels).toContain('skills:getAll')
     expect(channels).toContain('taskSource:sync')
     expect(channels).toContain('plugin:list')
+  })
+
+  it('terminal:kill ignores stale expectedPid and only kills matching process', async () => {
+    const db = {} as unknown as Parameters<typeof registerIpcHandlers>[0]
+    const agentManager = {} as unknown as Parameters<typeof registerIpcHandlers>[1]
+    const githubManager = {} as unknown as Parameters<typeof registerIpcHandlers>[2]
+    const worktreeManager = {} as unknown as Parameters<typeof registerIpcHandlers>[3]
+    const syncManager = {} as unknown as Parameters<typeof registerIpcHandlers>[4]
+    const pluginRegistry = {} as unknown as Parameters<typeof registerIpcHandlers>[5]
+
+    registerIpcHandlers(db, agentManager, githubManager, worktreeManager, syncManager, pluginRegistry)
+
+    const handleCalls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls as [string, (...args: unknown[]) => unknown][]
+    const createHandler = handleCalls.find((call) => call[0] === 'terminal:create')?.[1]
+    const killHandler = handleCalls.find((call) => call[0] === 'terminal:kill')?.[1]
+
+    expect(createHandler).toBeDefined()
+    expect(killHandler).toBeDefined()
+
+    const sender = { isDestroyed: () => false, send: vi.fn() }
+    await createHandler?.({ sender }, { id: 'panel-1', cols: 80, rows: 24 })
+
+    await killHandler?.({}, { id: 'panel-1', expectedPid: 9999 })
+    expect(mockChildKill).not.toHaveBeenCalled()
+
+    await killHandler?.({}, { id: 'panel-1', expectedPid: 4242 })
+    expect(mockChildKill).toHaveBeenCalledTimes(1)
+    expect(mockChildKill).toHaveBeenCalledWith('SIGTERM')
   })
 })

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1427,9 +1427,11 @@ else:
     return { lines: buf }
   })
 
-  ipcMain.handle('terminal:kill', (_, { id }: { id: string }) => {
+  ipcMain.handle('terminal:kill', (_, { id, expectedPid }: { id: string; expectedPid?: number }) => {
     const term = terminals.get(id)
     if (term) {
+      // Ignore stale cleanup calls from an older terminal instance.
+      if (expectedPid !== undefined && term.pid !== expectedPid) return
       term.kill()
       terminals.delete(id)
     }
@@ -1443,9 +1445,10 @@ else:
    *   2. Get the cwd of the deepest child (most recently forked = active shell)
    *   3. Use `lsof -p <childPid> -a -d cwd -Fn` for the cwd lookup
    */
-  ipcMain.handle('terminal:getCwd', async (_, { id }: { id: string }) => {
+  ipcMain.handle('terminal:getCwd', async (_, { id, expectedPid }: { id: string; expectedPid?: number }) => {
     const term = terminals.get(id)
     if (!term) return { cwd: null }
+    if (expectedPid !== undefined && term.pid !== expectedPid) return { cwd: null }
 
     try {
       const { execSync } = childProcess

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -416,10 +416,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('terminal:write', { id, data }),
     resize: (id: string, cols: number, rows: number): Promise<void> =>
       ipcRenderer.invoke('terminal:resize', { id, cols, rows }),
-    kill: (id: string): Promise<void> =>
-      ipcRenderer.invoke('terminal:kill', { id }),
-    getCwd: (id: string): Promise<{ cwd: string | null }> =>
-      ipcRenderer.invoke('terminal:getCwd', { id }),
+    kill: (id: string, expectedPid?: number): Promise<void> =>
+      ipcRenderer.invoke('terminal:kill', { id, expectedPid }),
+    getCwd: (id: string, expectedPid?: number): Promise<{ cwd: string | null }> =>
+      ipcRenderer.invoke('terminal:getCwd', { id, expectedPid }),
     getBuffer: (id: string, lines?: number): Promise<{ lines: string[] }> =>
       ipcRenderer.invoke('terminal:getBuffer', { id, lines }),
     onData: (callback: (data: { id: string; data: string }) => void): (() => void) => {

--- a/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
@@ -140,4 +140,41 @@ describe('TerminalPanelContent', () => {
       expect(terminalKill).toHaveBeenCalledWith('panel-1', 222)
     })
   })
+
+  it('kills a PTY that resolves after its component instance already unmounted', async () => {
+    const firstCreate = deferred<{ pid: number }>()
+    const secondCwd = deferred<{ cwd: string | null }>()
+
+    terminalCreate
+      .mockImplementationOnce(() => firstCreate.promise)
+      .mockResolvedValueOnce({ pid: 222 })
+    terminalGetCwd.mockImplementationOnce(() => secondCwd.promise)
+
+    const first = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(1)
+    })
+
+    first.unmount()
+
+    const second = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(2)
+    })
+
+    firstCreate.resolve({ pid: 111 })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 111)
+    })
+
+    expect(terminalGetCwd).not.toHaveBeenCalled()
+
+    second.unmount()
+    expect(terminalGetCwd).toHaveBeenNthCalledWith(1, 'panel-1', 222)
+
+    secondCwd.resolve({ cwd: '/tmp/two' })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 222)
+    })
+  })
 })

--- a/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+const terminalCreate = vi.fn()
+const terminalWrite = vi.fn()
+const terminalResize = vi.fn()
+const terminalKill = vi.fn()
+const terminalGetCwd = vi.fn()
+const terminalOnData = vi.fn(() => vi.fn())
+const terminalOnExit = vi.fn(() => vi.fn())
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    cols = 80
+    rows = 24
+    textarea = document.createElement('textarea')
+    loadAddon() {}
+    open() {}
+    focus() {}
+    clear() {}
+    write() {}
+    dispose() {}
+    onData() {
+      return { dispose: vi.fn() }
+    }
+    onKey() {
+      return { dispose: vi.fn() }
+    }
+  },
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class {},
+}))
+
+import { TerminalPanelContent } from './TerminalPanelContent'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('TerminalPanelContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    terminalWrite.mockResolvedValue(undefined)
+    terminalResize.mockResolvedValue(undefined)
+    terminalKill.mockResolvedValue(undefined)
+
+    Object.defineProperty(window, 'electronAPI', {
+      value: {
+        ...(window.electronAPI ?? {}),
+        terminal: {
+          create: terminalCreate,
+          write: terminalWrite,
+          resize: terminalResize,
+          kill: terminalKill,
+          getCwd: terminalGetCwd,
+          getBuffer: vi.fn(),
+          onData: terminalOnData,
+          onExit: terminalOnExit,
+        },
+      },
+      configurable: true,
+      writable: true,
+    })
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        disconnect() {}
+      }
+    )
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 640,
+      height: 480,
+      top: 0,
+      left: 0,
+      right: 640,
+      bottom: 480,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('kills only the PTY instance that owned the cleanup', async () => {
+    const firstCwd = deferred<{ cwd: string | null }>()
+    const secondCwd = deferred<{ cwd: string | null }>()
+
+    terminalCreate.mockResolvedValueOnce({ pid: 111 }).mockResolvedValueOnce({ pid: 222 })
+    terminalGetCwd.mockImplementationOnce(() => firstCwd.promise).mockImplementationOnce(() => secondCwd.promise)
+
+    const first = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(1)
+    })
+
+    first.unmount()
+
+    const second = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(2)
+    })
+
+    expect(terminalGetCwd).toHaveBeenNthCalledWith(1, 'panel-1', 111)
+
+    firstCwd.resolve({ cwd: '/tmp/one' })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 111)
+    })
+
+    second.unmount()
+    expect(terminalGetCwd).toHaveBeenNthCalledWith(2, 'panel-1', 222)
+
+    secondCwd.resolve({ cwd: '/tmp/two' })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 222)
+    })
+  })
+})

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -33,6 +33,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   const cleanupRef = useRef<(() => void)[]>([])
   const initCalledRef = useRef(false)
   const isReadyRef = useRef(false)
+  const activePidRef = useRef<number | null>(null)
 
   // Store cwd in a ref — only used at init time, never triggers re-init
   const cwdRef = useRef(cwd)
@@ -107,12 +108,13 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     if (!xtermRef.current) return
 
     try {
-      await window.electronAPI.terminal.create(
+      const { pid } = await window.electronAPI.terminal.create(
         terminalId,
         term.cols,
         term.rows,
         cwdRef.current // read from ref, not prop — stable reference
       )
+      activePidRef.current = pid
 
       console.log(`[Terminal:${terminalId}] PTY created, setting up listeners`)
 
@@ -145,7 +147,8 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
             term.cols,
             term.rows,
             cwdRef.current
-          ).then(() => {
+          ).then(({ pid }) => {
+            activePidRef.current = pid
             term.focus()
           }).catch(() => {
             processExited = true
@@ -220,15 +223,16 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
 
     return () => {
       observer.disconnect()
+      const expectedPid = activePidRef.current ?? undefined
 
       // Capture cwd before killing the terminal — persists across restarts
-      window.electronAPI.terminal.getCwd(terminalId).then(({ cwd: currentCwd }) => {
+      window.electronAPI.terminal.getCwd(terminalId, expectedPid).then(({ cwd: currentCwd }) => {
         if (currentCwd) {
           useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
         }
       }).catch(() => {}).finally(() => {
         // Kill PTY after cwd capture attempt
-        window.electronAPI.terminal.kill(terminalId).catch(() => {})
+        window.electronAPI.terminal.kill(terminalId, expectedPid).catch(() => {})
       })
 
       // Cleanup listeners
@@ -241,6 +245,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       fitAddonRef.current = null
       initCalledRef.current = false
       isReadyRef.current = false
+      activePidRef.current = null
     }
   }, [initTerminal, terminalId])
 
@@ -251,7 +256,8 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     if (!isReady) return
     const interval = setInterval(async () => {
       try {
-        const { cwd: currentCwd } = await window.electronAPI.terminal.getCwd(terminalId)
+        const expectedPid = activePidRef.current ?? undefined
+        const { cwd: currentCwd } = await window.electronAPI.terminal.getCwd(terminalId, expectedPid)
         if (currentCwd) {
           useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
         }

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -34,6 +34,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   const initCalledRef = useRef(false)
   const isReadyRef = useRef(false)
   const activePidRef = useRef<number | null>(null)
+  const isMountedRef = useRef(true)
 
   // Store cwd in a ref — only used at init time, never triggers re-init
   const cwdRef = useRef(cwd)
@@ -114,6 +115,14 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
         term.rows,
         cwdRef.current // read from ref, not prop — stable reference
       )
+
+      // StrictMode / fast remount can unmount this instance before create() resolves.
+      // In that case, kill only the PTY we just created and let the live instance continue.
+      if (!isMountedRef.current || xtermRef.current !== term) {
+        await window.electronAPI.terminal.kill(terminalId, pid).catch(() => {})
+        return
+      }
+
       activePidRef.current = pid
 
       console.log(`[Terminal:${terminalId}] PTY created, setting up listeners`)
@@ -186,6 +195,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   // zero-size container.
   useEffect(() => {
     if (!containerRef.current) return
+    isMountedRef.current = true
 
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0]
@@ -224,16 +234,19 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     return () => {
       observer.disconnect()
       const expectedPid = activePidRef.current ?? undefined
+      isMountedRef.current = false
 
-      // Capture cwd before killing the terminal — persists across restarts
-      window.electronAPI.terminal.getCwd(terminalId, expectedPid).then(({ cwd: currentCwd }) => {
-        if (currentCwd) {
-          useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
-        }
-      }).catch(() => {}).finally(() => {
-        // Kill PTY after cwd capture attempt
-        window.electronAPI.terminal.kill(terminalId, expectedPid).catch(() => {})
-      })
+      if (expectedPid !== undefined) {
+        // Capture cwd before killing the terminal — persists across restarts.
+        // Skip ID-only cleanup when this instance never acquired a PTY pid.
+        window.electronAPI.terminal.getCwd(terminalId, expectedPid).then(({ cwd: currentCwd }) => {
+          if (currentCwd) {
+            useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
+          }
+        }).catch(() => {}).finally(() => {
+          window.electronAPI.terminal.kill(terminalId, expectedPid).catch(() => {})
+        })
+      }
 
       // Cleanup listeners
       for (const fn of cleanupRef.current) fn()

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -365,8 +365,8 @@ interface ElectronAPI {
     create: (id: string, cols: number, rows: number, cwd?: string) => Promise<{ pid: number }>
     write: (id: string, data: string) => Promise<void>
     resize: (id: string, cols: number, rows: number) => Promise<void>
-    kill: (id: string) => Promise<void>
-    getCwd: (id: string) => Promise<{ cwd: string | null }>
+    kill: (id: string, expectedPid?: number) => Promise<void>
+    getCwd: (id: string, expectedPid?: number) => Promise<{ cwd: string | null }>
     getBuffer: (id: string, lines?: number) => Promise<{ lines: string[] }>
     onData: (callback: (data: { id: string; data: string }) => void) => () => void
     onExit: (callback: (data: { id: string }) => void) => () => void


### PR DESCRIPTION
## Summary
- scope terminal kill/getCwd calls by optional expected PID in IPC handlers
- track active PTY pid in TerminalPanelContent and pass it during cleanup/cwd capture
- keep preload and renderer types aligned with optional PID parameter
- add regression tests for stale cleanup ownership behavior (main + renderer)

## Test Plan
- pnpm test:run src/main/ipc-handlers.test.ts
- pnpm test:run src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
- pnpm test:run
- pnpm typecheck