### PR TITLE
fix: filter stale LiteLLM models client-side after OpenCode provider query

### DIFF
--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { OpencodeAdapter } from './opencode-adapter'
 import { SessionStatusType } from './coding-agent-adapter'
 import { ENTERPRISE_AI_GATEWAY_PROVIDER_ID } from '../enterprise-ai-gateway'
+
+import * as enterpriseAiGateway from '../enterprise-ai-gateway'
 
 describe('OpencodeAdapter', () => {
   describe('waitForMcpServersReady', () => {
@@ -363,187 +365,113 @@ describe('OpencodeAdapter', () => {
     })
   })
 
-  describe('getProvidersInner filters stale models', () => {
-    it('filters out stale models from peakflo provider using fresh SQLite config', async () => {
-      const mockDb = {
-        getSetting: vi.fn((key: string): string | undefined => {
-          // Return encrypted values for API key and base URL so readEnterpriseAiGatewayConfig works
-          if (key === 'enterprise_litellm_api_key') return Buffer.from('sk-test', 'utf8').toString('base64')
-          if (key === 'enterprise_litellm_base_url') return Buffer.from('https://litellm.example.com', 'utf8').toString('base64')
-          if (key === 'enterprise_litellm_models') return JSON.stringify([
-            { id: 'kept-model', name: 'Kept Model' },
-            { id: 'new-model', name: 'New Model' }
-          ])
-          return undefined
-        })
-      }
+  describe('filterStaleProviderModels', () => {
+    afterEach(() => vi.restoreAllMocks())
 
+    it('removes models not present in fresh SQLite config', () => {
+      const mockDb = { getSetting: vi.fn() }
       const adapter = new OpencodeAdapter(mockDb)
 
-      // Mock getClient to return a client whose config.providers returns stale data
-      const mockClient = {
-        config: {
-          providers: vi.fn().mockResolvedValue({
-            data: {
-              providers: [
-                {
-                  id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
-                  name: 'Peakflo',
-                  models: {
-                    'old-model-1': { name: 'Old Model 1' },
-                    'old-model-2': { name: 'Old Model 2' },
-                    'kept-model': { name: 'Kept Model' }
-                  }
-                },
-                {
-                  id: 'anthropic',
-                  name: 'Anthropic',
-                  models: { 'claude-4': { name: 'Claude 4' } }
-                }
-              ],
-              default: {}
-            }
-          })
+      vi.spyOn(enterpriseAiGateway, 'readEnterpriseAiGatewayConfig').mockReturnValue({
+        apiKey: 'sk-test',
+        baseUrl: 'https://litellm.example.com',
+        models: [
+          { id: 'kept-model', name: 'Kept Model' },
+          { id: 'new-model', name: 'New Model' }
+        ]
+      })
+
+      const providers = [
+        {
+          id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+          name: 'Peakflo',
+          models: {
+            'old-model-1': { name: 'Old Model 1' },
+            'old-model-2': { name: 'Old Model 2' },
+            'kept-model': { name: 'Kept Model' }
+          } as unknown
+        },
+        {
+          id: 'anthropic',
+          name: 'Anthropic',
+          models: { 'claude-4': { name: 'Claude 4' } } as unknown
         }
-      }
+      ]
 
-      vi.spyOn(adapter as any, 'getClient').mockResolvedValue(mockClient)
-      vi.spyOn(adapter as any, 'pushMergedConfigToClient').mockResolvedValue(undefined)
+      ;(adapter as any).filterStaleProviderModels(providers)
 
-      const result = await (adapter as any).getProvidersInner(undefined, '/tmp/ws', false)
-
-      expect(result).not.toBeNull()
-      const peakfloProvider = result.providers.find((p: { id: string }) => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
-      const models = peakfloProvider.models as Record<string, unknown>
-
-      // Stale models should be filtered out
+      const peakflo = providers.find(p => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)!
+      const models = peakflo.models as Record<string, unknown>
       expect(models['old-model-1']).toBeUndefined()
       expect(models['old-model-2']).toBeUndefined()
-      // Kept model should be preserved
       expect(models['kept-model']).toEqual({ name: 'Kept Model' })
-      // Other providers should be unaffected
-      const anthropic = result.providers.find((p: { id: string }) => p.id === 'anthropic')
+
+      // Other providers untouched
+      const anthropic = providers.find(p => p.id === 'anthropic')!
       expect(anthropic.models).toEqual({ 'claude-4': { name: 'Claude 4' } })
     })
 
-    it('does not filter when no db is available', async () => {
+    it('does not filter when no db is available', () => {
       const adapter = new OpencodeAdapter() // no db
+      const readSpy = vi.spyOn(enterpriseAiGateway, 'readEnterpriseAiGatewayConfig')
 
-      const mockClient = {
-        config: {
-          providers: vi.fn().mockResolvedValue({
-            data: {
-              providers: [
-                {
-                  id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
-                  name: 'Peakflo',
-                  models: {
-                    'model-a': { name: 'Model A' },
-                    'model-b': { name: 'Model B' }
-                  }
-                }
-              ],
-              default: {}
-            }
-          })
+      const providers = [
+        {
+          id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+          name: 'Peakflo',
+          models: { 'model-a': { name: 'A' }, 'model-b': { name: 'B' } } as unknown
         }
-      }
+      ]
 
-      vi.spyOn(adapter as any, 'getClient').mockResolvedValue(mockClient)
-      vi.spyOn(adapter as any, 'pushMergedConfigToClient').mockResolvedValue(undefined)
+      ;(adapter as any).filterStaleProviderModels(providers)
 
-      const result = await (adapter as any).getProvidersInner(undefined, '/tmp/ws', false)
-
-      const peakfloProvider = result.providers.find((p: { id: string }) => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
-      const models = peakfloProvider.models as Record<string, unknown>
-
-      // All models preserved — no filtering without db
-      expect(Object.keys(models)).toEqual(['model-a', 'model-b'])
+      expect(readSpy).not.toHaveBeenCalled()
+      expect(Object.keys(providers[0].models as Record<string, unknown>)).toEqual(['model-a', 'model-b'])
     })
 
-    it('does not filter when enterprise AI gateway config is not stored', async () => {
-      const mockDb = {
-        getSetting: vi.fn((): string | undefined => undefined)
-      }
-
+    it('does not filter when gateway config returns null', () => {
+      const mockDb = { getSetting: vi.fn() }
       const adapter = new OpencodeAdapter(mockDb)
 
-      const mockClient = {
-        config: {
-          providers: vi.fn().mockResolvedValue({
-            data: {
-              providers: [
-                {
-                  id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
-                  name: 'Peakflo',
-                  models: {
-                    'model-a': { name: 'Model A' }
-                  }
-                }
-              ],
-              default: {}
-            }
-          })
+      vi.spyOn(enterpriseAiGateway, 'readEnterpriseAiGatewayConfig').mockReturnValue(null)
+
+      const providers = [
+        {
+          id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+          name: 'Peakflo',
+          models: { 'model-a': { name: 'A' } } as unknown
         }
-      }
+      ]
 
-      vi.spyOn(adapter as any, 'getClient').mockResolvedValue(mockClient)
-      vi.spyOn(adapter as any, 'pushMergedConfigToClient').mockResolvedValue(undefined)
+      ;(adapter as any).filterStaleProviderModels(providers)
 
-      const result = await (adapter as any).getProvidersInner(undefined, '/tmp/ws', false)
-
-      const peakfloProvider = result.providers.find((p: { id: string }) => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
-      const models = peakfloProvider.models as Record<string, unknown>
-
-      // All models preserved — no filtering without stored config
-      expect(Object.keys(models)).toEqual(['model-a'])
+      expect(Object.keys(providers[0].models as Record<string, unknown>)).toEqual(['model-a'])
     })
 
-    it('keeps all models when all server models are in fresh config', async () => {
-      const mockDb = {
-        getSetting: vi.fn((key: string): string | undefined => {
-          if (key === 'enterprise_litellm_api_key') return Buffer.from('sk-test', 'utf8').toString('base64')
-          if (key === 'enterprise_litellm_base_url') return Buffer.from('https://litellm.example.com', 'utf8').toString('base64')
-          if (key === 'enterprise_litellm_models') return JSON.stringify([
-            { id: 'model-a', name: 'Model A' },
-            { id: 'model-b', name: 'Model B' }
-          ])
-          return undefined
-        })
-      }
-
+    it('is a no-op when all server models match fresh config', () => {
+      const mockDb = { getSetting: vi.fn() }
       const adapter = new OpencodeAdapter(mockDb)
 
-      const mockClient = {
-        config: {
-          providers: vi.fn().mockResolvedValue({
-            data: {
-              providers: [
-                {
-                  id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
-                  name: 'Peakflo',
-                  models: {
-                    'model-a': { name: 'Model A' },
-                    'model-b': { name: 'Model B' }
-                  }
-                }
-              ],
-              default: {}
-            }
-          })
+      vi.spyOn(enterpriseAiGateway, 'readEnterpriseAiGatewayConfig').mockReturnValue({
+        apiKey: 'sk-test',
+        baseUrl: 'https://litellm.example.com',
+        models: [
+          { id: 'model-a', name: 'A' },
+          { id: 'model-b', name: 'B' }
+        ]
+      })
+
+      const providers = [
+        {
+          id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+          name: 'Peakflo',
+          models: { 'model-a': { name: 'A' }, 'model-b': { name: 'B' } } as unknown
         }
-      }
+      ]
 
-      vi.spyOn(adapter as any, 'getClient').mockResolvedValue(mockClient)
-      vi.spyOn(adapter as any, 'pushMergedConfigToClient').mockResolvedValue(undefined)
+      ;(adapter as any).filterStaleProviderModels(providers)
 
-      const result = await (adapter as any).getProvidersInner(undefined, '/tmp/ws', false)
-
-      const peakfloProvider = result.providers.find((p: { id: string }) => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
-      const models = peakfloProvider.models as Record<string, unknown>
-
-      expect(models['model-a']).toEqual({ name: 'Model A' })
-      expect(models['model-b']).toEqual({ name: 'Model B' })
+      const models = providers[0].models as Record<string, unknown>
       expect(Object.keys(models)).toEqual(['model-a', 'model-b'])
     })
   })

--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { OpencodeAdapter } from './opencode-adapter'
 import { SessionStatusType } from './coding-agent-adapter'
+import { ENTERPRISE_AI_GATEWAY_PROVIDER_ID } from '../enterprise-ai-gateway'
 
 describe('OpencodeAdapter', () => {
   describe('waitForMcpServersReady', () => {
@@ -337,7 +338,7 @@ describe('OpencodeAdapter', () => {
       expect(status.type).toBe(SessionStatusType.IDLE)
     })
 
-    it('returns WAITING_APPROVAL if underlying status is waiting_user', async () => {
+    it('returns WAITING_APPROVAL if underlying status is waiting_user (question)', async () => {
       const adapter = new OpencodeAdapter()
       const mockClient = {
         session: {
@@ -359,6 +360,191 @@ describe('OpencodeAdapter', () => {
 
       const status = await adapter.getStatus('session-2', { agentId: 'agent-1', taskId: 'task-1', workspaceDir: '/tmp/ws' })
       expect(status.type).toBe(SessionStatusType.WAITING_APPROVAL)
+    })
+  })
+
+  describe('getProvidersInner filters stale models', () => {
+    it('filters out stale models from peakflo provider using fresh SQLite config', async () => {
+      const mockDb = {
+        getSetting: vi.fn((key: string): string | undefined => {
+          // Return encrypted values for API key and base URL so readEnterpriseAiGatewayConfig works
+          if (key === 'enterprise_litellm_api_key') return Buffer.from('sk-test', 'utf8').toString('base64')
+          if (key === 'enterprise_litellm_base_url') return Buffer.from('https://litellm.example.com', 'utf8').toString('base64')
+          if (key === 'enterprise_litellm_models') return JSON.stringify([
+            { id: 'kept-model', name: 'Kept Model' },
+            { id: 'new-model', name: 'New Model' }
+          ])
+          return undefined
+        })
+      }
+
+      const adapter = new OpencodeAdapter(mockDb)
+
+      // Mock getClient to return a client whose config.providers returns stale data
+      const mockClient = {
+        config: {
+          providers: vi.fn().mockResolvedValue({
+            data: {
+              providers: [
+                {
+                  id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+                  name: 'Peakflo',
+                  models: {
+                    'old-model-1': { name: 'Old Model 1' },
+                    'old-model-2': { name: 'Old Model 2' },
+                    'kept-model': { name: 'Kept Model' }
+                  }
+                },
+                {
+                  id: 'anthropic',
+                  name: 'Anthropic',
+                  models: { 'claude-4': { name: 'Claude 4' } }
+                }
+              ],
+              default: {}
+            }
+          })
+        }
+      }
+
+      vi.spyOn(adapter as any, 'getClient').mockResolvedValue(mockClient)
+      vi.spyOn(adapter as any, 'pushMergedConfigToClient').mockResolvedValue(undefined)
+
+      const result = await (adapter as any).getProvidersInner(undefined, '/tmp/ws', false)
+
+      expect(result).not.toBeNull()
+      const peakfloProvider = result.providers.find((p: { id: string }) => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
+      const models = peakfloProvider.models as Record<string, unknown>
+
+      // Stale models should be filtered out
+      expect(models['old-model-1']).toBeUndefined()
+      expect(models['old-model-2']).toBeUndefined()
+      // Kept model should be preserved
+      expect(models['kept-model']).toEqual({ name: 'Kept Model' })
+      // Other providers should be unaffected
+      const anthropic = result.providers.find((p: { id: string }) => p.id === 'anthropic')
+      expect(anthropic.models).toEqual({ 'claude-4': { name: 'Claude 4' } })
+    })
+
+    it('does not filter when no db is available', async () => {
+      const adapter = new OpencodeAdapter() // no db
+
+      const mockClient = {
+        config: {
+          providers: vi.fn().mockResolvedValue({
+            data: {
+              providers: [
+                {
+                  id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+                  name: 'Peakflo',
+                  models: {
+                    'model-a': { name: 'Model A' },
+                    'model-b': { name: 'Model B' }
+                  }
+                }
+              ],
+              default: {}
+            }
+          })
+        }
+      }
+
+      vi.spyOn(adapter as any, 'getClient').mockResolvedValue(mockClient)
+      vi.spyOn(adapter as any, 'pushMergedConfigToClient').mockResolvedValue(undefined)
+
+      const result = await (adapter as any).getProvidersInner(undefined, '/tmp/ws', false)
+
+      const peakfloProvider = result.providers.find((p: { id: string }) => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
+      const models = peakfloProvider.models as Record<string, unknown>
+
+      // All models preserved — no filtering without db
+      expect(Object.keys(models)).toEqual(['model-a', 'model-b'])
+    })
+
+    it('does not filter when enterprise AI gateway config is not stored', async () => {
+      const mockDb = {
+        getSetting: vi.fn((): string | undefined => undefined)
+      }
+
+      const adapter = new OpencodeAdapter(mockDb)
+
+      const mockClient = {
+        config: {
+          providers: vi.fn().mockResolvedValue({
+            data: {
+              providers: [
+                {
+                  id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+                  name: 'Peakflo',
+                  models: {
+                    'model-a': { name: 'Model A' }
+                  }
+                }
+              ],
+              default: {}
+            }
+          })
+        }
+      }
+
+      vi.spyOn(adapter as any, 'getClient').mockResolvedValue(mockClient)
+      vi.spyOn(adapter as any, 'pushMergedConfigToClient').mockResolvedValue(undefined)
+
+      const result = await (adapter as any).getProvidersInner(undefined, '/tmp/ws', false)
+
+      const peakfloProvider = result.providers.find((p: { id: string }) => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
+      const models = peakfloProvider.models as Record<string, unknown>
+
+      // All models preserved — no filtering without stored config
+      expect(Object.keys(models)).toEqual(['model-a'])
+    })
+
+    it('keeps all models when all server models are in fresh config', async () => {
+      const mockDb = {
+        getSetting: vi.fn((key: string): string | undefined => {
+          if (key === 'enterprise_litellm_api_key') return Buffer.from('sk-test', 'utf8').toString('base64')
+          if (key === 'enterprise_litellm_base_url') return Buffer.from('https://litellm.example.com', 'utf8').toString('base64')
+          if (key === 'enterprise_litellm_models') return JSON.stringify([
+            { id: 'model-a', name: 'Model A' },
+            { id: 'model-b', name: 'Model B' }
+          ])
+          return undefined
+        })
+      }
+
+      const adapter = new OpencodeAdapter(mockDb)
+
+      const mockClient = {
+        config: {
+          providers: vi.fn().mockResolvedValue({
+            data: {
+              providers: [
+                {
+                  id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+                  name: 'Peakflo',
+                  models: {
+                    'model-a': { name: 'Model A' },
+                    'model-b': { name: 'Model B' }
+                  }
+                }
+              ],
+              default: {}
+            }
+          })
+        }
+      }
+
+      vi.spyOn(adapter as any, 'getClient').mockResolvedValue(mockClient)
+      vi.spyOn(adapter as any, 'pushMergedConfigToClient').mockResolvedValue(undefined)
+
+      const result = await (adapter as any).getProvidersInner(undefined, '/tmp/ws', false)
+
+      const peakfloProvider = result.providers.find((p: { id: string }) => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
+      const models = peakfloProvider.models as Record<string, unknown>
+
+      expect(models['model-a']).toEqual({ name: 'Model A' })
+      expect(models['model-b']).toEqual({ name: 'Model B' })
+      expect(Object.keys(models)).toEqual(['model-a', 'model-b'])
     })
   })
 })

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -332,31 +332,45 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       // We apply a client-side filter using the fresh model list from SQLite
       // (which was just refreshed from LiteLLM by the caller in agent-manager).
       if (data?.providers && this.db) {
-        const freshConfig = readEnterpriseAiGatewayConfig(this.db)
-        if (freshConfig?.models) {
-          const freshModelIds = new Set(freshConfig.models.map(m => m.id))
-          const provider = data.providers.find(p => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
-          if (provider?.models && typeof provider.models === 'object') {
-            const serverModels = provider.models as Record<string, unknown>
-            const filtered: Record<string, unknown> = {}
-            for (const [modelId, modelConfig] of Object.entries(serverModels)) {
-              if (freshModelIds.has(modelId)) {
-                filtered[modelId] = modelConfig
-              }
-            }
-            provider.models = filtered
-            const removed = Object.keys(serverModels).length - Object.keys(filtered).length
-            if (removed > 0) {
-              console.log(`[OpencodeAdapter] Filtered out ${removed} stale model(s) from ${ENTERPRISE_AI_GATEWAY_PROVIDER_ID} provider`)
-            }
-          }
-        }
+        this.filterStaleProviderModels(data.providers)
       }
 
       return data ? { providers: data.providers || [], default: data.default || {} } : null
     } catch (error: unknown) {
       console.log('[OpencodeAdapter] Could not get providers:', error instanceof Error ? error.message : error)
       return null
+    }
+  }
+
+  /**
+   * Remove models from the enterprise AI gateway provider that are no longer
+   * present in the fresh config stored in SQLite. Mutates the providers array
+   * in place.
+   */
+  private filterStaleProviderModels(
+    providers: { id: string; name: string; models: unknown; [key: string]: unknown }[]
+  ): void {
+    if (!this.db) return
+
+    const freshConfig = readEnterpriseAiGatewayConfig(this.db)
+    if (!freshConfig?.models) return
+
+    const freshModelIds = new Set(freshConfig.models.map(m => m.id))
+    const provider = providers.find(p => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
+    if (!provider?.models || typeof provider.models !== 'object') return
+
+    const serverModels = provider.models as Record<string, unknown>
+    const filtered: Record<string, unknown> = {}
+    for (const [modelId, modelConfig] of Object.entries(serverModels)) {
+      if (freshModelIds.has(modelId)) {
+        filtered[modelId] = modelConfig
+      }
+    }
+
+    const removed = Object.keys(serverModels).length - Object.keys(filtered).length
+    if (removed > 0) {
+      provider.models = filtered
+      console.log(`[OpencodeAdapter] Filtered out ${removed} stale model(s) from ${ENTERPRISE_AI_GATEWAY_PROVIDER_ID} provider`)
     }
   }
 

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -4,6 +4,7 @@ import { join, delimiter } from 'path'
 import { homedir } from 'os'
 import { execSync } from 'child_process'
 import { buildMergedOpencodeConfig } from '../utils/opencode-config'
+import { ENTERPRISE_AI_GATEWAY_PROVIDER_ID, readEnterpriseAiGatewayConfig } from '../enterprise-ai-gateway'
 import type { DatabaseManager } from '../database'
 import type {
   CodingAgentAdapter,
@@ -324,6 +325,33 @@ export class OpencodeAdapter implements CodingAgentAdapter {
         providers?: { id: string; name: string; models: unknown; [key: string]: unknown }[]
         default?: Record<string, string>
       } | undefined
+
+      // Filter stale models from the enterprise AI gateway provider.
+      // The OpenCode server uses PATCH (merge semantics) for config updates,
+      // so models removed from LiteLLM persist in the server's config.
+      // We apply a client-side filter using the fresh model list from SQLite
+      // (which was just refreshed from LiteLLM by the caller in agent-manager).
+      if (data?.providers && this.db) {
+        const freshConfig = readEnterpriseAiGatewayConfig(this.db)
+        if (freshConfig?.models) {
+          const freshModelIds = new Set(freshConfig.models.map(m => m.id))
+          const provider = data.providers.find(p => p.id === ENTERPRISE_AI_GATEWAY_PROVIDER_ID)
+          if (provider?.models && typeof provider.models === 'object') {
+            const serverModels = provider.models as Record<string, unknown>
+            const filtered: Record<string, unknown> = {}
+            for (const [modelId, modelConfig] of Object.entries(serverModels)) {
+              if (freshModelIds.has(modelId)) {
+                filtered[modelId] = modelConfig
+              }
+            }
+            provider.models = filtered
+            const removed = Object.keys(serverModels).length - Object.keys(filtered).length
+            if (removed > 0) {
+              console.log(`[OpencodeAdapter] Filtered out ${removed} stale model(s) from ${ENTERPRISE_AI_GATEWAY_PROVIDER_ID} provider`)
+            }
+          }
+        }
+      }
 
       return data ? { providers: data.providers || [], default: data.default || {} } : null
     } catch (error: unknown) {

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1665,7 +1665,10 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
     expect(entry.hasSeenWork).toBe(true)
     expect(transitionSpy).not.toHaveBeenCalled()
 
-    // Second poll: IDLE after real work → transition
+    // Second poll: IDLE after real work → transition.
+    // Move lastPartReceivedAt into the past so the POST_DATA_GRACE_MS
+    // (5 s) check doesn't block the transition.
+    entry.lastPartReceivedAt = Date.now() - 10_000
     adapter.pollMessages.mockResolvedValueOnce([])
     adapter.getStatus.mockResolvedValueOnce({ type: SessionStatusType.IDLE })
     await (mgr as any).pollSingleSession(entry)


### PR DESCRIPTION
## Summary
- The OpenCode server's `config.update()` uses HTTP PATCH (merge semantics), which deep-merges provider model configs. When models are removed from LiteLLM, the old model keys persist in the server's state alongside new ones, causing the model dropdown to show both removed and current models.
- The server rejects `null` values (Zod validation), so JSON Merge Patch deletion is not possible.
- Fix: after querying providers from the OpenCode server in `getProvidersInner()`, filter the peakflo provider's models against the fresh model list from SQLite (just refreshed from LiteLLM by `agent-manager` before this call). Stale models are excluded from the result returned to the UI.

## Test plan
- [x] 4 new unit tests covering: stale model filtering, no-op without db, no-op without stored config, no-op when all models match
- [x] All 16 tests pass (`vitest run`)
- [x] TypeScript build passes (`tsc --build --noEmit`)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)