### PR TITLE
Fix main-process crash from stream logging errors

### DIFF
--- a/src/main/crash-logger.ts
+++ b/src/main/crash-logger.ts
@@ -26,10 +26,18 @@ function logCrash(error: Error | string): void {
   try {
     const entry = formatError(error)
     appendFileSync(getLogPath(), entry, 'utf-8')
-    console.error('[CrashLogger]', entry)
+    try {
+      console.error('[CrashLogger]', entry)
+    } catch {
+      // Console streams may be unavailable during crash handling.
+    }
   } catch {
     // Last resort — can't even write to disk
-    console.error('[CrashLogger] Failed to write crash log:', error)
+    try {
+      console.error('[CrashLogger] Failed to write crash log:', error)
+    } catch {
+      // Nothing else can be reported safely.
+    }
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import { startSecretBroker, stopSecretBroker, writeSecretShellWrapper } from './
 import { startMobileApiServer, stopMobileApiServer, broadcastToMobileClients, setMobileApiNotifier } from './mobile-api-server'
 import { registerUpdaterIpc, initAutoUpdater, isUpdateDownloaded, getPendingVersion } from './auto-updater'
 import { initCrashLogger } from './crash-logger'
+import { installProcessStreamErrorHandlers } from './process-stream-errors'
 
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
@@ -614,9 +615,7 @@ app.commandLine.appendSwitch('disable-features', [
   'AcceptCHFrame',                 // Electron-only ALPS extension not in Chrome
 ].join(','))
 
-// Ignore EPIPE errors from broken stdout/stderr pipes (e.g. when piped through head/tail)
-process.stdout?.on?.('error', (err: NodeJS.ErrnoException) => { if (err.code !== 'EPIPE') throw err })
-process.stderr?.on?.('error', (err: NodeJS.ErrnoException) => { if (err.code !== 'EPIPE') throw err })
+installProcessStreamErrorHandlers()
 
 app.whenReady().then(async () => {
   // Register protocol handler: app-attachment://taskId/attachmentId

--- a/src/main/process-stream-errors.test.ts
+++ b/src/main/process-stream-errors.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { handleProcessStreamError } from './process-stream-errors'
+
+describe('handleProcessStreamError', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each(['EPIPE', 'EIO'])('ignores %s without logging or throwing', (code) => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() => {
+      handleProcessStreamError('stderr', Object.assign(new Error(code), { code }))
+    }).not.toThrow()
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('logs unexpected stream errors without throwing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const err = Object.assign(new Error('unexpected stream failure'), { code: 'EINVAL' })
+
+    expect(() => {
+      handleProcessStreamError('stdout', err)
+    }).not.toThrow()
+
+    expect(warnSpy).toHaveBeenCalledWith('[Main] Ignoring stdout error:', err)
+  })
+
+  it('does not throw when fallback logging fails', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {
+      throw new Error('console unavailable')
+    })
+
+    expect(() => {
+      handleProcessStreamError(
+        'stderr',
+        Object.assign(new Error('unexpected stream failure'), { code: 'EINVAL' })
+      )
+    }).not.toThrow()
+  })
+})

--- a/src/main/process-stream-errors.ts
+++ b/src/main/process-stream-errors.ts
@@ -1,0 +1,26 @@
+const IGNORED_PROCESS_STREAM_ERROR_CODES = new Set(['EPIPE', 'EIO'])
+
+export function handleProcessStreamError(
+  streamName: 'stdout' | 'stderr',
+  err: NodeJS.ErrnoException
+): void {
+  if (err.code && IGNORED_PROCESS_STREAM_ERROR_CODES.has(err.code)) {
+    return
+  }
+
+  try {
+    console.warn(`[Main] Ignoring ${streamName} error:`, err)
+  } catch {
+    // Stream error handlers must never throw; they run on process-level diagnostics.
+  }
+}
+
+export function installProcessStreamErrorHandlers(): void {
+  process.stdout?.on?.('error', (err: NodeJS.ErrnoException) => {
+    handleProcessStreamError('stdout', err)
+  })
+
+  process.stderr?.on?.('error', (err: NodeJS.ErrnoException) => {
+    handleProcessStreamError('stderr', err)
+  })
+}


### PR DESCRIPTION
## Summary
- replace throwing stdout/stderr error handlers with non-throwing process stream handlers
- ignore both EPIPE and EIO stream errors, since diagnostic stream failures must not crash the app
- harden crash logger console writes so logging failures cannot throw during global crash/rejection handling

## RCA
The macOS crash report showed Node aborting from PromiseRejectCallback -> OnFatalError -> abort(). The vulnerable path was an unhandled rejection being logged through console.error while stderr emitted EIO. The old stderr handler threw for every non-EPIPE error, so EIO during rejection handling escalated into Node's fatal path.

## Verification
- pnpm test:main src/main/process-stream-errors.test.ts
- pnpm typecheck
- pre-commit hook: lint, typecheck, build, full test suite (85 files, 1247 tests passed)