### PR TITLE
fix: refresh AI gateway key on startup and before provider listing

### DIFF
--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -3138,6 +3138,18 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         return null
       }
 
+      // Refresh the AI gateway virtual key before querying providers so the
+      // OpenCode server config includes the Peakflo provider. This handles
+      // plans activated after the initial tenant selection (same pattern as
+      // startAdapterSession). Best-effort — fall back to the cached key.
+      if (this.enterpriseAuth) {
+        try {
+          await this.enterpriseAuth.refreshAiGatewayVirtualKey()
+        } catch (err) {
+          console.warn('[AgentManager] AI gateway key refresh before getProviders failed (will use cached key):', err)
+        }
+      }
+
       const adapter = this.getAdapterByType(resolvedBackend)
       if (!adapter?.getProviders) {
         console.log(`[AgentManager] Adapter for "${resolvedBackend}" does not support getProviders`)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -765,6 +765,15 @@ app.whenReady().then(async () => {
 
         syncManager.setEnterpriseConnection(apiClient, enterpriseSyncMgr, session.userId, enterpriseStateSyncInstance)
 
+        // Eagerly refresh AI gateway virtual key so the Peakflo provider is
+        // available in the DB before the OpenCode adapter starts its server.
+        // Handles plans activated after the initial tenant selection.
+        try {
+          await enterpriseAuth.refreshAiGatewayVirtualKey()
+        } catch (err) {
+          console.warn('[Main] AI gateway key refresh on startup failed (non-fatal):', err)
+        }
+
         console.log('[Main] Enterprise connection restored on startup (with heartbeat)')
         console.log('[EnterpriseAuth] auth_session_restore_result {"status":"restored"}')
       } else {


### PR DESCRIPTION
## Summary
Follow-up to #290 — the settings page and sync-resources fixes alone weren't enough because the OpenCode server starts **before** the user opens settings, and the server keeps stale provider config even after the key is stored.

Logs confirm the key IS fetched but the server doesn't pick it up:
```
[EnterpriseAuth] ai_gateway_models_stored {"modelCount":3,...}
[OpencodeAdapter] No providers configured on server
```

### Root cause (two issues)

1. **Session restore never refreshed the AI gateway key** — the OpenCode server started before the key was in the DB
2. **`getProviders()` never pushed updated config to the server** — it calls `getClient({ quick: true })` which skips `pushMergedConfigToClient()`, and `ensureServerRunning()` returns immediately when the server is already running. So even after the key was stored in the DB, the server kept its stale (empty) provider config.

### Fix (3 files)

| File | Change | Why |
|------|--------|-----|
| `index.ts` | Refresh AI gateway key during session restore | Key is in DB before OpenCode server starts |
| `agent-manager.ts` | Refresh key before `getProviders()` | Same pattern as `startAdapterSession` |
| `opencode-adapter.ts` | Call `pushMergedConfigToClient()` in `getProviders()` | **The key fix** — ensures the server has the latest provider config before querying providers, even when the quick client path skips it |

## Test plan
- [ ] Login with enterprise account that has active Pro subscription
- [ ] Restart the app — verify Peakflo models appear in model dropdown
- [ ] Verify logs show `ai_gateway_models_stored` followed by successful provider listing (no "No providers configured")
- [ ] Verify no startup delay or errors when subscription is inactive
- [ ] CI typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)