### PR TITLE
fix: push provider config to OpenCode server before querying models

### DIFF
--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -262,6 +262,12 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     try {
       const client = await this.getClient(serverUrl, { quick: true })
 
+      // Push the latest merged config (incl. enterprise AI gateway provider)
+      // before querying providers. The quick-path in getClient() skips this,
+      // and ensureServerRunning() skips it when the server is already running,
+      // so the server may still have stale provider config from an earlier start.
+      await this.pushMergedConfigToClient(client)
+
       const result = await client.config.providers({
         ...(directory && { directory })
       })


### PR DESCRIPTION
## Summary
Follow-up to #290 and #292 — the AI gateway key is now fetched on startup, but the **OpenCode server still doesn't show the models** because the provider config is never pushed to the running server before querying.

Logs confirm the key is stored but providers remain empty:
```
[EnterpriseAuth] ai_gateway_models_stored {"modelCount":3,...}
[OpencodeAdapter] No providers configured on server
```

### Root cause

`getProviders()` calls `getClient({ quick: true })` which takes the early-return path that **skips `pushMergedConfigToClient()`**. Additionally, `ensureServerRunning()` returns immediately when the server is already running — it only pushes config on first connect. So the server keeps its stale (empty) provider config from initial start, even after the key is stored in the DB.

### Fix

One line: call `pushMergedConfigToClient(client)` in `getProviders()` before querying `client.config.providers()`. This ensures the server always has the latest provider config (including the enterprise AI gateway) before the model dropdown is populated.

## Test plan
- [ ] Login with enterprise account that has active Pro subscription
- [ ] Restart the app — verify Peakflo models appear in model dropdown when creating a new agent
- [ ] Verify no "No providers configured on server" in logs after model dropdown opens
- [ ] CI typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)