### PR TITLE
feat: auto-run support for subtasks

### DIFF
--- a/src/renderer/src/hooks/use-agent-auto-start.test.tsx
+++ b/src/renderer/src/hooks/use-agent-auto-start.test.tsx
@@ -88,6 +88,7 @@ describe('useAgentAutoStart', () => {
   })
 
   afterEach(() => {
+    vi.clearAllTimers()
     vi.useRealTimers()
   })
 
@@ -248,5 +249,382 @@ describe('useAgentAutoStart', () => {
         [assignedAgent.id, task.id, undefined, undefined]
       ])
     )
+  })
+
+  // ── Subtask auto-run tests ──
+
+  it('does not auto-start parent tasks that have subtasks', async () => {
+    const parentTask = makeTask({
+      id: 'parent-1',
+      title: 'Parent task',
+      agent_id: 'agent-1',
+      status: TaskStatus.NotStarted
+    })
+    const subtask = makeTask({
+      id: 'sub-1',
+      title: 'Subtask 1',
+      parent_task_id: 'parent-1',
+      agent_id: 'agent-1',
+      sort_order: 0,
+      status: TaskStatus.NotStarted
+    })
+    const agent = makeAgent({ id: 'agent-1', is_default: true })
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [parentTask, subtask],
+        agents: [agent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    // Should start the first subtask, NOT the parent
+    const startCalls = (mockElectronAPI.agentSession.start as unknown as Mock).mock.calls
+    const startedTaskIds = startCalls.map((call: unknown[]) => call[1])
+    expect(startedTaskIds).toContain('sub-1')
+    expect(startedTaskIds).not.toContain('parent-1')
+  })
+
+  it('does not triage subtasks independently', async () => {
+    const parentTask = makeTask({
+      id: 'parent-notriage',
+      title: 'Parent task',
+      agent_id: 'agent-notriage',
+      status: TaskStatus.AgentWorking
+    })
+    const subtask = makeTask({
+      id: 'sub-notriage',
+      title: 'Subtask without agent',
+      parent_task_id: 'parent-notriage',
+      agent_id: null,
+      sort_order: 0,
+      status: TaskStatus.NotStarted
+    })
+    const agent = makeAgent({ id: 'agent-notriage', is_default: true })
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [parentTask, subtask],
+        agents: [agent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    // Should NOT triage the subtask (parent_task_id is set)
+    expect(mockElectronAPI.db.updateTask).not.toHaveBeenCalledWith('sub-notriage', { status: TaskStatus.Triaging })
+    // Subtask should not be started (no agent_id and parent is already working)
+    const startCalls = (mockElectronAPI.agentSession.start as unknown as Mock).mock.calls
+    const subtaskStartCalls = startCalls.filter((call: unknown[]) => call[1] === 'sub-notriage')
+    expect(subtaskStartCalls).toHaveLength(0)
+  })
+
+  it('only starts first subtask when multiple subtasks are not_started', async () => {
+    const parentTask = makeTask({
+      id: 'parent-1',
+      title: 'Parent task',
+      agent_id: 'agent-1',
+      status: TaskStatus.NotStarted
+    })
+    const subtask1 = makeTask({
+      id: 'sub-1',
+      title: 'Subtask 1',
+      parent_task_id: 'parent-1',
+      agent_id: 'agent-1',
+      sort_order: 0,
+      status: TaskStatus.NotStarted
+    })
+    const subtask2 = makeTask({
+      id: 'sub-2',
+      title: 'Subtask 2',
+      parent_task_id: 'parent-1',
+      agent_id: 'agent-1',
+      sort_order: 1,
+      status: TaskStatus.NotStarted
+    })
+    const agent = makeAgent({ id: 'agent-1', is_default: true })
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [parentTask, subtask1, subtask2],
+        agents: [agent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    // Should only start subtask 1, not subtask 2
+    const startCalls = (mockElectronAPI.agentSession.start as unknown as Mock).mock.calls
+    const startedTaskIds = startCalls.map((call: unknown[]) => call[1])
+    expect(startedTaskIds).toContain('sub-1')
+    expect(startedTaskIds).not.toContain('sub-2')
+  })
+
+  it('does not start next subtask while sibling is in ReadyForReview', async () => {
+    const parentTask = makeTask({
+      id: 'parent-1',
+      title: 'Parent task',
+      agent_id: 'agent-1',
+      status: TaskStatus.NotStarted
+    })
+    const subtask1 = makeTask({
+      id: 'sub-1',
+      title: 'Subtask 1',
+      parent_task_id: 'parent-1',
+      agent_id: 'agent-1',
+      sort_order: 0,
+      status: TaskStatus.ReadyForReview
+    })
+    const subtask2 = makeTask({
+      id: 'sub-2',
+      title: 'Subtask 2',
+      parent_task_id: 'parent-1',
+      agent_id: 'agent-1',
+      sort_order: 1,
+      status: TaskStatus.NotStarted
+    })
+    const agent = makeAgent({ id: 'agent-1', is_default: true })
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [parentTask, subtask1, subtask2],
+        agents: [agent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    // Should NOT start subtask 2 — subtask 1 is still in ReadyForReview
+    const startCalls = (mockElectronAPI.agentSession.start as unknown as Mock).mock.calls
+    const sub2StartCalls = startCalls.filter((call: unknown[]) => call[1] === 'sub-2')
+    expect(sub2StartCalls).toHaveLength(0)
+  })
+
+  it('starts first subtask instead of parent after triage creates subtasks', async () => {
+    const task = makeTask({ id: 'task-3', title: 'Complex task' })
+    const triageAgent = makeAgent({ id: 'agent-triage', is_default: true, name: 'Triage Agent' })
+    const subtaskAgent = makeAgent({ id: 'agent-sub', is_default: false, name: 'Subtask Agent' })
+
+    // After triage: task has agent_id and subtasks
+    ;(mockElectronAPI.db.getTask as unknown as Mock).mockResolvedValue({
+      ...task,
+      status: TaskStatus.NotStarted,
+      agent_id: subtaskAgent.id
+    })
+
+    // Triage created subtasks
+    const subtasks = [
+      makeTask({
+        id: 'sub-1',
+        title: 'Step 1',
+        parent_task_id: 'task-3',
+        agent_id: 'agent-sub',
+        sort_order: 0,
+        status: TaskStatus.NotStarted
+      }),
+      makeTask({
+        id: 'sub-2',
+        title: 'Step 2',
+        parent_task_id: 'task-3',
+        agent_id: 'agent-sub',
+        sort_order: 1,
+        status: TaskStatus.NotStarted
+      })
+    ]
+    ;(mockElectronAPI.db.getSubtasks as unknown as Mock).mockResolvedValue(subtasks)
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [task],
+        agents: [triageAgent, subtaskAgent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    // Trigger triage
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    expect(mockElectronAPI.agentSession.start).toHaveBeenCalledWith(triageAgent.id, task.id, undefined, undefined)
+
+    // Complete triage → agent goes idle
+    await act(async () => {
+      getLatestAgentStatusCallback()?.({
+        sessionId: 'triage-session',
+        agentId: triageAgent.id,
+        taskId: task.id,
+        status: SessionStatus.IDLE
+      })
+      vi.advanceTimersByTime(600)
+      await Promise.resolve()
+    })
+
+    // Should start the first subtask, NOT the parent task
+    const startCalls = (mockElectronAPI.agentSession.start as unknown as Mock).mock.calls
+    const startedTaskIds = startCalls.map((call: unknown[]) => call[1])
+    expect(startedTaskIds).toContain('sub-1')
+    // Parent task should NOT be started directly
+    const parentStartCalls = startCalls.filter((call: unknown[]) => call[0] === subtaskAgent.id && call[1] === task.id)
+    expect(parentStartCalls).toHaveLength(0)
+  })
+
+  it('starts next subtask when previous subtask is completed via task update', async () => {
+    const parentTask = makeTask({
+      id: 'parent-next',
+      title: 'Parent task',
+      agent_id: 'agent-next',
+      status: TaskStatus.NotStarted
+    })
+    // Start with subtask1 in ReadyForReview — prevents subtask2 from auto-starting initially
+    const subtask1 = makeTask({
+      id: 'sub-next-1',
+      title: 'Subtask 1',
+      parent_task_id: 'parent-next',
+      agent_id: 'agent-next',
+      sort_order: 0,
+      status: TaskStatus.ReadyForReview
+    })
+    const subtask2 = makeTask({
+      id: 'sub-next-2',
+      title: 'Subtask 2',
+      parent_task_id: 'parent-next',
+      agent_id: 'agent-next',
+      sort_order: 1,
+      status: TaskStatus.NotStarted
+    })
+    const agent = makeAgent({ id: 'agent-next', is_default: true })
+
+    // When startNextSubtask fetches subtasks, return them with sub1 now completed
+    ;(mockElectronAPI.db.getSubtasks as unknown as Mock).mockResolvedValue([
+      { ...subtask1, status: TaskStatus.Completed },
+      subtask2
+    ])
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [parentTask, subtask1, subtask2],
+        agents: [agent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    // Wait for initial render + debounce — subtask2 should NOT be started (sibling in ReadyForReview)
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    // Verify subtask2 was not started during initial check
+    const initialStartCalls = (mockElectronAPI.agentSession.start as unknown as Mock).mock.calls
+    expect(initialStartCalls.filter((c: unknown[]) => c[1] === 'sub-next-2')).toHaveLength(0)
+
+    ;(mockElectronAPI.agentSession.start as unknown as Mock).mockClear()
+
+    // Get the onTaskUpdated callback
+    const taskUpdatedCalls = (mockElectronAPI.onTaskUpdated as unknown as Mock).mock.calls
+    const latestTaskUpdatedCb = taskUpdatedCalls[taskUpdatedCalls.length - 1]?.[0]
+    expect(latestTaskUpdatedCb).toBeDefined()
+
+    // Simulate subtask 1 being completed → triggers startNextSubtask via 300ms setTimeout
+    await act(async () => {
+      latestTaskUpdatedCb?.({
+        taskId: 'sub-next-1',
+        updates: { status: TaskStatus.Completed }
+      })
+      // Advance past the 300ms setTimeout and flush async chain
+      await vi.advanceTimersByTimeAsync(400)
+    })
+
+    // Should start subtask 2 after subtask 1 is completed
+    const startCalls = (mockElectronAPI.agentSession.start as unknown as Mock).mock.calls
+    const startedTaskIds = startCalls.map((call: unknown[]) => call[1])
+    expect(startedTaskIds).toContain('sub-next-2')
+  })
+
+  it('marks parent as ready for review when all subtasks are completed', async () => {
+    const parentTask = makeTask({
+      id: 'parent-1',
+      title: 'Parent task',
+      agent_id: 'agent-1',
+      status: TaskStatus.NotStarted
+    })
+    const subtask1 = makeTask({
+      id: 'sub-1',
+      title: 'Subtask 1',
+      parent_task_id: 'parent-1',
+      agent_id: 'agent-1',
+      sort_order: 0,
+      status: TaskStatus.Completed
+    })
+    const subtask2 = makeTask({
+      id: 'sub-2',
+      title: 'Subtask 2',
+      parent_task_id: 'parent-1',
+      agent_id: 'agent-1',
+      sort_order: 1,
+      status: TaskStatus.Completed
+    })
+    const agent = makeAgent({ id: 'agent-1', is_default: true })
+
+    // All subtasks completed
+    ;(mockElectronAPI.db.getSubtasks as unknown as Mock).mockResolvedValue([subtask1, subtask2])
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [parentTask, subtask1, subtask2],
+        agents: [agent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    ;(mockElectronAPI.db.updateTask as unknown as Mock).mockClear()
+
+    // Get the onTaskUpdated callback
+    const taskUpdatedCalls = (mockElectronAPI.onTaskUpdated as unknown as Mock).mock.calls
+    const latestTaskUpdatedCb = taskUpdatedCalls[taskUpdatedCalls.length - 1]?.[0]
+
+    // Simulate the last subtask being completed
+    await act(async () => {
+      latestTaskUpdatedCb?.({
+        taskId: 'sub-2',
+        updates: { status: TaskStatus.Completed }
+      })
+      vi.advanceTimersByTime(400)
+      await Promise.resolve()
+    })
+
+    // Should mark parent as ReadyForReview
+    expect(mockElectronAPI.db.updateTask).toHaveBeenCalledWith('parent-1', { status: TaskStatus.ReadyForReview })
   })
 })

--- a/src/renderer/src/hooks/use-agent-auto-start.ts
+++ b/src/renderer/src/hooks/use-agent-auto-start.ts
@@ -47,6 +47,9 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
   // Track triage attempts per task to prevent infinite retry
   const triageAttemptsRef = useRef<Map<string, number>>(new Map())
 
+  // Track parent tasks currently launching a subtask to prevent duplicate launches
+  const launchingSubtaskForRef = useRef<Set<string>>(new Set())
+
   // Helper: Check if task is snoozed
   const isSnoozed = useCallback((snoozedUntil: string | null): boolean => {
     if (!snoozedUntil) return false
@@ -58,6 +61,86 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
     return task.is_recurring && !task.recurrence_parent_id
   }, [])
 
+  // Helper: Start the next eligible subtask for a parent task.
+  // Fetches fresh subtask data from DB, enforces sequential execution,
+  // and marks parent as ReadyForReview when all subtasks are completed.
+  const startNextSubtask = useCallback(
+    async (parentId: string) => {
+      // Prevent concurrent launches for the same parent
+      if (launchingSubtaskForRef.current.has(parentId)) {
+        console.log(`[AutoStart] Already launching subtask for parent ${parentId}, skipping`)
+        return
+      }
+      launchingSubtaskForRef.current.add(parentId)
+
+      try {
+        const subtasks = await taskApi.getSubtasks(parentId)
+        const sorted = subtasks.sort(
+          (a: WorkfloTask, b: WorkfloTask) => (a.sort_order ?? 0) - (b.sort_order ?? 0)
+        )
+
+        if (sorted.length === 0) return
+
+        // Check if all subtasks are completed → mark parent as ready for review
+        if (sorted.every((s: WorkfloTask) => s.status === TaskStatus.Completed)) {
+          console.log(`[AutoStart] All subtasks completed for parent ${parentId}, marking parent as ready for review`)
+          await taskApi.update(parentId, { status: TaskStatus.ReadyForReview })
+          return
+        }
+
+        // If any subtask is currently active (working/review/triaging/learning), wait
+        const hasActive = sorted.some(
+          (s: WorkfloTask) =>
+            s.status === TaskStatus.AgentWorking ||
+            s.status === TaskStatus.ReadyForReview ||
+            s.status === TaskStatus.Triaging ||
+            s.status === TaskStatus.AgentLearning
+        )
+        if (hasActive) {
+          console.log(`[AutoStart] A subtask is still active for parent ${parentId}, waiting`)
+          return
+        }
+
+        // Find next not_started subtask with an assigned agent
+        const nextSubtask = sorted.find(
+          (s: WorkfloTask) => s.status === TaskStatus.NotStarted && !!s.agent_id
+        )
+        if (!nextSubtask || !nextSubtask.agent_id) {
+          console.log(`[AutoStart] No eligible next subtask for parent ${parentId}`)
+          return
+        }
+
+        const subtaskAgent = agents.find((a) => a.id === nextSubtask.agent_id)
+        if (!subtaskAgent) {
+          console.log(`[AutoStart] Agent ${nextSubtask.agent_id} not found for subtask ${nextSubtask.id}`)
+          return
+        }
+
+        console.log(`[AutoStart] Starting next subtask "${nextSubtask.title}" (${nextSubtask.id}) for parent ${parentId}`)
+        const maxParallel = subtaskAgent.config.max_parallel_sessions || 1
+        const currentRunning = getRunningCount(nextSubtask.agent_id)
+        if (currentRunning < maxParallel) {
+          incrementRunningCount(nextSubtask.agent_id)
+          try {
+            await start(nextSubtask.agent_id, nextSubtask.id)
+            showToast(`Started subtask "${nextSubtask.title}" with ${subtaskAgent.name}`)
+          } catch (error) {
+            console.error(`[AutoStart] Failed to start subtask ${nextSubtask.id}:`, error)
+            decrementRunningCount(nextSubtask.agent_id)
+          }
+        } else {
+          addToQueue(nextSubtask.agent_id, nextSubtask.id)
+        }
+      } catch (error) {
+        console.error(`[AutoStart] startNextSubtask error for parent ${parentId}:`, error)
+      } finally {
+        // Remove lock after a delay to allow status propagation
+        setTimeout(() => launchingSubtaskForRef.current.delete(parentId), 2000)
+      }
+    },
+    [agents, getRunningCount, incrementRunningCount, start, showToast, decrementRunningCount, addToQueue]
+  )
+
   // Helper: Select triage candidates (tasks with no agent_id that need triage)
   const selectTriageCandidates = useCallback(
     (allTasks: WorkfloTask[], allSessions: Map<string, TaskSession>): string[] => {
@@ -65,6 +148,9 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
         .filter((task) => {
           // Skip recurring parent template tasks — they are templates, not actionable tasks
           if (isRecurringTemplate(task)) return false
+
+          // Skip subtasks — they are managed by sequential subtask orchestration
+          if (task.parent_task_id) return false
 
           const isNotStarted = task.status === TaskStatus.NotStarted
           const hasNoAgent = !task.agent_id
@@ -134,6 +220,41 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
       allTasks.forEach((task) => {
         // Skip recurring parent template tasks — they are templates, not actionable tasks
         if (isRecurringTemplate(task)) return
+
+        // Skip parent tasks that have subtasks — subtasks will run sequentially instead
+        const hasChildren = allTasks.some((t) => t.parent_task_id === task.id)
+        if (hasChildren) {
+          console.log(`[AutoStart] Task "${task.title}" skipped: has subtasks (will run sequentially)`)
+          return
+        }
+
+        // For subtasks, enforce sequential execution within parent
+        if (task.parent_task_id) {
+          const siblings = allTasks
+            .filter((t) => t.parent_task_id === task.parent_task_id)
+            .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
+
+          // Don't start if any sibling is actively being worked on or awaiting review
+          const hasActiveSibling = siblings.some(
+            (s) =>
+              s.id !== task.id &&
+              (s.status === TaskStatus.AgentWorking ||
+                s.status === TaskStatus.ReadyForReview ||
+                s.status === TaskStatus.Triaging ||
+                s.status === TaskStatus.AgentLearning)
+          )
+          if (hasActiveSibling) {
+            console.log(`[AutoStart] Subtask "${task.title}" skipped: sibling is still active`)
+            return
+          }
+
+          // Only start if this is the first not-started subtask (by sort_order)
+          const firstNotStarted = siblings.find((s) => s.status === TaskStatus.NotStarted)
+          if (firstNotStarted && firstNotStarted.id !== task.id) {
+            console.log(`[AutoStart] Subtask "${task.title}" skipped: not next in sequence`)
+            return
+          }
+        }
 
         // Log why tasks are excluded
         const isNotStarted = task.status === TaskStatus.NotStarted
@@ -249,6 +370,31 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
         return
       }
 
+      // For subtasks, enforce sequential execution within parent
+      if (task.parent_task_id) {
+        const siblings = tasks.filter((t) => t.parent_task_id === task.parent_task_id)
+        const hasActiveSibling = siblings.some(
+          (s) =>
+            s.id !== task.id &&
+            (s.status === TaskStatus.AgentWorking ||
+              s.status === TaskStatus.ReadyForReview ||
+              s.status === TaskStatus.Triaging ||
+              s.status === TaskStatus.AgentLearning)
+        )
+        if (hasActiveSibling) {
+          // Keep in queue — will be started when sibling completes
+          console.log(`[AutoStart] Subtask "${task.title}" deferred: sibling still active`)
+          return
+        }
+
+        const sortedSiblings = siblings.sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0))
+        const firstNotStarted = sortedSiblings.find((s) => s.status === TaskStatus.NotStarted)
+        if (firstNotStarted && firstNotStarted.id !== task.id) {
+          removeFromQueue(agentId, nextTaskId)
+          return
+        }
+      }
+
       // Start the task
       try {
         removeFromQueue(agentId, nextTaskId)
@@ -360,6 +506,14 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
             // Clean up attempts on success
             triageAttemptsRef.current.delete(taskId)
 
+            // Check if triage created subtasks — if so, start first subtask instead of parent
+            const subtasks = await taskApi.getSubtasks(taskId)
+            if (subtasks.length > 0) {
+              console.log(`[AutoStart] Triage created ${subtasks.length} subtask(s) for "${updatedTask.title}", starting first subtask`)
+              await startNextSubtask(taskId)
+              return
+            }
+
             const assignedAgentId = updatedTask.agent_id
             const assignedAgent = agents.find((a) => a.id === assignedAgentId)
             if (!assignedAgent) {
@@ -401,7 +555,7 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
     })
 
     return unsubscribe
-  }, [isEnabled, tasks, agents, decrementRunningCount, showToast, processNextTask, getRunningCount, addToQueue, startTasksForAgent])
+  }, [isEnabled, tasks, agents, decrementRunningCount, showToast, processNextTask, getRunningCount, addToQueue, startTasksForAgent, startNextSubtask])
 
   // Listen to new task creation — trigger triage for tasks with no agent_id
   useEffect(() => {
@@ -411,6 +565,8 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
       const task = event.task as WorkfloTask
       // Skip recurring parent template tasks
       if (task.is_recurring && !task.recurrence_parent_id) return
+      // Skip subtasks — they are managed by sequential subtask orchestration
+      if (task.parent_task_id) return
       if (
         task.status === TaskStatus.NotStarted &&
         !task.agent_id &&
@@ -446,6 +602,13 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
       // Skip recurring parent template tasks
       if (task.is_recurring && !task.recurrence_parent_id) return
 
+      // Handle subtask completion — trigger next subtask or mark parent as done
+      if (task.parent_task_id && task.status === TaskStatus.Completed) {
+        console.log(`[AutoStart] Subtask "${task.title}" completed, checking for next subtask`)
+        setTimeout(() => startNextSubtask(task.parent_task_id!), 300)
+        return
+      }
+
       // Check if task is eligible for auto-start (has agent_id)
       if (
         task.status === TaskStatus.NotStarted &&
@@ -453,22 +616,35 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
         !isSnoozed(task.snoozed_until) &&
         !sessions.has(task.id)
       ) {
+        // Skip if task is being handled by triage completion (avoids race condition)
+        if (triagingRef.current.has(task.id)) return
+
         const agentId = task.agent_id
         const agent = agents.find((a) => a.id === agentId)
         if (!agent) return
 
-        const maxParallel = agent.config.max_parallel_sessions || 1
-        const currentRunning = getRunningCount(agentId)
+        // Check if this parent task has subtasks — start first subtask instead
+        setTimeout(async () => {
+          try {
+            const subtasks = await taskApi.getSubtasks(task.id)
+            if (subtasks.length > 0) {
+              console.log(`[AutoStart] Task "${task.title}" has ${subtasks.length} subtask(s), starting first subtask instead`)
+              await startNextSubtask(task.id)
+              return
+            }
+          } catch {
+            // If subtask check fails, proceed with normal start
+          }
 
-        if (currentRunning < maxParallel) {
-          // Start immediately
-          setTimeout(() => {
+          const maxParallel = agent.config.max_parallel_sessions || 1
+          const currentRunning = getRunningCount(agentId)
+
+          if (currentRunning < maxParallel) {
             startTasksForAgent(agentId, [task.id], agent)
-          }, 100)
-        } else {
-          // Add to queue
-          addToQueue(agentId, task.id)
-        }
+          } else {
+            addToQueue(agentId, task.id)
+          }
+        }, 100)
       }
 
       // Check if task needs triage (no agent_id, not_started)
@@ -480,6 +656,8 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
         !triagingRef.current.has(task.id) &&
         (triageAttemptsRef.current.get(task.id) || 0) < MAX_TRIAGE_ATTEMPTS
       ) {
+        // Skip subtasks — they don't need independent triage
+        if (task.parent_task_id) return
         setTimeout(() => startTriage(task.id), 200)
       }
     })
@@ -494,7 +672,8 @@ export function useAgentAutoStart({ tasks, agents, sessions, showToast }: UseAge
     getRunningCount,
     addToQueue,
     startTasksForAgent,
-    startTriage
+    startTriage,
+    startNextSubtask
   ])
 
   // Clear queues when disabled


### PR DESCRIPTION
## Summary
- When a triage agent creates subtasks for a parent task, the system now skips executing the parent and instead launches subtasks sequentially by `sort_order`
- When each subtask completes, the next one starts automatically; when all subtasks finish, the parent task is marked as ReadyForReview
- Subtasks are excluded from independent triage and auto-start — they are fully managed by the sequential orchestration in `startNextSubtask()`

## Changes
- **`use-agent-auto-start.ts`**: Added `startNextSubtask()` helper, modified `selectTriageCandidates`, `selectEligibleTasks`, `processNextTask`, `onTaskUpdated`, `onTaskCreated`, and triage completion handler
- **`use-agent-auto-start.test.tsx`**: Added 7 new tests covering subtask skip, sequential execution, triage→subtask flow, completion chaining, and parent ready-for-review

## Test plan
- [x] All 12 unit tests pass (including 7 new subtask tests)
- [x] Full renderer test suite passes (462 tests, 37 files)
- [x] TypeScript type check passes (`tsc --build --noEmit`)
- [ ] CI pipeline passes
- [ ] Manual verification: create task with subtasks, verify sequential execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)