### PR TITLE
feat: auto-clean workspaces after 7 days post-task completion

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,7 @@ import { registerIpcHandlers } from './ipc-handlers'
 import { EnterpriseAuth } from './enterprise-auth'
 import { RecurrenceScheduler } from './recurrence-scheduler'
 import { HeartbeatScheduler } from './heartbeat-scheduler'
+import { WorkspaceCleanupScheduler } from './workspace-cleanup-scheduler'
 import { ClaudePluginManager } from './claude-plugin-manager'
 import { EnterpriseHeartbeat } from './enterprise-heartbeat'
 import { EnterpriseStateSync } from './enterprise-state-sync'
@@ -47,6 +48,7 @@ let oauthManager: OAuthManager | null = null
 let enterpriseAuth: EnterpriseAuth | null = null
 let recurrenceScheduler: RecurrenceScheduler | null = null
 let heartbeatScheduler: HeartbeatScheduler | null = null
+let workspaceCleanupScheduler: WorkspaceCleanupScheduler | null = null
 let claudePluginManager: ClaudePluginManager | null = null
 let enterpriseHeartbeatInstance: EnterpriseHeartbeat | null = null
 let enterpriseStateSyncInstance: EnterpriseStateSync | null = null
@@ -55,6 +57,7 @@ let isShuttingDown = false
 async function shutdownAppServices(): Promise<void> {
   enterpriseHeartbeatInstance?.stop()
   heartbeatScheduler?.stop()
+  workspaceCleanupScheduler?.stop()
 
   await agentManager?.stopAllSessions()
   await agentManager?.stopServer()
@@ -126,6 +129,11 @@ function createWindow(): void {
     // Start heartbeat scheduler
     if (heartbeatScheduler && mainWindow) {
       heartbeatScheduler.start(mainWindow)
+    }
+
+    // Start workspace cleanup scheduler
+    if (workspaceCleanupScheduler && mainWindow) {
+      workspaceCleanupScheduler.start(mainWindow)
     }
 
     // Periodic overdue check — nudges renderer every 60s
@@ -681,6 +689,7 @@ app.whenReady().then(async () => {
 
   recurrenceScheduler = new RecurrenceScheduler(db)
   heartbeatScheduler = new HeartbeatScheduler(db, agentManager)
+  workspaceCleanupScheduler = new WorkspaceCleanupScheduler(db, worktreeManager)
 
   // Initialize enterprise auth (gracefully — missing env vars just disable the feature)
   try {
@@ -756,7 +765,7 @@ app.whenReady().then(async () => {
     console.log('[EnterpriseAuth] auth_session_restore_result {"status":"skipped","reason":"enterprise_auth_not_initialized"}')
   }
 
-  registerIpcHandlers(db, agentManager, githubManager, worktreeManager, syncManager, pluginRegistry, mcpToolCaller, oauthManager, recurrenceScheduler, enterpriseAuth ?? undefined, claudePluginManager, heartbeatScheduler, enterpriseHeartbeatInstance ?? undefined, enterpriseStateSyncInstance ?? undefined, gitlabManager ?? undefined)
+  registerIpcHandlers(db, agentManager, githubManager, worktreeManager, syncManager, pluginRegistry, mcpToolCaller, oauthManager, recurrenceScheduler, enterpriseAuth ?? undefined, claudePluginManager, heartbeatScheduler, enterpriseHeartbeatInstance ?? undefined, enterpriseStateSyncInstance ?? undefined, gitlabManager ?? undefined, workspaceCleanupScheduler ?? undefined)
 
   // Register updater IPC handlers (safe in dev mode — returns no-op results)
   registerUpdaterIpc()

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -76,7 +76,8 @@ export function registerIpcHandlers(
   heartbeatScheduler?: import('./heartbeat-scheduler').HeartbeatScheduler,
   initialEnterpriseHeartbeat?: EnterpriseHeartbeat,
   initialEnterpriseStateSync?: EnterpriseStateSync,
-  gitlabManager?: GitLabManager
+  gitlabManager?: GitLabManager,
+  workspaceCleanupScheduler?: import('./workspace-cleanup-scheduler').WorkspaceCleanupScheduler
 ): void {
   // Mutable references — created on selectTenant, cleared on logout
   let enterpriseHeartbeat = initialEnterpriseHeartbeat
@@ -475,6 +476,11 @@ export function registerIpcHandlers(
 
   ipcMain.handle('worktree:cleanup', async (_, taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean) => {
     await worktreeManager.cleanupTaskWorkspace(taskId, repos, org, removeTaskDir ?? true)
+  })
+
+  ipcMain.handle('workspace:runCleanupNow', async () => {
+    if (!workspaceCleanupScheduler) return { cleaned: 0, errors: ['Cleanup scheduler not initialized'] }
+    return await workspaceCleanupScheduler.runNow()
   })
 
   // Task Source handlers

--- a/src/main/workspace-cleanup-scheduler.test.ts
+++ b/src/main/workspace-cleanup-scheduler.test.ts
@@ -255,6 +255,44 @@ describe('WorkspaceCleanupScheduler', () => {
     })
   })
 
+  describe('concurrent run guard', () => {
+    it('rejects concurrent runNow calls', async () => {
+      const oldDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+      const task = makeTask({
+        id: 'task-slow',
+        status: TaskStatus.Completed,
+        updated_at: oldDate,
+        repos: ['org/repo']
+      })
+      ;(db.getTasks as ReturnType<typeof vi.fn>).mockReturnValue([task])
+      ;(db.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === 'github_org') return 'test-org'
+        if (key === 'workspace_autocleanup_days') return '7'
+        return undefined
+      })
+      mockedExistsSync.mockReturnValue(true)
+
+      // Make cleanup take time by returning a deferred promise
+      let resolveCleanup!: () => void
+      ;(worktree.cleanupTaskWorkspace as ReturnType<typeof vi.fn>).mockReturnValue(
+        new Promise<void>((resolve) => { resolveCleanup = resolve })
+      )
+
+      // Start first cleanup (will hang on the slow cleanupTaskWorkspace)
+      const first = scheduler.runNow()
+
+      // Second call should be rejected immediately because first is still running
+      const second = await scheduler.runNow()
+      expect(second.cleaned).toBe(0)
+      expect(second.errors).toEqual(['Cleanup is already in progress'])
+
+      // Resolve the first one to avoid hanging
+      resolveCleanup()
+      const firstResult = await first
+      expect(firstResult.cleaned).toBe(1)
+    })
+  })
+
   describe('getRetentionDays (via runNow behavior)', () => {
     it('uses default 7 days when invalid setting', async () => {
       const sixDaysAgo = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString()

--- a/src/main/workspace-cleanup-scheduler.test.ts
+++ b/src/main/workspace-cleanup-scheduler.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { WorkspaceCleanupScheduler } from './workspace-cleanup-scheduler'
+import type { DatabaseManager, TaskRecord } from './database'
+import type { WorktreeManager } from './worktree-manager'
+import { TaskStatus } from '../shared/constants'
+
+// Mock fs module at the top level (ESM-safe)
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+    readdirSync: vi.fn().mockReturnValue([]),
+    statSync: vi.fn().mockReturnValue({ mtime: new Date() }),
+    rmSync: vi.fn(),
+  }
+})
+
+import { existsSync, rmSync } from 'fs'
+
+// ── Helpers ──────────────────────────────────────────────
+
+function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id: 'task-1',
+    title: 'Test Task',
+    description: '',
+    type: 'general',
+    priority: 'medium',
+    status: TaskStatus.Completed,
+    assignee: '',
+    due_date: null,
+    labels: [],
+    attachments: [],
+    repos: ['org/repo'],
+    output_fields: [],
+    agent_id: null,
+    external_id: null,
+    source_id: null,
+    source: 'local',
+    skill_ids: null,
+    session_id: null,
+    snoozed_until: null,
+    resolution: null,
+    feedback_rating: null,
+    feedback_comment: null,
+    is_recurring: false,
+    recurrence_pattern: null,
+    recurrence_parent_id: null,
+    last_occurrence_at: null,
+    next_occurrence_at: null,
+    heartbeat_enabled: false,
+    heartbeat_interval_minutes: null,
+    heartbeat_last_check_at: null,
+    heartbeat_next_check_at: null,
+    parent_task_id: null,
+    sort_order: 0,
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  } as TaskRecord
+}
+
+function mockDbManager(overrides: Record<string, unknown> = {}): DatabaseManager {
+  const settings: Record<string, string> = {}
+  return {
+    getTasks: vi.fn().mockReturnValue([]),
+    getSetting: vi.fn((key: string) => settings[key]),
+    setSetting: vi.fn((key: string, value: string) => { settings[key] = value }),
+    ...overrides,
+  } as unknown as DatabaseManager
+}
+
+function mockWorktreeManager(overrides: Record<string, unknown> = {}): WorktreeManager {
+  return {
+    cleanupTaskWorkspace: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as WorktreeManager
+}
+
+// ── Tests ──────────────────────────────────────────────
+
+describe('WorkspaceCleanupScheduler', () => {
+  let scheduler: WorkspaceCleanupScheduler
+  let db: ReturnType<typeof mockDbManager>
+  let worktree: ReturnType<typeof mockWorktreeManager>
+  const mockedExistsSync = vi.mocked(existsSync)
+  const mockedRmSync = vi.mocked(rmSync)
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    db = mockDbManager()
+    worktree = mockWorktreeManager()
+    scheduler = new WorkspaceCleanupScheduler(db, worktree)
+
+    // Reset fs mocks
+    mockedExistsSync.mockReturnValue(false)
+    mockedRmSync.mockReturnValue(undefined)
+  })
+
+  afterEach(() => {
+    scheduler.stop()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  describe('runNow', () => {
+    it('returns zero cleaned when no completed tasks exist', async () => {
+      (db.getTasks as ReturnType<typeof vi.fn>).mockReturnValue([])
+
+      const result = await scheduler.runNow()
+
+      expect(result.cleaned).toBe(0)
+      expect(result.errors).toEqual([])
+    })
+
+    it('does not clean tasks that are not completed', async () => {
+      const task = makeTask({ status: TaskStatus.NotStarted, updated_at: '2020-01-01T00:00:00.000Z' })
+      ;(db.getTasks as ReturnType<typeof vi.fn>).mockReturnValue([task])
+      ;(db.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === 'github_org') return 'test-org'
+        if (key === 'workspace_autocleanup_days') return '7'
+        return undefined
+      })
+
+      const result = await scheduler.runNow()
+
+      expect(result.cleaned).toBe(0)
+      expect(worktree.cleanupTaskWorkspace).not.toHaveBeenCalled()
+    })
+
+    it('does not clean recently completed tasks within retention period', async () => {
+      const task = makeTask({
+        status: TaskStatus.Completed,
+        updated_at: new Date().toISOString()
+      })
+      ;(db.getTasks as ReturnType<typeof vi.fn>).mockReturnValue([task])
+      ;(db.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === 'github_org') return 'test-org'
+        if (key === 'workspace_autocleanup_days') return '7'
+        return undefined
+      })
+
+      const result = await scheduler.runNow()
+
+      expect(result.cleaned).toBe(0)
+      expect(worktree.cleanupTaskWorkspace).not.toHaveBeenCalled()
+    })
+
+    it('cleans completed tasks past retention period', async () => {
+      const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+      const task = makeTask({
+        id: 'task-old',
+        status: TaskStatus.Completed,
+        updated_at: eightDaysAgo,
+        repos: ['org/repo']
+      })
+      ;(db.getTasks as ReturnType<typeof vi.fn>).mockReturnValue([task])
+      ;(db.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === 'github_org') return 'test-org'
+        return undefined // no cleanup days set → should use default 7
+      })
+      mockedExistsSync.mockReturnValue(true)
+
+      const result = await scheduler.runNow()
+
+      expect(result.cleaned).toBe(1)
+      expect(worktree.cleanupTaskWorkspace).toHaveBeenCalledWith(
+        'task-old',
+        [{ fullName: 'org/repo' }],
+        'test-org',
+        true
+      )
+    })
+
+    it('respects custom retention days', async () => {
+      const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
+      const task = makeTask({
+        id: 'task-recent',
+        status: TaskStatus.Completed,
+        updated_at: fiveDaysAgo,
+        repos: ['org/repo']
+      })
+      ;(db.getTasks as ReturnType<typeof vi.fn>).mockReturnValue([task])
+      ;(db.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === 'github_org') return 'test-org'
+        if (key === 'workspace_autocleanup_days') return '3' // 3 day retention
+        return undefined
+      })
+      mockedExistsSync.mockReturnValue(true)
+
+      const result = await scheduler.runNow()
+
+      // 5 days > 3 days retention → should be cleaned
+      expect(result.cleaned).toBe(1)
+      expect(worktree.cleanupTaskWorkspace).toHaveBeenCalled()
+    })
+
+    it('handles cleanup errors gracefully', async () => {
+      const oldDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+      const task = makeTask({
+        id: 'task-error',
+        status: TaskStatus.Completed,
+        updated_at: oldDate,
+        repos: ['org/repo']
+      })
+      ;(db.getTasks as ReturnType<typeof vi.fn>).mockReturnValue([task])
+      ;(db.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === 'github_org') return 'test-org'
+        if (key === 'workspace_autocleanup_days') return '7'
+        return undefined
+      })
+      mockedExistsSync.mockReturnValue(true)
+
+      ;(worktree.cleanupTaskWorkspace as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Permission denied')
+      )
+
+      const result = await scheduler.runNow()
+
+      expect(result.cleaned).toBe(0)
+      expect(result.errors.length).toBe(1)
+      expect(result.errors[0]).toContain('Permission denied')
+    })
+
+    it('cleans tasks with no repos by removing directory directly', async () => {
+      const oldDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+      const task = makeTask({
+        id: 'task-no-repo',
+        status: TaskStatus.Completed,
+        updated_at: oldDate,
+        repos: [] // no repos
+      })
+      ;(db.getTasks as ReturnType<typeof vi.fn>).mockReturnValue([task])
+      ;(db.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === 'github_org') return 'test-org'
+        if (key === 'workspace_autocleanup_days') return '7'
+        return undefined
+      })
+      mockedExistsSync.mockReturnValue(true)
+
+      const result = await scheduler.runNow()
+
+      expect(result.cleaned).toBe(1)
+      // Should not call worktreeManager since there are no repos
+      expect(worktree.cleanupTaskWorkspace).not.toHaveBeenCalled()
+      // Should directly remove the directory
+      expect(mockedRmSync).toHaveBeenCalled()
+    })
+  })
+
+  describe('stop', () => {
+    it('stops without error when not started', () => {
+      expect(() => scheduler.stop()).not.toThrow()
+    })
+  })
+
+  describe('getRetentionDays (via runNow behavior)', () => {
+    it('uses default 7 days when invalid setting', async () => {
+      const sixDaysAgo = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000).toISOString()
+      const task = makeTask({
+        status: TaskStatus.Completed,
+        updated_at: sixDaysAgo
+      })
+      ;(db.getTasks as ReturnType<typeof vi.fn>).mockReturnValue([task])
+      ;(db.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === 'workspace_autocleanup_days') return 'invalid'
+        return undefined
+      })
+
+      // 6 days < 7 days default → should NOT be cleaned
+      const result = await scheduler.runNow()
+      expect(result.cleaned).toBe(0)
+    })
+  })
+})

--- a/src/main/workspace-cleanup-scheduler.ts
+++ b/src/main/workspace-cleanup-scheduler.ts
@@ -1,0 +1,196 @@
+import { BrowserWindow, app } from 'electron'
+import { existsSync, readdirSync, statSync, rmSync } from 'fs'
+import { join } from 'path'
+import type { DatabaseManager } from './database'
+import type { WorktreeManager } from './worktree-manager'
+import { TaskStatus } from '../shared/constants'
+
+const WORKSPACES_DIR = join(app.getPath('userData'), 'workspaces')
+
+/**
+ * WorkspaceCleanupScheduler - Automatic cleanup of old completed task workspaces
+ *
+ * Runs once daily (every 24 hours). On each tick:
+ * 1. Checks if auto-cleanup is enabled via settings
+ * 2. Queries completed tasks where `updated_at` is older than the configured retention period
+ * 3. Cleans up worktrees and workspace directories for those tasks
+ * 4. Also removes orphaned workspace directories (no matching task in DB)
+ *
+ * Settings:
+ * - `workspace_autocleanup_enabled` — "true"/"false" (default: "false")
+ * - `workspace_autocleanup_days` — number of days after completion (default: 7)
+ */
+export class WorkspaceCleanupScheduler {
+  private dbManager: DatabaseManager
+  private worktreeManager: WorktreeManager
+  private intervalId: NodeJS.Timeout | null = null
+  private mainWindow: BrowserWindow | null = null
+  private isRunning = false
+
+  /** Check every hour, but only actually clean once per day */
+  private readonly CHECK_INTERVAL = 60 * 60 * 1000 // 1 hour
+  private readonly DEFAULT_RETENTION_DAYS = 7
+
+  constructor(dbManager: DatabaseManager, worktreeManager: WorktreeManager) {
+    this.dbManager = dbManager
+    this.worktreeManager = worktreeManager
+  }
+
+  start(mainWindow: BrowserWindow): void {
+    this.mainWindow = mainWindow
+    console.log('[WorkspaceCleanup] Starting scheduler...')
+
+    // Run once on startup (delayed by 2 minutes to not slow down app launch)
+    setTimeout(() => {
+      this.runCleanup()
+    }, 2 * 60 * 1000)
+
+    // Then check every hour
+    this.intervalId = setInterval(() => {
+      this.runCleanup()
+    }, this.CHECK_INTERVAL)
+  }
+
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+      console.log('[WorkspaceCleanup] Scheduler stopped')
+    }
+  }
+
+  /**
+   * Manually trigger a cleanup run. Returns the number of workspaces cleaned.
+   */
+  async runNow(): Promise<{ cleaned: number; errors: string[] }> {
+    return this.doCleanup()
+  }
+
+  // ── Core Logic ──────────────────────────────────────────────
+
+  private async runCleanup(): Promise<void> {
+    if (this.isRunning) return
+
+    try {
+      // Check if auto-cleanup is enabled
+      const enabled = this.dbManager.getSetting('workspace_autocleanup_enabled')
+      if (enabled !== 'true') return
+
+      // Check if we already ran today
+      const lastRun = this.dbManager.getSetting('workspace_autocleanup_last_run')
+      if (lastRun) {
+        const lastRunDate = new Date(lastRun)
+        const now = new Date()
+        const hoursSinceLastRun = (now.getTime() - lastRunDate.getTime()) / (1000 * 60 * 60)
+        if (hoursSinceLastRun < 23) return // Run at most once per day
+      }
+
+      this.isRunning = true
+      const result = await this.doCleanup()
+
+      // Record last run time
+      this.dbManager.setSetting('workspace_autocleanup_last_run', new Date().toISOString())
+
+      if (result.cleaned > 0) {
+        console.log(`[WorkspaceCleanup] Cleaned ${result.cleaned} workspace(s)`)
+        this.sendToRenderer('workspace:cleanup-complete', {
+          cleaned: result.cleaned,
+          errors: result.errors
+        })
+      }
+    } catch (err) {
+      console.error('[WorkspaceCleanup] Error in runCleanup:', err)
+    } finally {
+      this.isRunning = false
+    }
+  }
+
+  private async doCleanup(): Promise<{ cleaned: number; errors: string[] }> {
+    const retentionDays = this.getRetentionDays()
+    const cutoffDate = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000)
+    const org = this.dbManager.getSetting('github_org') || ''
+
+    let cleaned = 0
+    const errors: string[] = []
+
+    // Phase 1: Clean workspaces for completed tasks past retention
+    const allTasks = this.dbManager.getTasks()
+    const completedTasks = allTasks.filter(
+      (t) =>
+        t.status === TaskStatus.Completed &&
+        new Date(t.updated_at) < cutoffDate
+    )
+
+    for (const task of completedTasks) {
+      const taskDir = join(WORKSPACES_DIR, task.id)
+      if (!existsSync(taskDir)) continue
+
+      try {
+        if (task.repos.length > 0 && org) {
+          await this.worktreeManager.cleanupTaskWorkspace(
+            task.id,
+            task.repos.map((r) => ({ fullName: r })),
+            org,
+            true
+          )
+        } else {
+          // No repos — just remove the workspace directory
+          rmSync(taskDir, { recursive: true, force: true })
+        }
+        cleaned++
+        console.log(`[WorkspaceCleanup] Cleaned workspace for completed task "${task.title}" (${task.id})`)
+      } catch (err) {
+        const message = `Failed to clean workspace for task ${task.id}: ${err instanceof Error ? err.message : String(err)}`
+        console.error(`[WorkspaceCleanup] ${message}`)
+        errors.push(message)
+      }
+    }
+
+    // Phase 2: Clean orphaned workspace directories (no matching task in DB)
+    try {
+      if (existsSync(WORKSPACES_DIR)) {
+        const taskIds = new Set(allTasks.map((t) => t.id))
+        const dirs = readdirSync(WORKSPACES_DIR, { withFileTypes: true })
+
+        for (const dir of dirs) {
+          if (!dir.isDirectory()) continue
+          if (taskIds.has(dir.name)) continue
+
+          // Orphan detected — check if it's old enough
+          const dirPath = join(WORKSPACES_DIR, dir.name)
+          try {
+            const stat = statSync(dirPath)
+            if (stat.mtime < cutoffDate) {
+              rmSync(dirPath, { recursive: true, force: true })
+              cleaned++
+              console.log(`[WorkspaceCleanup] Cleaned orphaned workspace directory: ${dir.name}`)
+            }
+          } catch (err) {
+            const message = `Failed to clean orphaned directory ${dir.name}: ${err instanceof Error ? err.message : String(err)}`
+            console.error(`[WorkspaceCleanup] ${message}`)
+            errors.push(message)
+          }
+        }
+      }
+    } catch (err) {
+      console.error('[WorkspaceCleanup] Error scanning workspace directory:', err)
+    }
+
+    return { cleaned, errors }
+  }
+
+  private getRetentionDays(): number {
+    const setting = this.dbManager.getSetting('workspace_autocleanup_days')
+    if (setting) {
+      const parsed = parseInt(setting, 10)
+      if (!isNaN(parsed) && parsed >= 1) return parsed
+    }
+    return this.DEFAULT_RETENTION_DAYS
+  }
+
+  private sendToRenderer(channel: string, data: unknown): void {
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send(channel, data)
+    }
+  }
+}

--- a/src/main/workspace-cleanup-scheduler.ts
+++ b/src/main/workspace-cleanup-scheduler.ts
@@ -61,9 +61,27 @@ export class WorkspaceCleanupScheduler {
 
   /**
    * Manually trigger a cleanup run. Returns the number of workspaces cleaned.
+   * Rejects if a cleanup is already in progress (prevents concurrent runs).
    */
   async runNow(): Promise<{ cleaned: number; errors: string[] }> {
-    return this.doCleanup()
+    if (this.isRunning) {
+      return { cleaned: 0, errors: ['Cleanup is already in progress'] }
+    }
+    this.isRunning = true
+    this.sendToRenderer('workspace:cleanup-progress', { phase: 'starting', current: 0, total: 0 })
+    try {
+      const result = await this.doCleanup(true)
+      this.sendToRenderer('workspace:cleanup-progress', {
+        phase: 'done',
+        current: result.cleaned,
+        total: result.cleaned,
+        cleaned: result.cleaned,
+        errors: result.errors
+      })
+      return result
+    } finally {
+      this.isRunning = false
+    }
   }
 
   // ── Core Logic ──────────────────────────────────────────────
@@ -86,7 +104,7 @@ export class WorkspaceCleanupScheduler {
       }
 
       this.isRunning = true
-      const result = await this.doCleanup()
+      const result = await this.doCleanup(false)
 
       // Record last run time
       this.dbManager.setSetting('workspace_autocleanup_last_run', new Date().toISOString())
@@ -105,7 +123,7 @@ export class WorkspaceCleanupScheduler {
     }
   }
 
-  private async doCleanup(): Promise<{ cleaned: number; errors: string[] }> {
+  private async doCleanup(reportProgress: boolean): Promise<{ cleaned: number; errors: string[] }> {
     const retentionDays = this.getRetentionDays()
     const cutoffDate = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000)
     const org = this.dbManager.getSetting('github_org') || ''
@@ -121,9 +139,55 @@ export class WorkspaceCleanupScheduler {
         new Date(t.updated_at) < cutoffDate
     )
 
-    for (const task of completedTasks) {
+    // Count eligible workspaces (ones that actually exist on disk)
+    const eligibleTasks = completedTasks.filter((t) =>
+      existsSync(join(WORKSPACES_DIR, t.id))
+    )
+
+    // Count orphaned directories
+    let orphanDirs: string[] = []
+    try {
+      if (existsSync(WORKSPACES_DIR)) {
+        const taskIds = new Set(allTasks.map((t) => t.id))
+        const dirs = readdirSync(WORKSPACES_DIR, { withFileTypes: true })
+        orphanDirs = dirs
+          .filter((d) => d.isDirectory() && !taskIds.has(d.name))
+          .map((d) => d.name)
+          .filter((name) => {
+            try {
+              return statSync(join(WORKSPACES_DIR, name)).mtime < cutoffDate
+            } catch {
+              return false
+            }
+          })
+      }
+    } catch {
+      // ignore scan errors for counting
+    }
+
+    const total = eligibleTasks.length + orphanDirs.length
+    let processed = 0
+
+    if (reportProgress) {
+      this.sendToRenderer('workspace:cleanup-progress', {
+        phase: 'scanning',
+        current: 0,
+        total,
+        message: `Found ${total} workspace${total !== 1 ? 's' : ''} to clean`
+      })
+    }
+
+    for (const task of eligibleTasks) {
       const taskDir = join(WORKSPACES_DIR, task.id)
-      if (!existsSync(taskDir)) continue
+
+      if (reportProgress) {
+        this.sendToRenderer('workspace:cleanup-progress', {
+          phase: 'cleaning',
+          current: processed,
+          total,
+          message: `Cleaning "${task.title}"...`
+        })
+      }
 
       try {
         if (task.repos.length > 0 && org) {
@@ -144,36 +208,32 @@ export class WorkspaceCleanupScheduler {
         console.error(`[WorkspaceCleanup] ${message}`)
         errors.push(message)
       }
+      processed++
     }
 
     // Phase 2: Clean orphaned workspace directories (no matching task in DB)
-    try {
-      if (existsSync(WORKSPACES_DIR)) {
-        const taskIds = new Set(allTasks.map((t) => t.id))
-        const dirs = readdirSync(WORKSPACES_DIR, { withFileTypes: true })
+    for (const name of orphanDirs) {
+      const dirPath = join(WORKSPACES_DIR, name)
 
-        for (const dir of dirs) {
-          if (!dir.isDirectory()) continue
-          if (taskIds.has(dir.name)) continue
-
-          // Orphan detected — check if it's old enough
-          const dirPath = join(WORKSPACES_DIR, dir.name)
-          try {
-            const stat = statSync(dirPath)
-            if (stat.mtime < cutoffDate) {
-              rmSync(dirPath, { recursive: true, force: true })
-              cleaned++
-              console.log(`[WorkspaceCleanup] Cleaned orphaned workspace directory: ${dir.name}`)
-            }
-          } catch (err) {
-            const message = `Failed to clean orphaned directory ${dir.name}: ${err instanceof Error ? err.message : String(err)}`
-            console.error(`[WorkspaceCleanup] ${message}`)
-            errors.push(message)
-          }
-        }
+      if (reportProgress) {
+        this.sendToRenderer('workspace:cleanup-progress', {
+          phase: 'cleaning',
+          current: processed,
+          total,
+          message: `Cleaning orphaned workspace ${name.substring(0, 12)}...`
+        })
       }
-    } catch (err) {
-      console.error('[WorkspaceCleanup] Error scanning workspace directory:', err)
+
+      try {
+        rmSync(dirPath, { recursive: true, force: true })
+        cleaned++
+        console.log(`[WorkspaceCleanup] Cleaned orphaned workspace directory: ${name}`)
+      } catch (err) {
+        const message = `Failed to clean orphaned directory ${name}: ${err instanceof Error ? err.message : String(err)}`
+        console.error(`[WorkspaceCleanup] ${message}`)
+        errors.push(message)
+      }
+      processed++
     }
 
     return { cleaned, errors }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -305,6 +305,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('worktree:progress', handler)
     return () => ipcRenderer.removeListener('worktree:progress', handler)
   },
+  onWorkspaceCleanupProgress: (callback: (event: { phase: string; current: number; total: number; message?: string; cleaned?: number; errors?: string[] }) => void): (() => void) => {
+    const handler = (_: unknown, data: { phase: string; current: number; total: number; message?: string; cleaned?: number; errors?: string[] }): void => callback(data)
+    ipcRenderer.on('workspace:cleanup-progress', handler)
+    return () => ipcRenderer.removeListener('workspace:cleanup-progress', handler)
+  },
   onGithubDeviceCode: (callback: (code: string) => void): (() => void) => {
     const handler = (_: unknown, code: string): void => callback(code)
     ipcRenderer.on('github:deviceCode', handler)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -191,7 +191,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     setup: (taskId: string, repos: { fullName: string; defaultBranch: string }[], org: string, provider: 'github' | 'gitlab'): Promise<string> =>
       ipcRenderer.invoke('worktree:setup', taskId, repos, org, provider),
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> =>
-      ipcRenderer.invoke('worktree:cleanup', taskId, repos, org, removeTaskDir)
+      ipcRenderer.invoke('worktree:cleanup', taskId, repos, org, removeTaskDir),
+    runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> =>
+      ipcRenderer.invoke('workspace:runCleanupNow')
   },
   taskSources: {
     getAll: (): Promise<unknown[]> => ipcRenderer.invoke('taskSource:getAll'),

--- a/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
@@ -5,7 +5,7 @@ import { Label } from '@/components/ui/Label'
 import { Switch } from '@/components/ui/Switch'
 import { Button } from '@/components/ui/Button'
 import { ToolSetupDialog } from '@/components/AgentSetupWizard'
-import { settingsApi, mobileApi, updaterApi, worktreeApi } from '@/lib/ipc-client'
+import { settingsApi, mobileApi, updaterApi, worktreeApi, onWorkspaceCleanupProgress } from '@/lib/ipc-client'
 
 export function GeneralSettings() {
   const [setupDialogOpen, setSetupDialogOpen] = useState(false)
@@ -31,11 +31,33 @@ export function GeneralSettings() {
     return cleanup
   }, [])
 
+  // Workspace cleanup progress listener
+  useEffect(() => {
+    const cleanup = onWorkspaceCleanupProgress((event) => {
+      if (event.phase === 'done') {
+        setCleanupRunning(false)
+        setCleanupProgress(null)
+        if (event.cleaned !== undefined && event.cleaned > 0) {
+          setCleanupResult(`Cleaned ${event.cleaned} workspace${event.cleaned !== 1 ? 's' : ''}`)
+        } else if (event.errors && event.errors.length > 0) {
+          setCleanupResult(`Cleanup finished with ${event.errors.length} error${event.errors.length !== 1 ? 's' : ''}`)
+        } else {
+          setCleanupResult('No workspaces to clean')
+        }
+      } else {
+        setCleanupRunning(true)
+        setCleanupProgress({ current: event.current, total: event.total, message: event.message })
+      }
+    })
+    return cleanup
+  }, [])
+
   // Workspace cleanup settings
   const [autocleanEnabled, setAutocleanEnabled] = useState(false)
   const [autocleanDays, setAutocleanDays] = useState('7')
   const [cleanupRunning, setCleanupRunning] = useState(false)
   const [cleanupResult, setCleanupResult] = useState<string | null>(null)
+  const [cleanupProgress, setCleanupProgress] = useState<{ current: number; total: number; message?: string } | null>(null)
 
   // Heartbeat settings
   const [heartbeatEnabled, setHeartbeatEnabled] = useState(true)
@@ -282,47 +304,78 @@ export function GeneralSettings() {
           </select>
         </div>
 
-        <div className="flex items-center justify-between py-2">
-          <div className="space-y-0.5">
-            <Label>Manual cleanup</Label>
-            <p className="text-xs text-muted-foreground">
-              Run workspace cleanup now for all eligible completed tasks
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            {cleanupResult && (
-              <span className="text-xs text-muted-foreground">{cleanupResult}</span>
-            )}
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={cleanupRunning}
-              onClick={async () => {
-                setCleanupRunning(true)
-                setCleanupResult(null)
-                try {
-                  const result = await worktreeApi.runCleanupNow()
-                  if (result.cleaned > 0) {
-                    setCleanupResult(`Cleaned ${result.cleaned} workspace${result.cleaned !== 1 ? 's' : ''}`)
-                  } else {
-                    setCleanupResult('No workspaces to clean')
-                  }
-                } catch (error) {
-                  setCleanupResult('Cleanup failed')
-                  console.error('Workspace cleanup error:', error)
-                } finally {
-                  setCleanupRunning(false)
-                }
-              }}
-            >
-              {cleanupRunning ? (
-                <Loader2 className="size-3.5 mr-1.5 animate-spin" />
-              ) : (
-                <Trash2 className="size-3.5 mr-1.5" />
+        <div className="py-2">
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label>Manual cleanup</Label>
+              <p className="text-xs text-muted-foreground">
+                Run workspace cleanup now for all eligible completed tasks
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {!cleanupRunning && cleanupResult && (
+                <span className="text-xs text-muted-foreground">{cleanupResult}</span>
               )}
-              {cleanupRunning ? 'Cleaning...' : 'Clean Now'}
-            </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={cleanupRunning}
+                onClick={async () => {
+                  setCleanupRunning(true)
+                  setCleanupResult(null)
+                  setCleanupProgress(null)
+                  try {
+                    const result = await worktreeApi.runCleanupNow()
+                    // The progress listener handles the final state via the 'done' event,
+                    // but also handle the IPC response as a fallback
+                    if (!cleanupProgress) {
+                      if (result.cleaned > 0) {
+                        setCleanupResult(`Cleaned ${result.cleaned} workspace${result.cleaned !== 1 ? 's' : ''}`)
+                      } else if (result.errors.length > 0 && result.errors[0] === 'Cleanup is already in progress') {
+                        setCleanupResult('Cleanup already in progress')
+                      } else {
+                        setCleanupResult('No workspaces to clean')
+                      }
+                      setCleanupRunning(false)
+                    }
+                  } catch (error) {
+                    setCleanupResult('Cleanup failed')
+                    setCleanupRunning(false)
+                    console.error('Workspace cleanup error:', error)
+                  }
+                }}
+              >
+                {cleanupRunning ? (
+                  <Loader2 className="size-3.5 mr-1.5 animate-spin" />
+                ) : (
+                  <Trash2 className="size-3.5 mr-1.5" />
+                )}
+                {cleanupRunning ? 'Cleaning...' : 'Clean Now'}
+              </Button>
+            </div>
           </div>
+
+          {/* Progress bar */}
+          {cleanupRunning && cleanupProgress && (
+            <div className="mt-3 space-y-1.5">
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>{cleanupProgress.message || 'Preparing...'}</span>
+                {cleanupProgress.total > 0 && (
+                  <span>{cleanupProgress.current}/{cleanupProgress.total}</span>
+                )}
+              </div>
+              <div className="h-1.5 w-full bg-accent/50 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-primary rounded-full transition-all duration-300"
+                  style={{
+                    width: cleanupProgress.total > 0
+                      ? `${Math.round((cleanupProgress.current / cleanupProgress.total) * 100)}%`
+                      : '0%'
+                  }}
+                />
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </SettingsSection>

--- a/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react'
-import { Wrench, RefreshCw, Download, Check, Loader2 } from 'lucide-react'
+import { Wrench, RefreshCw, Download, Check, Loader2, Trash2 } from 'lucide-react'
 import { SettingsSection } from '../SettingsSection'
 import { Label } from '@/components/ui/Label'
 import { Switch } from '@/components/ui/Switch'
 import { Button } from '@/components/ui/Button'
 import { ToolSetupDialog } from '@/components/AgentSetupWizard'
-import { settingsApi, mobileApi, updaterApi } from '@/lib/ipc-client'
+import { settingsApi, mobileApi, updaterApi, worktreeApi } from '@/lib/ipc-client'
 
 export function GeneralSettings() {
   const [setupDialogOpen, setSetupDialogOpen] = useState(false)
@@ -30,6 +30,12 @@ export function GeneralSettings() {
     })
     return cleanup
   }, [])
+
+  // Workspace cleanup settings
+  const [autocleanEnabled, setAutocleanEnabled] = useState(false)
+  const [autocleanDays, setAutocleanDays] = useState('7')
+  const [cleanupRunning, setCleanupRunning] = useState(false)
+  const [cleanupResult, setCleanupResult] = useState<string | null>(null)
 
   // Heartbeat settings
   const [heartbeatEnabled, setHeartbeatEnabled] = useState(true)
@@ -58,6 +64,17 @@ export function GeneralSettings() {
         console.error('Failed to load app preferences:', error)
       } finally {
         setLoading(false)
+      }
+
+      // Load workspace cleanup settings
+      try {
+        const cleanupEnabled = await settingsApi.get('workspace_autocleanup_enabled')
+        if (cleanupEnabled !== null) setAutocleanEnabled(cleanupEnabled === 'true')
+
+        const cleanupDays = await settingsApi.get('workspace_autocleanup_days')
+        if (cleanupDays) setAutocleanDays(cleanupDays)
+      } catch (error) {
+        console.error('Failed to load workspace cleanup settings:', error)
       }
 
       // Load heartbeat settings
@@ -211,6 +228,101 @@ export function GeneralSettings() {
           ) : (
             <span className="text-sm text-muted-foreground">Unavailable</span>
           )}
+        </div>
+      </div>
+    </SettingsSection>
+
+    <SettingsSection
+      title="Workspace Auto-Cleanup"
+      description="Automatically clean up workspace files for completed tasks after a configurable retention period"
+    >
+      <div className="space-y-4">
+        <div className="flex items-center justify-between py-2 border-b border-border">
+          <div className="space-y-0.5">
+            <Label htmlFor="autoclean-enabled">Enable auto-cleanup</Label>
+            <p className="text-xs text-muted-foreground">
+              Automatically remove workspace files for tasks completed more than the configured number of days ago
+            </p>
+          </div>
+          <Switch
+            id="autoclean-enabled"
+            checked={autocleanEnabled}
+            onCheckedChange={async (checked) => {
+              setAutocleanEnabled(checked)
+              await settingsApi.set('workspace_autocleanup_enabled', checked ? 'true' : 'false')
+            }}
+            disabled={loading}
+          />
+        </div>
+
+        <div className="flex items-center justify-between py-2 border-b border-border">
+          <div className="space-y-0.5">
+            <Label htmlFor="autoclean-days">Retention period</Label>
+            <p className="text-xs text-muted-foreground">
+              Days to keep workspace files after task completion
+            </p>
+          </div>
+          <select
+            id="autoclean-days"
+            value={autocleanDays}
+            onChange={async (e) => {
+              setAutocleanDays(e.target.value)
+              await settingsApi.set('workspace_autocleanup_days', e.target.value)
+            }}
+            disabled={loading || !autocleanEnabled}
+            className="bg-transparent border rounded px-2 py-1 text-sm disabled:opacity-50"
+          >
+            <option value="1">1 day</option>
+            <option value="3">3 days</option>
+            <option value="7">7 days</option>
+            <option value="14">14 days</option>
+            <option value="30">30 days</option>
+            <option value="60">60 days</option>
+            <option value="90">90 days</option>
+          </select>
+        </div>
+
+        <div className="flex items-center justify-between py-2">
+          <div className="space-y-0.5">
+            <Label>Manual cleanup</Label>
+            <p className="text-xs text-muted-foreground">
+              Run workspace cleanup now for all eligible completed tasks
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {cleanupResult && (
+              <span className="text-xs text-muted-foreground">{cleanupResult}</span>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={cleanupRunning}
+              onClick={async () => {
+                setCleanupRunning(true)
+                setCleanupResult(null)
+                try {
+                  const result = await worktreeApi.runCleanupNow()
+                  if (result.cleaned > 0) {
+                    setCleanupResult(`Cleaned ${result.cleaned} workspace${result.cleaned !== 1 ? 's' : ''}`)
+                  } else {
+                    setCleanupResult('No workspaces to clean')
+                  }
+                } catch (error) {
+                  setCleanupResult('Cleanup failed')
+                  console.error('Workspace cleanup error:', error)
+                } finally {
+                  setCleanupRunning(false)
+                }
+              }}
+            >
+              {cleanupRunning ? (
+                <Loader2 className="size-3.5 mr-1.5 animate-spin" />
+              ) : (
+                <Trash2 className="size-3.5 mr-1.5" />
+              )}
+              {cleanupRunning ? 'Cleaning...' : 'Clean Now'}
+            </Button>
+          </div>
         </div>
       </div>
     </SettingsSection>

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -463,6 +463,9 @@ export const worktreeApi = {
   },
   cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> => {
     return window.electronAPI.worktree.cleanup(taskId, repos, org, removeTaskDir)
+  },
+  runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> => {
+    return window.electronAPI.worktree.runCleanupNow()
   }
 }
 

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -1,5 +1,5 @@
 import type { WorkfloTask, CreateTaskDTO, UpdateTaskDTO, FileAttachment, Agent, CreateAgentDTO, UpdateAgentDTO, McpServer, CreateMcpServerDTO, UpdateMcpServerDTO, Skill, CreateSkillDTO, UpdateSkillDTO, Secret, CreateSecretDTO, UpdateSecretDTO, TaskSource, CreateTaskSourceDTO, UpdateTaskSourceDTO, SyncResult, PluginMeta, ConfigFieldSchema, ConfigFieldOption, PluginAction, ActionResult, SourceUser, ReassignResult, MarketplaceSource, InstalledPlugin, DiscoverablePlugin, MarketplaceCatalog, PluginResources } from '@/types'
-import type { AgentOutputEvent, AgentOutputBatchEvent, AgentStatusEvent, AgentApprovalRequest, GhCliStatus, GlabCliStatus, GitHubRepo, GitHubCollaborator, WorktreeProgressEvent, McpTestResult, SkillSyncResult, DepsStatus, AgentMessageAttachment } from '@/types/electron'
+import type { AgentOutputEvent, AgentOutputBatchEvent, AgentStatusEvent, AgentApprovalRequest, GhCliStatus, GlabCliStatus, GitHubRepo, GitHubCollaborator, WorktreeProgressEvent, WorkspaceCleanupProgressEvent, McpTestResult, SkillSyncResult, DepsStatus, AgentMessageAttachment } from '@/types/electron'
 
 export const taskApi = {
   getAll: (): Promise<WorkfloTask[]> => {
@@ -471,6 +471,10 @@ export const worktreeApi = {
 
 export const onWorktreeProgress = (callback: (event: WorktreeProgressEvent) => void): (() => void) => {
   return window.electronAPI.onWorktreeProgress(callback)
+}
+
+export const onWorkspaceCleanupProgress = (callback: (event: WorkspaceCleanupProgressEvent) => void): (() => void) => {
+  return window.electronAPI.onWorkspaceCleanupProgress(callback)
 }
 
 export const enterpriseApi = {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -251,6 +251,7 @@ interface ElectronAPI {
   worktree: {
     setup: (taskId: string, repos: { fullName: string; defaultBranch: string }[], org: string, provider: 'github' | 'gitlab') => Promise<string>
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean) => Promise<void>
+    runCleanupNow: () => Promise<{ cleaned: number; errors: string[] }>
   }
   taskSources: {
     getAll: () => Promise<TaskSource[]>

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -132,6 +132,15 @@ export interface WorktreeProgressEvent {
   error?: string
 }
 
+export interface WorkspaceCleanupProgressEvent {
+  phase: 'starting' | 'scanning' | 'cleaning' | 'done'
+  current: number
+  total: number
+  message?: string
+  cleaned?: number
+  errors?: string[]
+}
+
 export interface ToolStatus {
   installed: boolean
   version: string | null
@@ -396,6 +405,7 @@ interface ElectronAPI {
   onHeartbeatAlert: (callback: (event: HeartbeatAlertEvent) => void) => () => void
   onHeartbeatDisabled: (callback: (event: { taskId: string; reason: string }) => void) => () => void
   onWorktreeProgress: (callback: (event: WorktreeProgressEvent) => void) => () => void
+  onWorkspaceCleanupProgress: (callback: (event: WorkspaceCleanupProgressEvent) => void) => () => void
   onGithubDeviceCode: (callback: (code: string) => void) => () => void
   browser: {
     getCdpPort: () => Promise<{ port: number }>


### PR DESCRIPTION
## Summary
- Add `WorkspaceCleanupScheduler` that runs daily to automatically remove workspace files for completed tasks older than a configurable retention period (default 7 days)
- Also cleans orphaned workspace directories (no matching task in DB) past the retention cutoff
- Add "Workspace Auto-Cleanup" settings section in General Settings with enable toggle, retention period selector (1–90 days), and a manual "Clean Now" button

## Changes
- **`workspace-cleanup-scheduler.ts`** — New scheduler class (hourly tick, daily cleanup, 2-min startup delay)
- **`index.ts`** — Wire up scheduler initialization, start, and stop
- **`ipc-handlers.ts`** — Add `workspace:runCleanupNow` IPC handler for manual trigger
- **`preload/index.ts`** + **`electron.d.ts`** + **`ipc-client.ts`** — Expose cleanup API to renderer
- **`GeneralSettings.tsx`** — New settings UI section with toggle, retention dropdown, and clean button
- **`workspace-cleanup-scheduler.test.ts`** — 9 unit tests covering all key behaviors

## Settings keys
- `workspace_autocleanup_enabled` — `"true"` / `"false"` (default: disabled)
- `workspace_autocleanup_days` — retention days (default: `"7"`)
- `workspace_autocleanup_last_run` — ISO timestamp of last run (internal)

## Test plan
- [x] TypeScript typecheck passes (`pnpm typecheck`)
- [x] All 9 unit tests pass (`pnpm vitest run workspace-cleanup-scheduler.test.ts`)
- [ ] Manual: enable auto-cleanup in Settings > General > Workspace Auto-Cleanup
- [ ] Manual: click "Clean Now" to verify immediate cleanup works
- [ ] Manual: verify completed tasks within retention period are NOT cleaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)