### PR TITLE
fix: close dashboard preview modal when opening canvas

### DIFF
--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -95,8 +95,8 @@ export const useUIStore = create<UIState>((set) => ({
   closeModal: () => set({ activeModal: null, editingTaskId: null, deletingTaskId: null }),
   openDashboardPreview: (taskId) => set({ dashboardPreviewTaskId: taskId }),
   closeDashboardPreview: () => set({ dashboardPreviewTaskId: null }),
-  openTaskOnCanvas: (taskId) => set({ sidebarView: 'canvas', canvasPendingTaskId: taskId }),
+  openTaskOnCanvas: (taskId) => set({ sidebarView: 'canvas', canvasPendingTaskId: taskId, dashboardPreviewTaskId: null }),
   clearCanvasPendingTask: () => set({ canvasPendingTaskId: null }),
-  openAppOnCanvas: (workflowId, name) => set({ sidebarView: 'canvas', canvasPendingApp: { workflowId, name } }),
+  openAppOnCanvas: (workflowId, name) => set({ sidebarView: 'canvas', canvasPendingApp: { workflowId, name }, dashboardPreviewTaskId: null }),
   clearCanvasPendingApp: () => set({ canvasPendingApp: null })
 }))


### PR DESCRIPTION
## Summary
- When clicking the Canvas button from a task opened via the dashboard preview modal, the modal stayed open behind the canvas view
- Root cause: `openTaskOnCanvas` and `openAppOnCanvas` in UIStore set `sidebarView` and pending state but didn't clear `dashboardPreviewTaskId`
- Fix: include `dashboardPreviewTaskId: null` in both actions' state updates

## Test plan
- [ ] Open dashboard → click a task card to open preview modal → click Canvas button → modal should close and canvas should open with the task
- [ ] All 82 renderer test files pass (1230 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)