### PR TITLE
feat: light mode theme and transparency redesign

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@zed-industries/codex-acp": "^0.13.0",
     "better-sqlite3": "^12.6.2",
     "cron-parser": "^5.5.0",
+    "electron-liquid-glass": "^1.1.1",
     "electron-updater": "^6.8.3",
     "js-yaml": "^4.1.1",
     "node-pty": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       cron-parser:
         specifier: ^5.5.0
         version: 5.5.0
+      electron-liquid-glass:
+        specifier: ^1.1.1
+        version: 1.1.1
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.3
@@ -2824,6 +2827,11 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  electron-liquid-glass@1.1.1:
+    resolution: {integrity: sha512-AfPxcu6RJYxlsW2sjgjDEON0rVOjhh5QYM6ur5hsfILQmfY5ewHCWJZJZoDsQxhjeW1DAhbRbvB79IvgW4ansA==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
   electron-publish@25.1.7:
     resolution: {integrity: sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==}
 
@@ -4024,8 +4032,16 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-addon-api@8.7.0:
+    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-gyp@11.5.0:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
@@ -7878,6 +7894,13 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
+  electron-liquid-glass@1.1.1:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 8.7.0
+    optionalDependencies:
+      node-gyp-build: 4.8.4
+
   electron-publish@25.1.7:
     dependencies:
       '@types/fs-extra': 9.0.13
@@ -9369,9 +9392,14 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
+  node-addon-api@8.7.0: {}
+
   node-api-version@0.2.1:
     dependencies:
       semver: 7.7.4
+
+  node-gyp-build@4.8.4:
+    optional: true
 
   node-gyp@11.5.0:
     dependencies:

--- a/remotion/theme.ts
+++ b/remotion/theme.ts
@@ -1,18 +1,37 @@
+/** Dark theme (used by Remotion for video rendering) */
 export const theme = {
-  background: '#09090b',
-  foreground: '#fafafa',
-  card: '#0c0c0f',
-  primary: '#3b82f6',
-  secondary: '#1a1a2e',
-  muted: '#18181b',
-  mutedForeground: '#71717a',
-  accent: '#1a1a2e',
-  border: '#1e1e2e',
-  destructive: '#ef4444',
-  sidebar: '#0c0c0f',
-  sidebarForeground: '#a1a1aa',
-  sidebarBorder: '#1e1e2e',
-  sidebarAccent: '#1a1a2e',
+  background: '#181818',
+  foreground: '#FFFFFF',
+  card: '#1E1E1E',
+  primary: '#339CFF',
+  secondary: '#2A2A2A',
+  muted: '#2A2A2A',
+  mutedForeground: '#888888',
+  accent: '#333333',
+  border: '#333333',
+  destructive: '#C06771',
+  sidebar: '#181818',
+  sidebarForeground: '#E4E8F0',
+  sidebarBorder: '#333333',
+  sidebarAccent: '#333333',
+}
+
+/** Light theme variant */
+export const lightTheme = {
+  background: '#FFFFFF',
+  foreground: '#1A1C1F',
+  card: '#FFFFFF',
+  primary: '#339CFF',
+  secondary: '#F3F4F6',
+  muted: '#F3F4F6',
+  mutedForeground: '#6B7280',
+  accent: '#E5E7EB',
+  border: '#E5E7EB',
+  destructive: '#DC2626',
+  sidebar: '#FFFFFF',
+  sidebarForeground: '#1A1C1F',
+  sidebarBorder: '#E5E7EB',
+  sidebarAccent: '#F3F4F6',
 }
 
 export const statusColors: Record<string, string> = {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -113,17 +113,15 @@ function createWindow(): void {
     height: 900,
     minWidth: 900,
     minHeight: 600,
-    // macOS: vibrancy lets the sidebar show the desktop through.
-    // NOTE: Do NOT use transparent:true — it conflicts with vibrancy on Electron 34+.
-    // Instead, vibrancy alone makes the window translucent where CSS backgrounds are transparent.
+    // macOS: transparent window + vibrancy lets the sidebar show the desktop through
     ...(isMac
       ? {
           titleBarStyle: 'hiddenInset' as const,
           trafficLightPosition: { x: 16, y: 16 },
+          transparent: true,
           vibrancy: 'under-window' as const,
           visualEffectState: 'active' as const,
           backgroundColor: '#00000000',
-          hasShadow: true,
         }
       : {
           backgroundColor: '#181818',
@@ -142,12 +140,6 @@ function createWindow(): void {
   })
 
   mainWindow.on('ready-to-show', () => {
-    // Re-apply vibrancy after the window is ready — Electron 34 sometimes
-    // drops the constructor vibrancy before first paint.
-    if (isMac && mainWindow) {
-      mainWindow.setVibrancy('under-window')
-    }
-
     mainWindow?.show()
 
     // Initialize auto-updater (only in production)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -113,12 +113,12 @@ function createWindow(): void {
     height: 900,
     minWidth: 900,
     minHeight: 600,
-    backgroundColor: '#1E2127',
+    backgroundColor: '#181818',
     ...(isMac
       ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 16, y: 16 } }
       : {
           titleBarStyle: 'hidden' as const,
-          titleBarOverlay: { color: '#1E2127', symbolColor: '#535D71', height: 36 },
+          titleBarOverlay: { color: '#181818', symbolColor: '#888888', height: 36 },
           icon: is.dev ? join(__dirname, '../../resources/icon.ico') : join(process.resourcesPath, 'icon.ico')
         }),
     show: false,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -113,10 +113,18 @@ function createWindow(): void {
     height: 900,
     minWidth: 900,
     minHeight: 600,
-    backgroundColor: '#181818',
+    // macOS: transparent window + vibrancy lets the sidebar show the desktop through
     ...(isMac
-      ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 16, y: 16 } }
+      ? {
+          titleBarStyle: 'hiddenInset' as const,
+          trafficLightPosition: { x: 16, y: 16 },
+          transparent: true,
+          vibrancy: 'under-window' as const,
+          visualEffectState: 'active' as const,
+          backgroundColor: '#00000000',
+        }
       : {
+          backgroundColor: '#181818',
           titleBarStyle: 'hidden' as const,
           titleBarOverlay: { color: '#181818', symbolColor: '#888888', height: 36 },
           icon: is.dev ? join(__dirname, '../../resources/icon.ico') : join(process.resourcesPath, 'icon.ico')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import { startMobileApiServer, stopMobileApiServer, broadcastToMobileClients, se
 import { registerUpdaterIpc, initAutoUpdater, isUpdateDownloaded, getPendingVersion } from './auto-updater'
 import { initCrashLogger } from './crash-logger'
 import { installProcessStreamErrorHandlers } from './process-stream-errors'
+import liquidGlass from 'electron-liquid-glass'
 
 /**
  * Validate that a URL is safe to open via shell.openExternal.
@@ -113,14 +114,13 @@ function createWindow(): void {
     height: 900,
     minWidth: 900,
     minHeight: 600,
-    // macOS: transparent window + vibrancy lets the sidebar show the desktop through
+    // macOS: transparent window + electron-liquid-glass for native glass effect.
+    // NOTE: Do NOT set `vibrancy` — it conflicts with the glass view and makes it blurry.
     ...(isMac
       ? {
           titleBarStyle: 'hiddenInset' as const,
           trafficLightPosition: { x: 16, y: 16 },
           transparent: true,
-          vibrancy: 'under-window' as const,
-          visualEffectState: 'active' as const,
           backgroundColor: '#00000000',
         }
       : {
@@ -138,6 +138,25 @@ function createWindow(): void {
       webviewTag: true
     }
   })
+
+  // macOS: apply native glass effect after web content has loaded.
+  // On macOS 26+ this uses NSGlassEffectView (Liquid Glass);
+  // on older macOS it falls back to NSVisualEffectView.
+  // The glass sits behind ALL web content — CSS semi-transparent areas
+  // (sidebar, top bar) let it through; opaque areas (main content) block it.
+  if (isMac) {
+    mainWindow.webContents.once('did-finish-load', () => {
+      if (!mainWindow || mainWindow.isDestroyed()) return
+      try {
+        liquidGlass.addView(mainWindow.getNativeWindowHandle(), {
+          cornerRadius: 10,
+        })
+        console.log('[Main] Liquid glass view applied')
+      } catch (err) {
+        console.warn('[Main] Failed to apply liquid glass:', err)
+      }
+    })
+  }
 
   mainWindow.on('ready-to-show', () => {
     mainWindow?.show()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -113,15 +113,17 @@ function createWindow(): void {
     height: 900,
     minWidth: 900,
     minHeight: 600,
-    // macOS: transparent window + vibrancy lets the sidebar show the desktop through
+    // macOS: vibrancy lets the sidebar show the desktop through.
+    // NOTE: Do NOT use transparent:true — it conflicts with vibrancy on Electron 34+.
+    // Instead, vibrancy alone makes the window translucent where CSS backgrounds are transparent.
     ...(isMac
       ? {
           titleBarStyle: 'hiddenInset' as const,
           trafficLightPosition: { x: 16, y: 16 },
-          transparent: true,
           vibrancy: 'under-window' as const,
           visualEffectState: 'active' as const,
           backgroundColor: '#00000000',
+          hasShadow: true,
         }
       : {
           backgroundColor: '#181818',
@@ -140,6 +142,12 @@ function createWindow(): void {
   })
 
   mainWindow.on('ready-to-show', () => {
+    // Re-apply vibrancy after the window is ready — Electron 34 sometimes
+    // drops the constructor vibrancy before first paint.
+    if (isMac && mainWindow) {
+      mainWindow.setVibrancy('under-window')
+    }
+
     mainWindow?.show()
 
     // Initialize auto-updater (only in production)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -766,12 +766,17 @@ export function registerIpcHandlers(
     return enabled
   })
 
-  // Theme change — update window titlebar overlay colors on Windows
+  // Theme change — update window chrome to match theme
   ipcMain.handle('app:setTheme', (event, theme: 'light' | 'dark') => {
     const win = BrowserWindow.fromWebContents(event.sender)
     if (!win) return
     const isLight = theme === 'light'
-    if (process.platform === 'win32') {
+
+    if (process.platform === 'darwin') {
+      // macOS: update vibrancy appearance to match theme
+      // The window is transparent with vibrancy; the CSS handles the rest
+      win.setBackgroundColor('#00000000')
+    } else if (process.platform === 'win32') {
       try {
         win.setTitleBarOverlay({
           color: isLight ? '#FFFFFF' : '#181818',
@@ -780,8 +785,10 @@ export function registerIpcHandlers(
       } catch {
         // setTitleBarOverlay may not be available on all Windows versions
       }
+      win.setBackgroundColor(isLight ? '#FFFFFF' : '#181818')
+    } else {
+      win.setBackgroundColor(isLight ? '#FFFFFF' : '#181818')
     }
-    win.setBackgroundColor(isLight ? '#FFFFFF' : '#181818')
   })
 
   // Mobile web UI info — include auth token in URL hash so mobile SPA can authenticate

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, shell, Notification, app, session, webContents } from 'electron'
+import { ipcMain, dialog, shell, Notification, app, session, webContents, BrowserWindow } from 'electron'
 import * as childProcess from 'child_process'
 import { copyFileSync, existsSync, unlinkSync, readdirSync, statSync, readFileSync, rmSync } from 'fs'
 import { join, basename, extname } from 'path'
@@ -764,6 +764,24 @@ export function registerIpcHandlers(
   ipcMain.handle('app:setMinimizeToTray', async (_, enabled: boolean) => {
     await db.setSetting('minimize_to_tray', enabled.toString())
     return enabled
+  })
+
+  // Theme change — update window titlebar overlay colors on Windows
+  ipcMain.handle('app:setTheme', (event, theme: 'light' | 'dark') => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win) return
+    const isLight = theme === 'light'
+    if (process.platform === 'win32') {
+      try {
+        win.setTitleBarOverlay({
+          color: isLight ? '#FFFFFF' : '#181818',
+          symbolColor: isLight ? '#6B7280' : '#888888',
+        })
+      } catch {
+        // setTitleBarOverlay may not be available on all Windows versions
+      }
+    }
+    win.setBackgroundColor(isLight ? '#FFFFFF' : '#181818')
   })
 
   // Mobile web UI info — include auth token in URL hash so mobile SPA can authenticate

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -773,8 +773,8 @@ export function registerIpcHandlers(
     const isLight = theme === 'light'
 
     if (process.platform === 'darwin') {
-      // macOS: update vibrancy appearance to match theme
-      // The window is transparent with vibrancy; the CSS handles the rest
+      // macOS: keep transparent background — the liquid glass view behind
+      // the web content adapts automatically via system appearance.
       win.setBackgroundColor('#00000000')
     } else if (process.platform === 'win32') {
       try {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -773,9 +773,10 @@ export function registerIpcHandlers(
     const isLight = theme === 'light'
 
     if (process.platform === 'darwin') {
-      // macOS: update vibrancy appearance to match theme
-      // The window is transparent with vibrancy; the CSS handles the rest
+      // macOS: re-apply vibrancy on theme switch so the translucent
+      // sidebar keeps showing the desktop through.
       win.setBackgroundColor('#00000000')
+      win.setVibrancy('under-window')
     } else if (process.platform === 'win32') {
       try {
         win.setTitleBarOverlay({

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -773,10 +773,9 @@ export function registerIpcHandlers(
     const isLight = theme === 'light'
 
     if (process.platform === 'darwin') {
-      // macOS: re-apply vibrancy on theme switch so the translucent
-      // sidebar keeps showing the desktop through.
+      // macOS: update vibrancy appearance to match theme
+      // The window is transparent with vibrancy; the CSS handles the rest
       win.setBackgroundColor('#00000000')
-      win.setVibrancy('under-window')
     } else if (process.platform === 'win32') {
       try {
         win.setTitleBarOverlay({

--- a/src/mobile/index.html
+++ b/src/mobile/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
-    <meta name="theme-color" content="#1E2127" />
+    <meta name="theme-color" content="#181818" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data:; font-src 'self';" />

--- a/src/mobile/styles/globals.css
+++ b/src/mobile/styles/globals.css
@@ -1,27 +1,84 @@
 @import "tailwindcss";
 
+/* ── Theme tokens: Tailwind CSS 4 compatible ──────────────── */
 @theme {
-  /* Cursor Dark Midnight palette */
-  --color-background: #1E2127;
-  --color-foreground: #EBEEF4;
-  --color-card: #191D23;
-  --color-card-foreground: #EBEEF4;
-  --color-primary: #85A4C3;
-  --color-primary-foreground: #1E2127;
-  --color-secondary: #30353F;
-  --color-secondary-foreground: #EBEEF4;
-  --color-muted: #30353F;
-  --color-muted-foreground: #535D71;
-  --color-accent: #313C47;
-  --color-accent-foreground: #EBEEF4;
-  --color-destructive: #C06771;
-  --color-destructive-foreground: #EBEEF4;
-  --color-border: #30353F;
-  --color-input: #30353F;
-  --color-ring: #85A4C3;
+  --color-background: #FFFFFF;
+  --color-foreground: #1A1C1F;
+  --color-card: #FFFFFF;
+  --color-card-foreground: #1A1C1F;
+  --color-primary: #339CFF;
+  --color-primary-foreground: #FFFFFF;
+  --color-secondary: #F3F4F6;
+  --color-secondary-foreground: #1A1C1F;
+  --color-muted: #F3F4F6;
+  --color-muted-foreground: #6B7280;
+  --color-accent: #E5E7EB;
+  --color-accent-foreground: #1A1C1F;
+  --color-destructive: #DC2626;
+  --color-destructive-foreground: #FFFFFF;
+  --color-border: #E5E7EB;
+  --color-input: #E5E7EB;
+  --color-ring: #339CFF;
   --radius-sm: 6px;
   --radius-md: 8px;
   --radius-lg: 12px;
+}
+
+@custom-variant dark (&:where([data-theme="dark"] *));
+
+/* ── Light mode (default) ────────────────────────────────── */
+:root,
+[data-theme="light"] {
+  --color-background: #FFFFFF;
+  --color-foreground: #1A1C1F;
+  --color-card: #FFFFFF;
+  --color-card-foreground: #1A1C1F;
+  --color-primary: #339CFF;
+  --color-primary-foreground: #FFFFFF;
+  --color-secondary: #F3F4F6;
+  --color-secondary-foreground: #1A1C1F;
+  --color-muted: #F3F4F6;
+  --color-muted-foreground: #6B7280;
+  --color-accent: #E5E7EB;
+  --color-accent-foreground: #1A1C1F;
+  --color-destructive: #DC2626;
+  --color-destructive-foreground: #FFFFFF;
+  --color-border: #E5E7EB;
+  --color-input: #E5E7EB;
+  --color-ring: #339CFF;
+
+  --color-overlay: rgba(0, 0, 0, 0.50);
+  --color-hover-overlay: rgba(0, 0, 0, 0.04);
+  --color-hover-overlay-strong: rgba(0, 0, 0, 0.08);
+  --color-scrollbar-thumb: #D1D5DB;
+  --color-scrollbar-thumb-hover: #9CA3AF;
+}
+
+/* ── Dark mode ───────────────────────────────────────────── */
+[data-theme="dark"] {
+  --color-background: #181818;
+  --color-foreground: #FFFFFF;
+  --color-card: #1E1E1E;
+  --color-card-foreground: #FFFFFF;
+  --color-primary: #339CFF;
+  --color-primary-foreground: #FFFFFF;
+  --color-secondary: #2A2A2A;
+  --color-secondary-foreground: #FFFFFF;
+  --color-muted: #2A2A2A;
+  --color-muted-foreground: #888888;
+  --color-accent: #333333;
+  --color-accent-foreground: #FFFFFF;
+  --color-destructive: #C06771;
+  --color-destructive-foreground: #FFFFFF;
+  --color-border: #333333;
+  --color-input: #333333;
+  --color-ring: #339CFF;
+
+  --color-overlay: rgba(0, 0, 0, 0.70);
+  --color-hover-overlay: rgba(255, 255, 255, 0.05);
+  --color-hover-overlay-strong: rgba(255, 255, 255, 0.10);
+  --color-scrollbar-thumb: #333333;
+  --color-scrollbar-thumb-hover: #535D71;
 }
 
 @font-face {
@@ -81,5 +138,5 @@ body {
 /* ── Scrollbar ────────────────────────────────── */
 ::-webkit-scrollbar { width: 5px; height: 5px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 99px; }
-::-webkit-scrollbar-thumb:hover { background: #535D71; }
+::-webkit-scrollbar-thumb { background: var(--color-scrollbar-thumb); border-radius: 99px; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-scrollbar-thumb-hover); }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -334,7 +334,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getMinimizeToTray: (): Promise<boolean> =>
       ipcRenderer.invoke('app:getMinimizeToTray'),
     setMinimizeToTray: (enabled: boolean): Promise<boolean> =>
-      ipcRenderer.invoke('app:setMinimizeToTray', enabled)
+      ipcRenderer.invoke('app:setMinimizeToTray', enabled),
+    setTheme: (theme: 'light' | 'dark'): Promise<void> =>
+      ipcRenderer.invoke('app:setTheme', theme)
   },
   mobile: {
     getInfo: (): Promise<{ url: string; port: number }> =>

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -158,7 +158,7 @@ function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessa
                           ? 'bg-primary/20 border-primary/50 text-foreground'
                           : isLocked
                             ? 'border-border/30 text-muted-foreground opacity-50 cursor-default'
-                            : 'border-border/50 hover:bg-white/5 hover:border-border text-foreground/80 cursor-pointer'
+                            : 'border-border/50 hover:bg-[var(--color-hover-overlay)] hover:border-border text-foreground/80 cursor-pointer'
                       }`}
                     >
                       <span className="font-medium">{opt.label}</span>
@@ -289,7 +289,7 @@ function TaskProgressMessage({ message }: { message: AgentMessage }) {
     }`}>
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-3 py-2 text-xs font-mono hover:bg-white/5 transition-colors"
+        className="w-full flex items-center gap-2 px-3 py-2 text-xs font-mono hover:bg-[var(--color-hover-overlay)] transition-colors"
       >
         <ChevronRight className={`h-3 w-3 text-muted-foreground shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`} />
         <Terminal className="h-3 w-3 text-blue-400 shrink-0" />
@@ -342,7 +342,7 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
     <div className="rounded-md bg-card border border-border/50 overflow-hidden">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-3 py-2 text-xs font-mono hover:bg-white/5 transition-colors"
+        className="w-full flex items-center gap-2 px-3 py-2 text-xs font-mono hover:bg-[var(--color-hover-overlay)] transition-colors"
       >
         <ChevronRight className={`h-3 w-3 text-muted-foreground shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`} />
         <Wrench className="h-3 w-3 text-muted-foreground shrink-0" />
@@ -475,7 +475,7 @@ function TodoSummary({ todos }: { todos: NonNullable<AgentMessage['tool']>['todo
     <div className="border-b border-border/50 shrink-0">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-4 py-2 text-xs hover:bg-white/5 transition-colors"
+        className="w-full flex items-center gap-2 px-4 py-2 text-xs hover:bg-[var(--color-hover-overlay)] transition-colors"
       >
         {expanded
           ? <ChevronDown className="h-3 w-3 text-muted-foreground shrink-0" />

--- a/src/renderer/src/components/canvas/AppPanelContent.tsx
+++ b/src/renderer/src/components/canvas/AppPanelContent.tsx
@@ -101,7 +101,7 @@ export function AppPanelContent({ appId, title }: AppPanelContentProps) {
             onClick={() => {
               setLaunched(false)
             }}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs bg-white/5 hover:bg-white/10 text-foreground/70 hover:text-foreground transition-colors"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs bg-[var(--color-hover-overlay)] hover:bg-[var(--color-hover-overlay-strong)] text-foreground/70 hover:text-foreground transition-colors"
           >
             <RefreshCw className="h-3 w-3" />
             Retry
@@ -117,7 +117,7 @@ export function AppPanelContent({ appId, title }: AppPanelContentProps) {
     return (
       <div className="flex flex-col h-full min-h-0">
         {/* URL bar */}
-        <div className="flex items-center gap-2 px-2 py-1.5 bg-[#0d1117]/40 border-b border-border/20 flex-shrink-0">
+        <div className="flex items-center gap-2 px-2 py-1.5 bg-[var(--color-canvas-panel-bg)]/80 border-b border-border/20 flex-shrink-0">
           <Globe className="h-3 w-3 text-green-400/60 flex-shrink-0" />
           <span className="text-[10px] text-muted-foreground/50 truncate flex-1 font-mono">
             {tab.url}

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -404,14 +404,14 @@ function BrowserUrlBar({
   return (
     <form
       onSubmit={onSubmit}
-      className="flex items-center gap-1.5 px-2 py-1.5 bg-[#0d1117]/60 border-b border-border/20 flex-shrink-0"
+      className="flex items-center gap-1.5 px-2 py-1.5 bg-[var(--color-canvas-panel-bg)]/80 border-b border-border/20 flex-shrink-0"
     >
       {/* Nav buttons */}
       <button
         type="button"
         onClick={onBack}
         disabled={!canGoBack}
-        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
+        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-[var(--color-hover-overlay)] disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
         title="Back"
       >
         <ArrowLeft className="h-3 w-3" />
@@ -420,7 +420,7 @@ function BrowserUrlBar({
         type="button"
         onClick={onForward}
         disabled={!canGoForward}
-        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
+        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-[var(--color-hover-overlay)] disabled:opacity-20 disabled:hover:bg-transparent transition-colors"
         title="Forward"
       >
         <ArrowRight className="h-3 w-3" />
@@ -428,7 +428,7 @@ function BrowserUrlBar({
       <button
         type="button"
         onClick={onRefresh}
-        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-[var(--color-hover-overlay)] transition-colors"
         title="Refresh"
       >
         {isLoading ? (
@@ -439,7 +439,7 @@ function BrowserUrlBar({
       </button>
 
       {/* URL input */}
-      <div className="flex-1 flex items-center gap-1.5 bg-[#1a2030] rounded-md px-2 py-1 border border-border/20 focus-within:border-orange-500/30 transition-colors">
+      <div className="flex-1 flex items-center gap-1.5 bg-[var(--color-canvas-panel-bg)] rounded-md px-2 py-1 border border-border/20 focus-within:border-orange-500/30 transition-colors">
         <Globe className="h-3 w-3 text-muted-foreground/30 flex-shrink-0" />
         <input
           type="text"

--- a/src/renderer/src/components/canvas/CanvasConnections.tsx
+++ b/src/renderer/src/components/canvas/CanvasConnections.tsx
@@ -273,7 +273,7 @@ function EdgeDeleteDot({
       className="pointer-events-auto cursor-pointer opacity-0 hover:opacity-100 transition-opacity"
       onClick={(e) => { e.stopPropagation(); onDelete() }}
     >
-      <circle cx={x} cy={y} r="7" fill="#161b22" stroke="rgba(99,102,241,0.3)" strokeWidth="1" />
+      <circle cx={x} cy={y} r="7" fill="var(--color-edge-delete-bg)" stroke="rgba(99,102,241,0.3)" strokeWidth="1" />
       <line x1={x - 2.5} y1={y - 2.5} x2={x + 2.5} y2={y + 2.5} stroke="rgba(239,68,68,0.7)" strokeWidth="1.5" strokeLinecap="round" />
       <line x1={x + 2.5} y1={y - 2.5} x2={x - 2.5} y2={y + 2.5} stroke="rgba(239,68,68,0.7)" strokeWidth="1.5" strokeLinecap="round" />
     </g>

--- a/src/renderer/src/components/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/src/components/canvas/CanvasContextMenu.tsx
@@ -90,7 +90,7 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
   return (
     <div
       ref={menuRef}
-      className="fixed z-[9999] min-w-[220px] max-w-[280px] bg-[#161b22] border border-border/50 rounded-xl shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-100"
+      className="fixed z-[9999] min-w-[220px] max-w-[280px] bg-[var(--color-canvas-context-menu)] border border-border/50 rounded-xl shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-100"
       style={{ left: position.clientX, top: position.clientY }}
     >
       {/* Header */}
@@ -234,7 +234,7 @@ function MenuItem({
   return (
     <button
       onClick={onClick}
-      className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-white/5 transition-colors group"
+      className="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-[var(--color-hover-overlay)] transition-colors group"
     >
       <span className="flex-shrink-0">{icon}</span>
       <div className="flex-1 min-w-0">

--- a/src/renderer/src/components/canvas/CanvasMinimap.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.tsx
@@ -158,7 +158,7 @@ export function CanvasMinimap({
     >
       {/* Header bar — always visible */}
       <div
-        className="flex items-center justify-between px-2 py-1 bg-[#1a2030]/95 backdrop-blur-sm border border-border/40 rounded-t-lg cursor-pointer"
+        className="flex items-center justify-between px-2 py-1 bg-[var(--color-canvas-minimap-header)] backdrop-blur-sm border border-border/40 rounded-t-lg cursor-pointer"
         style={{ width: MINIMAP_W, borderBottom: collapsed ? undefined : 'none', borderRadius: collapsed ? '8px' : undefined }}
         onClick={() => setCollapsed((c) => !c)}
       >
@@ -180,7 +180,7 @@ export function CanvasMinimap({
       {/* Minimap body */}
       {!collapsed && (
         <div
-          className="bg-[#0d1117]/95 backdrop-blur-sm border border-border/40 border-t-0 rounded-b-lg overflow-hidden"
+          className="bg-[var(--color-canvas-minimap-bg)] backdrop-blur-sm border border-border/40 border-t-0 rounded-b-lg overflow-hidden"
           style={{ width: MINIMAP_W }}
         >
           {/* SVG minimap */}
@@ -254,7 +254,7 @@ export function CanvasMinimap({
           {/* Zoom controls bar */}
           <div className="flex items-center justify-between px-1.5 py-1 border-t border-border/20">
             <button
-              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-[var(--color-hover-overlay)] transition-colors"
               onClick={(e) => { e.stopPropagation(); zoomTo(viewport.zoom / 1.2) }}
               title="Zoom out (Ctrl+-)"
             >
@@ -277,7 +277,7 @@ export function CanvasMinimap({
             />
 
             <button
-              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-[var(--color-hover-overlay)] transition-colors"
               onClick={(e) => { e.stopPropagation(); zoomTo(viewport.zoom * 1.2) }}
               title="Zoom in (Ctrl+=)"
             >
@@ -287,7 +287,7 @@ export function CanvasMinimap({
             <div className="w-px h-3 bg-border/20 mx-0.5" />
 
             <button
-              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+              className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-[var(--color-hover-overlay)] transition-colors"
               onClick={(e) => { e.stopPropagation(); fitToContent(containerWidth, containerHeight) }}
               title="Fit all panels"
             >

--- a/src/renderer/src/components/canvas/CanvasMinimap.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState, useMemo } from 'react'
 import { useCanvasStore, type CanvasPanelData, MIN_ZOOM, MAX_ZOOM } from '@/stores/canvas-store'
+import { useUIStore } from '@/stores/ui-store'
 import { Minus, Plus, Maximize2, ChevronDown, ChevronUp } from 'lucide-react'
 
 // ── Constants ─────────────────────────────────────────────
@@ -42,6 +43,13 @@ export function CanvasMinimap({
   const setViewport = useCanvasStore((s) => s.setViewport)
   const zoomTo = useCanvasStore((s) => s.zoomTo)
   const fitToContent = useCanvasStore((s) => s.fitToContent)
+
+  // Resolve current theme for conditional minimap colors
+  const isDark = useUIStore((s) => {
+    const t = s.theme
+    if (t === 'system') return window.matchMedia('(prefers-color-scheme: dark)').matches
+    return t === 'dark'
+  })
 
   const [collapsed, setCollapsed] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
@@ -231,7 +239,7 @@ export function CanvasMinimap({
                   height={ph}
                   rx="1"
                   fill={color}
-                  stroke="rgba(255,255,255,0.1)"
+                  stroke={isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'}
                   strokeWidth="0.5"
                 />
               )
@@ -244,8 +252,8 @@ export function CanvasMinimap({
               width={Math.max(4, vpRect.w)}
               height={Math.max(3, vpRect.h)}
               rx="1"
-              fill="rgba(255,255,255,0.06)"
-              stroke="rgba(255,255,255,0.3)"
+              fill={isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}
+              stroke={isDark ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.2)'}
               strokeWidth="1"
               className="pointer-events-none"
             />

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -325,12 +325,12 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   // ── Panel type styling ────────────────────────────────────
   const cfg = useMemo(() => {
     const TYPE_CONFIG: Record<string, { label: string; color: string; border: string; bg: string }> = {
-      task: { label: 'Task', color: 'bg-blue-500/20 text-blue-400', border: 'border-blue-500/40', bg: 'bg-[#141a26]' },
-      transcript: { label: 'Transcript', color: 'bg-purple-500/20 text-purple-400', border: 'border-purple-500/40', bg: 'bg-[#141a26]' },
-      app: { label: 'App', color: 'bg-green-500/20 text-green-400', border: 'border-green-500/40', bg: 'bg-[#141a26]' },
-      webpage: { label: 'Web', color: 'bg-cyan-500/20 text-cyan-400', border: 'border-cyan-500/40', bg: 'bg-[#141a26]' },
-      terminal: { label: 'Terminal', color: 'bg-amber-500/20 text-amber-400', border: 'border-amber-500/50', bg: 'bg-[#141a26]' },
-      browser: { label: 'Browser', color: 'bg-orange-500/20 text-orange-400', border: 'border-orange-500/40', bg: 'bg-[#141a26]' },
+      task: { label: 'Task', color: 'bg-blue-500/20 text-blue-400', border: 'border-blue-500/40', bg: 'bg-[var(--color-canvas-panel-bg)]' },
+      transcript: { label: 'Transcript', color: 'bg-purple-500/20 text-purple-400', border: 'border-purple-500/40', bg: 'bg-[var(--color-canvas-panel-bg)]' },
+      app: { label: 'App', color: 'bg-green-500/20 text-green-400', border: 'border-green-500/40', bg: 'bg-[var(--color-canvas-panel-bg)]' },
+      webpage: { label: 'Web', color: 'bg-cyan-500/20 text-cyan-400', border: 'border-cyan-500/40', bg: 'bg-[var(--color-canvas-panel-bg)]' },
+      terminal: { label: 'Terminal', color: 'bg-amber-500/20 text-amber-400', border: 'border-amber-500/50', bg: 'bg-[var(--color-canvas-panel-bg)]' },
+      browser: { label: 'Browser', color: 'bg-orange-500/20 text-orange-400', border: 'border-orange-500/40', bg: 'bg-[var(--color-canvas-panel-bg)]' },
     }
 
     if (panel.type === 'task' && taskStatus) {
@@ -350,7 +350,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       }
     }
 
-    return TYPE_CONFIG[panel.type] ?? { label: 'Panel', color: 'bg-muted/30 text-muted-foreground', border: 'border-border/50', bg: 'bg-[#141a26]' }
+    return TYPE_CONFIG[panel.type] ?? { label: 'Panel', color: 'bg-muted/30 text-muted-foreground', border: 'border-border/50', bg: 'bg-[var(--color-canvas-panel-bg)]' }
   }, [panel.type, taskStatus])
 
   return (
@@ -360,7 +360,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       onMouseDown={handleMouseDown}
       onMouseEnter={handlePanelMouseEnter}
       onMouseLeave={handlePanelMouseLeave}
-      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col transition-shadow duration-150 group/panel ${cfg.border} ${
+      className={`absolute rounded-xl border bg-[var(--color-canvas-panel-bg)] shadow-2xl flex flex-col select-none transition-shadow duration-150 group/panel ${cfg.border} ${
         isDragging ? 'shadow-indigo-500/10 ring-1 ring-indigo-500/30' : ''
       } ${isConnectingLocal ? 'ring-2 ring-orange-500/50' : ''} ${
         isProximityTarget ? 'ring-2 ring-orange-500/60 shadow-orange-500/20 shadow-2xl' : ''
@@ -405,8 +405,8 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
                 onClick={() => setTaskLayout(key)}
                 className={`h-5 w-5 rounded flex items-center justify-center transition-colors ${
                   taskLayout === key
-                    ? 'bg-white/15 text-foreground'
-                    : 'text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/10'
+                    ? 'bg-[var(--color-active-overlay)] text-foreground'
+                    : 'text-muted-foreground/40 hover:text-muted-foreground hover:bg-[var(--color-hover-overlay-strong)]'
                 }`}
                 title={label}
               >
@@ -422,7 +422,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
           <button
             onMouseDown={(e) => e.stopPropagation()}
             onClick={handleFocus}
-            className="h-5 w-5 rounded flex items-center justify-center hover:bg-white/10 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+            className="h-5 w-5 rounded flex items-center justify-center hover:bg-[var(--color-hover-overlay-strong)] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
             title="Focus panel (zoom to fit)"
           >
             <Focus className="h-3 w-3" />
@@ -432,7 +432,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
           <button
             onMouseDown={(e) => e.stopPropagation()}
             onClick={handleToggleCollapse}
-            className="h-5 w-5 rounded flex items-center justify-center hover:bg-white/10 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+            className="h-5 w-5 rounded flex items-center justify-center hover:bg-[var(--color-hover-overlay-strong)] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
             title={isCollapsed ? 'Expand' : 'Collapse'}
           >
             {isCollapsed ? (

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -360,7 +360,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       onMouseDown={handleMouseDown}
       onMouseEnter={handlePanelMouseEnter}
       onMouseLeave={handlePanelMouseLeave}
-      className={`absolute rounded-xl border bg-[var(--color-canvas-panel-bg)] shadow-2xl flex flex-col select-none transition-shadow duration-150 group/panel ${cfg.border} ${
+      className={`absolute rounded-xl border bg-[var(--color-canvas-panel-bg)] shadow-2xl flex flex-col transition-shadow duration-150 group/panel ${cfg.border} ${
         isDragging ? 'shadow-indigo-500/10 ring-1 ring-indigo-500/30' : ''
       } ${isConnectingLocal ? 'ring-2 ring-orange-500/50' : ''} ${
         isProximityTarget ? 'ring-2 ring-orange-500/60 shadow-orange-500/20 shadow-2xl' : ''

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -468,7 +468,7 @@ export function InfiniteCanvas() {
       : 'default'
 
   return (
-    <div data-canvas-root="true" className="overflow-hidden bg-[#131820]" style={{ position: 'relative', width: '100%', height: '100%' }}>
+    <div data-canvas-root="true" className="overflow-hidden bg-[var(--color-canvas-bg)]" style={{ position: 'relative', width: '100%', height: '100%' }}>
       {/* Canvas container */}
       <div
         ref={containerRef}
@@ -524,7 +524,7 @@ export function InfiniteCanvas() {
       </div>
 
       {/* ── HUD: zoom controls ── */}
-      <div className="absolute bottom-4 left-4 flex items-center gap-1 bg-[#1a2030]/90 backdrop-blur-sm border border-border/40 rounded-lg p-1 z-10">
+      <div className="absolute bottom-4 left-4 flex items-center gap-1 bg-[var(--color-canvas-hud-bg)] backdrop-blur-sm border border-border/40 rounded-lg p-1 z-10">
         <Button
           variant="ghost"
           size="sm"
@@ -662,7 +662,7 @@ function CanvasGrid({
         top: gridTop,
         width: gridWidth,
         height: gridHeight,
-        backgroundImage: `radial-gradient(circle, rgba(255,255,255,0.08) ${dotSize}px, transparent ${dotSize}px)`,
+        backgroundImage: `radial-gradient(circle, var(--color-canvas-grid-dot) ${dotSize}px, transparent ${dotSize}px)`,
         backgroundSize: `${GRID_SIZE}px ${GRID_SIZE}px`,
         backgroundPosition: `${GRID_SIZE / 2}px ${GRID_SIZE / 2}px`,
         pointerEvents: 'none',

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -3,7 +3,56 @@ import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { useCanvasStore } from '@/stores/canvas-store'
+import { useUIStore } from '@/stores/ui-store'
 import '@xterm/xterm/css/xterm.css'
+
+/** Terminal theme palettes keyed by light/dark mode */
+const TERMINAL_THEMES = {
+  dark: {
+    background: '#141a26',
+    foreground: '#c9d1d9',
+    cursor: '#58a6ff',
+    selectionBackground: '#264f78',
+    black: '#141a26',
+    red: '#ff7b72',
+    green: '#3fb950',
+    yellow: '#d29922',
+    blue: '#58a6ff',
+    magenta: '#bc8cff',
+    cyan: '#39c5cf',
+    white: '#c9d1d9',
+    brightBlack: '#484f58',
+    brightRed: '#ffa198',
+    brightGreen: '#56d364',
+    brightYellow: '#e3b341',
+    brightBlue: '#79c0ff',
+    brightMagenta: '#d2a8ff',
+    brightCyan: '#56d4dd',
+    brightWhite: '#f0f6fc',
+  },
+  light: {
+    background: '#FFFFFF',
+    foreground: '#1A1C1F',
+    cursor: '#0969DA',
+    selectionBackground: '#B6D5F7',
+    black: '#24292F',
+    red: '#CF222E',
+    green: '#116329',
+    yellow: '#9A6700',
+    blue: '#0969DA',
+    magenta: '#8250DF',
+    cyan: '#1B7C83',
+    white: '#6E7781',
+    brightBlack: '#57606A',
+    brightRed: '#A40E26',
+    brightGreen: '#1A7F37',
+    brightYellow: '#7D4E00',
+    brightBlue: '#218BFF',
+    brightMagenta: '#A475F9',
+    brightCyan: '#3192AA',
+    brightWhite: '#8C959F',
+  },
+} as const
 
 interface TerminalPanelContentProps {
   terminalId: string
@@ -39,6 +88,16 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   // Store cwd in a ref — only used at init time, never triggers re-init
   const cwdRef = useRef(cwd)
 
+  // Resolve terminal theme from current app theme
+  const resolvedTheme = useUIStore((s) => {
+    const t = s.theme
+    if (t === 'system') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    }
+    return t
+  })
+  const termTheme = TERMINAL_THEMES[resolvedTheme]
+
   const initTerminal = useCallback(async () => {
     console.log(`[Terminal:${terminalId}] initTerminal called`, {
       hasContainer: !!containerRef.current,
@@ -61,28 +120,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       fontSize: 13,
       fontFamily: 'Menlo, Monaco, "Courier New", monospace',
       lineHeight: 1.2,
-      theme: {
-        background: '#141a26',
-        foreground: '#c9d1d9',
-        cursor: '#58a6ff',
-        selectionBackground: '#264f78',
-        black: '#141a26',
-        red: '#ff7b72',
-        green: '#3fb950',
-        yellow: '#d29922',
-        blue: '#58a6ff',
-        magenta: '#bc8cff',
-        cyan: '#39c5cf',
-        white: '#c9d1d9',
-        brightBlack: '#484f58',
-        brightRed: '#ffa198',
-        brightGreen: '#56d364',
-        brightYellow: '#e3b341',
-        brightBlue: '#79c0ff',
-        brightMagenta: '#d2a8ff',
-        brightCyan: '#56d4dd',
-        brightWhite: '#f0f6fc',
-      },
+      theme: termTheme,
       allowProposedApi: true,
     })
 
@@ -279,6 +317,17 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     return () => clearInterval(interval)
   }, [isReady, terminalId])
 
+  // ── Update xterm colors when the app theme changes ──
+  useEffect(() => {
+    const term = xtermRef.current
+    if (!term?.options) return
+    term.options.theme = termTheme
+    // Update container background to match
+    if (containerRef.current) {
+      containerRef.current.style.background = termTheme.background
+    }
+  }, [termTheme])
+
   if (error) {
     return (
       <div className="flex items-center justify-center h-full text-red-400/60 text-xs">
@@ -305,7 +354,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       className="h-full w-full xterm-container"
       onClick={handleClick}
       style={{
-        background: '#141a26',
+        background: termTheme.background,
         // Minimum dimensions prevent xterm's internal canvas renderer from
         // computing NaN cell sizes (which causes the toFixed crash).
         minWidth: 100,

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -3,56 +3,7 @@ import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { useCanvasStore } from '@/stores/canvas-store'
-import { useUIStore } from '@/stores/ui-store'
 import '@xterm/xterm/css/xterm.css'
-
-/** Terminal theme palettes keyed by light/dark mode */
-const TERMINAL_THEMES = {
-  dark: {
-    background: '#141a26',
-    foreground: '#c9d1d9',
-    cursor: '#58a6ff',
-    selectionBackground: '#264f78',
-    black: '#141a26',
-    red: '#ff7b72',
-    green: '#3fb950',
-    yellow: '#d29922',
-    blue: '#58a6ff',
-    magenta: '#bc8cff',
-    cyan: '#39c5cf',
-    white: '#c9d1d9',
-    brightBlack: '#484f58',
-    brightRed: '#ffa198',
-    brightGreen: '#56d364',
-    brightYellow: '#e3b341',
-    brightBlue: '#79c0ff',
-    brightMagenta: '#d2a8ff',
-    brightCyan: '#56d4dd',
-    brightWhite: '#f0f6fc',
-  },
-  light: {
-    background: '#FFFFFF',
-    foreground: '#1A1C1F',
-    cursor: '#0969DA',
-    selectionBackground: '#B6D5F7',
-    black: '#24292F',
-    red: '#CF222E',
-    green: '#116329',
-    yellow: '#9A6700',
-    blue: '#0969DA',
-    magenta: '#8250DF',
-    cyan: '#1B7C83',
-    white: '#6E7781',
-    brightBlack: '#57606A',
-    brightRed: '#A40E26',
-    brightGreen: '#1A7F37',
-    brightYellow: '#7D4E00',
-    brightBlue: '#218BFF',
-    brightMagenta: '#A475F9',
-    brightCyan: '#3192AA',
-    brightWhite: '#8C959F',
-  },
-} as const
 
 interface TerminalPanelContentProps {
   terminalId: string
@@ -88,16 +39,6 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   // Store cwd in a ref — only used at init time, never triggers re-init
   const cwdRef = useRef(cwd)
 
-  // Resolve terminal theme from current app theme
-  const resolvedTheme = useUIStore((s) => {
-    const t = s.theme
-    if (t === 'system') {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-    }
-    return t
-  })
-  const termTheme = TERMINAL_THEMES[resolvedTheme]
-
   const initTerminal = useCallback(async () => {
     console.log(`[Terminal:${terminalId}] initTerminal called`, {
       hasContainer: !!containerRef.current,
@@ -120,7 +61,28 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       fontSize: 13,
       fontFamily: 'Menlo, Monaco, "Courier New", monospace',
       lineHeight: 1.2,
-      theme: termTheme,
+      theme: {
+        background: '#141a26',
+        foreground: '#c9d1d9',
+        cursor: '#58a6ff',
+        selectionBackground: '#264f78',
+        black: '#141a26',
+        red: '#ff7b72',
+        green: '#3fb950',
+        yellow: '#d29922',
+        blue: '#58a6ff',
+        magenta: '#bc8cff',
+        cyan: '#39c5cf',
+        white: '#c9d1d9',
+        brightBlack: '#484f58',
+        brightRed: '#ffa198',
+        brightGreen: '#56d364',
+        brightYellow: '#e3b341',
+        brightBlue: '#79c0ff',
+        brightMagenta: '#d2a8ff',
+        brightCyan: '#56d4dd',
+        brightWhite: '#f0f6fc',
+      },
       allowProposedApi: true,
     })
 
@@ -317,17 +279,6 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     return () => clearInterval(interval)
   }, [isReady, terminalId])
 
-  // ── Update xterm colors when the app theme changes ──
-  useEffect(() => {
-    const term = xtermRef.current
-    if (!term?.options) return
-    term.options.theme = termTheme
-    // Update container background to match
-    if (containerRef.current) {
-      containerRef.current.style.background = termTheme.background
-    }
-  }, [termTheme])
-
   if (error) {
     return (
       <div className="flex items-center justify-center h-full text-red-400/60 text-xs">
@@ -354,7 +305,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       className="h-full w-full xterm-container"
       onClick={handleClick}
       style={{
-        background: termTheme.background,
+        background: '#141a26',
         // Minimum dimensions prevent xterm's internal canvas renderer from
         // computing NaN cell sizes (which causes the toFixed crash).
         minWidth: 100,

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -3,7 +3,56 @@ import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { useCanvasStore } from '@/stores/canvas-store'
+import { useUIStore } from '@/stores/ui-store'
 import '@xterm/xterm/css/xterm.css'
+
+/** Terminal theme palettes keyed by light/dark mode */
+const TERMINAL_THEMES = {
+  dark: {
+    background: '#141a26',
+    foreground: '#c9d1d9',
+    cursor: '#58a6ff',
+    selectionBackground: '#264f78',
+    black: '#141a26',
+    red: '#ff7b72',
+    green: '#3fb950',
+    yellow: '#d29922',
+    blue: '#58a6ff',
+    magenta: '#bc8cff',
+    cyan: '#39c5cf',
+    white: '#c9d1d9',
+    brightBlack: '#484f58',
+    brightRed: '#ffa198',
+    brightGreen: '#56d364',
+    brightYellow: '#e3b341',
+    brightBlue: '#79c0ff',
+    brightMagenta: '#d2a8ff',
+    brightCyan: '#56d4dd',
+    brightWhite: '#f0f6fc',
+  },
+  light: {
+    background: '#FFFFFF',
+    foreground: '#1A1C1F',
+    cursor: '#0969DA',
+    selectionBackground: '#B6D5F7',
+    black: '#24292F',
+    red: '#CF222E',
+    green: '#116329',
+    yellow: '#9A6700',
+    blue: '#0969DA',
+    magenta: '#8250DF',
+    cyan: '#1B7C83',
+    white: '#6E7781',
+    brightBlack: '#57606A',
+    brightRed: '#A40E26',
+    brightGreen: '#1A7F37',
+    brightYellow: '#7D4E00',
+    brightBlue: '#218BFF',
+    brightMagenta: '#A475F9',
+    brightCyan: '#3192AA',
+    brightWhite: '#8C959F',
+  },
+} as const
 
 interface TerminalPanelContentProps {
   terminalId: string
@@ -39,6 +88,16 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
   // Store cwd in a ref — only used at init time, never triggers re-init
   const cwdRef = useRef(cwd)
 
+  // Resolve terminal theme from current app theme
+  const resolvedTheme = useUIStore((s) => {
+    const t = s.theme
+    if (t === 'system') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    }
+    return t
+  })
+  const termTheme = TERMINAL_THEMES[resolvedTheme]
+
   const initTerminal = useCallback(async () => {
     console.log(`[Terminal:${terminalId}] initTerminal called`, {
       hasContainer: !!containerRef.current,
@@ -61,28 +120,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       fontSize: 13,
       fontFamily: 'Menlo, Monaco, "Courier New", monospace',
       lineHeight: 1.2,
-      theme: {
-        background: '#141a26',
-        foreground: '#c9d1d9',
-        cursor: '#58a6ff',
-        selectionBackground: '#264f78',
-        black: '#141a26',
-        red: '#ff7b72',
-        green: '#3fb950',
-        yellow: '#d29922',
-        blue: '#58a6ff',
-        magenta: '#bc8cff',
-        cyan: '#39c5cf',
-        white: '#c9d1d9',
-        brightBlack: '#484f58',
-        brightRed: '#ffa198',
-        brightGreen: '#56d364',
-        brightYellow: '#e3b341',
-        brightBlue: '#79c0ff',
-        brightMagenta: '#d2a8ff',
-        brightCyan: '#56d4dd',
-        brightWhite: '#f0f6fc',
-      },
+      theme: termTheme,
       allowProposedApi: true,
     })
 
@@ -279,6 +317,16 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     return () => clearInterval(interval)
   }, [isReady, terminalId])
 
+  // ── Update xterm colors when the app theme changes ──
+  useEffect(() => {
+    const term = xtermRef.current
+    if (!term?.options) return
+    term.options.theme = termTheme
+    if (containerRef.current) {
+      containerRef.current.style.background = termTheme.background
+    }
+  }, [termTheme])
+
   if (error) {
     return (
       <div className="flex items-center justify-center h-full text-red-400/60 text-xs">
@@ -305,7 +353,7 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       className="h-full w-full xterm-container"
       onClick={handleClick}
       style={{
-        background: '#141a26',
+        background: termTheme.background,
         // Minimum dimensions prevent xterm's internal canvas renderer from
         // computing NaN cell sizes (which causes the toFixed crash).
         minWidth: 100,

--- a/src/renderer/src/components/canvas/WebPagePanelContent.tsx
+++ b/src/renderer/src/components/canvas/WebPagePanelContent.tsx
@@ -52,7 +52,7 @@ export function WebPagePanelContent({ panelId, url, title }: WebPagePanelContent
         {/* Editable URL bar */}
         <form
           onSubmit={(e) => { e.preventDefault(); handleNavigate() }}
-          className="flex items-center gap-2 px-2 py-1.5 bg-[#0d1117]/40 border-b border-border/20 flex-shrink-0"
+          className="flex items-center gap-2 px-2 py-1.5 bg-[var(--color-canvas-panel-bg)]/80 border-b border-border/20 flex-shrink-0"
         >
           <Globe className="h-3 w-3 text-cyan-400/60 flex-shrink-0" />
           <input
@@ -104,7 +104,7 @@ export function WebPagePanelContent({ panelId, url, title }: WebPagePanelContent
   return (
     <div className="flex flex-col h-full min-h-0">
       {/* URL bar — click to edit */}
-      <div className="flex items-center gap-2 px-2 py-1.5 bg-[#0d1117]/40 border-b border-border/20 flex-shrink-0">
+      <div className="flex items-center gap-2 px-2 py-1.5 bg-[var(--color-canvas-panel-bg)]/80 border-b border-border/20 flex-shrink-0">
         <Globe className="h-3 w-3 text-cyan-400/60 flex-shrink-0" />
         <button
           onClick={() => { setIsEditing(true); setInputValue(url) }}

--- a/src/renderer/src/components/dashboard/TaskBoard.tsx
+++ b/src/renderer/src/components/dashboard/TaskBoard.tsx
@@ -23,11 +23,11 @@ interface StatusColumn {
 }
 
 const COLUMNS: StatusColumn[] = [
-  { key: TaskStatus.NotStarted, label: 'Not Started', color: 'text-gray-400', dotColor: 'bg-gray-400', headerBg: 'bg-gray-500/8', columnBg: 'bg-gray-500/[0.03]' },
-  { key: TaskStatus.Triaging, label: 'Triaging', color: 'text-slate-300', dotColor: 'bg-slate-400', headerBg: 'bg-slate-500/8', columnBg: 'bg-slate-500/[0.03]' },
-  { key: TaskStatus.AgentWorking, label: 'Agent Working', color: 'text-amber-400', dotColor: 'bg-amber-400', headerBg: 'bg-amber-500/8', columnBg: 'bg-amber-500/[0.03]' },
-  { key: TaskStatus.ReadyForReview, label: 'Ready for Review', color: 'text-purple-400', dotColor: 'bg-purple-400', headerBg: 'bg-purple-500/8', columnBg: 'bg-purple-500/[0.03]' },
-  { key: TaskStatus.AgentLearning, label: 'Agent Learning', color: 'text-blue-400', dotColor: 'bg-blue-400', headerBg: 'bg-blue-500/8', columnBg: 'bg-blue-500/[0.03]' }
+  { key: TaskStatus.NotStarted, label: 'Not Started', color: 'text-gray-500 dark:text-gray-400', dotColor: 'bg-gray-400', headerBg: 'bg-gray-500/8', columnBg: 'bg-gray-500/[0.03]' },
+  { key: TaskStatus.Triaging, label: 'Triaging', color: 'text-slate-500 dark:text-slate-300', dotColor: 'bg-slate-400', headerBg: 'bg-slate-500/8', columnBg: 'bg-slate-500/[0.03]' },
+  { key: TaskStatus.AgentWorking, label: 'Agent Working', color: 'text-amber-600 dark:text-amber-400', dotColor: 'bg-amber-400', headerBg: 'bg-amber-500/8', columnBg: 'bg-amber-500/[0.03]' },
+  { key: TaskStatus.ReadyForReview, label: 'Ready for Review', color: 'text-purple-600 dark:text-purple-400', dotColor: 'bg-purple-400', headerBg: 'bg-purple-500/8', columnBg: 'bg-purple-500/[0.03]' },
+  { key: TaskStatus.AgentLearning, label: 'Agent Learning', color: 'text-blue-600 dark:text-blue-400', dotColor: 'bg-blue-400', headerBg: 'bg-blue-500/8', columnBg: 'bg-blue-500/[0.03]' }
 ]
 
 const PRIORITY_ORDER: Record<string, number> = {
@@ -126,7 +126,7 @@ function getInitials(name: string): string {
 function AssigneeAvatar({ name }: { name: string }) {
   return (
     <div
-      className={`h-5 w-5 rounded-full flex items-center justify-center text-[8px] font-bold text-white shrink-0 ring-1 ring-white/10 ${getAvatarColor(name)}`}
+      className={`h-5 w-5 rounded-full flex items-center justify-center text-[8px] font-bold text-white shrink-0 ring-1 ring-black/5 dark:ring-white/10 ${getAvatarColor(name)}`}
       title={name}
     >
       {getInitials(name)}
@@ -138,12 +138,12 @@ function AssigneeAvatar({ name }: { name: string }) {
 
 function getSourceConfig(source: string): { label: string; color: string } {
   const s = source.toLowerCase()
-  if (s.includes('trello')) return { label: 'Trello', color: 'text-blue-400 bg-blue-500/10 border-blue-500/20' }
-  if (s.includes('jira')) return { label: 'Jira', color: 'text-blue-300 bg-blue-400/10 border-blue-400/20' }
-  if (s.includes('linear')) return { label: 'Linear', color: 'text-indigo-400 bg-indigo-500/10 border-indigo-500/20' }
-  if (s.includes('asana')) return { label: 'Asana', color: 'text-rose-400 bg-rose-500/10 border-rose-500/20' }
-  if (s.includes('github')) return { label: 'GitHub', color: 'text-gray-300 bg-gray-500/10 border-gray-500/20' }
-  if (s.includes('notion')) return { label: 'Notion', color: 'text-gray-300 bg-gray-400/10 border-gray-400/20' }
+  if (s.includes('trello')) return { label: 'Trello', color: 'text-blue-600 dark:text-blue-400 bg-blue-500/10 border-blue-500/20' }
+  if (s.includes('jira')) return { label: 'Jira', color: 'text-blue-500 dark:text-blue-300 bg-blue-400/10 border-blue-400/20' }
+  if (s.includes('linear')) return { label: 'Linear', color: 'text-indigo-600 dark:text-indigo-400 bg-indigo-500/10 border-indigo-500/20' }
+  if (s.includes('asana')) return { label: 'Asana', color: 'text-rose-600 dark:text-rose-400 bg-rose-500/10 border-rose-500/20' }
+  if (s.includes('github')) return { label: 'GitHub', color: 'text-gray-600 dark:text-gray-300 bg-gray-500/10 border-gray-500/20' }
+  if (s.includes('notion')) return { label: 'Notion', color: 'text-gray-600 dark:text-gray-300 bg-gray-400/10 border-gray-400/20' }
   return { label: source, color: 'text-muted-foreground bg-muted/20 border-border/30' }
 }
 
@@ -173,7 +173,7 @@ function TaskCard({ task, onSelect, agent }: { task: WorkfloTask; onSelect: (id:
 
   return (
     <div
-      className={`group rounded-lg border border-border/30 bg-card/80 backdrop-blur-sm p-3.5 hover:border-border/60 hover:bg-card hover:shadow-md hover:shadow-black/10 transition-all duration-200 cursor-pointer border-l-2 ${getPriorityAccent(task.priority)}`}
+      className={`group rounded-lg border border-border/30 bg-card/80 backdrop-blur-sm p-3.5 hover:border-border/60 hover:bg-card hover:shadow-md hover:shadow-black/5 dark:hover:shadow-black/10 transition-all duration-200 cursor-pointer border-l-2 ${getPriorityAccent(task.priority)}`}
       onClick={() => onSelect(task.id)}
       role="button"
       tabIndex={0}
@@ -257,7 +257,7 @@ function TaskCard({ task, onSelect, agent }: { task: WorkfloTask; onSelect: (id:
 function ColumnHeader({ column, count }: { column: StatusColumn; count: number }) {
   return (
     <div className="flex items-center gap-2 px-3 py-2.5">
-      <div className={`h-2.5 w-2.5 rounded-full ${column.dotColor} ring-2 ring-black/20`} />
+      <div className={`h-2.5 w-2.5 rounded-full ${column.dotColor} ring-2 ring-black/10 dark:ring-black/20`} />
       <span className={`text-xs font-semibold tracking-wide ${column.color}`}>{column.label}</span>
       <span className={`text-[10px] font-medium rounded-full px-2 py-0.5 min-w-[22px] text-center ${column.headerBg} ${column.color}`}>
         {count}

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -139,7 +139,7 @@ export function AppLayout() {
   return (
     <>
       {/* ── Top bar: drag region with logo (left) + nav switcher (center) + actions (right) ── */}
-      <div className="drag-region h-12 flex-shrink-0 flex items-center justify-center px-4 border-b border-border/50 windows-titlebar-pad">
+      <div className="drag-region h-12 flex-shrink-0 flex items-center justify-center px-4 border-b border-border/50 windows-titlebar-pad bg-background/80 backdrop-blur-xl">
         {/* Logo + update indicator — pinned left */}
         <div className="no-drag absolute left-4 flex items-center gap-2 macos-titlebar-pad">
           <div className="relative">

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -139,7 +139,7 @@ export function AppLayout() {
   return (
     <>
       {/* ── Top bar: drag region with logo (left) + nav switcher (center) + actions (right) ── */}
-      <div className="drag-region h-12 flex-shrink-0 flex items-center justify-center px-4 border-b border-border/50 windows-titlebar-pad bg-background/80 backdrop-blur-xl vibrancy-topbar">
+      <div className="drag-region h-12 flex-shrink-0 flex items-center justify-center px-4 border-b border-border/50 windows-titlebar-pad bg-background/80 backdrop-blur-xl">
         {/* Logo + update indicator — pinned left */}
         <div className="no-drag absolute left-4 flex items-center gap-2 macos-titlebar-pad">
           <div className="relative">

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -139,7 +139,7 @@ export function AppLayout() {
   return (
     <>
       {/* ── Top bar: drag region with logo (left) + nav switcher (center) + actions (right) ── */}
-      <div className="drag-region h-12 flex-shrink-0 flex items-center justify-center px-4 border-b border-border/50 windows-titlebar-pad bg-background/80 backdrop-blur-xl">
+      <div className="drag-region h-12 flex-shrink-0 flex items-center justify-center px-4 border-b border-border/50 windows-titlebar-pad bg-background/80 backdrop-blur-xl vibrancy-topbar">
         {/* Logo + update indicator — pinned left */}
         <div className="no-drag absolute left-4 flex items-center gap-2 macos-titlebar-pad">
           <div className="relative">

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -91,7 +91,7 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
   const hasActiveFilters = statusFilter !== 'all' || priorityFilter !== 'all' || sourceFilter !== 'all'
 
   return (
-    <aside className="flex flex-col h-full w-[260px] shrink-0 border-r bg-sidebar backdrop-blur-xl overflow-hidden">
+    <aside className="flex flex-col h-full w-[260px] shrink-0 border-r bg-sidebar backdrop-blur-xl vibrancy-sidebar overflow-hidden">
       {sidebarView === 'tasks' ? (
         <>
           <div className="no-drag flex items-center justify-between px-4 py-3">

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -91,7 +91,7 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
   const hasActiveFilters = statusFilter !== 'all' || priorityFilter !== 'all' || sourceFilter !== 'all'
 
   return (
-    <aside className="flex flex-col h-full w-[260px] shrink-0 border-r bg-sidebar overflow-hidden">
+    <aside className="flex flex-col h-full w-[260px] shrink-0 border-r bg-sidebar backdrop-blur-xl overflow-hidden">
       {sidebarView === 'tasks' ? (
         <>
           <div className="no-drag flex items-center justify-between px-4 py-3">

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -91,7 +91,7 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
   const hasActiveFilters = statusFilter !== 'all' || priorityFilter !== 'all' || sourceFilter !== 'all'
 
   return (
-    <aside className="flex flex-col h-full w-[260px] shrink-0 border-r bg-sidebar backdrop-blur-xl vibrancy-sidebar overflow-hidden">
+    <aside className="flex flex-col h-full w-[260px] shrink-0 border-r bg-sidebar backdrop-blur-xl overflow-hidden">
       {sidebarView === 'tasks' ? (
         <>
           <div className="no-drag flex items-center justify-between px-4 py-3">

--- a/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
@@ -1,13 +1,22 @@
 import { useState, useEffect } from 'react'
-import { Wrench, RefreshCw, Download, Check, Loader2, Trash2 } from 'lucide-react'
+import { Wrench, RefreshCw, Download, Check, Loader2, Trash2, Sun, Moon, Monitor } from 'lucide-react'
 import { SettingsSection } from '../SettingsSection'
 import { Label } from '@/components/ui/Label'
 import { Switch } from '@/components/ui/Switch'
 import { Button } from '@/components/ui/Button'
 import { ToolSetupDialog } from '@/components/AgentSetupWizard'
 import { settingsApi, mobileApi, updaterApi, worktreeApi, onWorkspaceCleanupProgress } from '@/lib/ipc-client'
+import { useUIStore, type ThemeMode } from '@/stores/ui-store'
+
+const THEME_OPTIONS: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+]
 
 export function GeneralSettings() {
+  const theme = useUIStore((s) => s.theme)
+  const setTheme = useUIStore((s) => s.setTheme)
   const [setupDialogOpen, setSetupDialogOpen] = useState(false)
   const [launchAtStartup, setLaunchAtStartup] = useState(false)
   const [notificationsEnabled, setNotificationsEnabled] = useState(false)
@@ -214,6 +223,31 @@ export function GeneralSettings() {
             onCheckedChange={handleMinimizeToTrayChange}
             disabled={loading}
           />
+        </div>
+
+        <div className="flex items-center justify-between py-2 border-b border-border">
+          <div className="space-y-0.5">
+            <Label>Appearance</Label>
+            <p className="text-xs text-muted-foreground">
+              Choose between light and dark mode
+            </p>
+          </div>
+          <div className="flex items-center rounded-lg border border-border bg-muted/30 p-0.5">
+            {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+              <button
+                key={value}
+                onClick={() => setTheme(value)}
+                className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium transition-colors ${
+                  theme === value
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </SettingsSection>

--- a/src/renderer/src/components/ui/AlertDialog.tsx
+++ b/src/renderer/src/components/ui/AlertDialog.tsx
@@ -15,7 +15,7 @@ const AlertDialogOverlay = React.forwardRef<
   <AlertDialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-[var(--color-overlay)] backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}
@@ -32,7 +32,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 border border-border bg-card rounded-xl p-6 shadow-2xl shadow-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 border border-border bg-card rounded-xl p-6 shadow-2xl shadow-black/20 dark:shadow-black/40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
         className
       )}
       {...props}

--- a/src/renderer/src/components/ui/Badge.tsx
+++ b/src/renderer/src/components/ui/Badge.tsx
@@ -7,12 +7,12 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: 'border-border/50 bg-muted text-muted-foreground',
-        blue: 'border-blue-500/20 bg-blue-500/10 text-blue-400',
-        green: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-400',
-        yellow: 'border-amber-500/20 bg-amber-500/10 text-amber-400',
-        red: 'border-red-500/20 bg-red-500/10 text-red-400',
-        purple: 'border-purple-500/20 bg-purple-500/10 text-purple-400',
-        orange: 'border-orange-500/20 bg-orange-500/10 text-orange-400'
+        blue: 'border-blue-500/20 bg-blue-500/10 text-blue-600 dark:text-blue-400',
+        green: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+        yellow: 'border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400',
+        red: 'border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400',
+        purple: 'border-purple-500/20 bg-purple-500/10 text-purple-600 dark:text-purple-400',
+        orange: 'border-orange-500/20 bg-orange-500/10 text-orange-600 dark:text-orange-400'
       }
     },
     defaultVariants: {

--- a/src/renderer/src/components/ui/Dialog.tsx
+++ b/src/renderer/src/components/ui/Dialog.tsx
@@ -15,7 +15,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-[var(--color-overlay)] backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}
@@ -32,7 +32,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-1/2 top-1/2 z-50 w-full max-w-xl -translate-x-1/2 -translate-y-1/2 border border-border bg-card rounded-xl shadow-2xl shadow-black/40 max-h-[85vh] flex flex-col data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'fixed left-1/2 top-1/2 z-50 w-full max-w-xl -translate-x-1/2 -translate-y-1/2 border border-border bg-card rounded-xl shadow-2xl shadow-black/20 dark:shadow-black/40 max-h-[85vh] flex flex-col data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
         className
       )}
       {...props}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -23,6 +23,17 @@ if (navigator.userAgent.includes('Windows')) {
   document.documentElement.setAttribute('data-platform', 'linux')
 }
 
+// Apply theme early to prevent flash of wrong theme
+// The ui-store module also does this, but this runs before React hydration
+const savedTheme = localStorage.getItem('20x-theme') || 'dark'
+if (savedTheme === 'system') {
+  document.documentElement.setAttribute('data-theme',
+    window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  )
+} else {
+  document.documentElement.setAttribute('data-theme', savedTheme)
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -6,6 +6,21 @@ export type SortField = 'created_at' | 'updated_at' | 'priority' | 'due_date' | 
 export type SortDirection = 'asc' | 'desc'
 export type ActiveModal = 'create' | 'edit' | 'delete' | 'settings' | 'repo-selector' | 'gh-setup' | null
 export type SidebarView = 'tasks' | 'skills' | 'dashboard' | 'canvas'
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+/** Resolve the effective theme (light or dark) from the ThemeMode preference */
+function resolveTheme(mode: ThemeMode): 'light' | 'dark' {
+  if (mode === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  return mode
+}
+
+/** Apply the data-theme attribute to the document root */
+function applyThemeToDOM(mode: ThemeMode): void {
+  const resolved = resolveTheme(mode)
+  document.documentElement.setAttribute('data-theme', resolved)
+}
 
 interface UIState {
   sidebarView: SidebarView
@@ -25,6 +40,8 @@ interface UIState {
   canvasPendingTaskId: string | null
   /** App to add to canvas when switching to canvas view */
   canvasPendingApp: { workflowId: string; name: string } | null
+  /** Theme mode preference: light, dark, or system (auto) */
+  theme: ThemeMode
 
   setSidebarView: (view: SidebarView) => void
   setStatusFilter: (filter: TaskStatus | 'all') => void
@@ -35,6 +52,7 @@ interface UIState {
   setSearchQuery: (query: string) => void
   setSkillSearchQuery: (query: string) => void
   setSettingsTab: (tab: SettingsTab) => void
+  setTheme: (mode: ThemeMode) => void
   openCreateModal: () => void
   openEditModal: (taskId: string) => void
   openDeleteModal: (taskId: string) => void
@@ -66,6 +84,7 @@ export const useUIStore = create<UIState>((set) => ({
   dashboardPreviewTaskId: null,
   canvasPendingTaskId: null,
   canvasPendingApp: null,
+  theme: (localStorage.getItem('20x-theme') as ThemeMode) || 'dark',
 
   setSidebarView: (sidebarView) => set({ sidebarView }),
   setStatusFilter: (statusFilter) => set({ statusFilter }),
@@ -87,6 +106,14 @@ export const useUIStore = create<UIState>((set) => ({
   setSearchQuery: (searchQuery) => set({ searchQuery }),
   setSkillSearchQuery: (skillSearchQuery) => set({ skillSearchQuery }),
   setSettingsTab: (settingsTab) => set({ settingsTab }),
+  setTheme: (theme) => {
+    localStorage.setItem('20x-theme', theme)
+    applyThemeToDOM(theme)
+    // Sync native window chrome (titlebar, background color) with the theme
+    const resolved = resolveTheme(theme)
+    window.electronAPI?.app?.setTheme?.(resolved)
+    set({ theme })
+  },
 
   openCreateModal: () => set({ activeModal: 'create', editingTaskId: null }),
   openEditModal: (taskId) => set({ activeModal: 'edit', editingTaskId: taskId }),
@@ -100,3 +127,15 @@ export const useUIStore = create<UIState>((set) => ({
   openAppOnCanvas: (workflowId, name) => set({ sidebarView: 'canvas', canvasPendingApp: { workflowId, name }, dashboardPreviewTaskId: null }),
   clearCanvasPendingApp: () => set({ canvasPendingApp: null })
 }))
+
+// ── Initialize theme on load ───────────────────────────────
+const initialTheme = useUIStore.getState().theme
+applyThemeToDOM(initialTheme)
+
+// Listen for system theme changes when in 'system' mode
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  const { theme } = useUIStore.getState()
+  if (theme === 'system') {
+    applyThemeToDOM('system')
+  }
+})

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -184,6 +184,17 @@ html[data-platform="darwin"] #root {
   background: transparent !important;
 }
 
+/* On macOS, native vibrancy handles the blur — remove CSS backdrop-filter
+   to avoid creating a compositing layer that blocks native transparency. */
+html[data-platform="darwin"] .vibrancy-sidebar {
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+}
+html[data-platform="darwin"] .vibrancy-topbar {
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+}
+
 /* ── App Shell ────────────────────────────────── */
 #root {
   display: flex;

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -176,6 +176,14 @@ html, body, #root {
   font-size: 14px;
 }
 
+/* ── macOS vibrancy: make html/body transparent so native blur shows
+   through the sidebar. The <main> content area keeps bg-background. ── */
+html[data-platform="darwin"],
+html[data-platform="darwin"] body,
+html[data-platform="darwin"] #root {
+  background: transparent !important;
+}
+
 /* ── App Shell ────────────────────────────────── */
 #root {
   display: flex;

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -1,34 +1,139 @@
 @import "tailwindcss";
 
+/* ── Theme tokens: Tailwind CSS 4 compatible ──────────────── */
+/* @theme registers design tokens so Tailwind generates utility classes
+   (bg-background, text-foreground, etc.). Light mode values are the defaults.
+   :root / [data-theme] selectors below override them at runtime. */
 @theme {
-  /* Cursor Dark Midnight palette */
-  --color-background: #1E2127;
-  --color-foreground: #EBEEF4;
-  --color-card: #191D23;
-  --color-card-foreground: #EBEEF4;
-  --color-popover: #191D23;
-  --color-popover-foreground: #EBEEF4;
-  --color-primary: #85A4C3;
-  --color-primary-foreground: #1E2127;
-  --color-secondary: #30353F;
-  --color-secondary-foreground: #EBEEF4;
-  --color-muted: #30353F;
-  --color-muted-foreground: #535D71;
-  --color-accent: #313C47;
-  --color-accent-foreground: #EBEEF4;
-  --color-destructive: #C06771;
-  --color-destructive-foreground: #EBEEF4;
-  --color-border: #30353F;
-  --color-input: #30353F;
-  --color-ring: #85A4C3;
-  --color-sidebar: #191D23;
-  --color-sidebar-foreground: #E4E8F0;
-  --color-sidebar-border: #30353F;
-  --color-sidebar-accent: #313C47;
-  --color-sidebar-muted: #30353F;
+  --color-background: #FFFFFF;
+  --color-foreground: #1A1C1F;
+  --color-card: #FFFFFF;
+  --color-card-foreground: #1A1C1F;
+  --color-popover: #FFFFFF;
+  --color-popover-foreground: #1A1C1F;
+  --color-primary: #339CFF;
+  --color-primary-foreground: #FFFFFF;
+  --color-secondary: #F3F4F6;
+  --color-secondary-foreground: #1A1C1F;
+  --color-muted: #F3F4F6;
+  --color-muted-foreground: #6B7280;
+  --color-accent: #E5E7EB;
+  --color-accent-foreground: #1A1C1F;
+  --color-destructive: #DC2626;
+  --color-destructive-foreground: #FFFFFF;
+  --color-border: #E5E7EB;
+  --color-input: #E5E7EB;
+  --color-ring: #339CFF;
+  --color-sidebar: #FFFFFF;
+  --color-sidebar-foreground: #1A1C1F;
+  --color-sidebar-border: #E5E7EB;
+  --color-sidebar-accent: #F3F4F6;
+  --color-sidebar-muted: #F3F4F6;
   --radius-sm: 6px;
   --radius-md: 8px;
   --radius-lg: 12px;
+}
+
+/* Use @custom-variant for Tailwind dark: prefix support with data-theme */
+@custom-variant dark (&:where([data-theme="dark"] *));
+
+/* ── Light mode (default) ────────────────────────────────── */
+:root,
+[data-theme="light"] {
+  --color-background: #FFFFFF;
+  --color-foreground: #1A1C1F;
+  --color-card: #FFFFFF;
+  --color-card-foreground: #1A1C1F;
+  --color-popover: #FFFFFF;
+  --color-popover-foreground: #1A1C1F;
+  --color-primary: #339CFF;
+  --color-primary-foreground: #FFFFFF;
+  --color-secondary: #F3F4F6;
+  --color-secondary-foreground: #1A1C1F;
+  --color-muted: #F3F4F6;
+  --color-muted-foreground: #6B7280;
+  --color-accent: #E5E7EB;
+  --color-accent-foreground: #1A1C1F;
+  --color-destructive: #DC2626;
+  --color-destructive-foreground: #FFFFFF;
+  --color-border: #E5E7EB;
+  --color-input: #E5E7EB;
+  --color-ring: #339CFF;
+
+  /* Sidebar — translucent */
+  --color-sidebar: rgba(255, 255, 255, 0.70);
+  --color-sidebar-foreground: #1A1C1F;
+  --color-sidebar-border: #E5E7EB;
+  --color-sidebar-accent: #F3F4F6;
+  --color-sidebar-muted: #F3F4F6;
+
+  /* Canvas-specific tokens */
+  --color-canvas-bg: #F5F5F5;
+  --color-canvas-panel-bg: #FFFFFF;
+  --color-canvas-panel-border: #E5E7EB;
+  --color-canvas-grid-dot: rgba(0, 0, 0, 0.06);
+  --color-canvas-hud-bg: rgba(255, 255, 255, 0.85);
+  --color-canvas-minimap-bg: rgba(255, 255, 255, 0.92);
+  --color-canvas-minimap-header: rgba(255, 255, 255, 0.95);
+  --color-canvas-context-menu: #FFFFFF;
+
+  /* Overlay / UI */
+  --color-overlay: rgba(0, 0, 0, 0.50);
+  --color-hover-overlay: rgba(0, 0, 0, 0.04);
+  --color-hover-overlay-strong: rgba(0, 0, 0, 0.08);
+  --color-active-overlay: rgba(0, 0, 0, 0.12);
+  --color-scrollbar-thumb: #D1D5DB;
+  --color-scrollbar-thumb-hover: #9CA3AF;
+  --color-edge-delete-bg: #FFFFFF;
+}
+
+/* ── Dark mode ───────────────────────────────────────────── */
+[data-theme="dark"] {
+  --color-background: #181818;
+  --color-foreground: #FFFFFF;
+  --color-card: #1E1E1E;
+  --color-card-foreground: #FFFFFF;
+  --color-popover: #1E1E1E;
+  --color-popover-foreground: #FFFFFF;
+  --color-primary: #339CFF;
+  --color-primary-foreground: #FFFFFF;
+  --color-secondary: #2A2A2A;
+  --color-secondary-foreground: #FFFFFF;
+  --color-muted: #2A2A2A;
+  --color-muted-foreground: #888888;
+  --color-accent: #333333;
+  --color-accent-foreground: #FFFFFF;
+  --color-destructive: #C06771;
+  --color-destructive-foreground: #FFFFFF;
+  --color-border: #333333;
+  --color-input: #333333;
+  --color-ring: #339CFF;
+
+  /* Sidebar — translucent */
+  --color-sidebar: rgba(24, 24, 24, 0.70);
+  --color-sidebar-foreground: #E4E8F0;
+  --color-sidebar-border: #333333;
+  --color-sidebar-accent: #333333;
+  --color-sidebar-muted: #2A2A2A;
+
+  /* Canvas-specific tokens */
+  --color-canvas-bg: #131820;
+  --color-canvas-panel-bg: #1a2030;
+  --color-canvas-panel-border: #333333;
+  --color-canvas-grid-dot: rgba(255, 255, 255, 0.08);
+  --color-canvas-hud-bg: rgba(26, 32, 48, 0.90);
+  --color-canvas-minimap-bg: rgba(13, 17, 23, 0.95);
+  --color-canvas-minimap-header: rgba(26, 32, 48, 0.95);
+  --color-canvas-context-menu: #161b22;
+
+  /* Overlay / UI */
+  --color-overlay: rgba(0, 0, 0, 0.70);
+  --color-hover-overlay: rgba(255, 255, 255, 0.05);
+  --color-hover-overlay-strong: rgba(255, 255, 255, 0.10);
+  --color-active-overlay: rgba(255, 255, 255, 0.15);
+  --color-scrollbar-thumb: #333333;
+  --color-scrollbar-thumb-hover: #535D71;
+  --color-edge-delete-bg: #161b22;
 }
 
 @font-face {
@@ -94,8 +199,8 @@ html, body, #root {
 /* ── Scrollbar ────────────────────────────────── */
 ::-webkit-scrollbar { width: 5px; height: 5px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 99px; }
-::-webkit-scrollbar-thumb:hover { background: #535D71; }
+::-webkit-scrollbar-thumb { background: var(--color-scrollbar-thumb); border-radius: 99px; }
+::-webkit-scrollbar-thumb:hover { background: var(--color-scrollbar-thumb-hover); }
 
 /* ── Native form elements ─────────────────────── */
 select {
@@ -114,8 +219,12 @@ select option {
 }
 
 input[type="date"]::-webkit-calendar-picker-indicator {
-  filter: invert(0.5);
   cursor: pointer;
+}
+
+/* In dark mode, invert the date picker indicator to keep it visible */
+[data-theme="dark"] input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(0.5);
 }
 
 input[type="search"]::-webkit-search-cancel-button {

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -184,17 +184,6 @@ html[data-platform="darwin"] #root {
   background: transparent !important;
 }
 
-/* On macOS, native vibrancy handles the blur — remove CSS backdrop-filter
-   to avoid creating a compositing layer that blocks native transparency. */
-html[data-platform="darwin"] .vibrancy-sidebar {
-  -webkit-backdrop-filter: none !important;
-  backdrop-filter: none !important;
-}
-html[data-platform="darwin"] .vibrancy-topbar {
-  -webkit-backdrop-filter: none !important;
-  backdrop-filter: none !important;
-}
-
 /* ── App Shell ────────────────────────────────── */
 #root {
   display: flex;

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -330,6 +330,7 @@ interface ElectronAPI {
     requestNotificationPermission: () => Promise<'granted' | 'denied'>
     getMinimizeToTray: () => Promise<boolean>
     setMinimizeToTray: (enabled: boolean) => Promise<boolean>
+    setTheme: (theme: 'light' | 'dark') => Promise<void>
   }
   mobile: {
     getInfo: () => Promise<{ url: string; port: number }>


### PR DESCRIPTION
## Summary

- **Light/dark theme support** with CSS custom properties (`data-theme` attribute), Tailwind CSS 4 `@theme` tokens, and a Light/Dark/System toggle in Settings
- **Native macOS glass transparency** using [`electron-liquid-glass`](https://github.com/Meridius-Labs/electron-liquid-glass) — uses `NSGlassEffectView` on macOS 26+ (Liquid Glass) and falls back to `NSVisualEffectView` on older macOS
- **Theme-aware canvas** — all hardcoded hex colors in canvas components replaced with CSS variables that adapt to light/dark mode
- **Theme-aware terminal** — xterm.js gets light and dark color palettes that switch live when the app theme changes
- **Windows support** — titlebar overlay colors update on theme switch via IPC handler
- **Mobile sync** — mobile `globals.css` updated with the same theme variable structure

### Key design values
- Light: `#FFFFFF` bg, `#1A1C1F` fg, `#339CFF` accent, translucent sidebar `rgba(255,255,255,0.70)`
- Dark: `#181818` bg, `#FFFFFF` fg, `#339CFF` accent, translucent sidebar `rgba(24,24,24,0.70)`

### Native glass approach (macOS)
- Uses `electron-liquid-glass` which wraps native `NSGlassEffectView`
- `transparent: true` + `backgroundColor: '#00000000'` on BrowserWindow
- **No `vibrancy` option** — it conflicts with the glass view and makes things blurry
- Glass view applied after `did-finish-load` via `liquidGlass.addView()`
- Glass sits behind ALL web content — CSS semi-transparent areas (sidebar `rgba(255,255,255,0.70)`, top bar `bg-background/80`) let it through; opaque areas (`bg-background`) block it
- Auto dark mode adaptation via system appearance listener
- Falls back gracefully to `NSVisualEffectView` on older macOS, no-op on Windows/Linux

## Test plan
- [x] All 88 test files pass (1275 tests)
- [x] TypeScript compiles cleanly (both `tsconfig.node.json` and `tsconfig.web.json`)
- [x] Production build succeeds for renderer and mobile
- [ ] Manual: verify glass transparency shows desktop wallpaper through sidebar on macOS
- [ ] Manual: verify Light/Dark/System toggle in Settings works
- [ ] Manual: verify terminal colors change when switching themes
- [ ] Manual: verify canvas panels, minimap, context menu use correct colors in both themes
- [ ] Manual: verify Windows titlebar overlay colors match the theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)