### PR TITLE
feat: canvas panel interactions and integrations

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,9 +2,9 @@ name: Verify
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/canvas-browser-integration]
   push:
-    branches: [main]
+    branches: [main, feat/canvas-browser-integration]
 
 jobs:
   verify:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -105,7 +105,8 @@ function createWindow(): void {
       preload: join(__dirname, '../preload/index.js'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false
+      sandbox: false,
+      webviewTag: true
     }
   })
 
@@ -156,6 +157,41 @@ function createWindow(): void {
   mainWindow.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url)
     return { action: 'deny' }
+  })
+
+  // SAFETY: Prevent the main window from ever navigating away from the app.
+  // This guards against agent-browser or CDP accidentally targeting the main
+  // window instead of a webview panel.
+  //
+  // Layer 1: will-navigate (catches user-initiated navigations — NOT CDP)
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    const appOrigins = ['http://localhost:', 'file://']
+    const isAppUrl = appOrigins.some((origin) => url.startsWith(origin))
+    if (!isAppUrl) {
+      console.warn(`[Main] Blocked navigation of main window to: ${url}`)
+      event.preventDefault()
+    }
+  })
+
+  // Layer 2: Recovery — if CDP Page.navigate bypasses will-navigate and the main
+  // window ends up on a non-app URL, detect it and reload the app immediately.
+  // This is a safety net, not prevention — the window briefly shows the wrong page
+  // then snaps back to the app.
+  const appUrl = is.dev && process.env['ELECTRON_RENDERER_URL']
+    ? process.env['ELECTRON_RENDERER_URL']
+    : null // file:// URL set after loadFile
+  const mw = mainWindow // capture non-null reference for closure
+  mw.webContents.on('did-navigate', (_event, url) => {
+    const appOrigins = ['http://localhost:', 'file://']
+    const isAppUrl = appOrigins.some((origin) => url.startsWith(origin))
+    if (!isAppUrl) {
+      console.warn(`[Main] Main window navigated to non-app URL: ${url} — recovering...`)
+      if (appUrl) {
+        mw.loadURL(appUrl)
+      } else {
+        mw.loadFile(join(__dirname, '../renderer/index.html'))
+      }
+    }
   })
 
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
@@ -541,6 +577,12 @@ protocol.registerSchemesAsPrivileged([
 
 // Initialize crash logger as early as possible
 initCrashLogger()
+
+// Enable Chrome DevTools Protocol (CDP) on a fixed port so that agent-browser
+// (and other CDP clients) can connect to webview tabs embedded in the canvas.
+// Port 0 lets Chromium pick a free port; we read it back via the /json endpoint.
+const CDP_PORT = 19222
+app.commandLine.appendSwitch('remote-debugging-port', String(CDP_PORT))
 
 // Ignore EPIPE errors from broken stdout/stderr pipes (e.g. when piped through head/tail)
 process.stdout?.on?.('error', (err: NodeJS.ErrnoException) => { if (err.code !== 'EPIPE') throw err })

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 
 vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
@@ -7,10 +7,31 @@ vi.mock('electron', () => ({
   Notification: vi.fn().mockImplementation(() => ({ show: vi.fn() }))
 }))
 
+const { mockChildKill, mockSpawn } = vi.hoisted(() => {
+  const kill = vi.fn()
+  const spawn = vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    stdin: { writable: true, write: vi.fn() },
+    on: vi.fn(),
+    kill,
+    pid: 4242
+  }))
+  return { mockChildKill: kill, mockSpawn: spawn }
+})
+
+vi.mock('child_process', () => ({
+  spawn: mockSpawn
+}))
+
 import { ipcMain } from 'electron'
 import { registerIpcHandlers } from './ipc-handlers'
 
 describe('registerIpcHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('registers the expected number of IPC handlers', () => {
     const db = {} as unknown as Parameters<typeof registerIpcHandlers>[0]
     const agentManager = {} as unknown as Parameters<typeof registerIpcHandlers>[1]
@@ -36,5 +57,33 @@ describe('registerIpcHandlers', () => {
     expect(channels).toContain('skills:getAll')
     expect(channels).toContain('taskSource:sync')
     expect(channels).toContain('plugin:list')
+  })
+
+  it('terminal:kill ignores stale expectedPid and only kills matching process', async () => {
+    const db = {} as unknown as Parameters<typeof registerIpcHandlers>[0]
+    const agentManager = {} as unknown as Parameters<typeof registerIpcHandlers>[1]
+    const githubManager = {} as unknown as Parameters<typeof registerIpcHandlers>[2]
+    const worktreeManager = {} as unknown as Parameters<typeof registerIpcHandlers>[3]
+    const syncManager = {} as unknown as Parameters<typeof registerIpcHandlers>[4]
+    const pluginRegistry = {} as unknown as Parameters<typeof registerIpcHandlers>[5]
+
+    registerIpcHandlers(db, agentManager, githubManager, worktreeManager, syncManager, pluginRegistry)
+
+    const handleCalls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls as [string, (...args: unknown[]) => unknown][]
+    const createHandler = handleCalls.find((call) => call[0] === 'terminal:create')?.[1]
+    const killHandler = handleCalls.find((call) => call[0] === 'terminal:kill')?.[1]
+
+    expect(createHandler).toBeDefined()
+    expect(killHandler).toBeDefined()
+
+    const sender = { isDestroyed: () => false, send: vi.fn() }
+    await createHandler?.({ sender }, { id: 'panel-1', cols: 80, rows: 24 })
+
+    await killHandler?.({}, { id: 'panel-1', expectedPid: 9999 })
+    expect(mockChildKill).not.toHaveBeenCalled()
+
+    await killHandler?.({}, { id: 'panel-1', expectedPid: 4242 })
+    expect(mockChildKill).toHaveBeenCalledTimes(1)
+    expect(mockChildKill).toHaveBeenCalledWith('SIGTERM')
   })
 })

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, shell, Notification, app, session } from 'electron'
+import { ipcMain, dialog, shell, Notification, app, session, webContents } from 'electron'
 import * as childProcess from 'child_process'
 import { copyFileSync, existsSync, unlinkSync, readdirSync, statSync, readFileSync } from 'fs'
 import { join, basename, extname } from 'path'
@@ -1253,10 +1253,15 @@ export function registerIpcHandlers(
   // (which requires native module rebuild for Electron) and avoids macOS
   // `script` command (which fails with piped stdio).
 
+  /** Max lines to keep in terminal output buffer for agent log queries */
+  const TERMINAL_BUFFER_MAX_LINES = 500
+
   interface TerminalHandle {
     write: (data: string) => void
     kill: () => void
     pid: number
+    /** Circular buffer of recent terminal output lines */
+    outputBuffer: string[]
   }
 
   const terminals = new Map<string, TerminalHandle>()
@@ -1278,7 +1283,7 @@ export function registerIpcHandlers(
    */
   function createPythonPty(
     id: string, shellPath: string, cols: number, rows: number,
-    sender: Electron.WebContents
+    sender: Electron.WebContents, cwd?: string
   ): TerminalHandle {
     const { spawn } = childProcess
 
@@ -1360,29 +1365,58 @@ else:
         os.waitpid(pid, 0)
 `
 
+    const initialCwd = cwd || process.env.HOME || process.cwd()
     const child = spawn('python3', ['-u', '-c', pythonScript, shellPath, String(cols || 80), String(rows || 24)], {
       stdio: ['pipe', 'pipe', 'pipe'],
-      cwd: process.env.HOME || process.cwd(),
+      cwd: initialCwd,
       env: { ...process.env } as Record<string, string>,
     })
 
+    const outputBuffer: string[] = []
+
+    /** Append raw PTY output to the line buffer, stripping ANSI escape codes */
+    const appendToBuffer = (raw: string) => {
+      // Strip ANSI escape sequences for clean log output
+      // eslint-disable-next-line no-control-regex
+      const clean = raw.replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?(\x07|\x1b\\)|\x1b[()][A-Z0-9]|\r/g, '')
+      const lines = clean.split('\n')
+      for (const line of lines) {
+        if (line.trim()) outputBuffer.push(line)
+      }
+      // Trim to max buffer size
+      while (outputBuffer.length > TERMINAL_BUFFER_MAX_LINES) {
+        outputBuffer.shift()
+      }
+    }
+
     child.stdout?.on('data', (data: Buffer) => {
+      const str = data.toString()
+      appendToBuffer(str)
       if (!sender.isDestroyed()) {
-        sender.send('terminal:data', { id, data: data.toString() })
+        sender.send('terminal:data', { id, data: str })
       }
     })
 
     child.stderr?.on('data', (data: Buffer) => {
+      const str = data.toString()
+      appendToBuffer(str)
       // Forward stderr too (e.g. shell startup errors)
       if (!sender.isDestroyed()) {
-        sender.send('terminal:data', { id, data: data.toString() })
+        sender.send('terminal:data', { id, data: str })
       }
     })
 
-    child.on('exit', () => {
-      terminals.delete(id)
-      if (!sender.isDestroyed()) {
-        sender.send('terminal:exit', { id })
+    child.on('exit', (code, signal) => {
+      console.log(`[Terminal] PTY exited id=${id} code=${code} signal=${signal} pid=${child.pid}`)
+      // Only clean up if this handle is still the active one for this id.
+      // When terminal:create replaces an existing PTY, the old one's exit
+      // handler fires asynchronously and must NOT delete the new handle.
+      const current = terminals.get(id)
+      if (current && current.pid === (child.pid || 0)) {
+        terminals.delete(id)
+        if (!sender.isDestroyed()) {
+          sender.send('terminal:exit', { id })
+        }
       }
     })
 
@@ -1394,20 +1428,34 @@ else:
         try { child.kill('SIGTERM') } catch { /* ignore */ }
       },
       pid: child.pid || 0,
+      outputBuffer,
     }
   }
 
-  ipcMain.handle('terminal:create', async (event, { id, cols, rows }: { id: string; cols: number; rows: number }) => {
-    const shellPath = resolveShell()
-    console.log(`[Terminal] Creating terminal id=${id} shell=${shellPath} cols=${cols} rows=${rows}`)
+  ipcMain.handle('terminal:create', async (event, { id, cols, rows, cwd }: { id: string; cols: number; rows: number; cwd?: string }) => {
+    // Kill any existing terminal with the same ID (e.g. respawn after exit)
+    const existing = terminals.get(id)
+    if (existing) {
+      try { existing.kill() } catch { /* ignore */ }
+      terminals.delete(id)
+    }
 
-    const handle = createPythonPty(id, shellPath, cols, rows, event.sender)
+    const shellPath = resolveShell()
+    console.log(`[Terminal] Creating terminal id=${id} shell=${shellPath} cols=${cols} rows=${rows} cwd=${cwd || '(default)'}`)
+
+    const handle = createPythonPty(id, shellPath, cols, rows, event.sender, cwd)
     terminals.set(id, handle)
     return { pid: handle.pid }
   })
 
   ipcMain.handle('terminal:write', (_, { id, data }: { id: string; data: string }) => {
-    terminals.get(id)?.write(data)
+    const term = terminals.get(id)
+    if (!term) {
+      console.log(`[Terminal] write to dead terminal id=${id}`)
+      return { alive: false }
+    }
+    term.write(data)
+    return { alive: true }
   })
 
   ipcMain.handle('terminal:resize', (_event, { id, cols, rows }: { id: string; cols: number; rows: number }) => {
@@ -1415,11 +1463,161 @@ else:
     void id; void cols; void rows
   })
 
-  ipcMain.handle('terminal:kill', (_, { id }: { id: string }) => {
+  /** Get the last N lines from a terminal's output buffer */
+  ipcMain.handle('terminal:getBuffer', (_, { id, lines }: { id: string; lines?: number }) => {
+    const term = terminals.get(id)
+    if (!term) return { lines: [] }
+    const maxLines = Math.min(lines || 200, TERMINAL_BUFFER_MAX_LINES)
+    const buf = term.outputBuffer.slice(-maxLines)
+    return { lines: buf }
+  })
+
+  ipcMain.handle('terminal:kill', (_, { id, expectedPid }: { id: string; expectedPid?: number }) => {
     const term = terminals.get(id)
     if (term) {
+      // Ignore stale cleanup calls from an older terminal instance.
+      if (expectedPid !== undefined && term.pid !== expectedPid) return
       term.kill()
       terminals.delete(id)
+    }
+  })
+
+  /**
+   * Get the current working directory of a terminal's shell process.
+   * The PTY is a Python process that forks a shell child. We need the shell's
+   * cwd, not Python's. Strategy:
+   *   1. Find child PIDs of the Python process via `pgrep -P <pid>`
+   *   2. Get the cwd of the deepest child (most recently forked = active shell)
+   *   3. Use `lsof -p <childPid> -a -d cwd -Fn` for the cwd lookup
+   */
+  ipcMain.handle('terminal:getCwd', async (_, { id, expectedPid }: { id: string; expectedPid?: number }) => {
+    const term = terminals.get(id)
+    if (!term) return { cwd: null }
+    if (expectedPid !== undefined && term.pid !== expectedPid) return { cwd: null }
+
+    try {
+      const { execSync } = childProcess
+      const pythonPid = term.pid
+
+      // Find child PIDs of the Python process (the forked shell)
+      let targetPid = pythonPid
+      try {
+        const children = execSync(`pgrep -P ${pythonPid} 2>/dev/null || true`, {
+          encoding: 'utf-8',
+          timeout: 2000,
+        }).trim()
+        if (children) {
+          // Get the last child (deepest descendant = active process)
+          const childPids = children.split('\n').map((s) => parseInt(s.trim(), 10)).filter(Boolean)
+          if (childPids.length > 0) {
+            // Walk down — find children of children to get the deepest active shell
+            let deepest = childPids[childPids.length - 1]
+            for (let i = 0; i < 5; i++) { // max 5 levels deep
+              const grandchildren = execSync(`pgrep -P ${deepest} 2>/dev/null || true`, {
+                encoding: 'utf-8',
+                timeout: 1000,
+              }).trim()
+              if (!grandchildren) break
+              const gcPids = grandchildren.split('\n').map((s) => parseInt(s.trim(), 10)).filter(Boolean)
+              if (gcPids.length === 0) break
+              deepest = gcPids[gcPids.length - 1]
+            }
+            targetPid = deepest
+          }
+        }
+      } catch { /* ignore pgrep failures */ }
+
+      // Get cwd of the target process
+      const output = execSync(`lsof -p ${targetPid} -a -d cwd -Fn 2>/dev/null || true`, {
+        encoding: 'utf-8',
+        timeout: 2000,
+      })
+      const lines = output.split('\n')
+      const cwdLine = lines.find((l) => l.startsWith('n/'))
+      if (cwdLine) {
+        return { cwd: cwdLine.slice(1) }
+      }
+
+      // Fallback: try /proc on Linux
+      if (process.platform === 'linux') {
+        const linkTarget = execSync(`readlink /proc/${targetPid}/cwd 2>/dev/null || true`, {
+          encoding: 'utf-8',
+          timeout: 2000,
+        }).trim()
+        if (linkTarget) return { cwd: linkTarget }
+      }
+
+      return { cwd: null }
+    } catch {
+      return { cwd: null }
+    }
+  })
+
+  // ── Browser CDP ─────────────────────────────────────────
+  // Returns the CDP (Chrome DevTools Protocol) port that agent-browser
+  // can use to connect to webview tabs on the canvas.
+  ipcMain.handle('browser:getCdpPort', () => {
+    return { port: 19222 }
+  })
+
+  // Returns the CDP target ID for a webview given its webContentsId.
+  // This allows the renderer to store the target ID on the panel data,
+  // so agent-browser can connect directly via ws://localhost:19222/devtools/page/<targetId>
+  ipcMain.handle('browser:getTargetId', async (_event, webContentsId: number) => {
+    try {
+      const wc = webContents.fromId(webContentsId)
+      if (!wc) return { targetId: null }
+
+      // Use the debugger API to get the CDP target info
+      try {
+        wc.debugger.attach('1.3')
+        const { targetInfo } = await wc.debugger.sendCommand('Target.getTargetInfo')
+        const targetId = targetInfo?.targetId || null
+        wc.debugger.detach()
+        return { targetId }
+      } catch {
+        try { wc.debugger.detach() } catch { /* already detached */ }
+        // Fallback: query CDP /json/list and match by URL
+        const wcUrl = wc.getURL()
+        if (!wcUrl) return { targetId: null }
+        const res = await fetch(`http://localhost:19222/json/list`)
+        const targets = await res.json()
+        const match = targets.find((t: { url: string; type: string }) =>
+          t.type === 'webview' && t.url === wcUrl
+        )
+        return { targetId: match?.id || null }
+      }
+    } catch {
+      return { targetId: null }
+    }
+  })
+
+  // Returns all webview CDP targets. Called from the renderer to resolve
+  // CDP target IDs without CORS issues (renderer can't fetch localhost:19222).
+  ipcMain.handle('browser:getCdpTargets', async () => {
+    try {
+      const res = await fetch('http://localhost:19222/json/list')
+      const targets = (await res.json()) as Array<{ id: string; url: string; type: string; title: string }>
+      // agent-browser's `tab` command shows only page + webview targets (not iframes,
+      // service workers, etc.) and sorts them: pages first, then webviews.
+      // We replicate that ordering so the renderer can compute the exact tab ID.
+      const tabTargets = targets
+        .filter((t) => t.type === 'page' || t.type === 'webview')
+        .sort((a, b) => {
+          // page before webview (matches agent-browser ordering)
+          if (a.type === 'page' && b.type !== 'page') return -1
+          if (a.type !== 'page' && b.type === 'page') return 1
+          return 0
+        })
+      return tabTargets.map((t, i) => ({
+        id: t.id,
+        url: t.url,
+        title: t.title,
+        type: t.type,
+        tabId: `t${i + 1}`,
+      }))
+    } catch {
+      return []
     }
   })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -415,14 +415,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getPathForFile: (file: File): string => webUtils.getPathForFile(file)
   },
   terminal: {
-    create: (id: string, cols: number, rows: number): Promise<{ pid: number }> =>
-      ipcRenderer.invoke('terminal:create', { id, cols, rows }),
+    create: (id: string, cols: number, rows: number, cwd?: string): Promise<{ pid: number }> =>
+      ipcRenderer.invoke('terminal:create', { id, cols, rows, cwd }),
     write: (id: string, data: string): Promise<void> =>
       ipcRenderer.invoke('terminal:write', { id, data }),
     resize: (id: string, cols: number, rows: number): Promise<void> =>
       ipcRenderer.invoke('terminal:resize', { id, cols, rows }),
-    kill: (id: string): Promise<void> =>
-      ipcRenderer.invoke('terminal:kill', { id }),
+    kill: (id: string, expectedPid?: number): Promise<void> =>
+      ipcRenderer.invoke('terminal:kill', { id, expectedPid }),
+    getCwd: (id: string, expectedPid?: number): Promise<{ cwd: string | null }> =>
+      ipcRenderer.invoke('terminal:getCwd', { id, expectedPid }),
+    getBuffer: (id: string, lines?: number): Promise<{ lines: string[] }> =>
+      ipcRenderer.invoke('terminal:getBuffer', { id, lines }),
     onData: (callback: (data: { id: string; data: string }) => void): (() => void) => {
       const handler = (_: unknown, d: { id: string; data: string }): void => callback(d)
       ipcRenderer.on('terminal:data', handler)
@@ -433,5 +437,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('terminal:exit', handler)
       return () => ipcRenderer.removeListener('terminal:exit', handler)
     }
+  },
+  browser: {
+    getCdpPort: (): Promise<{ port: number }> =>
+      ipcRenderer.invoke('browser:getCdpPort'),
+    getTargetId: (webContentsId: number): Promise<{ targetId: string | null }> =>
+      ipcRenderer.invoke('browser:getTargetId', webContentsId),
+    getCdpTargets: (): Promise<Array<{ id: string; url: string; title: string }>> =>
+      ipcRenderer.invoke('browser:getCdpTargets')
   }
 })

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -1,0 +1,347 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import {
+  Globe,
+  RefreshCw,
+  ArrowLeft,
+  ArrowRight,
+  Loader2,
+  Zap,
+} from 'lucide-react'
+import { useCanvasStore } from '@/stores/canvas-store'
+
+interface BrowserPanelContentProps {
+  panelId: string
+  /** Initial URL to load */
+  url?: string
+  sessionName?: string
+  streamPort?: number
+}
+
+/** CDP port exposed by the Electron app for agent-browser to connect to */
+const CDP_PORT = 19222
+
+/**
+ * Canvas panel with a real Electron <webview> — a fully interactive browser.
+ *
+ * The agent can control this browser via CDP (connecting to the webview's
+ * debugger port), and the user sees + interacts with the same page live
+ * on the canvas.
+ */
+export function BrowserPanelContent({
+  panelId,
+  url: initialUrl,
+}: BrowserPanelContentProps) {
+  const updatePanel = useCanvasStore((s) => s.updatePanel)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const webviewRef = useRef<any>(null)
+
+  // initialSrc is set once and never changed — prevents the webview from
+  // reloading when React re-renders.  All subsequent navigations go through
+  // webviewRef.current.loadURL() which doesn't touch this ref.
+  const DEFAULT_URL = 'https://www.google.com'
+  const initialSrc = useRef(initialUrl || DEFAULT_URL)
+  const [inputValue, setInputValue] = useState(initialUrl || DEFAULT_URL)
+  const [isLoading, setIsLoading] = useState(false)
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
+
+  // ── Check if this browser is connected to a task via an edge ──
+  // Uses imperative reads + subscribe to avoid re-rendering on every panel move
+  const [connectedTaskName, setConnectedTaskName] = useState<string | null>(null)
+
+  useEffect(() => {
+    function computeConnectedTask(): string | null {
+      const { edges, panels } = useCanvasStore.getState()
+      const browserEdges = edges.filter(
+        (e) =>
+          e.edgeType === 'browser' &&
+          (e.fromPanelId === panelId || e.toPanelId === panelId)
+      )
+      if (browserEdges.length === 0) return null
+      for (const edge of browserEdges) {
+        const otherId = edge.fromPanelId === panelId ? edge.toPanelId : edge.fromPanelId
+        const otherPanel = panels.find((p) => p.id === otherId)
+        if (otherPanel?.type === 'task') return otherPanel.title
+      }
+      return 'Agent'
+    }
+
+    setConnectedTaskName(computeConnectedTask())
+
+    // Only re-compute when edges change, not on every panel position change
+    const unsub = useCanvasStore.subscribe((state, prevState) => {
+      if (state.edges !== prevState.edges) {
+        setConnectedTaskName(computeConnectedTask())
+      }
+    })
+    return unsub
+  }, [panelId])
+
+  // ── Resolve CDP target ID once the webview is ready ──────
+  // The webview exposes getWebContentsId() which we send to main process
+  // to get the CDP target ID — stored on the panel for agent-browser to use.
+  const cdpTargetResolved = useRef(false)
+  useEffect(() => {
+    const wv = webviewRef.current
+    if (!wv || cdpTargetResolved.current) return
+
+    const resolveTargetId = async () => {
+      try {
+        // First try via IPC (uses debugger API or CDP match in main process)
+        const wcId = wv.getWebContentsId?.()
+        console.log(`[BrowserPanel:${panelId}] webContentsId=${wcId}, url=${wv.getURL?.()?.slice(0, 60)}`)
+        if (wcId) {
+          // Store webContentsId on panel for reliable CDP target resolution
+          updatePanel(panelId, { webContentsId: wcId })
+          const result = await window.electronAPI.browser.getTargetId(wcId)
+          if (result.targetId) {
+            cdpTargetResolved.current = true
+            updatePanel(panelId, { cdpTargetId: result.targetId, webContentsId: wcId })
+            return
+          }
+        }
+
+        // Fallback: query CDP targets via IPC (avoids CORS) and match by webview URL
+        const wvUrl = wv.getURL?.()
+        if (!wvUrl) return
+        const targets = await window.electronAPI.browser.getCdpTargets()
+        const match = targets.find((t) => t.url === wvUrl)
+        if (match) {
+          cdpTargetResolved.current = true
+          updatePanel(panelId, { cdpTargetId: match.id })
+        }
+      } catch {
+        // Silently ignore — webview may not be ready yet
+      }
+    }
+
+    wv.addEventListener('did-navigate', resolveTargetId)
+    wv.addEventListener('dom-ready', resolveTargetId)
+    // Also try immediately in case it's already loaded
+    resolveTargetId()
+    return () => {
+      wv.removeEventListener('did-navigate', resolveTargetId)
+      wv.removeEventListener('dom-ready', resolveTargetId)
+    }
+  }, [panelId, updatePanel])
+
+  // ── Webview event wiring ──────────────────────────────────
+  // Debounce store updates to avoid re-render storms from SPA sites (e.g. Google Maps)
+  const pendingUrlUpdate = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingTitleUpdate = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const wv = webviewRef.current
+    if (!wv) return
+
+    const onStartLoading = () => setIsLoading(true)
+    const onStopLoading = () => {
+      setIsLoading(false)
+      setCanGoBack(wv.canGoBack())
+      setCanGoForward(wv.canGoForward())
+    }
+    const onNavigate = (e: { url: string }) => {
+      // Only update the URL bar text — never feed back into <webview src>
+      setInputValue(e.url)
+      // Debounce store update to avoid flooding zustand on SPA navigations
+      if (pendingUrlUpdate.current) clearTimeout(pendingUrlUpdate.current)
+      pendingUrlUpdate.current = setTimeout(() => {
+        updatePanel(panelId, { url: e.url })
+      }, 500)
+    }
+    const onTitleUpdate = (e: { title: string }) => {
+      if (pendingTitleUpdate.current) clearTimeout(pendingTitleUpdate.current)
+      pendingTitleUpdate.current = setTimeout(() => {
+        updatePanel(panelId, { title: e.title || 'Browser' })
+      }, 500)
+    }
+
+    // Prevent webview from going fullscreen — it covers the entire app
+    const onEnterFullScreen = () => {
+      // Immediately exit fullscreen by pressing Escape in the webview
+      wv.executeJavaScript('document.exitFullscreen?.().catch(()=>{})').catch(() => {})
+    }
+
+    wv.addEventListener('did-start-loading', onStartLoading)
+    wv.addEventListener('did-stop-loading', onStopLoading)
+    wv.addEventListener('did-navigate', onNavigate)
+    wv.addEventListener('did-navigate-in-page', onNavigate as any)
+    wv.addEventListener('page-title-updated', onTitleUpdate)
+    wv.addEventListener('enter-html-full-screen', onEnterFullScreen)
+
+    return () => {
+      wv.removeEventListener('did-start-loading', onStartLoading)
+      wv.removeEventListener('did-stop-loading', onStopLoading)
+      wv.removeEventListener('did-navigate', onNavigate)
+      wv.removeEventListener('did-navigate-in-page', onNavigate as any)
+      wv.removeEventListener('page-title-updated', onTitleUpdate)
+      wv.removeEventListener('enter-html-full-screen', onEnterFullScreen)
+      if (pendingUrlUpdate.current) clearTimeout(pendingUrlUpdate.current)
+      if (pendingTitleUpdate.current) clearTimeout(pendingTitleUpdate.current)
+    }
+  }, [panelId, updatePanel])
+
+  // ── Navigation handlers ───────────────────────────────────
+  const navigate = useCallback((url: string) => {
+    let finalUrl = url.trim()
+    if (!finalUrl) return
+    if (!/^https?:\/\//i.test(finalUrl)) {
+      // Check if it looks like a URL or a search query
+      if (/^[\w-]+\.[\w]{2,}/.test(finalUrl)) {
+        finalUrl = 'https://' + finalUrl
+      } else {
+        finalUrl = `https://www.google.com/search?q=${encodeURIComponent(finalUrl)}`
+      }
+    }
+    setInputValue(finalUrl)
+    // Navigate via loadURL — never set the src attribute reactively
+    const wv = webviewRef.current
+    if (wv) {
+      wv.loadURL(finalUrl)
+    } else {
+      // Webview not mounted yet — set initial src for first render
+      initialSrc.current = finalUrl
+    }
+  }, [])
+
+  const handleSubmit = useCallback((e: React.FormEvent) => {
+    e.preventDefault()
+    navigate(inputValue)
+  }, [inputValue, navigate])
+
+  const handleBack = useCallback(() => {
+    webviewRef.current?.goBack()
+  }, [])
+
+  const handleForward = useCallback(() => {
+    webviewRef.current?.goForward()
+  }, [])
+
+  const handleRefresh = useCallback(() => {
+    webviewRef.current?.reload()
+  }, [])
+
+  // ── Live browser ──────────────────────────────────────────
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <BrowserUrlBar
+        inputValue={inputValue}
+        isLoading={isLoading}
+        canGoBack={canGoBack}
+        canGoForward={canGoForward}
+        onInputChange={setInputValue}
+        onSubmit={handleSubmit}
+        onBack={handleBack}
+        onForward={handleForward}
+        onRefresh={handleRefresh}
+        connectedTaskName={connectedTaskName}
+      />
+
+      {/* Webview — real browser */}
+      <div className="flex-1 min-h-0">
+        <webview
+          ref={webviewRef as any}
+          src={initialSrc.current}
+          className="w-full h-full"
+          /* @ts-expect-error — Electron webview attributes not typed in JSX */
+          allowpopups="true"
+          style={{ display: 'flex', flex: 1, width: '100%', height: '100%' }}
+        />
+      </div>
+    </div>
+  )
+}
+
+// ── URL Bar component ─────────────────────────────────────────
+
+function BrowserUrlBar({
+  inputValue,
+  isLoading,
+  canGoBack,
+  canGoForward,
+  onInputChange,
+  onSubmit,
+  onBack,
+  onForward,
+  onRefresh,
+  connectedTaskName,
+  autoFocus,
+}: {
+  inputValue: string
+  isLoading: boolean
+  canGoBack: boolean
+  canGoForward: boolean
+  onInputChange: (v: string) => void
+  onSubmit: (e: React.FormEvent) => void
+  onBack: () => void
+  onForward: () => void
+  onRefresh: () => void
+  connectedTaskName?: string | null
+  autoFocus?: boolean
+}) {
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="flex items-center gap-1.5 px-2 py-1.5 bg-[#0d1117]/60 border-b border-border/20 flex-shrink-0"
+    >
+      {/* Nav buttons */}
+      <button
+        type="button"
+        onClick={onBack}
+        disabled={!canGoBack}
+        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
+        title="Back"
+      >
+        <ArrowLeft className="h-3 w-3" />
+      </button>
+      <button
+        type="button"
+        onClick={onForward}
+        disabled={!canGoForward}
+        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
+        title="Forward"
+      >
+        <ArrowRight className="h-3 w-3" />
+      </button>
+      <button
+        type="button"
+        onClick={onRefresh}
+        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+        title="Refresh"
+      >
+        {isLoading ? (
+          <Loader2 className="h-3 w-3 animate-spin" />
+        ) : (
+          <RefreshCw className="h-3 w-3" />
+        )}
+      </button>
+
+      {/* URL input */}
+      <div className="flex-1 flex items-center gap-1.5 bg-[#1a2030] rounded-md px-2 py-1 border border-border/20 focus-within:border-orange-500/30 transition-colors">
+        <Globe className="h-3 w-3 text-muted-foreground/30 flex-shrink-0" />
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => onInputChange(e.target.value)}
+          placeholder="Search or enter URL"
+          autoFocus={autoFocus}
+          className="flex-1 text-[11px] bg-transparent text-foreground placeholder:text-muted-foreground/25 focus:outline-none font-mono"
+          onFocus={(e) => e.target.select()}
+        />
+      </div>
+
+      {/* Agent connection indicator */}
+      {connectedTaskName && (
+        <div
+          className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-orange-500/10 border border-orange-500/20 flex-shrink-0"
+          title={`Connected to "${connectedTaskName}" — agent can control this browser via CDP port ${CDP_PORT}`}
+        >
+          <Zap className="h-2.5 w-2.5 text-orange-400" />
+          <span className="text-[9px] font-medium text-orange-400/80 whitespace-nowrap">
+            CDP
+          </span>
+        </div>
+      )}
+    </form>
+  )
+}

--- a/src/renderer/src/components/canvas/CanvasConnections.tsx
+++ b/src/renderer/src/components/canvas/CanvasConnections.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react'
 import { useCanvasStore, type CanvasPanelData, type CanvasEdge } from '@/stores/canvas-store'
-import { X } from 'lucide-react'
 
 /**
- * Renders SVG connection lines between panels.
- * Also renders the in-progress connection line when drawing a new edge.
+ * Renders smooth bezier connection curves between panels.
+ * Follows Figma/React Flow best practice: clean curves, small anchor dots,
+ * subtle color distinction for typed edges (browser = orange, default = indigo).
  */
 export function CanvasConnections({
   mouseCanvasPos,
@@ -14,6 +14,7 @@ export function CanvasConnections({
   const panels = useCanvasStore((s) => s.panels)
   const edges = useCanvasStore((s) => s.edges)
   const connectingFromId = useCanvasStore((s) => s.connectingFromId)
+  const proximityEdge = useCanvasStore((s) => s.proximityEdge)
   const removeEdge = useCanvasStore((s) => s.removeEdge)
 
   const panelMap = useMemo(() => {
@@ -22,126 +23,243 @@ export function CanvasConnections({
     return map
   }, [panels])
 
-  // Calculate edge lines with center-to-center positioning
-  const edgeLines = useMemo(() => {
+  /**
+   * Find the best connection anchor point on a panel edge
+   * given a target point — connects from the nearest edge midpoint.
+   */
+  const getAnchor = (panel: CanvasPanelData, targetX: number, targetY: number) => {
+    const cx = panel.x + panel.width / 2
+    const cy = panel.y + panel.height / 2
+    const dx = targetX - cx
+    const dy = targetY - cy
+
+    // Pick the edge that faces the target
+    if (Math.abs(dx) / panel.width > Math.abs(dy) / panel.height) {
+      // Horizontal — left or right edge
+      return dx > 0
+        ? { x: panel.x + panel.width, y: cy, dir: 'right' as const }
+        : { x: panel.x, y: cy, dir: 'left' as const }
+    } else {
+      // Vertical — top or bottom edge
+      return dy > 0
+        ? { x: cx, y: panel.y + panel.height, dir: 'down' as const }
+        : { x: cx, y: panel.y, dir: 'up' as const }
+    }
+  }
+
+  /** Build a smooth cubic bezier path between two anchored points */
+  const makePath = (
+    from: { x: number; y: number; dir: string },
+    to: { x: number; y: number; dir: string }
+  ) => {
+    const dist = Math.hypot(to.x - from.x, to.y - from.y)
+    const offset = Math.min(80, dist * 0.4)
+
+    const cp = (anchor: { x: number; y: number; dir: string }, sign: number) => {
+      switch (anchor.dir) {
+        case 'right': return { x: anchor.x + offset * sign, y: anchor.y }
+        case 'left':  return { x: anchor.x - offset * sign, y: anchor.y }
+        case 'down':  return { x: anchor.x, y: anchor.y + offset * sign }
+        case 'up':    return { x: anchor.x, y: anchor.y - offset * sign }
+        default:      return { x: anchor.x + offset * sign, y: anchor.y }
+      }
+    }
+
+    const c1 = cp(from, 1)
+    const c2 = cp(to, 1)
+    return `M ${from.x} ${from.y} C ${c1.x} ${c1.y}, ${c2.x} ${c2.y}, ${to.x} ${to.y}`
+  }
+
+  // Calculate edge data
+  const edgeData = useMemo(() => {
     return edges
       .map((edge) => {
         const from = panelMap.get(edge.fromPanelId)
         const to = panelMap.get(edge.toPanelId)
         if (!from || !to) return null
-        return {
-          id: edge.id,
-          x1: from.x + from.width / 2,
-          y1: from.y + from.height / 2,
-          x2: to.x + to.width / 2,
-          y2: to.y + to.height / 2,
-          edge,
-        }
+
+        const toCenter = { x: to.x + to.width / 2, y: to.y + to.height / 2 }
+        const fromCenter = { x: from.x + from.width / 2, y: from.y + from.height / 2 }
+        const fromAnchor = getAnchor(from, toCenter.x, toCenter.y)
+        const toAnchor = getAnchor(to, fromCenter.x, fromCenter.y)
+        const path = makePath(fromAnchor, toAnchor)
+
+        return { id: edge.id, edge, fromAnchor, toAnchor, path }
       })
       .filter(Boolean) as Array<{
       id: string
-      x1: number
-      y1: number
-      x2: number
-      y2: number
       edge: CanvasEdge
+      fromAnchor: { x: number; y: number; dir: string }
+      toAnchor: { x: number; y: number; dir: string }
+      path: string
     }>
   }, [edges, panelMap])
 
-  // In-progress connection line
-  const connectingFrom = connectingFromId ? panelMap.get(connectingFromId) : null
-  const pendingLine =
-    connectingFrom && mouseCanvasPos
-      ? {
-          x1: connectingFrom.x + connectingFrom.width / 2,
-          y1: connectingFrom.y + connectingFrom.height / 2,
-          x2: mouseCanvasPos.x,
-          y2: mouseCanvasPos.y,
-        }
-      : null
+  // Pending connection line
+  const pendingPath = useMemo(() => {
+    if (!connectingFromId || !mouseCanvasPos) return null
+    const from = panelMap.get(connectingFromId)
+    if (!from) return null
 
-  if (edgeLines.length === 0 && !pendingLine) return null
+    const fromAnchor = getAnchor(from, mouseCanvasPos.x, mouseCanvasPos.y)
+    const toAnchor = { ...mouseCanvasPos, dir: fromAnchor.dir === 'right' ? 'left' : fromAnchor.dir === 'left' ? 'right' : fromAnchor.dir === 'down' ? 'up' : 'down' }
+    return { fromAnchor, path: makePath(fromAnchor, toAnchor) }
+  }, [connectingFromId, mouseCanvasPos, panelMap])
+
+  // Proximity edge preview (glowing edge during drag)
+  const proximityPath = useMemo(() => {
+    if (!proximityEdge) return null
+    const from = panelMap.get(proximityEdge.fromId)
+    const to = panelMap.get(proximityEdge.toId)
+    if (!from || !to) return null
+
+    const toCenter = { x: to.x + to.width / 2, y: to.y + to.height / 2 }
+    const fromCenter = { x: from.x + from.width / 2, y: from.y + from.height / 2 }
+    const fromAnchor = getAnchor(from, toCenter.x, toCenter.y)
+    const toAnchor = getAnchor(to, fromCenter.x, fromCenter.y)
+    const path = makePath(fromAnchor, toAnchor)
+    return { fromAnchor, toAnchor, path }
+  }, [proximityEdge, panelMap])
+
+  if (edgeData.length === 0 && !pendingPath && !proximityPath) return null
 
   return (
     <svg
       className="absolute inset-0 pointer-events-none"
       style={{ overflow: 'visible', zIndex: 0 }}
     >
-      <defs>
-        <marker
-          id="canvas-arrow"
-          markerWidth="8"
-          markerHeight="6"
-          refX="8"
-          refY="3"
-          orient="auto"
-        >
-          <path d="M0,0 L8,3 L0,6" fill="none" stroke="rgba(99,102,241,0.5)" strokeWidth="1" />
-        </marker>
-        <marker
-          id="canvas-arrow-pending"
-          markerWidth="8"
-          markerHeight="6"
-          refX="8"
-          refY="3"
-          orient="auto"
-        >
-          <path d="M0,0 L8,3 L0,6" fill="none" stroke="rgba(99,102,241,0.3)" strokeWidth="1" />
-        </marker>
-      </defs>
-
       {/* Existing edges */}
-      {edgeLines.map((line) => (
-        <g key={line.id}>
-          {/* Invisible wider line for easier click target */}
-          <line
-            x1={line.x1}
-            y1={line.y1}
-            x2={line.x2}
-            y2={line.y2}
-            stroke="transparent"
-            strokeWidth="12"
-            className="pointer-events-auto cursor-pointer"
-            onClick={() => removeEdge(line.id)}
-          />
-          {/* Visible line */}
-          <line
-            x1={line.x1}
-            y1={line.y1}
-            x2={line.x2}
-            y2={line.y2}
-            stroke="rgba(99,102,241,0.35)"
-            strokeWidth="1.5"
-            strokeDasharray="6 4"
-            markerEnd="url(#canvas-arrow)"
-          />
-          {/* Delete button at midpoint */}
-          <EdgeDeleteButton
-            x={(line.x1 + line.x2) / 2}
-            y={(line.y1 + line.y2) / 2}
-            onDelete={() => removeEdge(line.id)}
-          />
-        </g>
-      ))}
+      {edgeData.map((edge) => {
+        const edgeType = edge.edge.edgeType
+        const colorFaded = edgeType === 'browser' ? 'rgba(249,115,22,0.5)'
+          : edgeType === 'terminal' ? 'rgba(34,197,94,0.5)'
+          : 'rgba(99,102,241,0.45)'
+        const colorDot = edgeType === 'browser' ? 'rgba(249,115,22,0.8)'
+          : edgeType === 'terminal' ? 'rgba(34,197,94,0.8)'
+          : 'rgba(99,102,241,0.7)'
+
+        return (
+          <g key={edge.id}>
+            {/* Invisible wider path for click target */}
+            <path
+              d={edge.path}
+              fill="none"
+              stroke="transparent"
+              strokeWidth="14"
+              className="pointer-events-auto cursor-pointer"
+              onClick={() => removeEdge(edge.id)}
+            />
+
+            {/* Visible bezier curve */}
+            <path
+              d={edge.path}
+              fill="none"
+              stroke={colorFaded}
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+
+            {/* Source anchor dot */}
+            <circle
+              cx={edge.fromAnchor.x}
+              cy={edge.fromAnchor.y}
+              r="3"
+              fill={colorDot}
+            />
+
+            {/* Target anchor dot */}
+            <circle
+              cx={edge.toAnchor.x}
+              cy={edge.toAnchor.y}
+              r="3"
+              fill={colorDot}
+            />
+
+            {/* Delete dot on hover (midpoint) */}
+            <EdgeDeleteDot
+              x={(edge.fromAnchor.x + edge.toAnchor.x) / 2}
+              y={(edge.fromAnchor.y + edge.toAnchor.y) / 2}
+              onDelete={() => removeEdge(edge.id)}
+            />
+          </g>
+        )
+      })}
 
       {/* Pending connection line */}
-      {pendingLine && (
-        <line
-          x1={pendingLine.x1}
-          y1={pendingLine.y1}
-          x2={pendingLine.x2}
-          y2={pendingLine.y2}
-          stroke="rgba(99,102,241,0.3)"
-          strokeWidth="1.5"
-          strokeDasharray="4 4"
-          markerEnd="url(#canvas-arrow-pending)"
-        />
+      {pendingPath && (
+        <>
+          <path
+            d={pendingPath.path}
+            fill="none"
+            stroke="rgba(99,102,241,0.3)"
+            strokeWidth="2"
+            strokeDasharray="6 4"
+            strokeLinecap="round"
+          />
+          <circle
+            cx={pendingPath.fromAnchor.x}
+            cy={pendingPath.fromAnchor.y}
+            r="3"
+            fill="rgba(99,102,241,0.5)"
+          />
+          {mouseCanvasPos && (
+            <circle
+              cx={mouseCanvasPos.x}
+              cy={mouseCanvasPos.y}
+              r="4"
+              fill="none"
+              stroke="rgba(99,102,241,0.4)"
+              strokeWidth="1.5"
+            />
+          )}
+        </>
+      )}
+
+      {/* Proximity edge preview — glowing orange dashed line during drag */}
+      {proximityPath && (
+        <>
+          {/* Glow layer */}
+          <path
+            d={proximityPath.path}
+            fill="none"
+            stroke="rgba(249,115,22,0.3)"
+            strokeWidth="8"
+            strokeLinecap="round"
+            className="animate-pulse"
+          />
+          {/* Main dashed line */}
+          <path
+            d={proximityPath.path}
+            fill="none"
+            stroke="rgba(249,115,22,0.7)"
+            strokeWidth="2"
+            strokeDasharray="8 4"
+            strokeLinecap="round"
+          />
+          {/* Anchor dots */}
+          <circle
+            cx={proximityPath.fromAnchor.x}
+            cy={proximityPath.fromAnchor.y}
+            r="4"
+            fill="rgba(249,115,22,0.8)"
+            className="animate-pulse"
+          />
+          <circle
+            cx={proximityPath.toAnchor.x}
+            cy={proximityPath.toAnchor.y}
+            r="4"
+            fill="rgba(249,115,22,0.8)"
+            className="animate-pulse"
+          />
+        </>
       )}
     </svg>
   )
 }
 
-function EdgeDeleteButton({
+// ── Delete dot for edges (appears on hover) ─────────────────
+
+function EdgeDeleteDot({
   x,
   y,
   onDelete,
@@ -153,17 +271,11 @@ function EdgeDeleteButton({
   return (
     <g
       className="pointer-events-auto cursor-pointer opacity-0 hover:opacity-100 transition-opacity"
-      onClick={(e) => {
-        e.stopPropagation()
-        onDelete()
-      }}
+      onClick={(e) => { e.stopPropagation(); onDelete() }}
     >
-      <circle cx={x} cy={y} r="8" fill="#161b22" stroke="rgba(99,102,241,0.3)" strokeWidth="1" />
-      <foreignObject x={x - 5} y={y - 5} width="10" height="10">
-        <div className="flex items-center justify-center w-full h-full">
-          <X className="h-2.5 w-2.5 text-red-400" />
-        </div>
-      </foreignObject>
+      <circle cx={x} cy={y} r="7" fill="#161b22" stroke="rgba(99,102,241,0.3)" strokeWidth="1" />
+      <line x1={x - 2.5} y1={y - 2.5} x2={x + 2.5} y2={y + 2.5} stroke="rgba(239,68,68,0.7)" strokeWidth="1.5" strokeLinecap="round" />
+      <line x1={x + 2.5} y1={y - 2.5} x2={x - 2.5} y2={y + 2.5} stroke="rgba(239,68,68,0.7)" strokeWidth="1.5" strokeLinecap="round" />
     </g>
   )
 }

--- a/src/renderer/src/components/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/src/components/canvas/CanvasContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react'
-import { CheckSquare, MessageSquare, Monitor, AppWindow, X } from 'lucide-react'
+import { CheckSquare, MessageSquare, Monitor, AppWindow, Globe, TerminalSquare, X } from 'lucide-react'
 import { useTaskStore } from '@/stores/task-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useDashboardStore } from '@/stores/dashboard-store'
@@ -50,7 +50,7 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
   }, [onClose])
 
   const handleAddPanel = useCallback(
-    (type: CanvasPanelType, title: string, refId?: string) => {
+    (type: CanvasPanelType, title: string, refId?: string, url?: string) => {
       // Don't add duplicate task/transcript/app panels for the same refId
       if (refId && (type === 'task' || type === 'transcript' || type === 'app')) {
         const exists = panels.some((p) => p.type === type && p.refId === refId)
@@ -66,6 +66,7 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
         type,
         title,
         refId,
+        url,
         x: position.canvasX + offset,
         y: position.canvasY + offset,
         width: DEFAULT_PANEL_WIDTH,
@@ -106,6 +107,22 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
       </div>
 
       <div className="py-1 max-h-[400px] overflow-y-auto custom-scrollbar">
+        {/* Browser & Terminal — always available */}
+        <MenuSection title="Tools">
+          <MenuItem
+            icon={<Globe className="h-3.5 w-3.5 text-orange-400" />}
+            label="Agent Browser"
+            sublabel="Browser controlled by agent via CDP"
+            onClick={() => handleAddPanel('browser', 'Agent Browser', undefined, 'https://www.google.com')}
+          />
+          <MenuItem
+            icon={<TerminalSquare className="h-3.5 w-3.5 text-amber-400" />}
+            label="Terminal"
+            sublabel="Interactive shell session"
+            onClick={() => handleAddPanel('terminal', 'Terminal')}
+          />
+        </MenuSection>
+
         {/* Applications section */}
         {applications.length > 0 && (
           <MenuSection title="Applications">

--- a/src/renderer/src/components/canvas/CanvasMinimap.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useRef, useState, useMemo } from 'react'
+import { useCanvasStore, type CanvasPanelData, MIN_ZOOM, MAX_ZOOM } from '@/stores/canvas-store'
+import { Minus, Plus, Maximize2, ChevronDown, ChevronUp } from 'lucide-react'
+
+// ── Constants ─────────────────────────────────────────────
+const MINIMAP_W = 180
+const MINIMAP_H = 120
+const MINIMAP_PAD = 12 // padding inside the minimap
+
+// Panel type → color mapping
+const PANEL_COLORS: Record<string, string> = {
+  task: 'rgba(99,102,241,0.7)',     // indigo
+  browser: 'rgba(249,115,22,0.7)',  // orange
+  terminal: 'rgba(34,197,94,0.7)',  // green
+  app: 'rgba(168,85,247,0.7)',      // purple
+  transcript: 'rgba(59,130,246,0.6)', // blue
+  webpage: 'rgba(236,72,153,0.6)',  // pink
+  placeholder: 'rgba(107,114,128,0.4)', // gray
+}
+
+/**
+ * CanvasMinimap — a small overview map in the bottom-right corner.
+ *
+ * Shows all panels as colored rectangles, the current viewport as a
+ * semi-transparent rectangle, and supports:
+ * - Click to navigate to a location
+ * - Drag the viewport rectangle to pan
+ * - Zoom controls (+/-)
+ * - Fit-to-content button
+ * - Collapsible
+ */
+export function CanvasMinimap({
+  containerWidth,
+  containerHeight,
+}: {
+  containerWidth: number
+  containerHeight: number
+}) {
+  const panels = useCanvasStore((s) => s.panels)
+  const viewport = useCanvasStore((s) => s.viewport)
+  const edges = useCanvasStore((s) => s.edges)
+  const setViewport = useCanvasStore((s) => s.setViewport)
+  const zoomTo = useCanvasStore((s) => s.zoomTo)
+  const fitToContent = useCanvasStore((s) => s.fitToContent)
+
+  const [collapsed, setCollapsed] = useState(false)
+  const [isDragging, setIsDragging] = useState(false)
+  const svgRef = useRef<SVGSVGElement>(null)
+
+  // ── Compute bounding box of all panels ──────────────────
+  const bounds = useMemo(() => {
+    if (panels.length === 0) {
+      return { minX: 0, minY: 0, maxX: 1000, maxY: 800 }
+    }
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const p of panels) {
+      minX = Math.min(minX, p.x)
+      minY = Math.min(minY, p.y)
+      maxX = Math.max(maxX, p.x + p.width)
+      maxY = Math.max(maxY, p.y + p.height)
+    }
+    // Also include the viewport visible area so it never clips out
+    const vpLeft = -viewport.x / viewport.zoom
+    const vpTop = -viewport.y / viewport.zoom
+    const vpRight = vpLeft + containerWidth / viewport.zoom
+    const vpBottom = vpTop + containerHeight / viewport.zoom
+    minX = Math.min(minX, vpLeft)
+    minY = Math.min(minY, vpTop)
+    maxX = Math.max(maxX, vpRight)
+    maxY = Math.max(maxY, vpBottom)
+
+    // Add padding
+    const pad = 100
+    return { minX: minX - pad, minY: minY - pad, maxX: maxX + pad, maxY: maxY + pad }
+  }, [panels, viewport, containerWidth, containerHeight])
+
+  // ── Scale factor: canvas space → minimap space ──────────
+  const canvasW = bounds.maxX - bounds.minX
+  const canvasH = bounds.maxY - bounds.minY
+  const innerW = MINIMAP_W - MINIMAP_PAD * 2
+  const innerH = MINIMAP_H - MINIMAP_PAD * 2
+  const scale = Math.min(innerW / canvasW, innerH / canvasH)
+
+  // Transform canvas coord → minimap coord
+  const toMiniX = (cx: number) => MINIMAP_PAD + (cx - bounds.minX) * scale
+  const toMiniY = (cy: number) => MINIMAP_PAD + (cy - bounds.minY) * scale
+
+  // ── Viewport rectangle in minimap ──────────────────────
+  const vpLeft = -viewport.x / viewport.zoom
+  const vpTop = -viewport.y / viewport.zoom
+  const vpW = containerWidth / viewport.zoom
+  const vpH = containerHeight / viewport.zoom
+  const vpRect = {
+    x: toMiniX(vpLeft),
+    y: toMiniY(vpTop),
+    w: vpW * scale,
+    h: vpH * scale,
+  }
+
+  // ── Click/drag on minimap → pan canvas ──────────────────
+  const panToMinimapPoint = useCallback(
+    (clientX: number, clientY: number) => {
+      const svg = svgRef.current
+      if (!svg) return
+      const rect = svg.getBoundingClientRect()
+      const mx = clientX - rect.left
+      const my = clientY - rect.top
+
+      // Convert minimap coord → canvas coord
+      const canvasX = (mx - MINIMAP_PAD) / scale + bounds.minX
+      const canvasY = (my - MINIMAP_PAD) / scale + bounds.minY
+
+      // Center the viewport on this point
+      const newVpX = -(canvasX * viewport.zoom - containerWidth / 2)
+      const newVpY = -(canvasY * viewport.zoom - containerHeight / 2)
+      setViewport({ x: newVpX, y: newVpY })
+    },
+    [scale, bounds, viewport.zoom, containerWidth, containerHeight, setViewport]
+  )
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setIsDragging(true)
+      panToMinimapPoint(e.clientX, e.clientY)
+    },
+    [panToMinimapPoint]
+  )
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isDragging) return
+      panToMinimapPoint(e.clientX, e.clientY)
+    },
+    [isDragging, panToMinimapPoint]
+  )
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false)
+  }, [])
+
+  // ── Edge lines in minimap ─────────────────────────────
+  const panelMap = useMemo(() => {
+    const map = new Map<string, CanvasPanelData>()
+    for (const p of panels) map.set(p.id, p)
+    return map
+  }, [panels])
+
+  const zoomPercent = Math.round(viewport.zoom * 100)
+
+  if (panels.length === 0) return null
+
+  return (
+    <div
+      className="absolute bottom-4 right-4 z-10 select-none"
+      style={{ pointerEvents: 'auto' }}
+    >
+      {/* Header bar — always visible */}
+      <div
+        className="flex items-center justify-between px-2 py-1 bg-[#1a2030]/95 backdrop-blur-sm border border-border/40 rounded-t-lg cursor-pointer"
+        style={{ width: MINIMAP_W, borderBottom: collapsed ? undefined : 'none', borderRadius: collapsed ? '8px' : undefined }}
+        onClick={() => setCollapsed((c) => !c)}
+      >
+        <span className="text-[10px] font-medium text-muted-foreground/60 uppercase tracking-wider">
+          Map
+        </span>
+        <div className="flex items-center gap-1">
+          <span className="text-[10px] text-muted-foreground/40 tabular-nums">
+            {zoomPercent}%
+          </span>
+          {collapsed ? (
+            <ChevronUp className="h-3 w-3 text-muted-foreground/40" />
+          ) : (
+            <ChevronDown className="h-3 w-3 text-muted-foreground/40" />
+          )}
+        </div>
+      </div>
+
+      {/* Minimap body */}
+      {!collapsed && (
+        <div
+          className="bg-[#0d1117]/95 backdrop-blur-sm border border-border/40 border-t-0 rounded-b-lg overflow-hidden"
+          style={{ width: MINIMAP_W }}
+        >
+          {/* SVG minimap */}
+          <svg
+            ref={svgRef}
+            width={MINIMAP_W}
+            height={MINIMAP_H}
+            className="cursor-crosshair"
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseUp}
+          >
+            {/* Edge lines */}
+            {edges.map((edge) => {
+              const from = panelMap.get(edge.fromPanelId)
+              const to = panelMap.get(edge.toPanelId)
+              if (!from || !to) return null
+              const edgeColor = edge.edgeType === 'browser' ? 'rgba(249,115,22,0.4)'
+                : edge.edgeType === 'terminal' ? 'rgba(34,197,94,0.4)'
+                : 'rgba(99,102,241,0.3)'
+              return (
+                <line
+                  key={edge.id}
+                  x1={toMiniX(from.x + from.width / 2)}
+                  y1={toMiniY(from.y + from.height / 2)}
+                  x2={toMiniX(to.x + to.width / 2)}
+                  y2={toMiniY(to.y + to.height / 2)}
+                  stroke={edgeColor}
+                  strokeWidth="1"
+                />
+              )
+            })}
+
+            {/* Panel rectangles */}
+            {panels.map((p) => {
+              const color = PANEL_COLORS[p.type] || 'rgba(148,163,184,0.5)'
+              const px = toMiniX(p.x)
+              const py = toMiniY(p.y)
+              const pw = Math.max(3, p.width * scale)
+              const ph = Math.max(2, p.height * scale)
+              return (
+                <rect
+                  key={p.id}
+                  x={px}
+                  y={py}
+                  width={pw}
+                  height={ph}
+                  rx="1"
+                  fill={color}
+                  stroke="rgba(255,255,255,0.1)"
+                  strokeWidth="0.5"
+                />
+              )
+            })}
+
+            {/* Viewport rectangle */}
+            <rect
+              x={vpRect.x}
+              y={vpRect.y}
+              width={Math.max(4, vpRect.w)}
+              height={Math.max(3, vpRect.h)}
+              rx="1"
+              fill="rgba(255,255,255,0.06)"
+              stroke="rgba(255,255,255,0.3)"
+              strokeWidth="1"
+              className="pointer-events-none"
+            />
+          </svg>
+
+          {/* Zoom controls bar */}
+          <div className="flex items-center justify-between px-1.5 py-1 border-t border-border/20">
+            <button
+              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+              onClick={(e) => { e.stopPropagation(); zoomTo(viewport.zoom / 1.2) }}
+              title="Zoom out (Ctrl+-)"
+            >
+              <Minus className="h-3 w-3" />
+            </button>
+
+            {/* Zoom slider */}
+            <input
+              type="range"
+              min={MIN_ZOOM * 100}
+              max={MAX_ZOOM * 100}
+              value={viewport.zoom * 100}
+              onChange={(e) => {
+                e.stopPropagation()
+                zoomTo(Number(e.target.value) / 100)
+              }}
+              className="flex-1 mx-1.5 h-1 accent-indigo-500 cursor-pointer"
+              style={{ opacity: 0.5 }}
+              title={`Zoom: ${zoomPercent}%`}
+            />
+
+            <button
+              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+              onClick={(e) => { e.stopPropagation(); zoomTo(viewport.zoom * 1.2) }}
+              title="Zoom in (Ctrl+=)"
+            >
+              <Plus className="h-3 w-3" />
+            </button>
+
+            <div className="w-px h-3 bg-border/20 mx-0.5" />
+
+            <button
+              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+              onClick={(e) => { e.stopPropagation(); fitToContent(containerWidth, containerHeight) }}
+              title="Fit all panels"
+            >
+              <Maximize2 className="h-3 w-3" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -2,21 +2,29 @@ import { useCallback, useRef, useState, useEffect, memo } from 'react'
 import {
   useCanvasStore,
   calculateSnap,
+  detectProximityEdge,
+  DEFAULT_PANEL_WIDTH,
+  DEFAULT_PANEL_HEIGHT,
   type CanvasPanelData,
 } from '@/stores/canvas-store'
-import { X, Focus, Maximize2, Minimize2, PanelLeft, PanelRight, Columns2 } from 'lucide-react'
+import { X, Focus, Maximize2, Minimize2, PanelLeft, PanelRight, Columns2, Globe } from 'lucide-react'
 import type { TaskWorkspaceLayout } from '@/components/tasks/TaskWorkspace'
 import { TaskPanelContent } from './TaskPanelContent'
 import { TranscriptPanelContent } from './TranscriptPanelContent'
 import { AppPanelContent } from './AppPanelContent'
 import { WebPagePanelContent } from './WebPagePanelContent'
 import { TerminalPanelContent } from './TerminalPanelContent'
+import { BrowserPanelContent } from './BrowserPanelContent'
 
 interface CanvasPanelProps {
   panel: CanvasPanelData
   zoom: number
   /** When true, the panel is off-viewport — heavy content (iframes, terminals) is hidden */
   frozen?: boolean
+  /** 0-based index of this panel in the panels array */
+  panelIndex?: number
+  /** When true, show the panel index number as an overlay badge */
+  showIndex?: boolean
 }
 
 /**
@@ -26,13 +34,17 @@ interface CanvasPanelProps {
  * Memoized so that only the panel whose data changed re-renders — prevents
  * iframes/terminals from being remounted when a *different* panel moves.
  */
-export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = false }: CanvasPanelProps) {
+export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = false, panelIndex, showIndex = false }: CanvasPanelProps) {
   const bringToFront = useCanvasStore((s) => s.bringToFront)
   const updatePanel = useCanvasStore((s) => s.updatePanel)
   const removePanel = useCanvasStore((s) => s.removePanel)
   const focusPanel = useCanvasStore((s) => s.focusPanel)
   const setDraggingPanelId = useCanvasStore((s) => s.setDraggingPanelId)
   const setSnapGuides = useCanvasStore((s) => s.setSnapGuides)
+  // Read connectingFromId imperatively to avoid re-rendering ALL panels when it changes.
+  // Only the connect button click handlers need it — not the render path.
+  const setConnectingFromId = useCanvasStore((s) => s.setConnectingFromId)
+  const addEdge = useCanvasStore((s) => s.addEdge)
 
   const panelRef = useRef<HTMLDivElement>(null)
   const [isDragging, setIsDragging] = useState(false)
@@ -71,7 +83,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       const newY = dragStart.current.panelY + dy
 
       // Read panels imperatively — avoids reactive subscription that re-renders all panels
-      const otherPanels = useCanvasStore.getState().panels.filter((p) => p.id !== panel.id)
+      const { panels: allPanels, edges } = useCanvasStore.getState()
+      const otherPanels = allPanels.filter((p) => p.id !== panel.id)
       const { x: snappedX, y: snappedY, guides } = calculateSnap(
         { x: newX, y: newY, width: panel.width, height: panel.height },
         otherPanels
@@ -79,9 +92,35 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
 
       updatePanel(panel.id, { x: snappedX, y: snappedY })
       setSnapGuides(guides)
+
+      // Auto-connect proximity detection (browser ↔ task)
+      const draggedWithPos = { ...panel, x: snappedX, y: snappedY }
+      const prox = detectProximityEdge(draggedWithPos, otherPanels, edges)
+      useCanvasStore.getState().setProximityEdge(prox)
     }
 
     const handleUp = () => {
+      // If there's a proximity edge, auto-connect on drop
+      const prox = useCanvasStore.getState().proximityEdge
+      if (prox) {
+        const { edges } = useCanvasStore.getState()
+        const alreadyExists = edges.some(
+          (e) =>
+            (e.fromPanelId === prox.fromId && e.toPanelId === prox.toId) ||
+            (e.fromPanelId === prox.toId && e.toPanelId === prox.fromId)
+        )
+        if (!alreadyExists) {
+          // Determine edge type from the panel types
+          const allPanels = useCanvasStore.getState().panels
+          const fromP = allPanels.find((p) => p.id === prox.fromId)
+          const toP = allPanels.find((p) => p.id === prox.toId)
+          const isBrowser = fromP?.type === 'browser' || toP?.type === 'browser'
+          const isTerminal = fromP?.type === 'terminal' || toP?.type === 'terminal'
+          addEdge(prox.fromId, prox.toId, isBrowser ? 'browser' : isTerminal ? 'terminal' : undefined)
+        }
+        useCanvasStore.getState().setProximityEdge(null)
+      }
+
       setIsDragging(false)
       setDraggingPanelId(null)
       setSnapGuides([])
@@ -136,12 +175,39 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     }
   }, [isResizing, panel.id, panel.minWidth, panel.minHeight, zoom, updatePanel])
 
+  // ── Connect (edge drawing) ─────────────────────────────────
+  // Local state tracks whether THIS panel initiated connecting — avoids global subscription
+  const [isConnectingLocal, setIsConnectingLocal] = useState(false)
+
+  // Sync local state when store clears connectingFromId (Escape, background click, or edge completed)
+  useEffect(() => {
+    if (!isConnectingLocal) return
+    const unsub = useCanvasStore.subscribe((s) => {
+      if (s.connectingFromId !== panel.id) {
+        setIsConnectingLocal(false)
+      }
+    })
+    return unsub
+  }, [isConnectingLocal, panel.id])
+
   // ── Click handling ────────────────────────────────────────
   const handleMouseDown = useCallback(
     () => {
+      // Read connecting state imperatively — no subscription cost
+      const connectingFrom = useCanvasStore.getState().connectingFromId
+      if (connectingFrom && connectingFrom !== panel.id) {
+        // Complete the edge
+        const fromPanel = useCanvasStore.getState().panels.find((p) => p.id === connectingFrom)
+        const isBrowserEdge = panel.type === 'browser' || fromPanel?.type === 'browser'
+        const isTerminalEdge = panel.type === 'terminal' || fromPanel?.type === 'terminal'
+        const edgeType = isBrowserEdge ? 'browser' : isTerminalEdge ? 'terminal' : undefined
+        addEdge(connectingFrom, panel.id, edgeType)
+        setConnectingFromId(null)
+        return
+      }
       bringToFront(panel.id)
     },
-    [bringToFront, panel.id]
+    [bringToFront, panel.id, panel.type, addEdge, setConnectingFromId]
   )
 
   // ── Focus (zoom-to-fit this panel) ────────────────────────
@@ -175,6 +241,79 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     []
   )
 
+  // ── Side handle auto-hide after 20s of panel inactivity ──────
+  const [sideHandleVisible, setSideHandleVisible] = useState(false)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handlePanelMouseEnter = useCallback(() => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+    setSideHandleVisible(true)
+    hideTimerRef.current = setTimeout(() => setSideHandleVisible(false), 20_000)
+  }, [])
+
+  const handlePanelMouseLeave = useCallback(() => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+    setSideHandleVisible(false)
+  }, [])
+
+  // Clean up timer on unmount
+  useEffect(() => {
+    return () => { if (hideTimerRef.current) clearTimeout(hideTimerRef.current) }
+  }, [])
+
+  // ── Proximity glow — this panel is a target of auto-connect proximity ──
+  const [isProximityTarget, setIsProximityTarget] = useState(false)
+  useEffect(() => {
+    const unsub = useCanvasStore.subscribe((s, prev) => {
+      if (s.proximityEdge !== prev.proximityEdge) {
+        const isTarget = s.proximityEdge
+          ? (s.proximityEdge.fromId === panel.id || s.proximityEdge.toId === panel.id) &&
+            s.draggingPanelId !== panel.id
+          : false
+        setIsProximityTarget(isTarget)
+      }
+    })
+    return unsub
+  }, [panel.id])
+
+  // ── Create connected browser panel (from side handle click) ──
+  const handleCreateBrowser = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+      // Place new browser panel to the right of this panel with a gap
+      const gap = 40
+      const newX = panel.x + panel.width + gap
+      const newY = panel.y
+      const addPanel = useCanvasStore.getState().addPanel
+      const newId = addPanel({
+        type: 'browser',
+        title: 'Browser',
+        x: newX,
+        y: newY,
+        width: DEFAULT_PANEL_WIDTH,
+        height: DEFAULT_PANEL_HEIGHT,
+      })
+      // Auto-connect with browser edge
+      if (newId) {
+        addEdge(panel.id, newId, 'browser')
+      }
+    },
+    [panel.id, panel.x, panel.y, panel.width, addEdge]
+  )
+
+  // ── Start connecting from side handle (drag) ──
+  const handleSideHandleDrag = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+      // Enter connection mode — the user drags to an existing browser panel
+      setConnectingFromId(panel.id)
+      setIsConnectingLocal(true)
+    },
+    [setConnectingFromId, panel.id]
+  )
+
   // ── Panel type styling ────────────────────────────────────
   const TYPE_CONFIG: Record<string, { label: string; color: string; border: string }> = {
     task: { label: 'Task', color: 'bg-blue-500/20 text-blue-400', border: 'border-blue-500/40' },
@@ -182,6 +321,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     app: { label: 'App', color: 'bg-green-500/20 text-green-400', border: 'border-green-500/40' },
     webpage: { label: 'Web', color: 'bg-cyan-500/20 text-cyan-400', border: 'border-cyan-500/40' },
     terminal: { label: 'Terminal', color: 'bg-amber-500/20 text-amber-400', border: 'border-amber-500/50' },
+    browser: { label: 'Browser', color: 'bg-orange-500/20 text-orange-400', border: 'border-orange-500/40' },
   }
   const cfg = TYPE_CONFIG[panel.type] ?? { label: 'Panel', color: 'bg-muted/30 text-muted-foreground', border: 'border-border/50' }
 
@@ -190,8 +330,12 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       ref={panelRef}
       data-canvas-panel="true"
       onMouseDown={handleMouseDown}
-      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col overflow-hidden select-none transition-shadow duration-150 ${cfg.border} ${
+      onMouseEnter={handlePanelMouseEnter}
+      onMouseLeave={handlePanelMouseLeave}
+      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col select-none transition-shadow duration-150 group/panel ${cfg.border} ${
         isDragging ? 'shadow-indigo-500/10 ring-1 ring-indigo-500/30' : ''
+      } ${isConnectingLocal ? 'ring-2 ring-orange-500/50' : ''} ${
+        isProximityTarget ? 'ring-2 ring-orange-500/60 shadow-orange-500/20 shadow-2xl' : ''
       }`}
       style={{
         left: panel.x,
@@ -203,6 +347,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         minHeight: isCollapsed ? undefined : (panel.minHeight ?? 150),
       }}
     >
+      {/* Inner wrapper — clips content within rounded corners */}
+      <div className="flex flex-col flex-1 min-h-0 overflow-hidden rounded-[11px]">
       {/* Title bar — drag handle */}
       <div
         className="flex items-center gap-2 px-3 py-2 border-b border-border/40 bg-[#141a26] flex-shrink-0 cursor-grab active:cursor-grabbing group"
@@ -243,7 +389,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         )}
 
         {/* Panel actions — visible on hover */}
-        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+        <div className={`flex items-center gap-0.5 transition-opacity duration-150 opacity-0 group-hover:opacity-100`}>
           {/* Focus / zoom-to-fit button */}
           <button
             onMouseDown={(e) => e.stopPropagation()}
@@ -283,7 +429,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       {/* Content area */}
       {!isCollapsed && (
         <div
-          className={`flex-1 overflow-hidden min-h-0 ${panel.type === 'task' || panel.type === 'transcript' || panel.type === 'webpage' || panel.type === 'terminal' || (panel.type === 'app' && panel.refId) ? '' : 'p-3 overflow-auto'}`}
+          className={`flex-1 overflow-hidden min-h-0 ${panel.type === 'task' || panel.type === 'transcript' || panel.type === 'webpage' || panel.type === 'terminal' || panel.type === 'browser' || (panel.type === 'app' && panel.refId) ? '' : 'p-3 overflow-auto'}`}
           style={frozen ? { visibility: 'hidden' } : undefined}
         >
           <MemoizedPanelContent
@@ -293,9 +439,13 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
             url={panel.url}
             title={panel.title}
             taskLayout={taskLayout}
+            browserSessionId={panel.browserSessionId}
+            streamPort={panel.streamPort}
           />
         </div>
       )}
+
+      </div>{/* end inner wrapper */}
 
       {/* Resize handle (bottom-right corner) */}
       {!isCollapsed && (
@@ -315,6 +465,63 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
           </svg>
         </div>
       )}
+
+      {/* Side handle — React Flow style, for task panels: click to create browser, drag to connect */}
+      {panel.type === 'task' && !isCollapsed && !isDragging && (
+        <div
+          className={`absolute transition-opacity duration-200 ${sideHandleVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+          style={{
+            right: -18,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            zIndex: 10,
+          }}
+        >
+          <button
+            onMouseDown={(e) => {
+              e.stopPropagation()
+              const startX = e.clientX
+              const startY = e.clientY
+              let moved = false
+
+              const onMove = (me: MouseEvent) => {
+                if (Math.abs(me.clientX - startX) > 5 || Math.abs(me.clientY - startY) > 5) {
+                  moved = true
+                  handleSideHandleDrag(e)
+                  window.removeEventListener('mousemove', onMove)
+                }
+              }
+              const onUp = () => {
+                window.removeEventListener('mousemove', onMove)
+                window.removeEventListener('mouseup', onUp)
+                if (!moved) {
+                  handleCreateBrowser(e)
+                }
+              }
+              window.addEventListener('mousemove', onMove)
+              window.addEventListener('mouseup', onUp)
+            }}
+            className="flex items-center justify-center w-8 h-8 rounded-full bg-orange-500/20 border border-orange-500/40 hover:bg-orange-500/30 hover:border-orange-500/60 hover:scale-110 transition-all duration-150 cursor-pointer shadow-lg shadow-orange-500/10"
+            title="Click to add browser · Drag to connect to existing browser"
+          >
+            <Globe className="h-3.5 w-3.5 text-orange-400" />
+          </button>
+        </div>
+      )}
+
+      {/* Panel index badge — shown when Ctrl/Cmd is held */}
+      {showIndex && panelIndex !== undefined && panelIndex < 9 && (
+        <div
+          className="absolute inset-0 flex items-center justify-center pointer-events-none z-50"
+          style={{ background: 'rgba(0,0,0,0.5)', borderRadius: 'inherit' }}
+        >
+          <div className="flex items-center justify-center w-16 h-16 rounded-2xl bg-indigo-500/90 shadow-2xl shadow-indigo-500/40 border border-indigo-400/50">
+            <span className="text-3xl font-bold text-white tabular-nums">
+              {panelIndex + 1}
+            </span>
+          </div>
+        </div>
+      )}
     </div>
   )
 })
@@ -330,9 +537,11 @@ interface PanelContentProps {
   url?: string
   title: string
   taskLayout?: TaskWorkspaceLayout
+  browserSessionId?: string
+  streamPort?: number
 }
 
-const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, title, taskLayout }: PanelContentProps) {
+const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, title, taskLayout, browserSessionId, streamPort }: PanelContentProps) {
   if (type === 'task' && refId) {
     return <TaskPanelContent taskId={refId} panelLayout={taskLayout} />
   }
@@ -346,7 +555,10 @@ const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, 
     return <WebPagePanelContent panelId={id} url={url} title={title} />
   }
   if (type === 'terminal') {
-    return <TerminalPanelContent terminalId={id} />
+    return <TerminalPanelContent terminalId={id} cwd={url} />
+  }
+  if (type === 'browser') {
+    return <BrowserPanelContent panelId={id} url={url} sessionName={browserSessionId} streamPort={streamPort} />
   }
   return (
     <div className="flex items-center justify-center h-full text-muted-foreground/50 text-xs">

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -6,7 +6,8 @@ import { useTaskStore } from '@/stores/task-store'
 import { CanvasPanel } from './CanvasPanel'
 import { CanvasConnections } from './CanvasConnections'
 import { CanvasContextMenu } from './CanvasContextMenu'
-import { Move, ZoomIn, ZoomOut, RotateCcw, Plus, Globe, TerminalSquare, X } from 'lucide-react'
+import { CanvasMinimap } from './CanvasMinimap'
+import { Move, ZoomIn, ZoomOut, RotateCcw, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 
 /**
@@ -102,9 +103,10 @@ export function InfiniteCanvas() {
     canvasY: number
   } | null>(null)
 
-  // Add panel dropdown state
-  const [showAddMenu, setShowAddMenu] = useState(false)
-  const addMenuRef = useRef<HTMLDivElement>(null)
+  // Connection drawing state
+  const connectingFromId = useCanvasStore((s) => s.connectingFromId)
+  const setConnectingFromId = useCanvasStore((s) => s.setConnectingFromId)
+  const [mouseCanvasPos, setMouseCanvasPos] = useState<{ x: number; y: number } | null>(null)
 
   // Track container size for viewport visibility culling
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
@@ -275,6 +277,18 @@ export function InfiniteCanvas() {
         return
       }
 
+      // Cancel connection drawing on background click
+      const { connectingFromId: cid } = useCanvasStore.getState()
+      if (cid && e.button === 0) {
+        const target = e.target as HTMLElement
+        const isBackground = target === containerRef.current || target.dataset?.canvasBg === 'true'
+        if (isBackground) {
+          setConnectingFromId(null)
+          setMouseCanvasPos(null)
+          return
+        }
+      }
+
       const isMiddle = e.button === 1
       const isLeftOnCanvas =
         e.button === 0 &&
@@ -293,6 +307,19 @@ export function InfiniteCanvas() {
 
   const handleMouseMove = useCallback(
     (e: React.MouseEvent) => {
+      // Track mouse position in canvas space for connection line rendering
+      if (connectingFromId) {
+        const container = containerRef.current
+        if (container) {
+          const rect = container.getBoundingClientRect()
+          const vp = useCanvasStore.getState().viewport
+          setMouseCanvasPos({
+            x: (e.clientX - rect.left - vp.x) / vp.zoom,
+            y: (e.clientY - rect.top - vp.y) / vp.zoom,
+          })
+        }
+      }
+
       if (!isPanning) return
       const dx = e.clientX - panStartRef.current.x
       const dy = e.clientY - panStartRef.current.y
@@ -325,68 +352,89 @@ export function InfiniteCanvas() {
     [viewport]
   )
 
-  // ── Add panel helpers ────────────────────────────────────
-  const addPanelAtCenter = useCallback(
-    (type: 'webpage' | 'terminal', title: string) => {
-      const container = containerRef.current
-      const rect = container?.getBoundingClientRect()
-      const vp = useCanvasStore.getState().viewport
-      const currentPanels = useCanvasStore.getState().panels
-      const centerX = rect
-        ? (rect.width / 2 - vp.x) / vp.zoom - DEFAULT_PANEL_WIDTH / 2
-        : 0
-      const centerY = rect
-        ? (rect.height / 2 - vp.y) / vp.zoom - DEFAULT_PANEL_HEIGHT / 2
-        : 0
-      const offset = (currentPanels.length % 5) * 30
-      addPanel({
-        type,
-        title,
-        x: centerX + offset,
-        y: centerY + offset,
-        width: DEFAULT_PANEL_WIDTH,
-        height: DEFAULT_PANEL_HEIGHT,
-      })
-      setShowAddMenu(false)
-    },
-    [addPanel]
-  )
+  // ── Focused panel tracking (for Tab cycling) ─────────────
+  const [focusedPanelIndex, setFocusedPanelIndex] = useState(-1)
 
-  // Close add menu on outside click
-  useEffect(() => {
-    if (!showAddMenu) return
-    const handleClick = (e: MouseEvent) => {
-      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
-        setShowAddMenu(false)
-      }
-    }
-    const timer = setTimeout(() => document.addEventListener('mousedown', handleClick), 0)
-    return () => {
-      clearTimeout(timer)
-      document.removeEventListener('mousedown', handleClick)
-    }
-  }, [showAddMenu])
+  // ── Ctrl-held state (shows panel index badges) ──────────
+  const [ctrlHeld, setCtrlHeld] = useState(false)
 
   // ── Keyboard shortcuts ───────────────────────────────────
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.code === 'Space' && !e.repeat) {
+      // Ignore shortcuts when typing in an input/textarea or xterm terminal
+      const tag = (e.target as HTMLElement)?.tagName?.toLowerCase()
+      const isXtermFocused = !!(e.target as HTMLElement)?.closest('.xterm')
+      const isInputFocused = tag === 'input' || tag === 'textarea' || (e.target as HTMLElement)?.isContentEditable || isXtermFocused
+
+      // Track Ctrl held state — shows panel index badges (Ctrl only, not Cmd)
+      if (e.key === 'Control' && !e.repeat) {
+        setCtrlHeld(true)
+      }
+      // Clear stale ctrlHeld if Ctrl was released while OS had focus
+      // (e.g. after Ctrl+Cmd+Shift+3 screenshot, OS swallows the keyup)
+      if (!e.ctrlKey && e.key !== 'Control') {
+        setCtrlHeld(false)
+      }
+
+      if (e.code === 'Space' && !e.repeat && !isInputFocused) {
         setSpaceHeld(true)
       }
-      if (e.code === 'Equal' && (e.ctrlKey || e.metaKey)) {
+      if (e.code === 'Equal' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
         zoomTo(viewport.zoom * 1.2)
       }
-      if (e.code === 'Minus' && (e.ctrlKey || e.metaKey)) {
+      if (e.code === 'Minus' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
         zoomTo(viewport.zoom / 1.2)
       }
-      if (e.code === 'Digit0' && (e.ctrlKey || e.metaKey)) {
+      if (e.code === 'Digit0' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
         resetViewport()
       }
-      // Escape: close context menu
+
+      // Ctrl/Cmd + 1-9: focus panel by index
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && !isInputFocused) {
+        const digitMatch = e.code.match(/^Digit([1-9])$/)
+        if (digitMatch) {
+          const idx = parseInt(digitMatch[1], 10) - 1
+          const currentPanels = useCanvasStore.getState().panels
+          if (idx < currentPanels.length) {
+            e.preventDefault()
+            const container = containerRef.current
+            if (container) {
+              const rect = container.getBoundingClientRect()
+              useCanvasStore.getState().focusPanel(currentPanels[idx].id, rect.width, rect.height)
+              setFocusedPanelIndex(idx)
+            }
+          }
+        }
+      }
+
+      // Tab / Shift+Tab: cycle through panels
+      if (e.code === 'Tab' && !isInputFocused && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault()
+        const currentPanels = useCanvasStore.getState().panels
+        if (currentPanels.length === 0) return
+
+        const next = e.shiftKey
+          ? (focusedPanelIndex <= 0 ? currentPanels.length - 1 : focusedPanelIndex - 1)
+          : (focusedPanelIndex >= currentPanels.length - 1 ? 0 : focusedPanelIndex + 1)
+
+        setFocusedPanelIndex(next)
+        const container = containerRef.current
+        if (container) {
+          const rect = container.getBoundingClientRect()
+          useCanvasStore.getState().focusPanel(currentPanels[next].id, rect.width, rect.height)
+        }
+      }
+
+      // Escape: cancel connecting or close context menu
       if (e.code === 'Escape') {
+        const { connectingFromId: cid } = useCanvasStore.getState()
+        if (cid) {
+          setConnectingFromId(null)
+          setMouseCanvasPos(null)
+        }
         setContextMenu(null)
       }
     }
@@ -394,14 +442,24 @@ export function InfiniteCanvas() {
       if (e.code === 'Space') {
         setSpaceHeld(false)
       }
+      if (e.key === 'Control') {
+        setCtrlHeld(false)
+      }
+    }
+    // Also clear on window blur (Ctrl+Tab to another window)
+    const handleBlur = () => {
+      setCtrlHeld(false)
+      setSpaceHeld(false)
     }
     window.addEventListener('keydown', handleKeyDown)
     window.addEventListener('keyup', handleKeyUp)
+    window.addEventListener('blur', handleBlur)
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', handleBlur)
     }
-  }, [viewport.zoom, zoomTo, resetViewport])
+  }, [viewport.zoom, zoomTo, resetViewport, focusedPanelIndex])
 
   const zoomPercent = Math.round(viewport.zoom * 100)
 
@@ -446,15 +504,17 @@ export function InfiniteCanvas() {
           <SnapGuides guides={snapGuides} containerRef={containerRef} viewport={viewport} />
 
           {/* Connection lines */}
-          <CanvasConnections mouseCanvasPos={null} />
+          <CanvasConnections mouseCanvasPos={mouseCanvasPos} />
 
           {/* Render panels — off-viewport panels are frozen (content hidden) */}
-          {panels.map((panel) => (
+          {panels.map((panel, index) => (
             <CanvasPanel
               key={panel.id}
               panel={panel}
               zoom={viewport.zoom}
               frozen={!visiblePanelIds.has(panel.id)}
+              panelIndex={index}
+              showIndex={ctrlHeld}
             />
           ))}
         </div>
@@ -498,64 +558,30 @@ export function InfiniteCanvas() {
         </Button>
       </div>
 
-      {/* ── HUD: Add Panel button ── */}
-      <div ref={addMenuRef} className="absolute bottom-4 right-4 z-10">
-        {showAddMenu && (
-          <div className="absolute bottom-full right-0 mb-2 w-56 bg-[#1a2030]/95 backdrop-blur-sm border border-border/40 rounded-xl shadow-2xl overflow-hidden animate-in fade-in slide-in-from-bottom-2 duration-150">
-            <div className="flex items-center justify-between px-3 py-2 border-b border-border/20">
-              <span className="text-[11px] font-medium text-muted-foreground/70">Add Panel</span>
-              <button
-                onClick={() => setShowAddMenu(false)}
-                className="text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </div>
-            <div className="py-1">
-              <button
-                onClick={() => addPanelAtCenter('webpage', 'Web Page')}
-                className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-white/5 transition-colors group"
-              >
-                <Globe className="h-4 w-4 text-cyan-400 flex-shrink-0" />
-                <div>
-                  <div className="text-[12px] text-foreground/80 group-hover:text-foreground transition-colors">
-                    Web Page
-                  </div>
-                  <div className="text-[10px] text-muted-foreground/40">
-                    Embed any website
-                  </div>
-                </div>
-              </button>
-              <button
-                onClick={() => addPanelAtCenter('terminal', 'Terminal')}
-                className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-white/5 transition-colors group"
-              >
-                <TerminalSquare className="h-4 w-4 text-amber-400 flex-shrink-0" />
-                <div>
-                  <div className="text-[12px] text-foreground/80 group-hover:text-foreground transition-colors">
-                    Terminal
-                  </div>
-                  <div className="text-[10px] text-muted-foreground/40">
-                    Interactive shell session
-                  </div>
-                </div>
-              </button>
-            </div>
-          </div>
-        )}
+      {/* ── HUD: Add button (top-left, primary CTA) ── */}
+      <div className="absolute top-3 left-3 z-10">
         <Button
-          variant="ghost"
           size="sm"
-          className="h-8 px-3 bg-[#1a2030]/90 backdrop-blur-sm border border-border/40 hover:border-border/60 text-xs gap-1.5"
-          onClick={() => setShowAddMenu(!showAddMenu)}
-          title="Add panel"
+          className="h-8 px-3 bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm text-xs gap-1.5"
+          onClick={(e) => {
+            const btn = e.currentTarget.getBoundingClientRect()
+            const rect = containerRef.current?.getBoundingClientRect()
+            if (!rect) return
+            setContextMenu({
+              clientX: btn.left,
+              clientY: btn.bottom + 4,
+              canvasX: (btn.left - rect.left - viewport.x) / viewport.zoom,
+              canvasY: (btn.bottom + 4 - rect.top - viewport.y) / viewport.zoom,
+            })
+          }}
+          title="Add to canvas"
         >
           <Plus className="h-3.5 w-3.5" />
-          <span>Add Panel</span>
+          <span>Add</span>
         </Button>
       </div>
 
-      {/* ── HUD: Viewport info ── */}
+      {/* ── HUD: Viewport info (top-right) ── */}
       <div className="absolute top-3 right-3 flex items-center gap-2 text-[10px] text-muted-foreground/40 z-10 select-none">
         <Move className="h-3 w-3" />
         <span className="tabular-nums">
@@ -563,6 +589,12 @@ export function InfiniteCanvas() {
           {Math.round(-viewport.y / viewport.zoom)}
         </span>
       </div>
+
+      {/* ── Minimap (bottom-right) ── */}
+      <CanvasMinimap
+        containerWidth={containerSize.width}
+        containerHeight={containerSize.height}
+      />
 
       {/* ── Empty state ── */}
       {panels.length === 0 && (

--- a/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+
+const terminalCreate = vi.fn()
+const terminalWrite = vi.fn()
+const terminalResize = vi.fn()
+const terminalKill = vi.fn()
+const terminalGetCwd = vi.fn()
+const terminalOnData = vi.fn(() => vi.fn())
+const terminalOnExit = vi.fn(() => vi.fn())
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class {
+    cols = 80
+    rows = 24
+    textarea = document.createElement('textarea')
+    loadAddon() {}
+    open() {}
+    focus() {}
+    clear() {}
+    write() {}
+    dispose() {}
+    onData() {
+      return { dispose: vi.fn() }
+    }
+    onKey() {
+      return { dispose: vi.fn() }
+    }
+  },
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: class {},
+}))
+
+import { TerminalPanelContent } from './TerminalPanelContent'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('TerminalPanelContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    terminalWrite.mockResolvedValue(undefined)
+    terminalResize.mockResolvedValue(undefined)
+    terminalKill.mockResolvedValue(undefined)
+
+    Object.defineProperty(window, 'electronAPI', {
+      value: {
+        ...(window.electronAPI ?? {}),
+        terminal: {
+          create: terminalCreate,
+          write: terminalWrite,
+          resize: terminalResize,
+          kill: terminalKill,
+          getCwd: terminalGetCwd,
+          getBuffer: vi.fn(),
+          onData: terminalOnData,
+          onExit: terminalOnExit,
+        },
+      },
+      configurable: true,
+      writable: true,
+    })
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        disconnect() {}
+      }
+    )
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 640,
+      height: 480,
+      top: 0,
+      left: 0,
+      right: 640,
+      bottom: 480,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('kills only the PTY instance that owned the cleanup', async () => {
+    const firstCwd = deferred<{ cwd: string | null }>()
+    const secondCwd = deferred<{ cwd: string | null }>()
+
+    terminalCreate.mockResolvedValueOnce({ pid: 111 }).mockResolvedValueOnce({ pid: 222 })
+    terminalGetCwd.mockImplementationOnce(() => firstCwd.promise).mockImplementationOnce(() => secondCwd.promise)
+
+    const first = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(1)
+    })
+
+    first.unmount()
+
+    const second = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(2)
+    })
+
+    expect(terminalGetCwd).toHaveBeenNthCalledWith(1, 'panel-1', 111)
+
+    firstCwd.resolve({ cwd: '/tmp/one' })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 111)
+    })
+
+    second.unmount()
+    expect(terminalGetCwd).toHaveBeenNthCalledWith(2, 'panel-1', 222)
+
+    secondCwd.resolve({ cwd: '/tmp/two' })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 222)
+    })
+  })
+
+  it('kills a PTY that resolves after its component instance already unmounted', async () => {
+    const firstCreate = deferred<{ pid: number }>()
+    const secondCwd = deferred<{ cwd: string | null }>()
+
+    terminalCreate
+      .mockImplementationOnce(() => firstCreate.promise)
+      .mockResolvedValueOnce({ pid: 222 })
+    terminalGetCwd.mockImplementationOnce(() => secondCwd.promise)
+
+    const first = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(1)
+    })
+
+    first.unmount()
+
+    const second = render(<TerminalPanelContent terminalId="panel-1" cwd="/tmp" />)
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalledTimes(2)
+    })
+
+    firstCreate.resolve({ pid: 111 })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 111)
+    })
+
+    expect(terminalGetCwd).not.toHaveBeenCalled()
+
+    second.unmount()
+    expect(terminalGetCwd).toHaveBeenNthCalledWith(1, 'panel-1', 222)
+
+    secondCwd.resolve({ cwd: '/tmp/two' })
+    await waitFor(() => {
+      expect(terminalKill).toHaveBeenCalledWith('panel-1', 222)
+    })
+  })
+})

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -2,10 +2,13 @@ import { useEffect, useRef, useCallback, useState } from 'react'
 import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
+import { useCanvasStore } from '@/stores/canvas-store'
 import '@xterm/xterm/css/xterm.css'
 
 interface TerminalPanelContentProps {
   terminalId: string
+  /** Initial working directory — restored from persisted panel state */
+  cwd?: string
 }
 
 /**
@@ -21,7 +24,7 @@ interface TerminalPanelContentProps {
  *      sees truly-zero values even during layout shifts.
  *   3. Every fit() call is wrapped in try-catch.
  */
-export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) {
+export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
@@ -29,14 +32,26 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
   const [error, setError] = useState<string | null>(null)
   const cleanupRef = useRef<(() => void)[]>([])
   const initCalledRef = useRef(false)
+  const isReadyRef = useRef(false)
+  const activePidRef = useRef<number | null>(null)
+  const isMountedRef = useRef(true)
+
+  // Store cwd in a ref — only used at init time, never triggers re-init
+  const cwdRef = useRef(cwd)
 
   const initTerminal = useCallback(async () => {
+    console.log(`[Terminal:${terminalId}] initTerminal called`, {
+      hasContainer: !!containerRef.current,
+      hasXterm: !!xtermRef.current,
+      initCalled: initCalledRef.current,
+    })
     if (!containerRef.current || xtermRef.current || initCalledRef.current) return
 
     // Wait until the container actually has dimensions.
     // During canvas viewport changes or panel open animations the container
     // may still be 0×0 when this runs.
     const rect = containerRef.current.getBoundingClientRect()
+    console.log(`[Terminal:${terminalId}] container rect`, { w: rect.width, h: rect.height })
     if (rect.width < 10 || rect.height < 10) return
 
     initCalledRef.current = true
@@ -94,11 +109,23 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
     if (!xtermRef.current) return
 
     try {
-      await window.electronAPI.terminal.create(
+      const { pid } = await window.electronAPI.terminal.create(
         terminalId,
         term.cols,
-        term.rows
+        term.rows,
+        cwdRef.current // read from ref, not prop — stable reference
       )
+
+      // StrictMode / fast remount can unmount this instance before create() resolves.
+      // In that case, kill only the PTY we just created and let the live instance continue.
+      if (!isMountedRef.current || xtermRef.current !== term) {
+        await window.electronAPI.terminal.kill(terminalId, pid).catch(() => {})
+        return
+      }
+
+      activePidRef.current = pid
+
+      console.log(`[Terminal:${terminalId}] PTY created, setting up listeners`)
 
       const inputDispose = term.onData((data) => {
         window.electronAPI.terminal.write(terminalId, data)
@@ -110,24 +137,57 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
         }
       })
 
+      let processExited = false
+
       const removeExitListener = window.electronAPI.terminal.onExit(({ id }) => {
         if (id === terminalId) {
-          term.write('\r\n\x1b[90m[Process exited]\x1b[0m\r\n')
+          processExited = true
+          term.write('\r\n\x1b[90m[Process exited — press Enter to restart]\x1b[0m\r\n')
+        }
+      })
+
+      // Respawn the shell when the user presses Enter after exit
+      const respawnDispose = term.onKey(({ domEvent }) => {
+        if (processExited && domEvent.key === 'Enter') {
+          processExited = false
+          term.clear()
+          window.electronAPI.terminal.create(
+            terminalId,
+            term.cols,
+            term.rows,
+            cwdRef.current
+          ).then(({ pid }) => {
+            activePidRef.current = pid
+            term.focus()
+          }).catch(() => {
+            processExited = true
+            term.write('\r\n\x1b[90m[Failed to restart shell]\x1b[0m\r\n')
+          })
         }
       })
 
       cleanupRef.current = [
         () => inputDispose.dispose(),
+        () => respawnDispose.dispose(),
         removeDataListener,
         removeExitListener,
       ]
 
+      // Focus the terminal so it can receive keyboard input
+      console.log(`[Terminal:${terminalId}] calling term.focus(), textarea exists:`, !!term.textarea)
+      term.focus()
+      // Verify focus actually took
+      setTimeout(() => {
+        console.log(`[Terminal:${terminalId}] after focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
+      }, 100)
+
+      isReadyRef.current = true
       setIsReady(true)
     } catch (err) {
       console.error('Failed to create terminal:', err)
       setError(err instanceof Error ? err.message : 'Failed to create terminal')
     }
-  }, [terminalId])
+  }, [terminalId]) // cwd intentionally NOT a dep — read from cwdRef at init
 
   // Use ResizeObserver to detect when the container first gets real
   // dimensions, then initialize xterm. This is the primary guard
@@ -135,6 +195,7 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
   // zero-size container.
   useEffect(() => {
     if (!containerRef.current) return
+    isMountedRef.current = true
 
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0]
@@ -152,7 +213,7 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
       if (width < 10 || height < 10) return // still too small — skip
       try {
         fitAddonRef.current.fit()
-        if (xtermRef.current && isReady) {
+        if (xtermRef.current && isReadyRef.current) {
           window.electronAPI.terminal.resize(
             terminalId,
             xtermRef.current.cols,
@@ -172,21 +233,51 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
 
     return () => {
       observer.disconnect()
+      const expectedPid = activePidRef.current ?? undefined
+      isMountedRef.current = false
+
+      if (expectedPid !== undefined) {
+        // Capture cwd before killing the terminal — persists across restarts.
+        // Skip ID-only cleanup when this instance never acquired a PTY pid.
+        window.electronAPI.terminal.getCwd(terminalId, expectedPid).then(({ cwd: currentCwd }) => {
+          if (currentCwd) {
+            useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
+          }
+        }).catch(() => {}).finally(() => {
+          window.electronAPI.terminal.kill(terminalId, expectedPid).catch(() => {})
+        })
+      }
 
       // Cleanup listeners
       for (const fn of cleanupRef.current) fn()
       cleanupRef.current = []
-
-      // Kill PTY
-      window.electronAPI.terminal.kill(terminalId).catch(() => {})
 
       // Dispose xterm
       xtermRef.current?.dispose()
       xtermRef.current = null
       fitAddonRef.current = null
       initCalledRef.current = false
+      isReadyRef.current = false
+      activePidRef.current = null
     }
-  }, [initTerminal, terminalId, isReady])
+  }, [initTerminal, terminalId])
+
+  // ── Periodically capture cwd so it persists on crash/force-quit ──
+  // Uses direct IPC + store update — does NOT change any props that would
+  // trigger re-initialization of the terminal.
+  useEffect(() => {
+    if (!isReady) return
+    const interval = setInterval(async () => {
+      try {
+        const expectedPid = activePidRef.current ?? undefined
+        const { cwd: currentCwd } = await window.electronAPI.terminal.getCwd(terminalId, expectedPid)
+        if (currentCwd) {
+          useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
+        }
+      } catch { /* ignore */ }
+    }, 30_000) // every 30 seconds (less aggressive)
+    return () => clearInterval(interval)
+  }, [isReady, terminalId])
 
   if (error) {
     return (
@@ -199,10 +290,20 @@ export function TerminalPanelContent({ terminalId }: TerminalPanelContentProps) 
     )
   }
 
+  // Focus the terminal when the container is clicked
+  const handleClick = useCallback(() => {
+    console.log(`[Terminal:${terminalId}] container clicked, focusing. hasXterm:`, !!xtermRef.current, 'textarea:', !!xtermRef.current?.textarea)
+    xtermRef.current?.focus()
+    setTimeout(() => {
+      console.log(`[Terminal:${terminalId}] after click-focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
+    }, 50)
+  }, [terminalId])
+
   return (
     <div
       ref={containerRef}
-      className="h-full w-full"
+      className="h-full w-full xterm-container"
+      onClick={handleClick}
       style={{
         background: '#141a26',
         // Minimum dimensions prevent xterm's internal canvas renderer from

--- a/src/renderer/src/stores/browser-store.ts
+++ b/src/renderer/src/stores/browser-store.ts
@@ -1,0 +1,176 @@
+import { create } from 'zustand'
+
+// ── Browser session types ────────────────────────────────────
+
+export interface BrowserTab {
+  tabId: string
+  title: string
+  url: string
+  active: boolean
+}
+
+export interface BrowserSession {
+  sessionName: string
+  /** WebSocket streaming port (auto-assigned by agent-browser) */
+  streamPort: number | null
+  /** CDP WebSocket URL */
+  cdpUrl: string | null
+  /** Whether streaming is active */
+  connected: boolean
+  /** Whether the browser is screencasting */
+  screencasting: boolean
+  /** Current viewport dimensions */
+  viewportWidth: number
+  viewportHeight: number
+  /** Open tabs */
+  tabs: BrowserTab[]
+  /** Current URL */
+  currentUrl: string | null
+  /** Latest command being executed */
+  lastCommand: string | null
+  /** WebSocket instance (transient — not persisted) */
+  ws: WebSocket | null
+  /** Associated canvas panel ID */
+  panelId: string | null
+  /** Associated task panel ID (for auto-edge creation) */
+  linkedTaskPanelId: string | null
+}
+
+interface BrowserStoreState {
+  sessions: Map<string, BrowserSession>
+
+  // Actions
+  createSession: (sessionName: string, panelId: string, linkedTaskPanelId?: string) => BrowserSession
+  removeSession: (sessionName: string) => void
+  updateSession: (sessionName: string, updates: Partial<BrowserSession>) => void
+  getSession: (sessionName: string) => BrowserSession | undefined
+
+  // WebSocket stream connection
+  connectStream: (sessionName: string, port: number) => void
+  disconnectStream: (sessionName: string) => void
+}
+
+export const useBrowserStore = create<BrowserStoreState>((set, get) => ({
+  sessions: new Map(),
+
+  createSession: (sessionName, panelId, linkedTaskPanelId) => {
+    const session: BrowserSession = {
+      sessionName,
+      streamPort: null,
+      cdpUrl: null,
+      connected: false,
+      screencasting: false,
+      viewportWidth: 1280,
+      viewportHeight: 720,
+      tabs: [],
+      currentUrl: null,
+      lastCommand: null,
+      ws: null,
+      panelId,
+      linkedTaskPanelId: linkedTaskPanelId ?? null,
+    }
+    set((s) => {
+      const next = new Map(s.sessions)
+      next.set(sessionName, session)
+      return { sessions: next }
+    })
+    return session
+  },
+
+  removeSession: (sessionName) => {
+    const session = get().sessions.get(sessionName)
+    if (session?.ws) {
+      session.ws.close()
+    }
+    set((s) => {
+      const next = new Map(s.sessions)
+      next.delete(sessionName)
+      return { sessions: next }
+    })
+  },
+
+  updateSession: (sessionName, updates) => {
+    set((s) => {
+      const existing = s.sessions.get(sessionName)
+      if (!existing) return s
+      const next = new Map(s.sessions)
+      next.set(sessionName, { ...existing, ...updates })
+      return { sessions: next }
+    })
+  },
+
+  getSession: (sessionName) => {
+    return get().sessions.get(sessionName)
+  },
+
+  connectStream: (sessionName, port) => {
+    const { sessions, updateSession } = get()
+    const session = sessions.get(sessionName)
+    if (!session) return
+
+    // Close existing connection
+    if (session.ws) {
+      session.ws.close()
+    }
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`)
+
+    ws.onopen = () => {
+      updateSession(sessionName, { connected: true, streamPort: port })
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const text = typeof event.data === 'string' ? event.data : new TextDecoder().decode(event.data)
+        const msg = JSON.parse(text)
+
+        switch (msg.type) {
+          case 'status':
+            updateSession(sessionName, {
+              connected: msg.connected,
+              screencasting: msg.screencasting,
+              viewportWidth: msg.viewportWidth,
+              viewportHeight: msg.viewportHeight,
+            })
+            break
+          case 'tabs':
+            updateSession(sessionName, {
+              tabs: msg.tabs?.map((t: BrowserTab) => ({
+                tabId: t.tabId,
+                title: t.title,
+                url: t.url,
+                active: t.active,
+              })) ?? [],
+            })
+            break
+          case 'url':
+            updateSession(sessionName, { currentUrl: msg.url })
+            break
+          case 'command':
+            updateSession(sessionName, { lastCommand: msg.action || msg.params?.action || null })
+            break
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+
+    ws.onclose = () => {
+      updateSession(sessionName, { connected: false, screencasting: false })
+    }
+
+    ws.onerror = () => {
+      updateSession(sessionName, { connected: false })
+    }
+
+    updateSession(sessionName, { ws, streamPort: port })
+  },
+
+  disconnectStream: (sessionName) => {
+    const session = get().sessions.get(sessionName)
+    if (session?.ws) {
+      session.ws.close()
+      get().updateSession(sessionName, { ws: null, connected: false })
+    }
+  },
+}))

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -2,12 +2,13 @@ import { create } from 'zustand'
 import { settingsApi } from '@/lib/ipc-client'
 
 const CANVAS_STORAGE_KEY = 'canvas_state'
+const CDP_PORT = 19222
 let saveTimer: ReturnType<typeof setTimeout> | null = null
 const SAVE_DEBOUNCE_MS = 1000
 
 // ── Panel types ────────────────────────────────────────────
 
-export type CanvasPanelType = 'task' | 'transcript' | 'app' | 'webpage' | 'terminal' | 'placeholder'
+export type CanvasPanelType = 'task' | 'transcript' | 'app' | 'webpage' | 'terminal' | 'browser' | 'placeholder'
 
 export interface CanvasPanelData {
   id: string
@@ -16,6 +17,14 @@ export interface CanvasPanelData {
   refId?: string
   /** URL for webpage panels */
   url?: string
+  /** Browser session name (for browser panels) */
+  browserSessionId?: string
+  /** WebSocket streaming port (for browser panels) */
+  streamPort?: number
+  /** CDP target ID for this webview — used to connect agent-browser directly */
+  cdpTargetId?: string
+  /** Electron webContentsId for this webview — used to resolve CDP target via IPC */
+  webContentsId?: number
   title: string
   x: number
   y: number
@@ -28,10 +37,14 @@ export interface CanvasPanelData {
 
 // ── Connections / Edges ───────────────────────────────────
 
+export type CanvasEdgeType = 'default' | 'browser' | 'terminal'
+
 export interface CanvasEdge {
   id: string
   fromPanelId: string
   toPanelId: string
+  /** Visual style for the edge — 'browser' gets animated pulsing style */
+  edgeType?: CanvasEdgeType
 }
 
 // ── Snapping helpers ──────────────────────────────────────
@@ -81,6 +94,9 @@ interface CanvasState {
   // Connection drawing state (transient)
   connectingFromId: string | null
 
+  // Auto-connect proximity state (transient, shown during drag)
+  proximityEdge: { fromId: string; toId: string } | null
+
   // Persistence
   isLoaded: boolean
   loadCanvas: () => Promise<void>
@@ -106,10 +122,11 @@ interface CanvasState {
   setSnapGuides: (guides: SnapGuide[]) => void
 
   // Edge / connection actions
-  addEdge: (fromPanelId: string, toPanelId: string) => string
+  addEdge: (fromPanelId: string, toPanelId: string, edgeType?: CanvasEdgeType) => string
   removeEdge: (id: string) => void
   removeEdgesForPanel: (panelId: string) => void
   setConnectingFromId: (id: string | null) => void
+  setProximityEdge: (edge: { fromId: string; toId: string } | null) => void
   clearEdges: () => void
 }
 
@@ -136,6 +153,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   draggingPanelId: null,
   snapGuides: [],
   connectingFromId: null,
+  proximityEdge: null,
   isLoaded: false,
 
   loadCanvas: async () => {
@@ -196,7 +214,11 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 
   zoomAtPoint: (delta, clientX, clientY, containerRect) => {
     const { viewport } = get()
-    const factor = delta > 0 ? 0.9 : 1.1
+    // Scale zoom factor by delta magnitude for smooth trackpad pinch-to-zoom.
+    // Mac trackpads send small deltas (~2-4px) per event; mice send larger (~100px).
+    // Clamp the intensity so it never exceeds a ~15% step per event.
+    const intensity = Math.min(Math.abs(delta) / 100, 0.15)
+    const factor = delta > 0 ? 1 - intensity : 1 + intensity
     const newZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, viewport.zoom * factor))
 
     const pointX = (clientX - containerRect.left - viewport.x) / viewport.zoom
@@ -320,8 +342,8 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   setSnapGuides: (guides) => set({ snapGuides: guides }),
 
   // Edges
-  addEdge: (fromPanelId, toPanelId) => {
-    const { edges } = get()
+  addEdge: (fromPanelId, toPanelId, edgeType) => {
+    const { edges, panels } = get()
     const exists = edges.some(
       (e) =>
         (e.fromPanelId === fromPanelId && e.toPanelId === toPanelId) ||
@@ -330,9 +352,18 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     if (exists) return ''
     const id = `edge-${++edgeCounter}-${Date.now()}`
     set((s) => ({
-      edges: [...s.edges, { id, fromPanelId, toPanelId }]
+      edges: [...s.edges, { id, fromPanelId, toPanelId, edgeType }]
     }))
     scheduleSave()
+
+    // ── Notify agent when a browser/terminal edge connects to a task ──
+    if (edgeType === 'browser') {
+      notifyAgentOfBrowserConnection(panels, fromPanelId, toPanelId)
+    }
+    if (edgeType === 'terminal') {
+      notifyAgentOfTerminalConnection(panels, fromPanelId, toPanelId)
+    }
+
     return id
   },
 
@@ -351,6 +382,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   },
 
   setConnectingFromId: (id) => set({ connectingFromId: id }),
+  setProximityEdge: (edge) => set({ proximityEdge: edge }),
 
   clearEdges: () => {
     set({ edges: [] })
@@ -434,4 +466,339 @@ export function calculateSnap(
   if (guideY) guides.push(guideY)
 
   return { x: bestDx < threshold ? snapX : x, y: bestDy < threshold ? snapY : y, guides }
+}
+
+// ── Auto-connect proximity detection ─────────────────────────
+
+/** Distance threshold (canvas px) for auto-connect proximity */
+export const PROXIMITY_THRESHOLD = 80
+
+/**
+ * Check if a dragged panel is close enough to a compatible panel for auto-connect.
+ * Returns { fromId, toId } of the browser↔task pair, or null.
+ * Only browser↔task pairings trigger proximity (not browser↔browser, etc.).
+ */
+export function detectProximityEdge(
+  draggedPanel: CanvasPanelData,
+  otherPanels: CanvasPanelData[],
+  existingEdges: CanvasEdge[]
+): { fromId: string; toId: string } | null {
+  // Only browser, terminal, or task panels participate in auto-connect
+  if (draggedPanel.type !== 'browser' && draggedPanel.type !== 'terminal' && draggedPanel.type !== 'task') return null
+
+  // Task connects to browser or terminal; browser/terminal connect to task
+  const compatibleTypes: CanvasPanelType[] =
+    draggedPanel.type === 'task' ? ['browser', 'terminal'] : ['task']
+  const dCx = draggedPanel.x + draggedPanel.width / 2
+  const dCy = draggedPanel.y + draggedPanel.height / 2
+
+  let bestDist = Infinity
+  let bestPanel: CanvasPanelData | null = null
+
+  for (const p of otherPanels) {
+    if (!compatibleTypes.includes(p.type)) continue
+    // Skip if already connected
+    const alreadyConnected = existingEdges.some(
+      (e) =>
+        (e.fromPanelId === draggedPanel.id && e.toPanelId === p.id) ||
+        (e.fromPanelId === p.id && e.toPanelId === draggedPanel.id)
+    )
+    if (alreadyConnected) continue
+
+    // Distance between panel edges (not centers) — more intuitive
+    const pRight = p.x + p.width
+    const pBottom = p.y + p.height
+    const dRight = draggedPanel.x + draggedPanel.width
+    const dBottom = draggedPanel.y + draggedPanel.height
+
+    // Gap between nearest edges
+    const gapX = Math.max(0, Math.max(p.x - dRight, draggedPanel.x - pRight))
+    const gapY = Math.max(0, Math.max(p.y - dBottom, draggedPanel.y - pBottom))
+    const dist = Math.sqrt(gapX * gapX + gapY * gapY)
+
+    // Also check overlapping panels (dist would be 0)
+    const effectiveDist = dist === 0
+      ? Math.hypot(dCx - (p.x + p.width / 2), dCy - (p.y + p.height / 2)) * 0.1
+      : dist
+
+    if (effectiveDist < PROXIMITY_THRESHOLD && effectiveDist < bestDist) {
+      bestDist = effectiveDist
+      bestPanel = p
+    }
+  }
+
+  if (!bestPanel) return null
+
+  // Always put task first, browser second for consistent edge direction
+  return draggedPanel.type === 'task'
+    ? { fromId: draggedPanel.id, toId: bestPanel.id }
+    : { fromId: bestPanel.id, toId: draggedPanel.id }
+}
+
+// ── Browser↔Task edge notification ──────────────────────────
+// Lazy-imports agent-store and ipc-client to avoid circular deps in tests.
+
+function notifyAgentOfBrowserConnection(
+  panels: CanvasPanelData[],
+  fromPanelId: string,
+  toPanelId: string
+) {
+  const fromPanel = panels.find((p) => p.id === fromPanelId)
+  const toPanel = panels.find((p) => p.id === toPanelId)
+  const taskPanel = fromPanel?.type === 'task' ? fromPanel : toPanel?.type === 'task' ? toPanel : null
+  const browserPanel = fromPanel?.type === 'browser' ? fromPanel : toPanel?.type === 'browser' ? toPanel : null
+
+  // Read fresh panel data from store — the `panels` parameter is a snapshot from
+  // edge creation and may have stale webContentsId from localStorage persistence.
+  const freshBrowserPanel = browserPanel
+    ? useCanvasStore.getState().panels.find((p) => p.id === browserPanel.id) || browserPanel
+    : browserPanel
+
+  console.log('[BrowserEdge] notifyAgentOfBrowserConnection called', {
+    fromPanelId, toPanelId,
+    fromType: fromPanel?.type, toType: toPanel?.type,
+    taskRefId: taskPanel?.refId, browserPanelId: freshBrowserPanel?.id,
+    browserUrl: freshBrowserPanel?.url, browserTitle: freshBrowserPanel?.title,
+    browserCdpTargetId: freshBrowserPanel?.cdpTargetId,
+    browserWebContentsId: freshBrowserPanel?.webContentsId,
+  })
+
+  if (!taskPanel?.refId || !browserPanel) {
+    console.log('[BrowserEdge] BAIL: no taskPanel.refId or no browserPanel')
+    return
+  }
+
+  const resolveAndNotify = async () => {
+    const [{ useAgentStore }, { agentSessionApi }, { useTaskStore }] = await Promise.all([
+      import('./agent-store'),
+      import('@/lib/ipc-client'),
+      import('./task-store'),
+    ])
+
+    const taskId = taskPanel.refId!
+    let session = useAgentStore.getState().getSession(taskId)
+    console.log('[BrowserEdge] session state', { taskId, sessionId: session?.sessionId, agentId: session?.agentId })
+
+    // If no active session, auto-start or resume the task
+    if (!session?.sessionId) {
+      const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
+      console.log('[BrowserEdge] no session, looking up task', { taskId, agentId: task?.agent_id, sessionId: task?.session_id })
+      if (!task?.agent_id) {
+        console.log('[BrowserEdge] BAIL: no agent_id on task')
+        return
+      }
+
+      const initSession = useAgentStore.getState().initSession
+      try {
+        if (task.session_id) {
+          useAgentStore.getState().clearMessageDedup(taskId)
+          initSession(taskId, '', task.agent_id)
+          const result = await agentSessionApi.resume(task.agent_id, taskId, task.session_id)
+          if (result.ended) {
+            initSession(taskId, '', task.agent_id)
+            const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
+            initSession(taskId, sessionId, task.agent_id)
+          } else {
+            initSession(taskId, result.sessionId, task.agent_id)
+          }
+        } else {
+          initSession(taskId, '', task.agent_id)
+          const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
+          initSession(taskId, sessionId, task.agent_id)
+        }
+        session = useAgentStore.getState().getSession(taskId)
+        console.log('[BrowserEdge] session after auto-start', { sessionId: session?.sessionId })
+      } catch (err) {
+        console.error('[BrowserEdge] Failed to auto-start/resume task:', err)
+        return
+      }
+    }
+
+    if (!session?.sessionId) {
+      console.log('[BrowserEdge] BAIL: still no sessionId after auto-start attempt')
+      return
+    }
+
+    // Re-read fresh panel data — webContentsId may have been updated since edge creation
+    const bp = useCanvasStore.getState().panels.find((p) => p.id === browserPanel.id) || browserPanel
+    const browserTitle = bp.title || 'Browser'
+    const browserUrl = bp.url || ''
+
+    // Resolve which agent-browser tab ID (t1, t2, t3...) corresponds to this
+    // browser panel's webview. Uses webContentsId for reliable direct lookup.
+    let tabId: string | null = null
+    const resolveTab = async (attempt: number): Promise<string | null> => {
+      const allTargets = await window.electronAPI.browser.getCdpTargets()
+      const webviews = allTargets.filter((t) => t.type === 'webview')
+      console.log(`[BrowserEdge] resolveTab attempt=${attempt}`, {
+        allTargets: allTargets.map((t) => ({ tabId: t.tabId, type: t.type, url: t.url?.slice(0, 60) })),
+        webviewsCount: webviews.length,
+        browserUrl,
+        webContentsId: bp.webContentsId,
+      })
+      if (webviews.length === 0) return null
+
+      let match: typeof webviews[0] | null = null
+
+      // 1. Best: use webContentsId → getTargetId for exact CDP target, then find its tabId
+      if (!match && bp.webContentsId) {
+        try {
+          const result = await window.electronAPI.browser.getTargetId(bp.webContentsId)
+          if (result.targetId) {
+            match = allTargets.find((t) => t.id === result.targetId) || null
+            if (match) console.log('[BrowserEdge] matched by webContentsId→getTargetId', match.tabId)
+          }
+        } catch { /* debugger API failed */ }
+      }
+
+      // 2. Match by URL
+      if (!match && browserUrl) {
+        const urlBase = browserUrl.split('?')[0].split('#')[0]
+        match = webviews.find((t) => t.url.startsWith(urlBase)) || null
+        if (match) console.log('[BrowserEdge] matched by URL', { tabId: match.tabId, matchUrl: match.url?.slice(0, 60) })
+      }
+
+      // 3. Last resort — first available webview
+      if (!match) {
+        match = webviews[0] || null
+        if (match) console.log('[BrowserEdge] fallback to first webview', match.tabId)
+      }
+
+      return match?.tabId || null
+    }
+
+    try {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        tabId = await resolveTab(attempt)
+        if (tabId) break
+        console.log(`[BrowserEdge] no tab found, retrying in 1s (attempt ${attempt + 1}/3)`)
+        await new Promise((r) => setTimeout(r, 1000))
+      }
+    } catch (err) {
+      console.error('[BrowserEdge] resolveTab error:', err)
+    }
+
+    console.log('[BrowserEdge] final result', { tabId, browserTitle, browserUrl })
+
+    if (!tabId) {
+      agentSessionApi.send(
+        session.sessionId,
+        `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas.\n\n` +
+        `The browser panel is loading. To connect once ready:\n` +
+        `  agent-browser connect ${CDP_PORT}\n` +
+        `  agent-browser tab    # find the [webview] target\n` +
+        `  agent-browser tab <tN>   # switch to the webview\n\n` +
+        `Then use commands normally (open, snapshot, click, etc.).\n` +
+        `Do NOT interact with the [page] target — that is the main app window.`,
+        taskPanel.refId!,
+        session.agentId
+      ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
+      return
+    }
+
+    agentSessionApi.send(
+      session.sessionId,
+      `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas. You now have access to control it.\n\n` +
+      `To use the browser, run these commands:\n` +
+      `  agent-browser connect ${CDP_PORT}\n` +
+      `  agent-browser tab ${tabId}\n\n` +
+      `Then use commands normally:\n` +
+      `  agent-browser open <url>\n` +
+      `  agent-browser snapshot -i\n` +
+      `  agent-browser click <ref>\n\n` +
+      `Do NOT use "agent-browser tab t1" — that is the main app window.\n` +
+      `The user can see everything you do in the browser in real time on the canvas.`,
+      taskPanel.refId!,
+      session.agentId
+    ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
+  }
+
+  resolveAndNotify().catch(() => {
+    // Silently ignore — can happen in test environments
+  })
+}
+
+// ── Terminal↔Task edge notification ──────────────────────────
+
+function notifyAgentOfTerminalConnection(
+  panels: CanvasPanelData[],
+  fromPanelId: string,
+  toPanelId: string
+) {
+  const fromPanel = panels.find((p) => p.id === fromPanelId)
+  const toPanel = panels.find((p) => p.id === toPanelId)
+  const taskPanel = fromPanel?.type === 'task' ? fromPanel : toPanel?.type === 'task' ? toPanel : null
+  const terminalPanel = fromPanel?.type === 'terminal' ? fromPanel : toPanel?.type === 'terminal' ? toPanel : null
+
+  if (!taskPanel?.refId || !terminalPanel) return
+
+  const resolveAndNotify = async () => {
+    const [{ useAgentStore }, { agentSessionApi }, { useTaskStore }] = await Promise.all([
+      import('./agent-store'),
+      import('@/lib/ipc-client'),
+      import('./task-store'),
+    ])
+
+    const taskId = taskPanel.refId!
+    let session = useAgentStore.getState().getSession(taskId)
+
+    // If no active session, auto-start or resume the task
+    if (!session?.sessionId) {
+      const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
+      if (!task?.agent_id) return
+
+      const initSession = useAgentStore.getState().initSession
+      try {
+        if (task.session_id) {
+          useAgentStore.getState().clearMessageDedup(taskId)
+          initSession(taskId, '', task.agent_id)
+          const result = await agentSessionApi.resume(task.agent_id, taskId, task.session_id)
+          if (result.ended) {
+            initSession(taskId, '', task.agent_id)
+            const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
+            initSession(taskId, sessionId, task.agent_id)
+          } else {
+            initSession(taskId, result.sessionId, task.agent_id)
+          }
+        } else {
+          initSession(taskId, '', task.agent_id)
+          const { sessionId } = await agentSessionApi.start(task.agent_id, taskId)
+          initSession(taskId, sessionId, task.agent_id)
+        }
+        session = useAgentStore.getState().getSession(taskId)
+      } catch (err) {
+        console.error('[TerminalEdge] Failed to auto-start/resume task:', err)
+        return
+      }
+    }
+
+    if (!session?.sessionId) return
+
+    // Get the current terminal buffer to include as initial context
+    const terminalId = terminalPanel.id
+    let bufferPreview = ''
+    try {
+      const { lines } = await window.electronAPI.terminal.getBuffer(terminalId, 50)
+      if (lines.length > 0) {
+        bufferPreview = `\n\nCurrent terminal output (last ${lines.length} lines):\n\`\`\`\n${lines.join('\n')}\n\`\`\``
+      }
+    } catch { /* ignore */ }
+
+    agentSessionApi.send(
+      session.sessionId,
+      `[System] A terminal panel "${terminalPanel.title}" has been connected to your task on the canvas.\n\n` +
+      `You can read the terminal's output log at any time by running:\n` +
+      `  read_terminal_log\n\n` +
+      `This is a read-only view — you cannot type into this terminal.\n` +
+      `The terminal panel ID is: ${terminalId}\n` +
+      `Use your own Bash tool for running commands. Use the terminal log to observe output from processes the user is running.` +
+      bufferPreview,
+      taskPanel.refId!,
+      session.agentId
+    ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of terminal connection:', err))
+  }
+
+  resolveAndNotify().catch(() => {
+    // Silently ignore — can happen in test environments
+  })
 }

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -374,10 +374,12 @@ interface ElectronAPI {
     getPathForFile: (file: File) => string
   }
   terminal: {
-    create: (id: string, cols: number, rows: number) => Promise<{ pid: number }>
+    create: (id: string, cols: number, rows: number, cwd?: string) => Promise<{ pid: number }>
     write: (id: string, data: string) => Promise<void>
     resize: (id: string, cols: number, rows: number) => Promise<void>
-    kill: (id: string) => Promise<void>
+    kill: (id: string, expectedPid?: number) => Promise<void>
+    getCwd: (id: string, expectedPid?: number) => Promise<{ cwd: string | null }>
+    getBuffer: (id: string, lines?: number) => Promise<{ lines: string[] }>
     onData: (callback: (data: { id: string; data: string }) => void) => () => void
     onExit: (callback: (data: { id: string }) => void) => () => void
   }
@@ -394,6 +396,11 @@ interface ElectronAPI {
   onHeartbeatDisabled: (callback: (event: { taskId: string; reason: string }) => void) => () => void
   onWorktreeProgress: (callback: (event: WorktreeProgressEvent) => void) => () => void
   onGithubDeviceCode: (callback: (code: string) => void) => () => void
+  browser: {
+    getCdpPort: () => Promise<{ port: number }>
+    getTargetId: (webContentsId: number) => Promise<{ targetId: string | null }>
+    getCdpTargets: () => Promise<Array<{ id: string; url: string; title: string; type: string; tabId: string }>>
+  }
   onGitlabDeviceCode: (callback: (code: string) => void) => () => void
   onOAuthCallback: (callback: (event: { code: string; state: string }) => void) => () => void
 }


### PR DESCRIPTION
## Summary

Builds on infinite canvas core (PR #217) with panel interactions and content integrations.

- Panel interactions: drag, connect, snap, close, content types
- Browser panel with agent-browser integration (originally #247)
- Terminal panel (Python PTY) with xterm toFixed crash fixes
- Web page panel: iframe embedding, COOP/COEP/CORP header stripping
- Add Panel button and embedded TaskWorkspace / AgentTranscriptPanel
- SQLite canvas state persistence
- Canvas minimap, viewport freezing, always-mount
- Task panel layout toggle (inline icon buttons in title bar)
- HUD positioning, UI contrast, double-add prevention

## Context

Supersedes #257. That PR was opened from \`feat/canvas-panel-interactions\`, which was originally branched from \`feat/infinite-canvas-core\` *before* #217 was squash-merged into main. The squash destroyed commit patch-ids, causing unresolvable merge conflicts on the old branch.

This PR re-applies the net diff of all 28 panel-interactions commits as a single commit on top of current main. Manually resolved conflicts in \`ipc-handlers.ts\`, \`preload/index.ts\`, \`electron.d.ts\` (terminal buffer/cwd + browser CDP additions) and preserved main's attachment-related additions to \`AgentTranscriptPanel\`.

## Test plan

- [ ] Open canvas, add terminal panel, verify shell works
- [ ] Add web page panel, verify iframe loads
- [ ] Add browser panel, verify agent-browser integration
- [ ] Add task / transcript panels from dashboard, verify they open
- [ ] Drag / connect / snap panels
- [ ] Reload app — canvas state persists
- [ ] Verify attachment drop on agent transcript still works (post-merge check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)