### PR TITLE
fix: stop skill selector dialog render loop

### DIFF
--- a/src/renderer/src/components/skills/SkillSelectorDialog.test.tsx
+++ b/src/renderer/src/components/skills/SkillSelectorDialog.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { Mock } from 'vitest'
+import { SkillSelectorDialog } from './SkillSelectorDialog'
+import { useSkillStore } from '@/stores/skill-store'
+
+const mockElectronAPI = window.electronAPI
+
+function SkillDialogHost() {
+  const skills = useSkillStore((state) => state.skills)
+
+  return (
+    <div data-testid="skill-count">{skills.length}
+      <SkillSelectorDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        initialSkillIds={[]}
+        onConfirm={vi.fn()}
+      />
+    </div>
+  )
+}
+
+describe('SkillSelectorDialog', () => {
+  beforeEach(() => {
+    useSkillStore.setState({
+      skills: [],
+      selectedSkillId: null,
+      isLoading: false,
+      error: null
+    })
+    vi.clearAllMocks()
+  })
+
+  it('does not loop when the parent rerenders with a fresh empty initialSkillIds array', async () => {
+    ;(mockElectronAPI.skills.getAll as unknown as Mock).mockResolvedValue([
+      {
+        id: 'skill-1',
+        name: 'Debugging',
+        description: 'Trace regressions',
+        content: '',
+        tags: ['bug'],
+        confidence: 0.9,
+        uses: 3,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z'
+      }
+    ])
+
+    render(<SkillDialogHost />)
+
+    await screen.findByText('Debugging')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('skill-count')).toHaveTextContent('1')
+    })
+
+    expect(mockElectronAPI.skills.getAll).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/skills/SkillSelectorDialog.tsx
+++ b/src/renderer/src/components/skills/SkillSelectorDialog.tsx
@@ -16,14 +16,26 @@ export function SkillSelectorDialog({ open, onOpenChange, initialSkillIds, onCon
   const { skills, fetchSkills } = useSkillStore()
   const [selected, setSelected] = useState<Set<string>>(new Set(initialSkillIds))
   const [search, setSearch] = useState('')
+  const initialSkillIdsKey = useMemo(() => [...initialSkillIds].sort().join('\0'), [initialSkillIds])
 
   useEffect(() => {
-    if (open) {
-      fetchSkills()
-      setSelected(new Set(initialSkillIds))
-      setSearch('')
-    }
-  }, [open, initialSkillIds])
+    if (!open) return
+
+    fetchSkills()
+    setSearch('')
+  }, [open, fetchSkills])
+
+  useEffect(() => {
+    if (!open) return
+
+    setSelected((prev) => {
+      const next = new Set(initialSkillIds)
+      if (prev.size === next.size && Array.from(next).every((id) => prev.has(id))) {
+        return prev
+      }
+      return next
+    })
+  }, [open, initialSkillIds, initialSkillIdsKey])
 
   const filtered = useMemo(() => {
     if (!search) return skills


### PR DESCRIPTION
## Summary
- stop the shared skill selector dialog from resetting local selection on every parent rerender
- split skill fetching/search reset from selected-skill synchronization so identical skill ID sets do not trigger nested state updates
- add a regression test covering the agent-editor all-skills path that previously passed a fresh empty array on each rerender

## Test plan
- pnpm test:run --project renderer src/renderer/src/components/skills/SkillSelectorDialog.test.tsx
- pnpm test:run
- pnpm exec tsc --build --noEmit
