### PR TITLE
fix: pass writable directory to config.providers() to prevent SQLite disk I/O error

### DIFF
--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -282,8 +282,14 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       // so the server may still have stale provider config from an earlier start.
       await this.pushMergedConfigToClient(client)
 
+      // Always pass a writable directory so the OpenCode server doesn't fall
+      // back to its CWD (which is read-only on macOS when launched from
+      // /Applications). Without this, fromDirectory() in the server tries to
+      // create an SQLite DB at the CWD and fails with "disk I/O error".
+      const safeDirectory = directory || homedir()
+
       const result = await client.config.providers({
-        ...(directory && { directory })
+        directory: safeDirectory
       })
 
       if (result.error) {


### PR DESCRIPTION
## Summary

- When OpenCode server is spawned by the SDK, it inherits the Electron app's CWD (read-only on macOS `/Applications`). The `config.providers()` call triggers `fromDirectory()` which tries to create a per-project SQLite database at CWD → `SQLiteError: disk I/O error` → no models shown
- Fix: always pass `homedir()` as fallback directory when no workspace directory is specified
- This was exposed by OpenCode's May 2-9 instance bootstrap refactoring (Effect-based services)

## Test plan

- [ ] Enterprise user with active Pro AI subscription sees Peakflo models in dropdown
- [ ] No `SQLiteError: disk I/O error` in logs when querying providers
- [ ] Test on macOS with app launched from `/Applications`

🤖 Generated with [Claude Code](https://claude.com/claude-code)