### PR TITLE
fix: fully tear down heartbeat sessions

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { AgentManager } from './agent-manager'
 import { SessionStatus, TaskStatus } from '../shared/constants'
 import { MessagePartType, MessageRole, SessionStatusType } from './adapters/coding-agent-adapter'
+import { unregisterSecretSession } from './secret-broker'
 
 // Mock filesystem operations
 vi.mock('fs', async (importOriginal) => {
@@ -102,6 +103,7 @@ function createMockDb(agentConfig: Record<string, unknown> = {}) {
     getMcpServer: vi.fn(() => null),
     getSecretsByIds: vi.fn(() => []),
     getSetting: vi.fn(() => null),
+    updateTask: vi.fn(),
   } as unknown as ConstructorParameters<typeof AgentManager>[0]
 }
 
@@ -1166,6 +1168,41 @@ describe('AgentManager session ID re-keying redirect', () => {
     // Redirect should be cleaned up
     expect((mgr as any).sessionIdRedirects.has('temp-id')).toBe(false)
     expect((mgr as any).sessions.has('real-id')).toBe(false)
+  })
+
+  it('cleanupHeartbeatSession fully tears down heartbeat sessions without resetting task status', async () => {
+    const mockDb = createMockDb()
+    const mgr = new AgentManager(mockDb)
+    const destroySession = vi.fn(async () => undefined)
+    const heartbeatSession = {
+      id: 'real-id',
+      agentId: 'agent-1',
+      taskId: 'heartbeat-task-1',
+      status: 'idle',
+      workspaceDir: '/tmp/workspace/task-1',
+      adapter: { destroySession },
+      pollingStarted: true,
+      createdAt: new Date(),
+      seenMessageIds: new Set<string>(),
+      seenPartIds: new Set<string>(),
+      partContentLengths: new Map<string, string>(),
+      secretSessionToken: 'secret-token',
+    }
+
+    ;(mgr as any).sessions.set('real-id', heartbeatSession)
+    ;(mgr as any).sessionIdRedirects.set('temp-id', 'real-id')
+
+    vi.spyOn(mgr as any, 'stopAdapterPolling').mockImplementation(() => undefined)
+    vi.spyOn(mgr as any, 'getAdapter').mockReturnValue({ destroySession })
+    vi.spyOn(mgr as any, 'buildSessionConfig').mockResolvedValue({})
+
+    await mgr.cleanupHeartbeatSession('task-1')
+
+    expect(destroySession).toHaveBeenCalledWith('real-id', {})
+    expect(unregisterSecretSession).toHaveBeenCalledWith('secret-token')
+    expect((mgr as any).sessionIdRedirects.has('temp-id')).toBe(false)
+    expect((mgr as any).sessions.has('real-id')).toBe(false)
+    expect(mockDb.updateTask).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -2019,13 +2019,13 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
    * Remove a heartbeat session from memory after the check completes.
    * Prevents heartbeat-{taskId} sessions from accumulating indefinitely.
    */
-  cleanupHeartbeatSession(taskId: string): void {
+  async cleanupHeartbeatSession(taskId: string): Promise<void> {
     const heartbeatTaskId = `heartbeat-${taskId}`
     for (const [id, session] of this.sessions.entries()) {
       if (session.taskId === heartbeatTaskId) {
-        this.sessions.delete(id)
+        await this.stopSession(id, false)
         console.log(`[AgentManager] Cleaned up heartbeat session ${id} for task ${taskId}`)
-        break
+        return
       }
     }
   }

--- a/src/main/heartbeat-scheduler.test.ts
+++ b/src/main/heartbeat-scheduler.test.ts
@@ -42,6 +42,7 @@ function mockDbManager(overrides: Record<string, unknown> = {}): DatabaseManager
 function mockAgentManager(overrides: Record<string, unknown> = {}): AgentManager {
   return {
     startHeartbeatSession: vi.fn().mockResolvedValue('session-1'),
+    cleanupHeartbeatSession: vi.fn().mockResolvedValue(undefined),
     getSession: vi.fn().mockReturnValue({ status: 'idle' }),
     getLastAssistantMessage: vi.fn().mockReturnValue(HEARTBEAT_OK_TOKEN),
     hasActiveSessionForTask: vi.fn().mockReturnValue(false),

--- a/src/main/heartbeat-scheduler.ts
+++ b/src/main/heartbeat-scheduler.ts
@@ -345,7 +345,7 @@ export class HeartbeatScheduler {
       this.advanceNextCheck(task)
     } finally {
       this.inProgress.delete(task.id)
-      this.agentManager.cleanupHeartbeatSession(task.id)
+      await this.agentManager.cleanupHeartbeatSession(task.id)
     }
   }
 
@@ -367,7 +367,7 @@ export class HeartbeatScheduler {
         this.logResult(task.id, logStatus, this.extractSummary(mastermindResult, logStatus), mastermindSessionId)
       }
     } finally {
-      this.agentManager.cleanupHeartbeatSession(task.id)
+      await this.agentManager.cleanupHeartbeatSession(task.id)
     }
   }
 


### PR DESCRIPTION
## Summary
- route heartbeat cleanup through full session teardown instead of only deleting the in-memory AgentManager entry
- await heartbeat cleanup in HeartbeatScheduler so adapter sessions, redirects, polling, and secret sessions are fully released
- add regression coverage for heartbeat session teardown and keep the scheduler test double aligned with the async cleanup API

## Test plan
- pnpm test:run src/main/agent-manager.test.ts src/main/heartbeat-scheduler.test.ts
- pnpm test:run
- pnpm typecheck