### PR TITLE
fix: improve canvas transcript selection and task navigation

### DIFF
--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -360,7 +360,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       onMouseDown={handleMouseDown}
       onMouseEnter={handlePanelMouseEnter}
       onMouseLeave={handlePanelMouseLeave}
-      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col select-none transition-shadow duration-150 group/panel ${cfg.border} ${
+      className={`absolute rounded-xl border bg-[#1a2030] shadow-2xl flex flex-col transition-shadow duration-150 group/panel ${cfg.border} ${
         isDragging ? 'shadow-indigo-500/10 ring-1 ring-indigo-500/30' : ''
       } ${isConnectingLocal ? 'ring-2 ring-orange-500/50' : ''} ${
         isProximityTarget ? 'ring-2 ring-orange-500/60 shadow-orange-500/20 shadow-2xl' : ''
@@ -379,7 +379,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       <div className="flex flex-col flex-1 min-h-0 overflow-hidden rounded-[11px]">
       {/* Title bar — drag handle */}
       <div
-        className={`flex items-center gap-2 px-3 py-2 border-b border-border/40 flex-shrink-0 cursor-grab active:cursor-grabbing group ${cfg.bg}`}
+        className={`flex items-center gap-2 px-3 py-2 border-b border-border/40 flex-shrink-0 cursor-grab active:cursor-grabbing group select-none ${cfg.bg}`}
         onMouseDown={handleDragStart}
       >
         <span
@@ -571,7 +571,7 @@ interface PanelContentProps {
 
 const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, title, taskLayout, browserSessionId, streamPort }: PanelContentProps) {
   if (type === 'task' && refId) {
-    return <TaskPanelContent taskId={refId} panelLayout={taskLayout} />
+    return <TaskPanelContent panelId={id} taskId={refId} panelLayout={taskLayout} />
   }
   if (type === 'transcript' && refId) {
     return <TranscriptPanelContent taskId={refId} />

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -178,4 +178,21 @@ describe('InfiniteCanvas', () => {
     expect(screen.getByTitle('Collapse')).toBeTruthy()
     expect(screen.getByTitle('Close panel')).toBeTruthy()
   })
+
+  it('keeps canvas content selectable inside panels', () => {
+    useCanvasStore.getState().addPanel({
+      type: 'task',
+      title: 'Selectable Panel',
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 300,
+    })
+
+    const { container } = render(<InfiniteCanvas />)
+    const panel = container.querySelector('[data-canvas-panel="true"]')
+
+    expect(panel).toBeTruthy()
+    expect(panel?.className).not.toContain('select-none')
+  })
 })

--- a/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
@@ -2,34 +2,35 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { TaskPanelContent } from './TaskPanelContent'
 
-const updatePanelMock = vi.fn()
-const selectTaskMock = vi.fn()
-const updateTaskMock = vi.fn()
-
-const taskList = [
-  {
-    id: 'task-1',
-    title: 'Current Task',
-    parent_task_id: null,
-    output_fields: [],
-    source_id: null,
-    repos: [],
-    priority: 'medium',
-    type: 'general',
-    attachments: [],
-  },
-  {
-    id: 'child-1',
-    title: 'Child Task',
-    parent_task_id: 'task-1',
-    output_fields: [],
-    source_id: null,
-    repos: [],
-    priority: 'medium',
-    type: 'general',
-    attachments: [],
-  },
-]
+const { updatePanelMock, selectTaskMock, updateTaskMock, taskList } = vi.hoisted(() => ({
+  updatePanelMock: vi.fn(),
+  selectTaskMock: vi.fn(),
+  updateTaskMock: vi.fn(),
+  taskList: [
+    {
+      id: 'task-1',
+      title: 'Current Task',
+      parent_task_id: null,
+      output_fields: [],
+      source_id: null,
+      repos: [],
+      priority: 'medium',
+      type: 'general',
+      attachments: [],
+    },
+    {
+      id: 'child-1',
+      title: 'Child Task',
+      parent_task_id: 'task-1',
+      output_fields: [],
+      source_id: null,
+      repos: [],
+      priority: 'medium',
+      type: 'general',
+      attachments: [],
+    },
+  ],
+}))
 
 vi.mock('@/components/tasks/TaskWorkspace', () => ({
   TaskWorkspace: ({ onNavigateToTask }: { onNavigateToTask?: (taskId: string) => void }) => (

--- a/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { TaskPanelContent } from './TaskPanelContent'
+
+const updatePanelMock = vi.fn()
+const selectTaskMock = vi.fn()
+const updateTaskMock = vi.fn()
+
+const taskList = [
+  {
+    id: 'task-1',
+    title: 'Current Task',
+    parent_task_id: null,
+    output_fields: [],
+    source_id: null,
+    repos: [],
+    priority: 'medium',
+    type: 'general',
+    attachments: [],
+  },
+  {
+    id: 'child-1',
+    title: 'Child Task',
+    parent_task_id: 'task-1',
+    output_fields: [],
+    source_id: null,
+    repos: [],
+    priority: 'medium',
+    type: 'general',
+    attachments: [],
+  },
+]
+
+vi.mock('@/components/tasks/TaskWorkspace', () => ({
+  TaskWorkspace: ({ onNavigateToTask }: { onNavigateToTask?: (taskId: string) => void }) => (
+    <button type="button" onClick={() => onNavigateToTask?.('child-1')}>
+      Navigate to child
+    </button>
+  ),
+}))
+
+vi.mock('@/stores/canvas-store', () => ({
+  useCanvasStore: (selector: (state: { updatePanel: typeof updatePanelMock }) => unknown) =>
+    selector({ updatePanel: updatePanelMock }),
+}))
+
+vi.mock('@/stores/task-store', () => {
+  const state = {
+    tasks: taskList,
+    updateTask: updateTaskMock,
+  }
+
+  const useTaskStore = (selector: (value: typeof state) => unknown) => selector(state)
+  useTaskStore.getState = () => ({
+    tasks: taskList,
+    selectTask: selectTaskMock,
+  })
+
+  return { useTaskStore }
+})
+
+vi.mock('@/stores/agent-store', () => ({
+  useAgentStore: (selector: (state: { agents: never[] }) => unknown) => selector({ agents: [] }),
+}))
+
+vi.mock('@/stores/ui-store', () => ({
+  useUIStore: () => ({
+    openEditModal: vi.fn(),
+    openDeleteModal: vi.fn(),
+  }),
+}))
+
+vi.mock('@/stores/task-source-store', () => ({
+  useTaskSourceStore: () => ({
+    executeAction: vi.fn(),
+  }),
+}))
+
+describe('TaskPanelContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('retargets the current canvas panel when navigating to another task', () => {
+    render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
+
+    fireEvent.click(screen.getByText('Navigate to child'))
+
+    expect(updatePanelMock).toHaveBeenCalledWith('panel-1', {
+      refId: 'child-1',
+      title: 'Child Task',
+    })
+    expect(selectTaskMock).toHaveBeenCalledWith('child-1')
+  })
+})

--- a/src/renderer/src/components/canvas/TaskPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { TaskWorkspace, type TaskWorkspaceLayout } from '@/components/tasks/TaskWorkspace'
+import { useCanvasStore } from '@/stores/canvas-store'
 import { useTaskStore } from '@/stores/task-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useUIStore } from '@/stores/ui-store'
@@ -8,6 +9,7 @@ import { TaskStatus, PluginActionId } from '@/types'
 import type { FileAttachment } from '@/types'
 
 interface TaskPanelContentProps {
+  panelId: string
   taskId: string
   /** Controlled layout from CanvasPanel title bar */
   panelLayout?: TaskWorkspaceLayout
@@ -17,10 +19,11 @@ interface TaskPanelContentProps {
  * Embeds the full TaskWorkspace inside a canvas panel.
  * Self-contained: fetches its own task from the store and provides all callbacks.
  */
-export function TaskPanelContent({ taskId, panelLayout = 'both' }: TaskPanelContentProps) {
+export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: TaskPanelContentProps) {
   const task = useTaskStore((s) => s.tasks.find((t) => t.id === taskId))
   const agents = useAgentStore((s) => s.agents)
   const updateTask = useTaskStore((s) => s.updateTask)
+  const updatePanel = useCanvasStore((s) => s.updatePanel)
   const { executeAction } = useTaskSourceStore()
   const { openEditModal, openDeleteModal } = useUIStore()
 
@@ -77,10 +80,16 @@ export function TaskPanelContent({ taskId, panelLayout = 'both' }: TaskPanelCont
 
   const handleNavigateToTask = useCallback(
     (tid: string) => {
-      // In canvas context, selecting a task just updates the sidebar selection
-      useTaskStore.getState().selectTask(tid)
+      const targetTask = useTaskStore.getState().tasks.find((candidate) => candidate.id === tid)
+      if (!targetTask) return
+
+      updatePanel(panelId, {
+        refId: targetTask.id,
+        title: targetTask.title,
+      })
+      useTaskStore.getState().selectTask(targetTask.id)
     },
-    []
+    [panelId, updatePanel]
   )
 
   if (!task) {
@@ -92,18 +101,20 @@ export function TaskPanelContent({ taskId, panelLayout = 'both' }: TaskPanelCont
   }
 
   return (
-    <TaskWorkspace
-      task={task}
-      agents={agents}
-      onEdit={handleEdit}
-      onDelete={handleDelete}
-      onUpdateAttachments={handleUpdateAttachments}
-      onUpdateOutputFields={handleUpdateOutputFields}
-      onCompleteTask={handleCompleteTask}
-      onAssignAgent={handleAssignAgent}
-      onUpdateTask={handleUpdateTask}
-      onNavigateToTask={handleNavigateToTask}
-      panelLayout={panelLayout}
-    />
+    <div className="h-full select-text">
+      <TaskWorkspace
+        task={task}
+        agents={agents}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onUpdateAttachments={handleUpdateAttachments}
+        onUpdateOutputFields={handleUpdateOutputFields}
+        onCompleteTask={handleCompleteTask}
+        onAssignAgent={handleAssignAgent}
+        onUpdateTask={handleUpdateTask}
+        onNavigateToTask={handleNavigateToTask}
+        panelLayout={panelLayout}
+      />
+    </div>
   )
 }

--- a/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
@@ -86,7 +86,7 @@ export function TranscriptPanelContent({ taskId }: TranscriptPanelContentProps) 
       onStop={handleStop}
       onRestart={handleRestart}
       onSend={handleSend}
-      className="h-full"
+      className="h-full select-text"
     />
   )
 }


### PR DESCRIPTION
## Summary
- allow text selection inside canvas task and transcript panels by limiting `select-none` to the draggable header
- make parent/child task navigation inside canvas task panels retarget the current panel instead of only updating sidebar selection
- add renderer coverage for canvas panel selectability and canvas task navigation

## Verification
- `pnpm test:renderer -- src/renderer/src/components/canvas/TaskPanelContent.test.tsx src/renderer/src/components/canvas/InfiniteCanvas.test.tsx` *(blocked locally: `node_modules` missing in this workspace)*
- `pnpm typecheck` *(blocked locally: dependencies missing, and `tsc --build --noEmit` also attempts `.tsbuildinfo` writes in the read-only sandbox)*