### PR TITLE
fix: correct mac installer asset resolution

### DIFF
--- a/src/main/agent-installer/install.js
+++ b/src/main/agent-installer/install.js
@@ -45,7 +45,7 @@ export function getInstallCommand(agentName) {
 
   if (agentName === 'gh') {
     if (isWin) return 'winget install --id GitHub.cli -e'
-    if (isMac) return 'Downloads gh .pkg from GitHub releases'
+    if (isMac) return 'Downloads gh from GitHub releases'
     if (isLinux) return 'Downloads gh tarball → ~/.local/bin'
     return 'See https://cli.github.com/manual/installation'
   }
@@ -69,6 +69,43 @@ export function getInstallCommand(agentName) {
   const info = INSTALL_COMMANDS[agentName]
   if (!info) return `Unknown agent: ${agentName}`
   return `${info.cmd} ${info.args.join(' ')}`
+}
+
+/**
+ * Build the expected Node.js archive name for a platform/arch/version tuple.
+ * macOS publishes a universal .pkg without an arch suffix.
+ * @param {string} platform
+ * @param {string} arch
+ * @param {string} version
+ * @returns {string}
+ */
+export function getNodejsAssetName(platform, arch, version) {
+  const normalizedArch = arch === 'arm64' ? 'arm64' : 'x64'
+  if (platform === 'darwin') return `node-${version}.pkg`
+  if (platform === 'win32') return `node-${version}-${normalizedArch}.msi`
+  if (platform === 'linux') return `node-${version}-linux-${normalizedArch}.tar.xz`
+  return `node-${version}-${normalizedArch}.msi`
+}
+
+/**
+ * Pick the preferred GitHub CLI macOS asset from a release payload.
+ * GitHub CLI publishes macOS zip archives consistently; some releases may
+ * also include pkg installers, so we support both.
+ * @param {{ assets?: Array<{ name?: string, browser_download_url?: string }> }} release
+ * @param {string} arch
+ * @returns {{ name: string, browser_download_url: string } | null}
+ */
+export function selectGhMacAsset(release, arch = process.arch) {
+  const releaseAssets = release?.assets || []
+  const normalizedArch = arch === 'arm64' ? 'arm64' : 'amd64'
+  const suffixes = [`macOS_${normalizedArch}.zip`, `macOS_${normalizedArch}.pkg`]
+
+  for (const suffix of suffixes) {
+    const asset = releaseAssets.find((entry) => entry?.name?.startsWith('gh_') && entry.name.endsWith(suffix))
+    if (asset?.browser_download_url) return asset
+  }
+
+  return null
 }
 
 /**
@@ -246,13 +283,6 @@ async function resolveNodejsUrl() {
   const isLinux = process.platform === 'linux'
   const arch = process.arch === 'arm64' ? 'arm64' : 'x64'
 
-  const buildAsset = (ver) => {
-    if (isMac) return `node-${ver}-${arch}.pkg`
-    if (isWin) return `node-${ver}-${arch}.msi`
-    if (isLinux) return `node-${ver}-linux-${arch}.tar.xz`
-    return `node-${ver}-${arch}.msi`
-  }
-
   try {
     const resp = await (await import('electron')).net.fetch('https://nodejs.org/dist/index.json', { signal: AbortSignal.timeout(8000) })
     if (resp.ok) {
@@ -260,13 +290,13 @@ async function resolveNodejsUrl() {
       const lts = releases.find(r => r.lts)
       if (lts) {
         const ver = lts.version // e.g. "v22.16.0"
-        return { url: `https://nodejs.org/dist/${ver}/${buildAsset(ver)}`, version: ver }
+        return { url: `https://nodejs.org/dist/${ver}/${getNodejsAssetName(process.platform, arch, ver)}`, version: ver }
       }
     }
   } catch { /* fall through to fallback */ }
   // Fallback: known-recent LTS
   const fallback = 'v22.20.0'
-  return { url: `https://nodejs.org/dist/${fallback}/${buildAsset(fallback)}`, version: fallback }
+  return { url: `https://nodejs.org/dist/${fallback}/${getNodejsAssetName(process.platform, arch, fallback)}`, version: fallback }
 }
 
 /**
@@ -696,17 +726,17 @@ export async function installAgent(agentName, onProgress) {
  * Install GitHub CLI on macOS by downloading the .pkg from GitHub releases.
  */
 async function installGhMac(onProgress) {
-  const arch = process.arch === 'arm64' ? 'arm64' : 'amd64'
   onProgress({ stage: 'starting', output: 'Resolving latest gh release...\n', percent: 5 })
 
   const downloadDir = join(tmpdir(), '20x-installers')
   if (!existsSync(downloadDir)) mkdirSync(downloadDir, { recursive: true })
-  const pkgPath = join(downloadDir, 'gh-install.pkg')
+  const archivePath = join(downloadDir, 'gh-install')
+  const extractDir = join(downloadDir, 'gh-extracted')
 
   try {
-    // Resolve latest .pkg URL from GitHub releases API
+    // Resolve latest macOS asset URL from GitHub releases API
     const { net } = await import('electron')
-    let pkgUrl = null
+    let asset = null
     try {
       const resp = await net.fetch('https://api.github.com/repos/cli/cli/releases/latest', {
         signal: AbortSignal.timeout(8000),
@@ -714,20 +744,70 @@ async function installGhMac(onProgress) {
       })
       if (resp.ok) {
         const release = await resp.json()
-        const asset = release.assets?.find(a => a.name.startsWith('gh_') && a.name.endsWith(`macOS_${arch}.pkg`))
-        if (asset?.browser_download_url) pkgUrl = asset.browser_download_url
+        asset = selectGhMacAsset(release)
       }
     } catch { /* fall through */ }
 
-    if (!pkgUrl) {
+    if (!asset?.browser_download_url || !asset?.name) {
       throw new Error('Could not resolve gh download URL. Install manually from https://cli.github.com/')
     }
 
     onProgress({ stage: 'installing', output: `Downloading gh from github.com...\n`, percent: 10 })
-    await downloadFile(pkgUrl, pkgPath, onProgress)
+    const assetPath = `${archivePath}${asset.name.endsWith('.pkg') ? '.pkg' : '.zip'}`
+    await downloadFile(asset.browser_download_url, assetPath, onProgress)
 
-    const result = await runMacPkgInstaller(pkgPath, onProgress)
-    try { unlinkSync(pkgPath) } catch { /* ignore */ }
+    let result
+    if (asset.name.endsWith('.pkg')) {
+      result = await runMacPkgInstaller(assetPath, onProgress)
+    } else {
+      onProgress({ stage: 'installing', output: 'Extracting gh archive...\n', percent: 70 })
+      if (!existsSync(extractDir)) mkdirSync(extractDir, { recursive: true })
+      await new Promise((resolve, reject) => {
+        const unzip = spawn('unzip', ['-q', assetPath, '-d', extractDir], { stdio: ['ignore', 'pipe', 'pipe'] })
+        let err = ''
+        unzip.stderr?.on('data', (chunk) => { err += chunk.toString() })
+        unzip.on('error', reject)
+        unzip.on('close', (code) => code === 0 ? resolve() : reject(new Error(`unzip exited with ${code}: ${err.trim()}`)))
+      })
+
+      const { readdirSync } = await import('fs')
+      const findGh = (dir) => {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const full = join(dir, entry.name)
+          if (entry.isDirectory()) {
+            const found = findGh(full)
+            if (found) return found
+          } else if (entry.name === 'gh') {
+            return full
+          }
+        }
+        return null
+      }
+
+      const ghBin = findGh(extractDir)
+      if (!ghBin) throw new Error('gh binary not found in extracted archive')
+
+      onProgress({ stage: 'installing', output: 'Installing gh to /usr/local/bin (admin prompt)...\n', percent: 85 })
+      const safeBin = ghBin.replace(/"/g, '\\"')
+      const installScript = `do shell script "mkdir -p /usr/local/bin && cp \\"${safeBin}\\" /usr/local/bin/gh && chmod +x /usr/local/bin/gh" with administrator privileges`
+
+      result = await new Promise((resolve) => {
+        const proc = spawn('osascript', ['-e', installScript], { stdio: ['ignore', 'pipe', 'pipe'] })
+        let stderr = ''
+        proc.stderr?.on('data', (c) => { stderr += c.toString() })
+        proc.on('error', (err) => resolve({ success: false, error: err.message }))
+        proc.on('close', (code) => {
+          if (code === 0) resolve({ success: true, error: null })
+          else resolve({
+            success: false,
+            error: stderr.includes('User canceled') ? 'Installation cancelled' : `Install failed: ${stderr.trim()}`
+          })
+        })
+      })
+    }
+
+    try { unlinkSync(assetPath) } catch { /* ignore */ }
+    try { rmSync(extractDir, { recursive: true, force: true }) } catch { /* ignore */ }
 
     if (result.success) {
       onProgress({ stage: 'complete', output: 'GitHub CLI installed successfully!\n', percent: 100 })
@@ -736,7 +816,9 @@ async function installGhMac(onProgress) {
     }
     return { success: result.success, error: result.error, newStatus: await detectInstalledAgents() }
   } catch (err) {
-    try { unlinkSync(pkgPath) } catch { /* ignore */ }
+    try { unlinkSync(`${archivePath}.pkg`) } catch { /* ignore */ }
+    try { unlinkSync(`${archivePath}.zip`) } catch { /* ignore */ }
+    try { rmSync(extractDir, { recursive: true, force: true }) } catch { /* ignore */ }
     onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
     return { success: false, error: err.message, newStatus: await detectInstalledAgents() }
   }

--- a/src/main/agent-installer/install.js
+++ b/src/main/agent-installer/install.js
@@ -5,6 +5,20 @@ import { tmpdir, homedir } from 'os'
 import { detectInstalledAgents } from './detect.js'
 
 /**
+ * Ensure a directory is on the running process's PATH so subsequently
+ * spawned child processes can find binaries placed there.
+ * Returns true if PATH was modified.
+ */
+function ensureOnPath(dir) {
+  const sep = process.platform === 'win32' ? ';' : ':'
+  const pathEnv = process.env.PATH || ''
+  const segments = pathEnv.split(sep)
+  if (segments.includes(dir) || segments.includes(`${dir}/`)) return false
+  process.env.PATH = `${dir}${sep}${pathEnv}`
+  return true
+}
+
+/**
  * Install commands per agent (npm-based tools).
  * @type {Record<string, { cmd: string, args: string[] } | null>}
  */
@@ -308,13 +322,16 @@ async function installNodejsLinux(onProgress) {
 
     try { unlinkSync(tarPath) } catch { /* ignore */ }
 
-    // Warn if ~/.local/bin not on PATH
-    const pathEnv = process.env.PATH || ''
-    const onPath = pathEnv.split(':').some((p) => p === binDir || p === `${binDir}/`)
-    if (!onPath) {
+    // Inject binDir into this process's PATH so subsequent installs in the
+    // same 20x session (npm-based: claudeCode, opencode, codex, pnpm) can
+    // find npm without requiring a 20x restart. Returns true if PATH was
+    // missing — implies user's shell rc probably also lacks it.
+    const pathWasMissing = ensureOnPath(binDir)
+
+    if (pathWasMissing) {
       onProgress({
         stage: 'complete',
-        output: `Node.js ${version} installed.\nNOTE: ${binDir} is not on your PATH. Add this to ~/.bashrc or ~/.zshrc:\n  export PATH="$HOME/.local/bin:$PATH"\nThen reopen your terminal.\n`,
+        output: `Node.js ${version} installed.\nNOTE: ${binDir} is not on your shell PATH. Add this to ~/.bashrc or ~/.zshrc:\n  export PATH="$HOME/.local/bin:$PATH"\nThen reopen your terminal. (20x has injected it for this session so subsequent installs will work.)\n`,
         percent: 100
       })
     } else {
@@ -494,7 +511,7 @@ async function installGitLinux(onProgress) {
     elevator = 'sudo'
   }
 
-  return new Promise(async (resolve) => {
+  return new Promise((resolve) => {
     onProgress({ stage: 'starting', output: `$ ${elevator} ${chosen.cmd.join(' ')}\n`, percent: 5 })
     onProgress({ stage: 'installing', output: `Detected ${chosen.bin}. ${elevator === 'pkexec' ? 'A GUI prompt will appear for your password.' : 'You may be prompted for your sudo password in the terminal.'}\n`, percent: 20 })
 
@@ -878,9 +895,12 @@ async function installLinuxBinaryFromTarball({ tarUrl, archiveName, binName, onP
     try { unlinkSync(tarPath) } catch { /* ignore */ }
     try { rmSync(extractDir, { recursive: true, force: true }) } catch { /* ignore */ }
 
-    const pathEnv = process.env.PATH || ''
-    const onPath = pathEnv.split(':').some((p) => p === binDir || p === `${binDir}/`)
-    const pathHint = onPath ? '' : `\nNOTE: ${binDir} is not on your PATH. Add to ~/.bashrc:\n  export PATH="$HOME/.local/bin:$PATH"\n`
+    // Inject binDir into this process's PATH so subsequent spawn() calls in
+    // the same 20x session can find the new binary.
+    const pathWasMissing = ensureOnPath(binDir)
+    const pathHint = pathWasMissing
+      ? `\nNOTE: ${binDir} is not on your shell PATH. Add to ~/.bashrc or ~/.zshrc:\n  export PATH="$HOME/.local/bin:$PATH"\n`
+      : ''
     onProgress({ stage: 'complete', output: `${binName} installed successfully!${pathHint}`, percent: 100 })
 
     return { success: true, error: null, newStatus: await detectInstalledAgents() }

--- a/src/main/agent-installer/install.js
+++ b/src/main/agent-installer/install.js
@@ -1,7 +1,7 @@
 import { spawn, execFile } from 'child_process'
-import { createWriteStream, mkdirSync, existsSync, unlinkSync } from 'fs'
+import { createWriteStream, mkdirSync, existsSync, unlinkSync, rmSync, symlinkSync, copyFileSync, chmodSync } from 'fs'
 import { join } from 'path'
-import { tmpdir } from 'os'
+import { tmpdir, homedir } from 'os'
 import { detectInstalledAgents } from './detect.js'
 
 /**
@@ -25,18 +25,33 @@ const INSTALL_COMMANDS = {
  * @returns {string}
  */
 export function getInstallCommand(agentName) {
+  const isWin = process.platform === 'win32'
+  const isMac = process.platform === 'darwin'
+  const isLinux = process.platform === 'linux'
+
   if (agentName === 'gh') {
-    if (process.platform === 'win32') return 'winget install --id GitHub.cli -e'
-    if (process.platform === 'darwin') return 'brew install gh'
+    if (isWin) return 'winget install --id GitHub.cli -e'
+    if (isMac) return 'Downloads gh .pkg from GitHub releases'
+    if (isLinux) return 'Downloads gh tarball → ~/.local/bin'
     return 'See https://cli.github.com/manual/installation'
   }
   if (agentName === 'glab') {
-    if (process.platform === 'win32') return 'winget install --id GLab.GLab -e'
-    if (process.platform === 'darwin') return 'brew install glab'
+    if (isWin) return 'winget install --id GLab.GLab -e'
+    if (isMac) return 'Downloads glab from GitLab releases'
+    if (isLinux) return 'Downloads glab tarball → ~/.local/bin'
     return 'See https://gitlab.com/gitlab-org/cli#installation'
   }
-  if (agentName === 'nodejs') return 'Downloads and installs Node.js automatically'
-  if (agentName === 'git') return 'Downloads and installs Git automatically'
+  if (agentName === 'nodejs') {
+    if (isWin || isMac) return 'Downloads and installs Node.js automatically'
+    if (isLinux) return 'Downloads Node.js tarball → ~/.local/share/20x/node'
+    return 'Install Node.js from https://nodejs.org/'
+  }
+  if (agentName === 'git') {
+    if (isWin) return 'Downloads and installs Git automatically'
+    if (isMac) return 'Triggers Xcode Command Line Tools install (includes Git)'
+    if (isLinux) return 'Installs git via system package manager (admin prompt)'
+    return 'Install Git from https://git-scm.com/'
+  }
   const info = INSTALL_COMMANDS[agentName]
   if (!info) return `Unknown agent: ${agentName}`
   return `${info.cmd} ${info.args.join(' ')}`
@@ -101,7 +116,7 @@ async function downloadFile(url, destPath, onProgress) {
 }
 
 /**
- * Run an installer executable (MSI/EXE) with optional elevation.
+ * Run a Windows installer (MSI/EXE) elevated via UAC.
  * @param {string} installerPath
  * @param {string[]} args
  * @param {string} agentName
@@ -153,11 +168,77 @@ function runInstaller(installerPath, args, agentName, onProgress) {
 }
 
 /**
- * Resolve the latest Node.js LTS download URL dynamically.
+ * Run a macOS .pkg installer with admin privileges via osascript.
+ * Shows the native macOS admin password prompt.
+ * @param {string} pkgPath
+ * @param {(progress: { stage: string, output: string, percent: number }) => void} onProgress
+ * @returns {Promise<{ success: boolean, error: string | null }>}
+ */
+function runMacPkgInstaller(pkgPath, onProgress) {
+  return new Promise((resolve) => {
+    onProgress({ stage: 'installing', output: `Running pkg installer (you may see an admin prompt)...\n`, percent: 75 })
+
+    // osascript admin prompt → installer -pkg <pkg> -target /
+    // Escape quotes in path
+    const safePath = pkgPath.replace(/"/g, '\\"')
+    const script = `do shell script "installer -pkg \\"${safePath}\\" -target /" with administrator privileges`
+
+    const proc = spawn('osascript', ['-e', script], {
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+
+    let output = ''
+    let stderr = ''
+
+    proc.stdout?.on('data', (chunk) => {
+      const text = chunk.toString()
+      output += text
+      onProgress({ stage: 'installing', output: text, percent: 85 })
+    })
+
+    proc.stderr?.on('data', (chunk) => {
+      const text = chunk.toString()
+      stderr += text
+      onProgress({ stage: 'installing', output: text, percent: 85 })
+    })
+
+    proc.on('error', (err) => {
+      resolve({ success: false, error: err.message })
+    })
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve({ success: true, error: null })
+      } else {
+        // osascript exit code 1 with "User canceled" message = user cancelled prompt
+        const error = stderr.includes('User canceled')
+          ? 'Installation cancelled by user'
+          : `Installer exited with code ${code}: ${stderr.trim() || output.trim()}`
+        resolve({ success: false, error })
+      }
+    })
+  })
+}
+
+/**
+ * Resolve the latest Node.js LTS download URL dynamically per platform.
+ * Returns { url, version } where version is e.g. "v22.20.0" (used by Linux
+ * to derive the extracted folder name).
  * Falls back to a known-good version if the API call fails.
  */
 async function resolveNodejsUrl() {
+  const isWin = process.platform === 'win32'
+  const isMac = process.platform === 'darwin'
+  const isLinux = process.platform === 'linux'
   const arch = process.arch === 'arm64' ? 'arm64' : 'x64'
+
+  const buildAsset = (ver) => {
+    if (isMac) return `node-${ver}-${arch}.pkg`
+    if (isWin) return `node-${ver}-${arch}.msi`
+    if (isLinux) return `node-${ver}-linux-${arch}.tar.xz`
+    return `node-${ver}-${arch}.msi`
+  }
+
   try {
     const resp = await (await import('electron')).net.fetch('https://nodejs.org/dist/index.json', { signal: AbortSignal.timeout(8000) })
     if (resp.ok) {
@@ -165,22 +246,106 @@ async function resolveNodejsUrl() {
       const lts = releases.find(r => r.lts)
       if (lts) {
         const ver = lts.version // e.g. "v22.16.0"
-        return `https://nodejs.org/dist/${ver}/node-${ver}-${arch}.msi`
+        return { url: `https://nodejs.org/dist/${ver}/${buildAsset(ver)}`, version: ver }
       }
     }
   } catch { /* fall through to fallback */ }
-  return `https://nodejs.org/dist/latest-lts/node-latest-lts-${arch}.msi`
+  // Fallback: known-recent LTS
+  const fallback = 'v22.20.0'
+  return { url: `https://nodejs.org/dist/${fallback}/${buildAsset(fallback)}`, version: fallback }
 }
 
 /**
- * Install Node.js on Windows by downloading the MSI installer.
+ * Install Node.js on Linux by extracting the tarball to ~/.local/share/20x/node
+ * and symlinking node/npm/npx into ~/.local/bin (no sudo required).
+ */
+async function installNodejsLinux(onProgress) {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64'
+  const home = homedir()
+  const installRoot = join(home, '.local', 'share', '20x', 'node')
+  const binDir = join(home, '.local', 'bin')
+
+  const downloadDir = join(tmpdir(), '20x-installers')
+  if (!existsSync(downloadDir)) mkdirSync(downloadDir, { recursive: true })
+  const tarPath = join(downloadDir, 'nodejs-install.tar.xz')
+
+  try {
+    onProgress({ stage: 'starting', output: 'Resolving latest Node.js LTS...\n', percent: 5 })
+    const { url, version } = await resolveNodejsUrl()
+    const extractedFolder = `node-${version}-linux-${arch}` // matches archive top-level dir
+
+    onProgress({ stage: 'installing', output: `Downloading from nodejs.org...\n`, percent: 10 })
+    await downloadFile(url, tarPath, onProgress)
+
+    onProgress({ stage: 'installing', output: 'Extracting tarball...\n', percent: 70 })
+    if (!existsSync(installRoot)) mkdirSync(installRoot, { recursive: true })
+
+    // Wipe any prior extracted folder of the same version
+    const extractedPath = join(installRoot, extractedFolder)
+    try { rmSync(extractedPath, { recursive: true, force: true }) } catch { /* ignore */ }
+
+    await new Promise((resolve, reject) => {
+      const tar = spawn('tar', ['-xJf', tarPath, '-C', installRoot], { stdio: ['ignore', 'pipe', 'pipe'] })
+      let err = ''
+      tar.stderr?.on('data', (c) => { err += c.toString() })
+      tar.on('error', reject)
+      tar.on('close', (code) => code === 0 ? resolve() : reject(new Error(`tar exited with ${code}: ${err.trim()}`)))
+    })
+
+    if (!existsSync(extractedPath)) {
+      throw new Error(`Extracted folder not found at ${extractedPath}`)
+    }
+
+    onProgress({ stage: 'installing', output: 'Symlinking node/npm/npx into ~/.local/bin...\n', percent: 90 })
+    if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true })
+
+    for (const binary of ['node', 'npm', 'npx']) {
+      const target = join(extractedPath, 'bin', binary)
+      const link = join(binDir, binary)
+      try { unlinkSync(link) } catch { /* ignore if missing */ }
+      symlinkSync(target, link)
+    }
+
+    try { unlinkSync(tarPath) } catch { /* ignore */ }
+
+    // Warn if ~/.local/bin not on PATH
+    const pathEnv = process.env.PATH || ''
+    const onPath = pathEnv.split(':').some((p) => p === binDir || p === `${binDir}/`)
+    if (!onPath) {
+      onProgress({
+        stage: 'complete',
+        output: `Node.js ${version} installed.\nNOTE: ${binDir} is not on your PATH. Add this to ~/.bashrc or ~/.zshrc:\n  export PATH="$HOME/.local/bin:$PATH"\nThen reopen your terminal.\n`,
+        percent: 100
+      })
+    } else {
+      onProgress({ stage: 'complete', output: `Node.js ${version} installed successfully!\n`, percent: 100 })
+    }
+
+    return { success: true, error: null, newStatus: await detectInstalledAgents() }
+  } catch (err) {
+    try { unlinkSync(tarPath) } catch { /* ignore */ }
+    onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
+    return { success: false, error: err.message, newStatus: await detectInstalledAgents() }
+  }
+}
+
+/**
+ * Install Node.js by downloading the platform installer.
+ * Supports Windows (.msi), macOS (.pkg), and Linux (tarball → ~/.local).
  */
 async function installNodejs(onProgress) {
   const isWin = process.platform === 'win32'
-  if (!isWin) {
+  const isMac = process.platform === 'darwin'
+  const isLinux = process.platform === 'linux'
+
+  if (isLinux) {
+    return installNodejsLinux(onProgress)
+  }
+
+  if (!isWin && !isMac) {
     return {
       success: false,
-      error: 'Automatic Node.js installation is only supported on Windows. Please install from https://nodejs.org/',
+      error: 'Automatic Node.js installation is only supported on Windows, macOS, and Linux. Please install from https://nodejs.org/',
       newStatus: await detectInstalledAgents()
     }
   }
@@ -190,20 +355,25 @@ async function installNodejs(onProgress) {
   const downloadDir = join(tmpdir(), '20x-installers')
   if (!existsSync(downloadDir)) mkdirSync(downloadDir, { recursive: true })
 
-  const msiPath = join(downloadDir, 'nodejs-install.msi')
+  const ext = isMac ? 'pkg' : 'msi'
+  const installerPath = join(downloadDir, `nodejs-install.${ext}`)
 
   try {
-    const nodeUrl = await resolveNodejsUrl()
+    const { url: nodeUrl } = await resolveNodejsUrl()
     onProgress({ stage: 'installing', output: `Downloading from nodejs.org...\n`, percent: 10 })
-    await downloadFile(nodeUrl, msiPath, onProgress)
+    await downloadFile(nodeUrl, installerPath, onProgress)
 
-    onProgress({ stage: 'installing', output: 'Download complete. Starting installer (you may see a UAC prompt)...\n', percent: 70 })
-
-    // Run MSI with silent install + add to PATH
-    const result = await runInstaller('msiexec.exe', ['/i', msiPath, '/qn', '/norestart', 'ADDLOCAL=ALL'], 'nodejs', onProgress)
+    let result
+    if (isMac) {
+      onProgress({ stage: 'installing', output: 'Download complete. Starting installer (you may see an admin prompt)...\n', percent: 70 })
+      result = await runMacPkgInstaller(installerPath, onProgress)
+    } else {
+      onProgress({ stage: 'installing', output: 'Download complete. Starting installer (you may see a UAC prompt)...\n', percent: 70 })
+      result = await runInstaller('msiexec.exe', ['/i', installerPath, '/qn', '/norestart', 'ADDLOCAL=ALL'], 'nodejs', onProgress)
+    }
 
     // Clean up
-    try { unlinkSync(msiPath) } catch { /* ignore */ }
+    try { unlinkSync(installerPath) } catch { /* ignore */ }
 
     if (result.success) {
       onProgress({ stage: 'complete', output: 'Node.js installed successfully! npm is included.\n', percent: 100 })
@@ -213,7 +383,7 @@ async function installNodejs(onProgress) {
 
     return { success: result.success, error: result.error, newStatus: await detectInstalledAgents() }
   } catch (err) {
-    try { unlinkSync(msiPath) } catch { /* ignore */ }
+    try { unlinkSync(installerPath) } catch { /* ignore */ }
     onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
     return { success: false, error: err.message, newStatus: await detectInstalledAgents() }
   }
@@ -241,14 +411,140 @@ async function resolveGitUrl() {
 }
 
 /**
- * Install Git on Windows by downloading the installer.
+ * Install Git on macOS by triggering Xcode Command Line Tools install.
+ * This shows the native macOS GUI prompt to install CLT (which includes git).
+ */
+async function installGitMac(onProgress) {
+  return new Promise((resolve) => {
+    onProgress({ stage: 'starting', output: 'Triggering Xcode Command Line Tools install...\n', percent: 5 })
+    onProgress({ stage: 'installing', output: 'A macOS dialog will appear. Click "Install" to install Git via Command Line Tools.\nThis may take several minutes.\n', percent: 20 })
+
+    // xcode-select --install triggers the native installer GUI dialog and exits immediately.
+    // The actual install runs in the background managed by the OS.
+    const proc = spawn('xcode-select', ['--install'], {
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+
+    let stderr = ''
+    proc.stderr?.on('data', (chunk) => { stderr += chunk.toString() })
+
+    proc.on('error', async (err) => {
+      onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
+      resolve({ success: false, error: err.message, newStatus: await detectInstalledAgents() })
+    })
+
+    proc.on('close', async (code) => {
+      const status = await detectInstalledAgents()
+      // Exit 0 = dialog launched. Exit 1 + "already installed" stderr = already there.
+      if (code === 0) {
+        onProgress({ stage: 'complete', output: 'Install dialog launched. Once you finish installing in the macOS dialog, click "Refresh" here to detect git.\n', percent: 100 })
+        resolve({ success: true, error: null, newStatus: status })
+      } else if (stderr.includes('already installed')) {
+        onProgress({ stage: 'complete', output: 'Xcode Command Line Tools already installed.\n', percent: 100 })
+        resolve({ success: true, error: null, newStatus: status })
+      } else {
+        onProgress({ stage: 'error', output: `xcode-select exited with code ${code}: ${stderr.trim()}\n`, percent: 100 })
+        resolve({ success: false, error: stderr.trim() || `Exit code ${code}`, newStatus: status })
+      }
+    })
+  })
+}
+
+/**
+ * Install Git on Linux via the system package manager (apt/dnf/pacman/zypper).
+ * Uses pkexec to show a GUI sudo prompt if available, falling back to sudo.
+ */
+async function installGitLinux(onProgress) {
+  const { promisify } = await import('util')
+  const execFileAsync = promisify(execFile)
+
+  // Detect package manager
+  const pkgManagers = [
+    { bin: 'apt-get', cmd: ['apt-get', 'install', '-y', 'git'] },
+    { bin: 'dnf', cmd: ['dnf', 'install', '-y', 'git'] },
+    { bin: 'yum', cmd: ['yum', 'install', '-y', 'git'] },
+    { bin: 'pacman', cmd: ['pacman', '-S', '--noconfirm', 'git'] },
+    { bin: 'zypper', cmd: ['zypper', 'install', '-y', 'git'] },
+    { bin: 'apk', cmd: ['apk', 'add', 'git'] }
+  ]
+
+  let chosen = null
+  for (const pm of pkgManagers) {
+    try {
+      await execFileAsync('which', [pm.bin], { timeout: 3000 })
+      chosen = pm
+      break
+    } catch { /* try next */ }
+  }
+
+  if (!chosen) {
+    return {
+      success: false,
+      error: 'No supported package manager found (apt/dnf/yum/pacman/zypper/apk). Install git manually.',
+      newStatus: await detectInstalledAgents()
+    }
+  }
+
+  // Prefer pkexec (GUI sudo) over sudo (terminal-only)
+  let elevator
+  try {
+    await execFileAsync('which', ['pkexec'], { timeout: 3000 })
+    elevator = 'pkexec'
+  } catch {
+    elevator = 'sudo'
+  }
+
+  return new Promise(async (resolve) => {
+    onProgress({ stage: 'starting', output: `$ ${elevator} ${chosen.cmd.join(' ')}\n`, percent: 5 })
+    onProgress({ stage: 'installing', output: `Detected ${chosen.bin}. ${elevator === 'pkexec' ? 'A GUI prompt will appear for your password.' : 'You may be prompted for your sudo password in the terminal.'}\n`, percent: 20 })
+
+    const proc = spawn(elevator, chosen.cmd, { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stderr = ''
+
+    proc.stdout?.on('data', (c) => onProgress({ stage: 'installing', output: c.toString(), percent: 60 }))
+    proc.stderr?.on('data', (c) => {
+      stderr += c.toString()
+      onProgress({ stage: 'installing', output: c.toString(), percent: 60 })
+    })
+
+    proc.on('error', async (err) => {
+      onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
+      resolve({ success: false, error: err.message, newStatus: await detectInstalledAgents() })
+    })
+
+    proc.on('close', async (code) => {
+      const newStatus = await detectInstalledAgents()
+      if (code === 0) {
+        onProgress({ stage: 'complete', output: 'Git installed successfully!\n', percent: 100 })
+        resolve({ success: true, error: null, newStatus })
+      } else {
+        onProgress({ stage: 'error', output: `Process exited with code ${code}\n`, percent: 100 })
+        resolve({ success: false, error: `Install failed (code ${code}): ${stderr.trim()}`, newStatus })
+      }
+    })
+  })
+}
+
+/**
+ * Install Git on Windows, macOS, or Linux.
  */
 async function installGit(onProgress) {
   const isWin = process.platform === 'win32'
+  const isMac = process.platform === 'darwin'
+  const isLinux = process.platform === 'linux'
+
+  if (isMac) {
+    return installGitMac(onProgress)
+  }
+
+  if (isLinux) {
+    return installGitLinux(onProgress)
+  }
+
   if (!isWin) {
     return {
       success: false,
-      error: 'Automatic Git installation is only supported on Windows. Please install from https://git-scm.com/',
+      error: 'Automatic Git installation is only supported on Windows, macOS, and Linux. Please install from https://git-scm.com/',
       newStatus: await detectInstalledAgents()
     }
   }
@@ -312,10 +608,19 @@ export async function installAgent(agentName, onProgress) {
     return installNodejs(onProgress)
   }
 
+  const isMac = process.platform === 'darwin'
+  const isLinux = process.platform === 'linux'
+
   // GitHub CLI — special case
   if (agentName === 'gh') {
     if (isWin) {
       return spawnInstall('winget', ['install', '--id', 'GitHub.cli', '-e', '--accept-source-agreements', '--accept-package-agreements'], agentName, onProgress)
+    }
+    if (isMac) {
+      return installGhMac(onProgress)
+    }
+    if (isLinux) {
+      return installGhLinux(onProgress)
     }
     return {
       success: false,
@@ -328,6 +633,12 @@ export async function installAgent(agentName, onProgress) {
   if (agentName === 'glab') {
     if (isWin) {
       return spawnInstall('winget', ['install', '--id', 'GLab.GLab', '-e', '--accept-source-agreements', '--accept-package-agreements'], agentName, onProgress)
+    }
+    if (isMac) {
+      return installGlabMac(onProgress)
+    }
+    if (isLinux) {
+      return installGlabLinux(onProgress)
     }
     return {
       success: false,
@@ -362,6 +673,298 @@ export async function installAgent(agentName, onProgress) {
   // On Windows, npm is invoked as npm.cmd
   const cmd = isWin ? `${info.cmd}.cmd` : info.cmd
   return spawnInstall(cmd, info.args, agentName, onProgress)
+}
+
+/**
+ * Install GitHub CLI on macOS by downloading the .pkg from GitHub releases.
+ */
+async function installGhMac(onProgress) {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'amd64'
+  onProgress({ stage: 'starting', output: 'Resolving latest gh release...\n', percent: 5 })
+
+  const downloadDir = join(tmpdir(), '20x-installers')
+  if (!existsSync(downloadDir)) mkdirSync(downloadDir, { recursive: true })
+  const pkgPath = join(downloadDir, 'gh-install.pkg')
+
+  try {
+    // Resolve latest .pkg URL from GitHub releases API
+    const { net } = await import('electron')
+    let pkgUrl = null
+    try {
+      const resp = await net.fetch('https://api.github.com/repos/cli/cli/releases/latest', {
+        signal: AbortSignal.timeout(8000),
+        headers: { 'User-Agent': '20x-app' }
+      })
+      if (resp.ok) {
+        const release = await resp.json()
+        const asset = release.assets?.find(a => a.name.startsWith('gh_') && a.name.endsWith(`macOS_${arch}.pkg`))
+        if (asset?.browser_download_url) pkgUrl = asset.browser_download_url
+      }
+    } catch { /* fall through */ }
+
+    if (!pkgUrl) {
+      throw new Error('Could not resolve gh download URL. Install manually from https://cli.github.com/')
+    }
+
+    onProgress({ stage: 'installing', output: `Downloading gh from github.com...\n`, percent: 10 })
+    await downloadFile(pkgUrl, pkgPath, onProgress)
+
+    const result = await runMacPkgInstaller(pkgPath, onProgress)
+    try { unlinkSync(pkgPath) } catch { /* ignore */ }
+
+    if (result.success) {
+      onProgress({ stage: 'complete', output: 'GitHub CLI installed successfully!\n', percent: 100 })
+    } else {
+      onProgress({ stage: 'error', output: `Installation failed: ${result.error}\n`, percent: 100 })
+    }
+    return { success: result.success, error: result.error, newStatus: await detectInstalledAgents() }
+  } catch (err) {
+    try { unlinkSync(pkgPath) } catch { /* ignore */ }
+    onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
+    return { success: false, error: err.message, newStatus: await detectInstalledAgents() }
+  }
+}
+
+/**
+ * Install GitLab CLI (glab) on macOS by downloading the .tar.gz and copying
+ * the binary into /usr/local/bin (requires admin via osascript).
+ */
+async function installGlabMac(onProgress) {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x86_64'
+  onProgress({ stage: 'starting', output: 'Resolving latest glab release...\n', percent: 5 })
+
+  const downloadDir = join(tmpdir(), '20x-installers')
+  if (!existsSync(downloadDir)) mkdirSync(downloadDir, { recursive: true })
+  const tarPath = join(downloadDir, 'glab.tar.gz')
+  const extractDir = join(downloadDir, 'glab-extracted')
+
+  try {
+    // Resolve latest tarball from GitLab releases API
+    const { net } = await import('electron')
+    let tarUrl = null
+    try {
+      const resp = await net.fetch(
+        'https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest',
+        { signal: AbortSignal.timeout(8000) }
+      )
+      if (resp.ok) {
+        const release = await resp.json()
+        const wantSuffix = `_macOS_${arch}.tar.gz`
+        const link = release.assets?.links?.find(l => l.name?.endsWith(wantSuffix) || l.url?.endsWith(wantSuffix))
+        if (link?.url) tarUrl = link.url
+      }
+    } catch { /* fall through */ }
+
+    if (!tarUrl) {
+      throw new Error('Could not resolve glab download URL. Install manually from https://gitlab.com/gitlab-org/cli')
+    }
+
+    onProgress({ stage: 'installing', output: `Downloading glab from gitlab.com...\n`, percent: 10 })
+    await downloadFile(tarUrl, tarPath, onProgress)
+
+    // Extract tarball
+    onProgress({ stage: 'installing', output: 'Extracting...\n', percent: 70 })
+    if (!existsSync(extractDir)) mkdirSync(extractDir, { recursive: true })
+    await new Promise((resolve, reject) => {
+      const tar = spawn('tar', ['-xzf', tarPath, '-C', extractDir], { stdio: ['ignore', 'pipe', 'pipe'] })
+      tar.on('error', reject)
+      tar.on('close', (code) => code === 0 ? resolve() : reject(new Error(`tar exited with ${code}`)))
+    })
+
+    // Find the glab binary inside the extracted folder (usually bin/glab)
+    const { readdirSync } = await import('fs')
+    const findGlab = (dir) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name)
+        if (entry.isDirectory()) {
+          const found = findGlab(full)
+          if (found) return found
+        } else if (entry.name === 'glab') {
+          return full
+        }
+      }
+      return null
+    }
+    const glabBin = findGlab(extractDir)
+    if (!glabBin) throw new Error('glab binary not found in extracted archive')
+
+    // Copy to /usr/local/bin via admin osascript
+    onProgress({ stage: 'installing', output: 'Installing to /usr/local/bin (admin prompt)...\n', percent: 85 })
+    const safeBin = glabBin.replace(/"/g, '\\"')
+    const installScript = `do shell script "mkdir -p /usr/local/bin && cp \\"${safeBin}\\" /usr/local/bin/glab && chmod +x /usr/local/bin/glab" with administrator privileges`
+
+    const result = await new Promise((resolve) => {
+      const proc = spawn('osascript', ['-e', installScript], { stdio: ['ignore', 'pipe', 'pipe'] })
+      let stderr = ''
+      proc.stderr?.on('data', (c) => { stderr += c.toString() })
+      proc.on('error', (err) => resolve({ success: false, error: err.message }))
+      proc.on('close', (code) => {
+        if (code === 0) resolve({ success: true, error: null })
+        else resolve({
+          success: false,
+          error: stderr.includes('User canceled') ? 'Installation cancelled' : `Install failed: ${stderr.trim()}`
+        })
+      })
+    })
+
+    // Cleanup
+    try { unlinkSync(tarPath) } catch { /* ignore */ }
+    try { rmSync(extractDir, { recursive: true, force: true }) } catch { /* ignore */ }
+
+    if (result.success) {
+      onProgress({ stage: 'complete', output: 'GitLab CLI installed successfully!\n', percent: 100 })
+    } else {
+      onProgress({ stage: 'error', output: `Installation failed: ${result.error}\n`, percent: 100 })
+    }
+    return { success: result.success, error: result.error, newStatus: await detectInstalledAgents() }
+  } catch (err) {
+    try { unlinkSync(tarPath) } catch { /* ignore */ }
+    try { rmSync(extractDir, { recursive: true, force: true }) } catch { /* ignore */ }
+    onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
+    return { success: false, error: err.message, newStatus: await detectInstalledAgents() }
+  }
+}
+
+/**
+ * Generic helper: download a binary tarball, extract one binary by name,
+ * place it in ~/.local/bin/<binName>, chmod +x. No sudo required.
+ */
+async function installLinuxBinaryFromTarball({ tarUrl, archiveName, binName, onProgress }) {
+  const home = homedir()
+  const binDir = join(home, '.local', 'bin')
+  const downloadDir = join(tmpdir(), '20x-installers')
+  if (!existsSync(downloadDir)) mkdirSync(downloadDir, { recursive: true })
+  const tarPath = join(downloadDir, archiveName)
+  const extractDir = join(downloadDir, `${binName}-extracted`)
+
+  try {
+    onProgress({ stage: 'installing', output: `Downloading ${binName}...\n`, percent: 10 })
+    await downloadFile(tarUrl, tarPath, onProgress)
+
+    onProgress({ stage: 'installing', output: 'Extracting tarball...\n', percent: 70 })
+    if (!existsSync(extractDir)) mkdirSync(extractDir, { recursive: true })
+    await new Promise((resolve, reject) => {
+      const tar = spawn('tar', ['-xzf', tarPath, '-C', extractDir], { stdio: ['ignore', 'pipe', 'pipe'] })
+      let err = ''
+      tar.stderr?.on('data', (c) => { err += c.toString() })
+      tar.on('error', reject)
+      tar.on('close', (code) => code === 0 ? resolve() : reject(new Error(`tar exited with ${code}: ${err.trim()}`)))
+    })
+
+    // Find the binary (recurse) — usually under bin/<binName> or directly
+    const { readdirSync } = await import('fs')
+    const findBin = (dir) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name)
+        if (entry.isDirectory()) {
+          const found = findBin(full)
+          if (found) return found
+        } else if (entry.name === binName) {
+          return full
+        }
+      }
+      return null
+    }
+    const binPath = findBin(extractDir)
+    if (!binPath) throw new Error(`${binName} binary not found in extracted archive`)
+
+    onProgress({ stage: 'installing', output: `Installing to ${binDir}/${binName}...\n`, percent: 90 })
+    if (!existsSync(binDir)) mkdirSync(binDir, { recursive: true })
+    const dest = join(binDir, binName)
+    try { unlinkSync(dest) } catch { /* ignore */ }
+    copyFileSync(binPath, dest)
+    chmodSync(dest, 0o755)
+
+    try { unlinkSync(tarPath) } catch { /* ignore */ }
+    try { rmSync(extractDir, { recursive: true, force: true }) } catch { /* ignore */ }
+
+    const pathEnv = process.env.PATH || ''
+    const onPath = pathEnv.split(':').some((p) => p === binDir || p === `${binDir}/`)
+    const pathHint = onPath ? '' : `\nNOTE: ${binDir} is not on your PATH. Add to ~/.bashrc:\n  export PATH="$HOME/.local/bin:$PATH"\n`
+    onProgress({ stage: 'complete', output: `${binName} installed successfully!${pathHint}`, percent: 100 })
+
+    return { success: true, error: null, newStatus: await detectInstalledAgents() }
+  } catch (err) {
+    try { unlinkSync(tarPath) } catch { /* ignore */ }
+    try { rmSync(extractDir, { recursive: true, force: true }) } catch { /* ignore */ }
+    onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
+    return { success: false, error: err.message, newStatus: await detectInstalledAgents() }
+  }
+}
+
+/**
+ * Install GitHub CLI on Linux: download tarball → ~/.local/bin/gh.
+ */
+async function installGhLinux(onProgress) {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'amd64'
+  onProgress({ stage: 'starting', output: 'Resolving latest gh release...\n', percent: 5 })
+
+  let tarUrl = null
+  let archiveName = `gh.tar.gz`
+  try {
+    const { net } = await import('electron')
+    const resp = await net.fetch('https://api.github.com/repos/cli/cli/releases/latest', {
+      signal: AbortSignal.timeout(8000),
+      headers: { 'User-Agent': '20x-app' }
+    })
+    if (resp.ok) {
+      const release = await resp.json()
+      const asset = release.assets?.find(a => a.name.startsWith('gh_') && a.name.endsWith(`linux_${arch}.tar.gz`))
+      if (asset?.browser_download_url) {
+        tarUrl = asset.browser_download_url
+        archiveName = asset.name
+      }
+    }
+  } catch { /* fall through */ }
+
+  if (!tarUrl) {
+    onProgress({ stage: 'error', output: 'Could not resolve gh download URL.\n', percent: 100 })
+    return {
+      success: false,
+      error: 'Could not resolve gh download URL. Install manually from https://cli.github.com/',
+      newStatus: await detectInstalledAgents()
+    }
+  }
+
+  return installLinuxBinaryFromTarball({ tarUrl, archiveName, binName: 'gh', onProgress })
+}
+
+/**
+ * Install GitLab CLI (glab) on Linux: download tarball → ~/.local/bin/glab.
+ */
+async function installGlabLinux(onProgress) {
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x86_64'
+  onProgress({ stage: 'starting', output: 'Resolving latest glab release...\n', percent: 5 })
+
+  let tarUrl = null
+  let archiveName = 'glab.tar.gz'
+  try {
+    const { net } = await import('electron')
+    const resp = await net.fetch(
+      'https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest',
+      { signal: AbortSignal.timeout(8000) }
+    )
+    if (resp.ok) {
+      const release = await resp.json()
+      const wantSuffix = `_Linux_${arch}.tar.gz`
+      const link = release.assets?.links?.find(l => l.name?.endsWith(wantSuffix) || l.url?.endsWith(wantSuffix))
+      if (link?.url) {
+        tarUrl = link.url
+        archiveName = link.name || archiveName
+      }
+    }
+  } catch { /* fall through */ }
+
+  if (!tarUrl) {
+    onProgress({ stage: 'error', output: 'Could not resolve glab download URL.\n', percent: 100 })
+    return {
+      success: false,
+      error: 'Could not resolve glab download URL. Install manually from https://gitlab.com/gitlab-org/cli',
+      newStatus: await detectInstalledAgents()
+    }
+  }
+
+  return installLinuxBinaryFromTarball({ tarUrl, archiveName, binName: 'glab', onProgress })
 }
 
 /**

--- a/src/main/agent-installer/install.test.ts
+++ b/src/main/agent-installer/install.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { getNodejsAssetName, selectGhMacAsset } from './install.js'
+
+describe('getNodejsAssetName', () => {
+  it('uses the universal macOS pkg name without an arch suffix', () => {
+    expect(getNodejsAssetName('darwin', 'arm64', 'v22.20.0')).toBe('node-v22.20.0.pkg')
+    expect(getNodejsAssetName('darwin', 'x64', 'v22.20.0')).toBe('node-v22.20.0.pkg')
+  })
+
+  it('retains platform-specific naming for Windows and Linux', () => {
+    expect(getNodejsAssetName('win32', 'arm64', 'v22.20.0')).toBe('node-v22.20.0-arm64.msi')
+    expect(getNodejsAssetName('linux', 'x64', 'v22.20.0')).toBe('node-v22.20.0-linux-x64.tar.xz')
+  })
+})
+
+describe('selectGhMacAsset', () => {
+  it('prefers the macOS zip asset when present', () => {
+    const asset = selectGhMacAsset({
+      assets: [
+        { name: 'gh_2.92.0_macOS_arm64.pkg', browser_download_url: 'https://example.com/gh.pkg' },
+        { name: 'gh_2.92.0_macOS_arm64.zip', browser_download_url: 'https://example.com/gh.zip' }
+      ]
+    }, 'arm64')
+
+    expect(asset?.name).toBe('gh_2.92.0_macOS_arm64.zip')
+    expect(asset?.browser_download_url).toBe('https://example.com/gh.zip')
+  })
+
+  it('falls back to the macOS pkg asset when zip is unavailable', () => {
+    const asset = selectGhMacAsset({
+      assets: [
+        { name: 'gh_2.92.0_macOS_amd64.pkg', browser_download_url: 'https://example.com/gh.pkg' }
+      ]
+    }, 'x64')
+
+    expect(asset?.name).toBe('gh_2.92.0_macOS_amd64.pkg')
+  })
+
+  it('returns null when no compatible macOS asset exists', () => {
+    const asset = selectGhMacAsset({
+      assets: [
+        { name: 'gh_2.92.0_linux_arm64.tar.gz', browser_download_url: 'https://example.com/gh.tgz' }
+      ]
+    }, 'arm64')
+
+    expect(asset).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- carry forward the mac setup wizard work from PR #279
- fix macOS Node.js asset resolution to use the published universal pkg name
- fix macOS GitHub CLI install by resolving real release assets and supporting zip-based installation
- add targeted unit tests for mac installer asset selection

## Test plan
- pnpm test:run src/main/agent-installer/install.test.ts
- pnpm test:run
- pnpm typecheck
- SKIP_NOTARIZE=true pnpm build:mac

## Context
Manual mac testing showed two broken flows in the original mac setup wizard work:
- Node.js download requested a non-existent mac pkg path
- GitHub CLI install could not resolve a mac release asset
