### PR TITLE
feat: add GPT-5.5 Codex model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Most AI tools make you copy-paste context between tabs. 20x flips it: **your tas
 ### 🤖 Multi-Agent Support
 - **Claude Code** — Anthropic's official agent SDK (Claude Sonnet 4.6)
 - **OpenCode** — Open-source coding agent
-- **Codex** — OpenAI's agent framework (GPT-5.4)
+- **Codex** — OpenAI's agent framework (GPT-5.5)
 - **Live transcripts** — Watch agents think and work in real time with message counts
 - **Human-in-the-loop** — Approve risky actions before execution
 - **Task progress tracking** — Real-time progress events during agent execution
@@ -259,7 +259,7 @@ We welcome contributions! Here's how:
 - ✅ Skills 2-way sync with Workflo
 - ✅ Heartbeat monitoring with CI failure detection
 - ✅ Presetup wizard and dashboard templates
-- ✅ Claude Sonnet 4.6 and GPT-5.4 model support
+- ✅ Claude Sonnet 4.6 and GPT-5.5 model support
 - ✅ Multi-agent support (OpenCode, Claude Code, Codex)
 - ✅ Skills system with auto-learning
 - ✅ Recurring tasks

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "@zed-industries/claude-code-acp": "^0.16.1",
-    "@zed-industries/codex-acp": "^0.11.1",
+    "@zed-industries/codex-acp": "^0.13.0",
     "better-sqlite3": "^12.6.2",
     "cron-parser": "^5.5.0",
     "electron-updater": "^6.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^0.16.1
         version: 0.16.1(zod@4.3.6)
       '@zed-industries/codex-acp':
-        specifier: ^0.11.1
-        version: 0.11.1
+        specifier: ^0.13.0
+        version: 0.13.0
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -335,6 +335,10 @@ packages:
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -2183,44 +2187,44 @@ packages:
     resolution: {integrity: sha512-/fKDYLCtiKthYUeOu4vPHSE79arh0ciYnBd5uSTY8OWMURJoelBwkK5QGZZSmxjAwG9tHkvjxUjxhMDgC071VA==}
     hasBin: true
 
-  '@zed-industries/codex-acp-darwin-arm64@0.11.1':
-    resolution: {integrity: sha512-zJ/CsOSH1NniKGF/liBtWokdkFtymTWeELV4lDlgMgzVSqMHQTB+t6fFSrxhwOcXHK86TErxAT81Z61e+bq5gg==}
+  '@zed-industries/codex-acp-darwin-arm64@0.13.0':
+    resolution: {integrity: sha512-SNJbpxOD1b98pK1Qw2pZjFJbfYBICheRs3mYvLMgHABehdypaeYKnEmEGp3Bu/gUT6JFAtOPRtaU+sfxKzgCvw==}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@zed-industries/codex-acp-darwin-x64@0.11.1':
-    resolution: {integrity: sha512-UZjIsEZPLeYMk+fj2ot1oT+tWuJpw+iZS9awnbmJYxTEEXMpY8BE6xQXMy7iyyxJ346We5MEpAdxg730vcem5Q==}
+  '@zed-industries/codex-acp-darwin-x64@0.13.0':
+    resolution: {integrity: sha512-R5CQi2mmi9Nk2P6t48T5JoOQx0jWnP9DzLf5jcTnCLqk1tsg9XtASpLBtsedll9MesBax6aflDvz+0dyWW+3Mw==}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@zed-industries/codex-acp-linux-arm64@0.11.1':
-    resolution: {integrity: sha512-I1f6WoSLbLlsWq4zH+vtwdoc4Y41mqRXPpSkfgIifxBw34QmWJmi37etZ7lKTYp6R+J/Z4PUN0rsmnsmKpBZTw==}
+  '@zed-industries/codex-acp-linux-arm64@0.13.0':
+    resolution: {integrity: sha512-Z3f2D94SOgy+BVFEIWxoR64IQB+d4/zgjHB1oeBS5yAYKaX7Wv3W6x+XGktDx+KnfD7c9vSSdFdknI6cZ8hO7g==}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@zed-industries/codex-acp-linux-x64@0.11.1':
-    resolution: {integrity: sha512-30vSoZuW1DP6Nuz24Gg3jgVC37IYe0bZ/Fgc5+372gc0h72NN4zHYAbu5bRd/gUJ9GdwABKrrEPCoFPlOTVTnQ==}
+  '@zed-industries/codex-acp-linux-x64@0.13.0':
+    resolution: {integrity: sha512-sWNfyeuwEHPo6DSbcjklnBr7M8+MWd2b9oVbIqgwxryTPpm0ZPF3U28PWR3/vGxS5UmhGiZIShe9tqx8FsvvBg==}
     cpu: [x64]
     os: [linux]
     hasBin: true
 
-  '@zed-industries/codex-acp-win32-arm64@0.11.1':
-    resolution: {integrity: sha512-yisGPG7JMJBtOTOB6qwzroOLfiQebDrBnybzvjOfWiSIHeha25Jf1nTlWrlZcEiV/eeX3/lERuU1MxftjK3Vgg==}
+  '@zed-industries/codex-acp-win32-arm64@0.13.0':
+    resolution: {integrity: sha512-oxd6IF5dVHsa7zLnK1VAClzGADqn4N9TVSPb+3X4CqnOs4y4M9JPHSEEPiRYF44ibDJTWR+9EZ673djRYEGraw==}
     cpu: [arm64]
     os: [win32]
     hasBin: true
 
-  '@zed-industries/codex-acp-win32-x64@0.11.1':
-    resolution: {integrity: sha512-nOdlp/xHQGzqt+GnB2rrpk0sT7pPJVKkL9M+UhmoFPSFwjWrkzAOJukbT4P59wU1mVBTe84dEW6UnzydWIrGJw==}
+  '@zed-industries/codex-acp-win32-x64@0.13.0':
+    resolution: {integrity: sha512-675+tZlhzDMBJUrgiTnbcCMB15MQ8B0Ih/GmzB9MqW/FDFJqOFjXe4P+M7joePzQqa7QYwf36le50sDokXDrew==}
     cpu: [x64]
     os: [win32]
     hasBin: true
 
-  '@zed-industries/codex-acp@0.11.1':
-    resolution: {integrity: sha512-My2VSlBtvJipJhImHjFDej2ut/p00QqOISRnZgLgLrSIzjgvdcQvAhaZviWj7XPhk4UIdIb0OoA+Lrls824uiQ==}
+  '@zed-industries/codex-acp@0.13.0':
+    resolution: {integrity: sha512-Ep3gINMVB8qQL3kozJxEzG4YP7NmWUb5s+8yu8tQ7YSPfaIPXBIQQmO5sQk2Uu2av+gIC2EchbwaSSG3Mo17YQ==}
     hasBin: true
 
   abbrev@1.1.1:
@@ -5283,6 +5287,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -6291,14 +6297,14 @@ snapshots:
       '@remotion/studio-shared': 4.0.434(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@rspack/core': 1.7.6
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
-      css-loader: 5.2.7(webpack@5.105.0)
+      css-loader: 5.2.7(webpack@5.105.0(esbuild@0.25.0))
       esbuild: 0.25.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-refresh: 0.18.0
       remotion: 4.0.434(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       source-map: 0.7.3
-      style-loader: 4.0.0(webpack@5.105.0)
+      style-loader: 4.0.0(webpack@5.105.0(esbuild@0.25.0))
       webpack: 5.105.0(esbuild@0.25.0)
     transitivePeerDependencies:
       - '@swc/core'
@@ -6739,7 +6745,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -7164,32 +7170,32 @@ snapshots:
       - supports-color
       - zod
 
-  '@zed-industries/codex-acp-darwin-arm64@0.11.1':
+  '@zed-industries/codex-acp-darwin-arm64@0.13.0':
     optional: true
 
-  '@zed-industries/codex-acp-darwin-x64@0.11.1':
+  '@zed-industries/codex-acp-darwin-x64@0.13.0':
     optional: true
 
-  '@zed-industries/codex-acp-linux-arm64@0.11.1':
+  '@zed-industries/codex-acp-linux-arm64@0.13.0':
     optional: true
 
-  '@zed-industries/codex-acp-linux-x64@0.11.1':
+  '@zed-industries/codex-acp-linux-x64@0.13.0':
     optional: true
 
-  '@zed-industries/codex-acp-win32-arm64@0.11.1':
+  '@zed-industries/codex-acp-win32-arm64@0.13.0':
     optional: true
 
-  '@zed-industries/codex-acp-win32-x64@0.11.1':
+  '@zed-industries/codex-acp-win32-x64@0.13.0':
     optional: true
 
-  '@zed-industries/codex-acp@0.11.1':
+  '@zed-industries/codex-acp@0.13.0':
     optionalDependencies:
-      '@zed-industries/codex-acp-darwin-arm64': 0.11.1
-      '@zed-industries/codex-acp-darwin-x64': 0.11.1
-      '@zed-industries/codex-acp-linux-arm64': 0.11.1
-      '@zed-industries/codex-acp-linux-x64': 0.11.1
-      '@zed-industries/codex-acp-win32-arm64': 0.11.1
-      '@zed-industries/codex-acp-win32-x64': 0.11.1
+      '@zed-industries/codex-acp-darwin-arm64': 0.13.0
+      '@zed-industries/codex-acp-darwin-x64': 0.13.0
+      '@zed-industries/codex-acp-linux-arm64': 0.13.0
+      '@zed-industries/codex-acp-linux-x64': 0.13.0
+      '@zed-industries/codex-acp-win32-arm64': 0.13.0
+      '@zed-industries/codex-acp-win32-x64': 0.13.0
 
   abbrev@1.1.1: {}
 
@@ -7707,7 +7713,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@5.2.7(webpack@5.105.0):
+  css-loader@5.2.7(webpack@5.105.0(esbuild@0.25.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       loader-utils: 2.0.4
@@ -10105,7 +10111,7 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
-  style-loader@4.0.0(webpack@5.105.0):
+  style-loader@4.0.0(webpack@5.105.0(esbuild@0.25.0)):
     dependencies:
       webpack: 5.105.0(esbuild@0.25.0)
 

--- a/src/main/adapters/codex-adapter.test.ts
+++ b/src/main/adapters/codex-adapter.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { DEFAULT_CODEX_MODEL } from './codex-adapter'
 
 describe('DEFAULT_CODEX_MODEL', () => {
-  it('defaults Codex sessions to GPT-5.4', () => {
-    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.4')
+  it('defaults Codex sessions to GPT-5.5', () => {
+    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.5')
   })
 })
 

--- a/src/main/adapters/codex-adapter.ts
+++ b/src/main/adapters/codex-adapter.ts
@@ -20,7 +20,7 @@ import type {
 } from './coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './coding-agent-adapter'
 
-export const DEFAULT_CODEX_MODEL = 'gpt-5.4'
+export const DEFAULT_CODEX_MODEL = 'gpt-5.5'
 
 interface JsonRpcRequest {
   jsonrpc: '2.0'

--- a/src/renderer/src/types/index.test.ts
+++ b/src/renderer/src/types/index.test.ts
@@ -11,10 +11,17 @@ describe('CLAUDE_MODELS', () => {
 })
 
 describe('CODEX_MODELS', () => {
-  it('lists GPT-5.4 first as the recommended model', () => {
+  it('lists GPT-5.5 first as the recommended model', () => {
     expect(CODEX_MODELS[0]).toEqual({
+      id: CodexModel.GPT_5_5,
+      name: 'GPT-5.5 (Recommended)'
+    })
+  })
+
+  it('still includes GPT-5.4 as a selectable fallback model', () => {
+    expect(CODEX_MODELS).toContainEqual({
       id: CodexModel.GPT_5_4,
-      name: 'GPT-5.4 (Recommended)'
+      name: 'GPT-5.4'
     })
   })
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -63,6 +63,7 @@ export const CLAUDE_MODELS: { id: ClaudeModel; name: string }[] = [
 ]
 
 export enum CodexModel {
+  GPT_5_5 = 'gpt-5.5',
   GPT_5_3_CODEX = 'gpt-5.3-codex',
   GPT_5_2_CODEX = 'gpt-5.2-codex',
   GPT_5_1_CODEX_MAX = 'gpt-5.1-codex-max',
@@ -75,7 +76,8 @@ export enum CodexModel {
 }
 
 export const CODEX_MODELS: { id: CodexModel; name: string }[] = [
-  { id: CodexModel.GPT_5_4, name: 'GPT-5.4 (Recommended)' },
+  { id: CodexModel.GPT_5_5, name: 'GPT-5.5 (Recommended)' },
+  { id: CodexModel.GPT_5_4, name: 'GPT-5.4' },
   { id: CodexModel.GPT_5_3_CODEX, name: 'GPT-5.3 Codex' },
   { id: CodexModel.GPT_5_2_CODEX, name: 'GPT-5.2 Codex' },
   { id: CodexModel.GPT_5_1_CODEX_MAX, name: 'GPT-5.1 Codex Max' },


### PR DESCRIPTION
## Summary
- add gpt-5.5 to the selectable Codex model list and make it the recommended option
- update the Codex adapter default model to gpt-5.5
- bump @zed-industries/codex-acp from ^0.11.1 to ^0.13.0 and refresh the pnpm lockfile
- refresh tests and README support notes for the new Codex defaults

## Test plan
- pnpm view @zed-industries/codex-acp version
- pnpm test:run src/main/adapters/acp-adapter.test.ts
- pnpm test:run src/main/adapters/codex-adapter.test.ts
- pnpm test:run src/renderer/src/types/index.test.ts
- pnpm test:run
- pnpm typecheck
- pnpm build