### PR TITLE
fix: prevent macOS about:blank popup

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,21 @@ import { registerUpdaterIpc, initAutoUpdater, isUpdateDownloaded, getPendingVers
 import { initCrashLogger } from './crash-logger'
 import { installProcessStreamErrorHandlers } from './process-stream-errors'
 
+/**
+ * Validate that a URL is safe to open via shell.openExternal.
+ * Rejects about:blank, empty strings, and non-http(s)/mailto URLs
+ * to avoid the macOS "no application set to open the URL" popup.
+ */
+function isExternalUrl(url: string): boolean {
+  if (!url || url === 'about:blank' || url === 'about:srcdoc') return false
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' || parsed.protocol === 'mailto:'
+  } catch {
+    return false
+  }
+}
+
 let mainWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let isQuitting = false
@@ -164,7 +179,9 @@ function createWindow(): void {
   })
 
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    shell.openExternal(details.url)
+    if (isExternalUrl(details.url)) {
+      shell.openExternal(details.url)
+    }
     return { action: 'deny' }
   })
 
@@ -870,6 +887,16 @@ app.whenReady().then(async () => {
   // fingerprinting that Akamai runs after the page loads).
   app.on('web-contents-created', (_event, contents) => {
     if (contents.getType() === 'webview') {
+      // Intercept window.open calls from webviews — open valid URLs externally,
+      // silently ignore about:blank and other invalid URLs to prevent the macOS
+      // "no application set to open the URL" popup.
+      contents.setWindowOpenHandler((details) => {
+        if (isExternalUrl(details.url)) {
+          shell.openExternal(details.url)
+        }
+        return { action: 'deny' }
+      })
+
       contents.on('dom-ready', () => {
         contents.executeJavaScript(`
           try {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -277,7 +277,17 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('shell:openExternal', async (_, url: string) => {
-    await shell.openExternal(url)
+    // Validate URL before opening — skip about:blank and non-http(s)/mailto URLs
+    // to avoid macOS "no application set to open the URL" popup
+    if (!url || url === 'about:blank' || url === 'about:srcdoc') return
+    try {
+      const parsed = new URL(url)
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:' || parsed.protocol === 'mailto:') {
+        await shell.openExternal(url)
+      }
+    } catch {
+      // Invalid URL — silently ignore
+    }
   })
 
   // Notification handler


### PR DESCRIPTION
## Summary
- **Root cause**: `setWindowOpenHandler` in `src/main/index.ts` unconditionally passed `details.url` to `shell.openExternal()` without validation. When a webview or renderer triggered `window.open('about:blank')`, macOS showed the OS-level error: "There is no application set to open the URL about:blank".
- **Fix**: Added `isExternalUrl()` validation that rejects empty strings, `about:blank`, `about:srcdoc`, and non-http(s)/mailto protocols before calling `shell.openExternal()`.
- **Additional hardening**: Added `setWindowOpenHandler` on webview contents (via `web-contents-created`) so `window.open()` from embedded browser panels is also validated. Also added the same validation to the `shell:openExternal` IPC handler.

## Changes
| File | Change |
|------|--------|
| `src/main/index.ts` | Added `isExternalUrl()` helper, guarded `setWindowOpenHandler` on main window, added `setWindowOpenHandler` on webview contents |
| `src/main/ipc-handlers.ts` | Added URL validation to `shell:openExternal` IPC handler |

## Test plan
- [ ] Launch 20x, open a browser panel, visit a page with `target="_blank"` links — valid URLs should still open in the default browser
- [ ] Verify that `about:blank` navigation attempts no longer trigger the macOS popup
- [ ] Verify markdown links with empty hrefs don't trigger the popup
- [ ] Build passes (`pnpm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)