### PR TITLE
fix: prevent session file cleaning from orphaning tool_results

### DIFF
--- a/src/main/adapters/claude-code-adapter.test.ts
+++ b/src/main/adapters/claude-code-adapter.test.ts
@@ -476,6 +476,171 @@ describe('ClaudeCodeAdapter error result handling', () => {
   })
 })
 
+describe('ClaudeCodeAdapter cleanSessionFile', () => {
+  // Test the core logic of cleanSessionFile: filtering empty text blocks
+  // without removing entire messages that also contain tool_use blocks.
+  //
+  // We test the filtering logic directly with the same algorithm as the
+  // production code, since the method is private and uses filesystem I/O.
+
+  function simulateCleanSessionFile(lines: string[]): string[] {
+    const cleanedLines: string[] = []
+    for (const line of lines) {
+      const entry = JSON.parse(line)
+
+      // Keep non-message entries as-is
+      if (entry.type !== 'user' && entry.type !== 'assistant') {
+        cleanedLines.push(line)
+        continue
+      }
+
+      if (entry.message?.content && Array.isArray(entry.message.content)) {
+        const originalLength = entry.message.content.length
+        const filteredContent = entry.message.content.filter(
+          (contentPart: { type?: string; text?: string }) => {
+            if (!contentPart || typeof contentPart !== 'object') return false
+            if (contentPart.type === 'text' && (!contentPart.text || contentPart.text.trim() === '')) return false
+            return true
+          }
+        )
+
+        if (filteredContent.length === 0) {
+          continue
+        }
+
+        if (filteredContent.length !== originalLength) {
+          entry.message.content = filteredContent
+          cleanedLines.push(JSON.stringify(entry))
+          continue
+        }
+      }
+
+      cleanedLines.push(line)
+    }
+    return cleanedLines
+  }
+
+  it('keeps messages with non-empty text blocks unchanged', () => {
+    const lines = [
+      JSON.stringify({ type: 'assistant', uuid: 'a1', message: { content: [{ type: 'text', text: 'Hello' }] } }),
+    ]
+    const result = simulateCleanSessionFile(lines)
+    expect(result).toHaveLength(1)
+    expect(JSON.parse(result[0]).message.content[0].text).toBe('Hello')
+  })
+
+  it('removes messages where ALL content blocks are empty text', () => {
+    const lines = [
+      JSON.stringify({ type: 'assistant', uuid: 'a1', message: { content: [{ type: 'text', text: '' }] } }),
+    ]
+    const result = simulateCleanSessionFile(lines)
+    expect(result).toHaveLength(0)
+  })
+
+  it('preserves tool_use blocks when filtering out empty text from same message (THE BUG FIX)', () => {
+    // This is the core regression: an assistant message has both an empty text block
+    // AND a tool_use block. The old code removed the ENTIRE message, orphaning the
+    // tool_result in the next user message and causing the Claude CLI to crash.
+    const assistantMsg = {
+      type: 'assistant',
+      uuid: 'a1',
+      message: {
+        id: 'msg_01ABC',
+        content: [
+          { type: 'text', text: '' },
+          { type: 'tool_use', id: 'toolu_01XYZ', name: 'Read', input: { file_path: '/tmp/test' } },
+        ],
+      },
+    }
+    const userMsg = {
+      type: 'user',
+      uuid: 'u1',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'toolu_01XYZ', content: 'file contents' },
+        ],
+      },
+    }
+    const lines = [JSON.stringify(assistantMsg), JSON.stringify(userMsg)]
+    const result = simulateCleanSessionFile(lines)
+
+    // Both messages should be kept
+    expect(result).toHaveLength(2)
+
+    // The assistant message should have the empty text filtered out but tool_use preserved
+    const cleaned = JSON.parse(result[0])
+    expect(cleaned.message.content).toHaveLength(1)
+    expect(cleaned.message.content[0].type).toBe('tool_use')
+    expect(cleaned.message.content[0].id).toBe('toolu_01XYZ')
+
+    // The user message should be unchanged (tool_result still has matching tool_use)
+    const userResult = JSON.parse(result[1])
+    expect(userResult.message.content[0].tool_use_id).toBe('toolu_01XYZ')
+  })
+
+  it('handles messages with multiple empty text blocks and one valid block', () => {
+    const msg = {
+      type: 'assistant',
+      uuid: 'a1',
+      message: {
+        content: [
+          { type: 'text', text: '' },
+          { type: 'text', text: '   ' },
+          { type: 'text', text: 'Valid text' },
+        ],
+      },
+    }
+    const lines = [JSON.stringify(msg)]
+    const result = simulateCleanSessionFile(lines)
+
+    expect(result).toHaveLength(1)
+    const cleaned = JSON.parse(result[0])
+    expect(cleaned.message.content).toHaveLength(1)
+    expect(cleaned.message.content[0].text).toBe('Valid text')
+  })
+
+  it('filters out null/undefined content parts', () => {
+    const msg = {
+      type: 'assistant',
+      uuid: 'a1',
+      message: {
+        content: [
+          null,
+          undefined,
+          { type: 'text', text: 'Valid text' },
+        ],
+      },
+    }
+    const lines = [JSON.stringify(msg)]
+    const result = simulateCleanSessionFile(lines)
+
+    expect(result).toHaveLength(1)
+    const cleaned = JSON.parse(result[0])
+    // null serializes to null in JSON, undefined is omitted from arrays (becomes null)
+    // The filter should remove them
+    expect(cleaned.message.content).toHaveLength(1)
+    expect(cleaned.message.content[0].text).toBe('Valid text')
+  })
+
+  it('preserves non-message entries (queue-operation, etc.)', () => {
+    const lines = [
+      JSON.stringify({ type: 'queue-operation', data: 'something' }),
+      JSON.stringify({ type: 'assistant', uuid: 'a1', message: { content: [{ type: 'text', text: '' }] } }),
+    ]
+    const result = simulateCleanSessionFile(lines)
+    expect(result).toHaveLength(1) // Only the queue-operation survives
+    expect(JSON.parse(result[0]).type).toBe('queue-operation')
+  })
+
+  it('preserves messages without content (no filtering needed)', () => {
+    const lines = [
+      JSON.stringify({ type: 'assistant', uuid: 'a1', message: {} }),
+    ]
+    const result = simulateCleanSessionFile(lines)
+    expect(result).toHaveLength(1)
+  })
+})
+
 describe('Workspace path encoding', () => {
   // The adapter encodes workspace paths the same way Claude Code CLI does:
   // all non-alphanumeric, non-hyphen characters are replaced with hyphens.
@@ -676,6 +841,98 @@ describe('ClaudeCodeAdapter task_progress handling', () => {
     expect(progressUpdate).toBeDefined()
     expect(progressUpdate!.tool!.status).toBe('running')
     expect(progressUpdate!.tool!.title).toContain('15s')
+  })
+})
+
+describe('convertSDKMessageToParts handles undefined/null content blocks', () => {
+  it('skips undefined content blocks in assistant messages without crashing', () => {
+    const adapter = new ClaudeCodeAdapter()
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+
+    // Simulate an assistant message with undefined/null content blocks
+    const msg = {
+      type: 'assistant',
+      uuid: 'msg-1',
+      message: {
+        id: 'msg_01ABC',
+        content: [
+          undefined,
+          null,
+          { type: 'text', text: 'Hello' },
+          undefined,
+          { type: 'tool_use', id: 'toolu_01XYZ', name: 'Read', input: { file_path: '/tmp/test' } },
+        ],
+      },
+    }
+
+    // Should NOT throw — undefined/null blocks are skipped
+    const parts = (adapter as any).convertSDKMessageToParts(msg, seenPartIds, partContentLengths)
+
+    // Only the valid text and tool blocks should be processed
+    const textPart = parts.find((p: any) => p.type === 'text')
+    expect(textPart).toBeDefined()
+    expect(textPart!.text).toBe('Hello')
+
+    const toolPart = parts.find((p: any) => p.type === 'tool')
+    expect(toolPart).toBeDefined()
+    expect(toolPart!.id).toBe('tool-toolu_01XYZ')
+  })
+
+  it('skips undefined content blocks in user messages without crashing', () => {
+    const adapter = new ClaudeCodeAdapter()
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+
+    // First emit a tool_use so the tool_result has something to match
+    const toolUseMsg = {
+      type: 'assistant',
+      uuid: 'msg-1',
+      message: {
+        id: 'msg_01ABC',
+        content: [
+          { type: 'tool_use', id: 'toolu_01XYZ', name: 'Read', input: { file_path: '/tmp/test' } },
+        ],
+      },
+    }
+    ;(adapter as any).convertSDKMessageToParts(toolUseMsg, seenPartIds, partContentLengths)
+
+    const userMsg = {
+      type: 'user',
+      uuid: 'msg-2',
+      message: {
+        content: [
+          undefined,
+          null,
+          { type: 'tool_result', tool_use_id: 'toolu_01XYZ', content: 'file contents here' },
+        ],
+      },
+    }
+
+    // Should NOT throw — undefined/null blocks are skipped
+    const parts = (adapter as any).convertSDKMessageToParts(userMsg, seenPartIds, partContentLengths)
+
+    const toolResultPart = parts.find((p: any) => p.type === 'tool')
+    expect(toolResultPart).toBeDefined()
+    expect(toolResultPart!.tool!.status).toBe('success')
+  })
+
+  it('handles content array with all undefined/null entries', () => {
+    const adapter = new ClaudeCodeAdapter()
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+
+    const msg = {
+      type: 'assistant',
+      uuid: 'msg-1',
+      message: {
+        id: 'msg_01ALL_NULL',
+        content: [undefined, null, undefined],
+      },
+    }
+
+    const parts = (adapter as any).convertSDKMessageToParts(msg, seenPartIds, partContentLengths)
+    expect(parts).toHaveLength(0)
   })
 })
 

--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -363,19 +363,36 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
           continue
         }
 
-        // Check if message has content with empty text blocks
-        if (entry.message?.content) {
-          let hasEmptyText = false
-          for (const contentPart of entry.message.content) {
-            if (contentPart.type === 'text' && (!contentPart.text || contentPart.text.trim() === '')) {
-              hasEmptyText = true
-              break
+        // Filter out empty text blocks from message content.
+        // IMPORTANT: Only remove the empty text blocks themselves, NOT the entire message.
+        // Assistant messages often have both an empty text block AND tool_use blocks.
+        // Removing the entire message would orphan the corresponding tool_result in the
+        // next user message, causing the Claude CLI to crash with
+        // "undefined is not an object (evaluating 'A.type')" when it tries to look up
+        // the missing tool_use.
+        if (entry.message?.content && Array.isArray(entry.message.content)) {
+          const originalLength = entry.message.content.length
+          const filteredContent = entry.message.content.filter(
+            (contentPart: { type?: string; text?: string }) => {
+              // Remove undefined/null content parts
+              if (!contentPart || typeof contentPart !== 'object') return false
+              // Remove empty text blocks
+              if (contentPart.type === 'text' && (!contentPart.text || contentPart.text.trim() === '')) return false
+              return true
             }
+          )
+
+          // If all content blocks were removed, skip the entire message
+          if (filteredContent.length === 0) {
+            console.log(`[ClaudeCodeAdapter] Removing fully empty message: ${entry.uuid}`)
+            continue
           }
 
-          // Skip messages with empty text blocks
-          if (hasEmptyText) {
-            console.log(`[ClaudeCodeAdapter] Removing message with empty text block: ${entry.uuid}`)
+          // If some blocks were filtered, re-serialize the message with the filtered content
+          if (filteredContent.length !== originalLength) {
+            entry.message.content = filteredContent
+            console.log(`[ClaudeCodeAdapter] Filtered ${originalLength - filteredContent.length} empty text block(s) from message: ${entry.uuid} (kept ${filteredContent.length} block(s))`)
+            cleanedLines.push(JSON.stringify(entry))
             continue
           }
         }
@@ -438,6 +455,8 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
         if (entry.message?.content) {
           for (let blockIdx = 0; blockIdx < entry.message.content.length; blockIdx++) {
             const contentPart = entry.message.content[blockIdx]
+            // Guard against undefined/null content parts (can happen with corrupted session files)
+            if (!contentPart || typeof contentPart !== 'object') continue
             if (contentPart.type === 'text') {
               // Skip empty text blocks (corrupt messages)
               if (!contentPart.text || contentPart.text.trim() === '') continue
@@ -1211,6 +1230,9 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
 
       for (let blockIdx = 0; blockIdx < content.length; blockIdx++) {
         const block = content[blockIdx]
+        // Guard against undefined/null content blocks (can happen during stream
+        // processing, lock acquisition failures, or SDK bugs)
+        if (!block || typeof block !== 'object') continue
         const blockWithProps = block as { type?: string; text?: string; name?: string; input?: unknown; id?: string }
         // For text blocks (no id), use stable message ID + block index for consistent dedup.
         // For tool_use blocks, blockWithProps.id is the tool_use_id which is already stable.
@@ -1329,6 +1351,8 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
       const content = msgWithProps.message?.content || (Array.isArray(msgWithProps.content) ? msgWithProps.content : [])
 
       for (const block of content) {
+        // Guard against undefined/null content blocks
+        if (!block || typeof block !== 'object') continue
         const blockWithProps = block as {
           type?: string
           tool_use_id?: string


### PR DESCRIPTION
## Summary
- **Root cause**: `cleanSessionFile` was removing entire messages that contained empty text blocks, even when those messages also had `tool_use` blocks. This created orphaned `tool_result` entries in subsequent user messages, causing the Claude CLI to crash with `undefined is not an object (evaluating 'A.type')` when it tried to look up the missing `tool_use`.
- **Fix**: Changed `cleanSessionFile` to filter out only the empty text blocks from content arrays (keeping `tool_use` blocks intact), instead of removing the entire message. Only removes a message entirely if ALL content blocks are filtered out.
- **Defensive guards**: Added null/undefined guards in `loadSessionHistory` and `convertSDKMessageToParts` to prevent crashes when content arrays contain undefined entries (can happen during stream processing, lock acquisition failures, or SDK bugs).

## Test plan
- [x] Added 10 new unit tests covering the fix and edge cases
- [x] All 1287 tests pass (88 test files)
- [x] TypeScript build passes (`tsc --build --noEmit`)
- [ ] CI pipeline passes
- [ ] Manual test: start 20X session, chat in terminal, verify no `A.type` crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)