### PR TITLE
fix: prevent task detail crash on malformed output fields

### DIFF
--- a/src/renderer/src/components/tasks/OutputFieldsDisplay.test.tsx
+++ b/src/renderer/src/components/tasks/OutputFieldsDisplay.test.tsx
@@ -122,4 +122,24 @@ describe('OutputFieldsDisplay', () => {
 
     expect(screen.getByText('Complete Task')).toBeInTheDocument()
   })
+
+  it('renders malformed legacy output fields without crashing', () => {
+    render(
+      <OutputFieldsDisplay
+        fields={[
+          {
+            id: 'pr_url',
+            type: undefined as never,
+            name: undefined as never,
+            value: 'https://example.com/pr/123'
+          }
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByDisplayValue('https://example.com/pr/123')).toBeInTheDocument()
+    expect(screen.getByText('pr url')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Enter pr url...')).toBeInTheDocument()
+  })
 })

--- a/src/renderer/src/components/tasks/OutputFieldsDisplay.tsx
+++ b/src/renderer/src/components/tasks/OutputFieldsDisplay.tsx
@@ -9,6 +9,12 @@ import { Label } from '@/components/ui/Label'
 import { shellApi } from '@/lib/ipc-client'
 import type { OutputField } from '@/types'
 
+function getFieldLabel(field: OutputField): string {
+  if (typeof field.name === 'string' && field.name.trim()) return field.name
+  if (typeof field.id === 'string' && field.id.trim()) return field.id.replace(/_/g, ' ')
+  return 'Output'
+}
+
 function isFieldFilled(field: OutputField): boolean {
   const v = field.value
   if (v === null || v === undefined) return false
@@ -68,6 +74,7 @@ export function OutputFieldsDisplay({ fields, onChange, isActive, onComplete, ta
 
 function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: OutputField; onValueChange: (value: unknown) => void; taskUpdatedAt?: string }) {
   const [localValue, setLocalValue] = useState<string>(String(field.value ?? ''))
+  const fieldLabel = getFieldLabel(field)
 
   // Sync local state when field.value changes externally (e.g. agent extraction)
   useEffect(() => {
@@ -84,13 +91,13 @@ function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: Outp
       return (
         <div className="space-y-1.5">
           <Label className="text-xs">
-            {field.name}
+            {fieldLabel}
             {field.required && <span className="text-destructive ml-0.5">*</span>}
           </Label>
           <Textarea
             value={localValue}
             onChange={(e) => handleChange(e.target.value)}
-            placeholder={`Enter ${field.name.toLowerCase()}...`}
+            placeholder={`Enter ${fieldLabel.toLowerCase()}...`}
             rows={3}
           />
         </div>
@@ -104,7 +111,7 @@ function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: Outp
             onCheckedChange={(checked) => onValueChange(!!checked)}
           />
           <Label className="text-xs">
-            {field.name}
+            {fieldLabel}
             {field.required && <span className="text-destructive ml-0.5">*</span>}
           </Label>
         </div>
@@ -114,7 +121,7 @@ function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: Outp
       return (
         <div className="space-y-1.5">
           <Label className="text-xs">
-            {field.name}
+            {fieldLabel}
             {field.required && <span className="text-destructive ml-0.5">*</span>}
           </Label>
           {field.options && field.options.length > 0 ? (
@@ -122,7 +129,7 @@ function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: Outp
               value={String(field.value ?? '')}
               onChange={(e) => onValueChange(e.target.value)}
               options={[
-                { value: '', label: `Select ${field.name.toLowerCase()}...` },
+                { value: '', label: `Select ${fieldLabel.toLowerCase()}...` },
                 ...field.options.map((opt) => ({ value: opt, label: opt }))
               ]}
             />
@@ -130,7 +137,7 @@ function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: Outp
             <Input
               value={localValue}
               onChange={(e) => handleChange(e.target.value)}
-              placeholder={`Enter ${field.name.toLowerCase()}...`}
+              placeholder={`Enter ${fieldLabel.toLowerCase()}...`}
             />
           )}
         </div>
@@ -143,7 +150,7 @@ function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: Outp
       return (
         <div className="space-y-1.5">
           <Label className="text-xs">
-            {field.name}
+            {fieldLabel}
             {field.required && <span className="text-destructive ml-0.5">*</span>}
           </Label>
           {filePaths.length > 0 ? (
@@ -165,14 +172,14 @@ function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: Outp
       return (
         <div className="space-y-1.5">
           <Label className="text-xs">
-            {field.name}
+            {fieldLabel}
             {field.required && <span className="text-destructive ml-0.5">*</span>}
           </Label>
           <Input
             type="number"
             value={localValue}
             onChange={(e) => handleChange(e.target.value)}
-            placeholder={`Enter ${field.name.toLowerCase()}...`}
+            placeholder={`Enter ${fieldLabel.toLowerCase()}...`}
           />
         </div>
       )
@@ -181,7 +188,7 @@ function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: Outp
       return (
         <div className="space-y-1.5">
           <Label className="text-xs">
-            {field.name}
+            {fieldLabel}
             {field.required && <span className="text-destructive ml-0.5">*</span>}
           </Label>
           <Input
@@ -197,14 +204,14 @@ function OutputFieldInput({ field, onValueChange, taskUpdatedAt }: { field: Outp
       return (
         <div className="space-y-1.5">
           <Label className="text-xs">
-            {field.name}
+            {fieldLabel}
             {field.required && <span className="text-destructive ml-0.5">*</span>}
           </Label>
           <Input
             type={field.type === 'email' ? 'email' : field.type === 'url' ? 'url' : 'text'}
             value={localValue}
             onChange={(e) => handleChange(e.target.value)}
-            placeholder={`Enter ${field.name.toLowerCase()}...`}
+            placeholder={`Enter ${fieldLabel.toLowerCase()}...`}
           />
         </div>
       )

--- a/src/renderer/src/stores/task-store.test.ts
+++ b/src/renderer/src/stores/task-store.test.ts
@@ -175,8 +175,37 @@ describe('useTaskStore', () => {
       expect(task.skill_ids).toEqual(['s1', 's2'])
     })
 
+    it('sanitizes malformed output fields from external task updates', async () => {
+      const taskWithMalformedOutputs = {
+        id: 't3',
+        title: 'Agent-updated task',
+        output_fields: [
+          { id: 'pr_url', value: 'https://example.com/pr/123' },
+          { name: 'Approval', type: 'toggle', value: true, options: ['yes', 1, null] }
+        ]
+      }
+      ;(mockElectronAPI.db.getTasks as unknown as Mock).mockResolvedValue([taskWithMalformedOutputs])
+
+      await useTaskStore.getState().fetchTasks()
+
+      const [firstField, secondField] = useTaskStore.getState().tasks[0].output_fields
+      expect(firstField).toMatchObject({
+        id: 'pr_url',
+        name: 'pr url',
+        type: 'text',
+        value: 'https://example.com/pr/123'
+      })
+      expect(secondField).toMatchObject({
+        id: 'output_field_2',
+        name: 'Approval',
+        type: 'text',
+        value: true,
+        options: ['yes']
+      })
+    })
+
     it('preserves skill_ids null (agent defaults)', async () => {
-      const taskWithNullSkills = { id: 't3', title: 'Task', skill_ids: null }
+      const taskWithNullSkills = { id: 't4', title: 'Task', skill_ids: null }
       ;(mockElectronAPI.db.getTasks as unknown as Mock).mockResolvedValue([taskWithNullSkills])
 
       await useTaskStore.getState().fetchTasks()

--- a/src/renderer/src/stores/task-store.ts
+++ b/src/renderer/src/stores/task-store.ts
@@ -1,6 +1,38 @@
 import { create } from 'zustand'
-import type { WorkfloTask, CreateTaskDTO, UpdateTaskDTO } from '@/types'
+import type { WorkfloTask, CreateTaskDTO, UpdateTaskDTO, OutputField, OutputFieldType } from '@/types'
 import { taskApi, taskSourceApi, onTaskUpdated, onTaskCreated, onTasksRefresh } from '@/lib/ipc-client'
+
+const VALID_OUTPUT_FIELD_TYPES = new Set<OutputFieldType>([
+  'text',
+  'number',
+  'email',
+  'textarea',
+  'list',
+  'date',
+  'file',
+  'boolean',
+  'country',
+  'currency',
+  'url'
+])
+
+function normalizeOutputField(field: unknown, index: number): OutputField | null {
+  if (!field || typeof field !== 'object') return null
+
+  const raw = field as Partial<OutputField>
+  const id = typeof raw.id === 'string' && raw.id.trim() ? raw.id : `output_field_${index + 1}`
+  const name = typeof raw.name === 'string' && raw.name.trim() ? raw.name : id.replace(/_/g, ' ')
+  const rawType = typeof raw.type === 'string' ? raw.type : ''
+  const type = VALID_OUTPUT_FIELD_TYPES.has(rawType as OutputFieldType) ? (rawType as OutputFieldType) : 'text'
+
+  return {
+    ...raw,
+    id,
+    name,
+    type,
+    options: Array.isArray(raw.options) ? raw.options.filter((option): option is string => typeof option === 'string') : undefined
+  }
+}
 
 /** Ensure array fields on a task are always proper arrays (guards against undefined/null from external sources) */
 function normalizeTask(task: WorkfloTask): WorkfloTask {
@@ -9,7 +41,11 @@ function normalizeTask(task: WorkfloTask): WorkfloTask {
     labels: Array.isArray(task.labels) ? task.labels : [],
     repos: Array.isArray(task.repos) ? task.repos : [],
     attachments: Array.isArray(task.attachments) ? task.attachments : [],
-    output_fields: Array.isArray(task.output_fields) ? task.output_fields : [],
+    output_fields: Array.isArray(task.output_fields)
+      ? task.output_fields
+          .map((field, index) => normalizeOutputField(field, index))
+          .filter((field): field is OutputField => field !== null)
+      : [],
     skill_ids: task.skill_ids == null ? null : Array.isArray(task.skill_ids) ? task.skill_ids : []
   }
 }


### PR DESCRIPTION
## Summary
- normalize malformed task output fields from external and agent updates before they reach the renderer
- make OutputFieldsDisplay fall back to derived labels when legacy fields are missing a name
- add store and component regressions for malformed output field metadata

## Test plan
- pnpm test:run src/renderer/src/stores/task-store.test.ts src/renderer/src/components/tasks/OutputFieldsDisplay.test.tsx --project renderer
- pnpm test:run
- pnpm typecheck
- pnpm build