### PR TITLE
fix: expose refreshAiGatewayVirtualKey for stale key recovery

### DIFF
--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -444,6 +444,18 @@ export class OpencodeAdapter implements CodingAgentAdapter {
 
     await this.ensureServerRunning(config.serverUrl || DEFAULT_SERVER_URL)
 
+    // Always push the latest merged config (incl. refreshed AI gateway key)
+    // to the running server. ensureServerRunning skips the config push when
+    // the server is already running at the same URL, but provider credentials
+    // may have been rotated since the server was started.
+    if (this.sharedClient) {
+      try {
+        await this.pushMergedConfigToClient(this.sharedClient)
+      } catch {
+        // pushMergedConfigToClient already logs details; proceed with cached config
+      }
+    }
+
     const baseUrl = this.serverUrl || config.serverUrl || DEFAULT_SERVER_URL
     const ocClient = OpenCodeSDK!.createOpencodeClient({ baseUrl, fetch: noTimeoutFetch as unknown as (request: Request) => ReturnType<typeof fetch> })
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -1073,6 +1073,17 @@ export class AgentManager extends EventEmitter {
     }
     await yieldEL()
 
+    // Refresh the AI gateway virtual key before building the provider config
+    // so the adapter gets the latest key from the backend (handles key rotation,
+    // admin plan changes, etc.). Best-effort — fall back to the cached key.
+    if (this.enterpriseAuth) {
+      try {
+        await this.enterpriseAuth.refreshAiGatewayVirtualKey()
+      } catch (err) {
+        console.warn('[AgentManager] AI gateway key refresh failed (will use cached key):', err)
+      }
+    }
+
     // Initialize adapter
     console.log(`[AgentManager] startAdapterSession: agent=${agent.name}, coding_agent=${agent.config?.coding_agent || 'opencode'}, model=${agent.config?.model}, adapter=${adapter.constructor.name}`)
     await adapter.initialize()

--- a/src/main/enterprise-auth.ts
+++ b/src/main/enterprise-auth.ts
@@ -654,6 +654,15 @@ export class EnterpriseAuth {
     return jwt
   }
 
+  /**
+   * Re-fetch and store the AI gateway virtual key from the backend.
+   * Exposed publicly so callers (e.g. IPC handlers, adapter error recovery)
+   * can trigger a key refresh when LiteLLM returns "Invalid proxy server token".
+   */
+  async refreshAiGatewayVirtualKey(): Promise<void> {
+    return this.fetchAndStoreAiGatewayVirtualKey()
+  }
+
   private async fetchAndStoreAiGatewayVirtualKey(): Promise<void> {
     const result = await this.apiRequest('GET', '/api/20x/ai-gateway/virtual-key') as EnterpriseAiGatewayVirtualKeyResponse
 


### PR DESCRIPTION
## Summary

Fixes "Invalid proxy server token" auth errors when an admin rotates a user's AI gateway virtual key (removes and re-assigns a plan), and adds Plan & Usage visibility in the desktop app.

### Auth fix (3 commits)
- **Expose `refreshAiGatewayVirtualKey()`** on `EnterpriseAuth` so callers can trigger a key refresh on demand
- **Refresh the key before each agent session** — `AgentManager.startAdapterSession()` calls the refresh so the local SQLite cache always has the latest key from the backend
- **Push refreshed config to a running OpenCode server** — `createSession()` now calls `pushMergedConfigToClient()` after `ensureServerRunning()`, because `ensureServerRunning` early-returns when the server is already up, skipping the config push that bakes provider credentials

### Plan & Usage UI
- **New "Plan & Usage" section** in Settings > Enterprise showing current AI gateway plan name, status badge, monthly budget, and billing period
- Fetches from `GET /api/20x/ai-gateway/plan` via the existing enterprise API proxy
- Loading skeleton, error state with retry, graceful "No active plan" display

### Related PR
- workflow-builder: https://github.com/peakflo/workflow-builder/pull/1134 (merged) — adds 401 handling in `fetchExistingDynamicKey` so stale keys are cleaned up and regenerated server-side

## Test plan
- [ ] Remove AI gateway plan for a user, then re-assign it
- [ ] Verify the 20x desktop app picks up the new key on next session start (no "Invalid proxy server token" error)
- [ ] Verify existing sessions continue to work when the key hasn't changed
- [ ] Open Settings > Enterprise while connected — verify Plan & Usage section shows plan name, status, budget, and billing period
- [ ] Verify "No active plan" displays correctly for users without a plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)