### PR TITLE
feat: add Check for Updates button in updates modal

### DIFF
--- a/src/renderer/src/components/update/UpdateDialog.test.tsx
+++ b/src/renderer/src/components/update/UpdateDialog.test.tsx
@@ -113,4 +113,49 @@ describe('UpdateDialog', () => {
     fireEvent.click(closeButtons[closeButtons.length - 1])
     expect(onClose).toHaveBeenCalled()
   })
+
+  it('should show Check for Updates button when up-to-date', async () => {
+    let statusCallback: ((data: Record<string, unknown>) => void) | null = null
+    mockUpdater.onStatus.mockImplementation((cb: (data: Record<string, unknown>) => void) => {
+      statusCallback = cb
+      return vi.fn()
+    })
+
+    render(<UpdateDialog open={true} onClose={vi.fn()} />)
+
+    // Simulate main process sending 'up-to-date'
+    statusCallback!({ status: 'up-to-date', currentVersion: '0.0.31' })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /check for updates/i })).toBeInTheDocument()
+    })
+  })
+
+  it('should re-trigger check when Check for Updates button is clicked from up-to-date state', async () => {
+    let statusCallback: ((data: Record<string, unknown>) => void) | null = null
+    mockUpdater.onStatus.mockImplementation((cb: (data: Record<string, unknown>) => void) => {
+      statusCallback = cb
+      return vi.fn()
+    })
+
+    render(<UpdateDialog open={true} onClose={vi.fn()} />)
+
+    // Simulate reaching up-to-date state
+    statusCallback!({ status: 'up-to-date', currentVersion: '0.0.31' })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /check for updates/i })).toBeInTheDocument()
+    })
+
+    // Click the Check for Updates button
+    fireEvent.click(screen.getByRole('button', { name: /check for updates/i }))
+
+    // Should transition to checking state and call updater.check again
+    // Radix Dialog may render duplicate nodes, so we check at least one exists
+    await waitFor(() => {
+      expect(screen.getAllByText('Checking for updates...').length).toBeGreaterThan(0)
+    })
+    // check is called once on open (idle→checking) and once on button click
+    expect(mockUpdater.check).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/renderer/src/components/update/UpdateDialog.tsx
+++ b/src/renderer/src/components/update/UpdateDialog.tsx
@@ -91,6 +91,18 @@ export function UpdateDialog({ open, onClose }: UpdateDialogProps) {
     })
   }
 
+  const handleCheckForUpdates = () => {
+    setState((s) => ({ ...s, status: 'checking', error: null }))
+    updaterApi.check().then((result) => {
+      if (result && !result.success) {
+        setState((s) => s.status === 'checking'
+          ? { ...s, status: 'error', error: result.error ?? 'Update check failed' }
+          : s
+        )
+      }
+    })
+  }
+
   const hasUpdate = state.status === 'available' || state.status === 'downloading' || state.status === 'downloaded'
 
   return (
@@ -216,6 +228,11 @@ export function UpdateDialog({ open, onClose }: UpdateDialogProps) {
                 <Button onClick={handleRetry} className="flex-1">
                   <RefreshCw className="h-4 w-4 mr-2" />
                   Retry
+                </Button>
+              ) : (state.status === 'idle' || state.status === 'up-to-date') ? (
+                <Button onClick={handleCheckForUpdates} variant="outline" className="flex-1">
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  Check for Updates
                 </Button>
               ) : null}
               <Button variant="outline" onClick={onClose}>


### PR DESCRIPTION
## Summary
- Adds a **Check for Updates** button in the `UpdateDialog` that appears when the updater is in `idle` or `up-to-date` state
- Previously, once the modal showed "You're up to date!", users had no way to manually re-trigger a check without closing and reopening the dialog
- The button resets state to `checking` and calls `updaterApi.check()`, identical to the existing Retry (error-state) flow
- Two new tests added: one verifying the button renders in `up-to-date` state, and one verifying it re-triggers the check and transitions back to `checking`

## Test plan
- [x] All 1220 existing tests pass (78 test files)
- [x] New test: `should show Check for Updates button when up-to-date`
- [x] New test: `should re-trigger check when Check for Updates button is clicked from up-to-date state`
- [x] Lint and typecheck pass
- [x] Full build succeeds (main + renderer + mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)