### PR TITLE
fix(ci): unblock Windows installer by pinning Python 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,10 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/scripts/release-workflow.test.ts
+++ b/scripts/release-workflow.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+
+describe('release workflow windows native build prerequisites', () => {
+  it('configures Python 3.11 before Windows packaging steps', () => {
+    const workflowPath = join(__dirname, '..', '.github', 'workflows', 'release.yml')
+    const workflow = readFileSync(workflowPath, 'utf8')
+
+    const windowsJobStart = workflow.indexOf('  build-windows:')
+    const linuxJobStart = workflow.indexOf('  build-linux:')
+    expect(windowsJobStart).toBeGreaterThan(-1)
+    expect(linuxJobStart).toBeGreaterThan(windowsJobStart)
+
+    const windowsJob = workflow.slice(windowsJobStart, linuxJobStart)
+
+    expect(windowsJob).toContain('- uses: actions/setup-python@v5')
+    expect(windowsJob).toContain("python-version: '3.11'")
+
+    const setupPythonIndex = windowsJob.indexOf('- uses: actions/setup-python@v5')
+    const installIndex = windowsJob.indexOf('- run: pnpm install --frozen-lockfile')
+    expect(setupPythonIndex).toBeGreaterThan(-1)
+    expect(installIndex).toBeGreaterThan(-1)
+    expect(setupPythonIndex).toBeLessThan(installIndex)
+  })
+})


### PR DESCRIPTION
## Summary
- add Python setup to the Windows release job before dependency installation
- pin Python to 3.11 to avoid node-gyp v9 failures on Python 3.12+ caused by distutils removal
- add a regression test (scripts/release-workflow.test.ts) that enforces this prerequisite in release.yml

## Validation
- pnpm test:run scripts/release-workflow.test.ts
- pnpm test:run
- pnpm typecheck
- pnpm build