### PR TITLE
fix: auto-fetch AI gateway key when subscription is active but not configured

### DIFF
--- a/src/main/enterprise-ai-gateway.ts
+++ b/src/main/enterprise-ai-gateway.ts
@@ -5,6 +5,13 @@ import type { DatabaseManager } from './database'
 export const ENTERPRISE_AI_GATEWAY_PROVIDER_ID = 'peakflo'
 export const ENTERPRISE_AI_GATEWAY_PROVIDER_NAME = 'Peakflo'
 
+/** Mirrors AI_GATEWAY_SUBSCRIPTION_STATUS from workflow-builder core */
+export const AI_GATEWAY_SUBSCRIPTION_STATUS = {
+  ACTIVE: 'active',
+  SUSPENDED: 'suspended',
+  CANCELLED: 'cancelled'
+} as const
+
 // DB setting keys kept as 'enterprise_litellm_*' for migration safety
 export const ENTERPRISE_AI_GATEWAY_KEYS = {
   API_KEY: 'enterprise_litellm_api_key',

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1127,6 +1127,24 @@ export function registerIpcHandlers(
               status: sub.status,
               currentPeriodEnd: sub.currentPeriodEnd ?? null
             }
+
+            // Auto-fetch AI gateway key when subscription is active but not yet configured locally.
+            // This handles the case where a plan was activated after the initial tenant selection
+            // (e.g. by an enterprise admin), so the first fetch attempt failed silently.
+            if (sub.status === 'active' && !base.configured) {
+              try {
+                await enterpriseAuth.refreshAiGatewayVirtualKey()
+                const updatedConfig = readEnterpriseAiGatewayConfig(db)
+                if (updatedConfig) {
+                  base.configured = true
+                  base.modelCount = updatedConfig.models?.length ?? 0
+                  base.keyName = updatedConfig.keyName ?? null
+                  base.expiresAt = updatedConfig.expiresAt ?? null
+                }
+              } catch (keyErr) {
+                console.warn('[enterprise] Auto-fetch of AI gateway key failed:', keyErr)
+              }
+            }
           }
         } catch (apiErr) {
           // Server API may be unavailable (e.g. AI gateway disabled) — that's fine,
@@ -1143,6 +1161,16 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('enterprise:syncResources', async () => {
+    // Refresh AI gateway virtual key alongside resource sync so that
+    // clicking "Sync resources" also picks up newly-activated subscriptions.
+    if (enterpriseAuth) {
+      try {
+        await enterpriseAuth.refreshAiGatewayVirtualKey()
+      } catch (err) {
+        console.warn('[enterprise] AI gateway key refresh during sync failed (non-fatal):', err)
+      }
+    }
+
     const syncResult = await syncManager.syncEnterpriseResources()
     if (!syncResult) return null
     return {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1097,7 +1097,7 @@ export function registerIpcHandlers(
   ipcMain.handle('enterprise:getAiGatewayStatus', async () => {
     const base = { configured: false, modelCount: 0, keyName: null as string | null, expiresAt: null as string | null, subscription: null as { planName: string; status: string; planId: string; currentPeriodEnd: string | null } | null }
     try {
-      const { readEnterpriseAiGatewayConfig } = await import('./enterprise-ai-gateway')
+      const { readEnterpriseAiGatewayConfig, AI_GATEWAY_SUBSCRIPTION_STATUS } = await import('./enterprise-ai-gateway')
       const config = readEnterpriseAiGatewayConfig(db)
       if (config) {
         base.configured = true
@@ -1131,7 +1131,7 @@ export function registerIpcHandlers(
             // Auto-fetch AI gateway key when subscription is active but not yet configured locally.
             // This handles the case where a plan was activated after the initial tenant selection
             // (e.g. by an enterprise admin), so the first fetch attempt failed silently.
-            if (sub.status === 'active' && !base.configured) {
+            if (sub.status === AI_GATEWAY_SUBSCRIPTION_STATUS.ACTIVE && !base.configured) {
               try {
                 await enterpriseAuth.refreshAiGatewayVirtualKey()
                 const updatedConfig = readEnterpriseAiGatewayConfig(db)


### PR DESCRIPTION
## Summary
- **Bug**: Enterprise users with an active Pro AI subscription see "AI Gateway: Not configured" and no Peakflo models in the model dropdown. Only free OpenCode Zen models are shown.
- **Root cause**: During tenant selection, `fetchAndStoreAiGatewayVirtualKey()` is called but fails silently when no plan is active yet. If the plan is activated later (e.g., by an enterprise admin), there was **no mechanism** to re-fetch the virtual key — the gateway remained unconfigured permanently.

### Fix — four recovery points added:

| File | When | Why |
|------|------|-----|
| `index.ts` | App startup / session restore | Eagerly fetches the key so the Peakflo provider is in the DB before the OpenCode server starts |
| `agent-manager.ts` | Before `getProviders()` | Refreshes the key right before the model dropdown queries providers (same pattern as `startAdapterSession`) |
| `ipc-handlers.ts` | Settings page load (`getAiGatewayStatus`) | Auto-fetches when subscription is active but local config missing |
| `ipc-handlers.ts` | "Sync resources" button (`syncResources`) | Refreshes key alongside agents/skills/MCPs |

Also added `AI_GATEWAY_SUBSCRIPTION_STATUS` enum to `enterprise-ai-gateway.ts` (mirroring workflow-builder core) to avoid raw string comparisons.

All additions are best-effort with try/catch — failures don't break existing functionality.

## Test plan
- [ ] Login with an enterprise account that has an active Pro subscription
- [ ] Verify on app startup, AI gateway key is fetched (check logs for `refreshAiGatewayVirtualKey`)
- [ ] Verify Peakflo models appear in the model dropdown when creating a new agent
- [ ] Verify settings page shows AI Gateway as configured with model count
- [ ] Verify clicking "Sync resources" also recovers AI Gateway configuration
- [ ] Verify no regression when subscription is inactive (gateway should remain "Not configured")
- [ ] CI typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)