### PR TITLE
feat: add auto-start agent and auto-complete options for recurring tasks

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -867,7 +867,7 @@ function deserializeInstalledPlugin(row: InstalledPluginRow): InstalledPluginRec
 
 // Bump this whenever new migrations are added so returning users skip
 // the full migration check on startup.
-const SCHEMA_VERSION = 6
+const SCHEMA_VERSION = 7
 
 export class DatabaseManager {
   public db!: Database.Database

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -244,6 +244,8 @@ export interface TaskRow {
   heartbeat_interval_minutes: number | null
   heartbeat_last_check_at: string | null
   heartbeat_next_check_at: string | null
+  auto_start_agent: number
+  auto_complete_without_review: number
   parent_task_id: string | null
   sort_order: number
   created_at: string
@@ -304,6 +306,8 @@ export interface TaskRecord {
   heartbeat_interval_minutes: number | null
   heartbeat_last_check_at: string | null
   heartbeat_next_check_at: string | null
+  auto_start_agent: boolean
+  auto_complete_without_review: boolean
   parent_task_id: string | null
   sort_order: number
   created_at: string
@@ -341,6 +345,8 @@ export interface CreateTaskData {
   is_recurring?: boolean
   recurrence_pattern?: RecurrencePatternRecord | null
   recurrence_parent_id?: string | null
+  auto_start_agent?: boolean
+  auto_complete_without_review?: boolean
   parent_task_id?: string | null
   /** Cron expression — if provided, sets is_recurring=true and stores as recurrence_pattern */
   cron?: string
@@ -372,6 +378,8 @@ export interface UpdateTaskData {
   heartbeat_interval_minutes?: number | null
   heartbeat_last_check_at?: string | null
   heartbeat_next_check_at?: string | null
+  auto_start_agent?: boolean
+  auto_complete_without_review?: boolean
   parent_task_id?: string | null
   sort_order?: number
 }
@@ -403,6 +411,8 @@ const UPDATABLE_COLUMNS = new Set([
   'heartbeat_interval_minutes',
   'heartbeat_last_check_at',
   'heartbeat_next_check_at',
+  'auto_start_agent',
+  'auto_complete_without_review',
   'parent_task_id',
   'sort_order'
 ])
@@ -450,7 +460,9 @@ function deserializeTask(row: TaskRow): TaskRecord {
     heartbeat_enabled: row.heartbeat_enabled === 1,
     heartbeat_interval_minutes: row.heartbeat_interval_minutes ?? null,
     heartbeat_last_check_at: row.heartbeat_last_check_at ?? null,
-    heartbeat_next_check_at: row.heartbeat_next_check_at ?? null
+    heartbeat_next_check_at: row.heartbeat_next_check_at ?? null,
+    auto_start_agent: (row.auto_start_agent ?? 0) === 1,
+    auto_complete_without_review: (row.auto_complete_without_review ?? 0) === 1
   }
 }
 
@@ -933,6 +945,8 @@ export class DatabaseManager {
         heartbeat_interval_minutes INTEGER DEFAULT 30,
         heartbeat_last_check_at TEXT DEFAULT NULL,
         heartbeat_next_check_at TEXT DEFAULT NULL,
+        auto_start_agent INTEGER NOT NULL DEFAULT 0,
+        auto_complete_without_review INTEGER NOT NULL DEFAULT 0,
         parent_task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
         sort_order INTEGER NOT NULL DEFAULT 0,
         created_at TEXT NOT NULL,
@@ -1121,6 +1135,8 @@ export class DatabaseManager {
         heartbeat_interval_minutes INTEGER DEFAULT 30,
         heartbeat_last_check_at TEXT DEFAULT NULL,
         heartbeat_next_check_at TEXT DEFAULT NULL,
+        auto_start_agent INTEGER NOT NULL DEFAULT 0,
+        auto_complete_without_review INTEGER NOT NULL DEFAULT 0,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       )
@@ -1452,6 +1468,14 @@ export class DatabaseManager {
     // Add sort_order column for explicit subtask ordering (supports drag-and-drop)
     if (!columnNames.has('sort_order')) {
       this.db.exec(`ALTER TABLE tasks ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0`)
+    }
+
+    // Add auto_start_agent and auto_complete_without_review columns for recurring tasks
+    if (!columnNames.has('auto_start_agent')) {
+      this.db.exec(`ALTER TABLE tasks ADD COLUMN auto_start_agent INTEGER NOT NULL DEFAULT 0`)
+    }
+    if (!columnNames.has('auto_complete_without_review')) {
+      this.db.exec(`ALTER TABLE tasks ADD COLUMN auto_complete_without_review INTEGER NOT NULL DEFAULT 0`)
     }
 
     // Create heartbeat_logs table
@@ -1937,10 +1961,11 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
         id, title, description, type, priority, status, assignee, due_date,
         labels, attachments, repos, output_fields, external_id, source_id, source,
         is_recurring, recurrence_pattern, recurrence_parent_id,
+        auto_start_agent, auto_complete_without_review,
         parent_task_id, sort_order,
         created_at, updated_at
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       data.title,
@@ -1960,6 +1985,8 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
       isRecurring ? 1 : 0,
       recurrencePattern,
       data.recurrence_parent_id ?? null,
+      data.auto_start_agent ? 1 : 0,
+      data.auto_complete_without_review ? 1 : 0,
       data.parent_task_id ?? null,
       sortOrder,
       now,

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -111,6 +111,11 @@ export function registerIpcHandlers(
 
     const updated = db.updateTask(id, data)
 
+    // Initialize recurring task schedule when recurrence is added or changed
+    if (recurrenceScheduler && updated && updated.is_recurring && updated.recurrence_pattern) {
+      recurrenceScheduler.initializeRecurringTask(id)
+    }
+
     // Auto-disable heartbeat when task is completed
     if (heartbeatScheduler && data.status === TaskStatus.Completed && updated?.heartbeat_enabled) {
       heartbeatScheduler.disableHeartbeat(id)

--- a/src/main/recurrence-scheduler.ts
+++ b/src/main/recurrence-scheduler.ts
@@ -141,6 +141,9 @@ export class RecurrenceScheduler {
 
   private async checkAndCreateDueInstances(): Promise<void> {
     try {
+      // Repair any templates missing next_occurrence_at (e.g. recurrence added via update)
+      this.repairMissingNextOccurrence()
+
       const now = new Date().toISOString()
 
       // Query templates where next_occurrence_at <= NOW()
@@ -424,22 +427,26 @@ export class RecurrenceScheduler {
     }
   }
 
-  // Public method to initialize next_occurrence_at for a newly created recurring task
+  // Public method to initialize next_occurrence_at for a newly created recurring task.
+  // Calculates from 1 minute ago so that a cron matching the current minute fires
+  // on the very next scheduler tick instead of waiting until the next day/cycle.
   initializeRecurringTask(taskId: string): void {
     const task = this.dbManager.getTask(taskId)
     if (!task || !task.is_recurring || !task.recurrence_pattern) {
       return
     }
 
-    const now = new Date().toISOString()
-    const nextOccurrence = this.calculateNextOccurrence(task.recurrence_pattern, now)
+    const now = new Date()
+    // Look back 1 minute so the current minute's cron match is included
+    const lookback = new Date(now.getTime() - 60_000).toISOString()
+    const nextOccurrence = this.calculateNextOccurrence(task.recurrence_pattern, lookback)
 
     if (nextOccurrence) {
       this.dbManager.db.prepare(`
         UPDATE tasks
         SET next_occurrence_at = ?, updated_at = ?
         WHERE id = ?
-      `).run(nextOccurrence, now, taskId)
+      `).run(nextOccurrence, now.toISOString(), taskId)
 
       console.log(`[RecurrenceScheduler] Initialized recurring task ${taskId} with next occurrence: ${nextOccurrence}`)
     }

--- a/src/main/recurrence-scheduler.ts
+++ b/src/main/recurrence-scheduler.ts
@@ -273,6 +273,14 @@ export class RecurrenceScheduler {
     )
 
     console.log(`[RecurrenceScheduler] Created instance ${id} from template ${template.id}`)
+
+    // Emit task:created so the renderer auto-start hook can pick it up
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      const task = this.dbManager.getTask(id)
+      if (task) {
+        this.mainWindow.webContents.send('task:created', { task })
+      }
+    }
   }
 
   /**

--- a/src/main/recurrence-scheduler.ts
+++ b/src/main/recurrence-scheduler.ts
@@ -275,12 +275,22 @@ export class RecurrenceScheduler {
       now
     )
 
-    console.log(`[RecurrenceScheduler] Created instance ${id} from template ${template.id}`)
+    console.log(`[RecurrenceScheduler] Created instance ${id} from template ${template.id}`, {
+      auto_start_agent: template.auto_start_agent,
+      auto_complete_without_review: template.auto_complete_without_review,
+      agent_id: template.agent_id
+    })
 
     // Emit task:created so the renderer auto-start hook can pick it up
     if (this.mainWindow && !this.mainWindow.isDestroyed()) {
       const task = this.dbManager.getTask(id)
       if (task) {
+        console.log(`[RecurrenceScheduler] Emitting task:created for instance ${id}`, {
+          auto_start_agent: task.auto_start_agent,
+          auto_complete_without_review: task.auto_complete_without_review,
+          agent_id: task.agent_id,
+          recurrence_parent_id: task.recurrence_parent_id
+        })
         this.mainWindow.webContents.send('task:created', { task })
       }
     }

--- a/src/main/recurrence-scheduler.ts
+++ b/src/main/recurrence-scheduler.ts
@@ -43,6 +43,8 @@ interface RawTaskRow {
   heartbeat_interval_minutes: number
   heartbeat_last_check_at: string | null
   heartbeat_next_check_at: string | null
+  auto_start_agent: number
+  auto_complete_without_review: number
   parent_task_id: string | null
   sort_order: number
   created_at: string
@@ -241,9 +243,10 @@ export class RecurrenceScheduler {
         id, title, description, type, priority, status, assignee, due_date,
         labels, attachments, repos, output_fields, agent_id, source, skill_ids,
         is_recurring, recurrence_pattern, recurrence_parent_id,
+        auto_start_agent, auto_complete_without_review,
         created_at, updated_at
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       template.title,
@@ -263,6 +266,8 @@ export class RecurrenceScheduler {
       0, // Not recurring
       null, // No recurrence pattern
       template.id, // Link back to template
+      template.auto_start_agent ? 1 : 0,
+      template.auto_complete_without_review ? 1 : 0,
       occurrenceTime, // Use occurrence time as created_at
       now
     )
@@ -404,6 +409,8 @@ export class RecurrenceScheduler {
       heartbeat_interval_minutes: row.heartbeat_interval_minutes ?? 30,
       heartbeat_last_check_at: row.heartbeat_last_check_at ?? null,
       heartbeat_next_check_at: row.heartbeat_next_check_at ?? null,
+      auto_start_agent: (row.auto_start_agent ?? 0) === 1,
+      auto_complete_without_review: (row.auto_complete_without_review ?? 0) === 1,
       parent_task_id: row.parent_task_id ?? null,
       sort_order: row.sort_order ?? 0,
     }

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -485,6 +485,38 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
               </>
             )}
 
+            {/* Auto-start / Auto-complete toggles for recurring templates with agent */}
+            {task.is_recurring && !task.recurrence_parent_id && task.agent_id && (
+              <>
+                <span className="text-muted-foreground flex items-center gap-1.5">
+                  <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+                  Auto-start
+                </span>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={task.auto_start_agent}
+                    onChange={(e) => updateTask(task.id, { auto_start_agent: e.target.checked })}
+                    className="h-4 w-4 rounded"
+                  />
+                  <span className="text-sm">Auto-start agent on new instances</span>
+                </label>
+                <span className="text-muted-foreground flex items-center gap-1.5">
+                  <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/></svg>
+                  Auto-complete
+                </span>
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={task.auto_complete_without_review}
+                    onChange={(e) => updateTask(task.id, { auto_complete_without_review: e.target.checked })}
+                    className="h-4 w-4 rounded"
+                  />
+                  <span className="text-sm">Auto-complete without review</span>
+                </label>
+              </>
+            )}
+
             {/* Due date */}
             {task.due_date && (
               <>

--- a/src/mobile/pages/TaskFormPage.tsx
+++ b/src/mobile/pages/TaskFormPage.tsx
@@ -125,6 +125,10 @@ export function TaskFormPage({ taskId, onNavigate }: { taskId?: string; onNaviga
   const [cronMode, setCronMode] = useState(false)
   const [rawCron, setRawCron] = useState('')
 
+  // ── Auto-start / auto-complete flags ───────────────────
+  const [autoStartAgent, setAutoStartAgent] = useState(false)
+  const [autoCompleteWithoutReview, setAutoCompleteWithoutReview] = useState(false)
+
   // ── Submit state ────────────────────────────────────────
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -147,6 +151,10 @@ export function TaskFormPage({ taskId, onNavigate }: { taskId?: string; onNaviga
     setDueDate(existingTask.due_date ? existingTask.due_date.slice(0, 10) : '')
     setLabels(existingTask.labels.join(', '))
     setOutputFields((existingTask.output_fields || []) as OutputField[])
+
+    // Auto flags
+    setAutoStartAgent(existingTask.auto_start_agent)
+    setAutoCompleteWithoutReview(existingTask.auto_complete_without_review)
 
     // Recurrence
     if (existingTask.is_recurring && existingTask.recurrence_pattern) {
@@ -201,7 +209,9 @@ export function TaskFormPage({ taskId, onNavigate }: { taskId?: string; onNaviga
       labels: parsedLabels,
       output_fields: outputFields,
       is_recurring: recurringEnabled,
-      recurrence_pattern: recurrencePattern
+      recurrence_pattern: recurrencePattern,
+      auto_start_agent: recurringEnabled && autoStartAgent,
+      auto_complete_without_review: recurringEnabled && autoCompleteWithoutReview
     }
 
     try {
@@ -547,6 +557,31 @@ export function TaskFormPage({ taskId, onNavigate }: { taskId?: string; onNaviga
                   </div>
                 )}
               </div>
+
+              {/* ── Auto-start / Auto-complete (visible when recurring) ── */}
+              {recurringEnabled && (
+                <div className="space-y-3 rounded-md border border-border/50 p-3" data-testid="auto-flags-section">
+                  <label className="text-xs font-medium text-muted-foreground">Automation</label>
+                  <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
+                    <input
+                      type="checkbox"
+                      checked={autoStartAgent}
+                      onChange={(e) => setAutoStartAgent(e.target.checked)}
+                      className="h-4 w-4 rounded"
+                    />
+                    <span className="text-xs">Auto-start agent on new instances</span>
+                  </label>
+                  <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
+                    <input
+                      type="checkbox"
+                      checked={autoCompleteWithoutReview}
+                      onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
+                      className="h-4 w-4 rounded"
+                    />
+                    <span className="text-xs">Auto-complete without review</span>
+                  </label>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/mobile/pages/TaskFormPage.tsx
+++ b/src/mobile/pages/TaskFormPage.tsx
@@ -556,32 +556,32 @@ export function TaskFormPage({ taskId, onNavigate }: { taskId?: string; onNaviga
                     </p>
                   </div>
                 )}
-              </div>
 
-              {/* ── Auto-start / Auto-complete (visible when recurring) ── */}
-              {recurringEnabled && (
-                <div className="space-y-3 rounded-md border border-border/50 p-3" data-testid="auto-flags-section">
-                  <label className="text-xs font-medium text-muted-foreground">Automation</label>
-                  <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
-                    <input
-                      type="checkbox"
-                      checked={autoStartAgent}
-                      onChange={(e) => setAutoStartAgent(e.target.checked)}
-                      className="h-4 w-4 rounded"
-                    />
-                    <span className="text-xs">Auto-start agent on new instances</span>
-                  </label>
-                  <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
-                    <input
-                      type="checkbox"
-                      checked={autoCompleteWithoutReview}
-                      onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
-                      className="h-4 w-4 rounded"
-                    />
-                    <span className="text-xs">Auto-complete without review</span>
-                  </label>
-                </div>
-              )}
+                {/* ── Auto-start / Auto-complete (inside recurrence block) ── */}
+                {recurringEnabled && (
+                  <div className="space-y-3 pt-3 mt-3 border-t border-border/50" data-testid="auto-flags-section">
+                    <label className="text-xs font-medium text-muted-foreground">Automation</label>
+                    <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
+                      <input
+                        type="checkbox"
+                        checked={autoStartAgent}
+                        onChange={(e) => setAutoStartAgent(e.target.checked)}
+                        className="h-4 w-4 rounded"
+                      />
+                      <span className="text-xs">Auto-start agent on new instances</span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
+                      <input
+                        type="checkbox"
+                        checked={autoCompleteWithoutReview}
+                        onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
+                        className="h-4 w-4 rounded"
+                      />
+                      <span className="text-xs">Auto-complete without review</span>
+                    </label>
+                  </div>
+                )}
+              </div>
             </div>
           )}
 

--- a/src/mobile/stores/task-store.ts
+++ b/src/mobile/stores/task-store.ts
@@ -46,6 +46,8 @@ export interface Task {
   heartbeat_interval_minutes?: number | null
   heartbeat_last_check_at?: string | null
   heartbeat_next_check_at?: string | null
+  auto_start_agent: boolean
+  auto_complete_without_review: boolean
   parent_task_id: string | null
   sort_order: number
   created_at: string

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
@@ -88,6 +88,8 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     recurrence_parent_id: null,
     last_occurrence_at: null,
     next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
     parent_task_id: null,
     sort_order: 0,
     created_at: '2026-03-28T08:00:00Z',

--- a/src/renderer/src/components/tasks/RecurrenceEditor.tsx
+++ b/src/renderer/src/components/tasks/RecurrenceEditor.tsx
@@ -172,7 +172,7 @@ export function RecurrenceEditor({ value, onChange }: RecurrenceEditorProps) {
   }
 
   return (
-    <div className="space-y-4 border-t border-border pt-4">
+    <div className="space-y-4">
       <div className="flex items-center gap-2">
         <input
           type="checkbox"

--- a/src/renderer/src/components/tasks/TaskDetailView.test.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.test.tsx
@@ -52,6 +52,8 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     recurrence_parent_id: null,
     last_occurrence_at: null,
     next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
     parent_task_id: null,
@@ -94,6 +96,7 @@ function renderDetailView(overrides: {
   canRestartAgent?: boolean
   onCompleteTask?: () => void
   onUpdateDescription?: (description: string) => void | Promise<void>
+  onUpdateAutoFlags?: (updates: { auto_start_agent?: boolean; auto_complete_without_review?: boolean }) => void
 } = {}) {
   const task = makeTask(overrides.task)
   return render(
@@ -120,6 +123,7 @@ function renderDetailView(overrides: {
       onRestartAgent={overrides.onRestartAgent}
       canRestartAgent={overrides.canRestartAgent}
       onUpdateDescription={overrides.onUpdateDescription}
+      onUpdateAutoFlags={overrides.onUpdateAutoFlags}
     />
   )
 }
@@ -473,5 +477,149 @@ describe('TaskDetailView – inline description editing', () => {
       task: { description: '' }
     })
     expect(container.querySelector('[data-testid="collapsible-description"]')).toBeNull()
+  })
+})
+
+describe('TaskDetailView – recurring task auto-start/auto-complete toggles', () => {
+  it('shows auto-start and auto-complete toggles for recurring templates with agent', () => {
+    const onUpdateAutoFlags = vi.fn()
+    renderDetailView({
+      task: {
+        is_recurring: true,
+        recurrence_parent_id: null,
+        recurrence_pattern: '0 9 * * 1-5',
+        agent_id: 'agent-1',
+        auto_start_agent: false,
+        auto_complete_without_review: false
+      },
+      agents: [makeAgent()],
+      onUpdateAutoFlags
+    })
+
+    expect(screen.getByTestId('auto-start-agent-toggle')).toBeDefined()
+    expect(screen.getByTestId('auto-complete-toggle')).toBeDefined()
+  })
+
+  it('does not show toggles for non-recurring tasks', () => {
+    renderDetailView({
+      task: {
+        is_recurring: false,
+        agent_id: 'agent-1'
+      },
+      agents: [makeAgent()],
+      onUpdateAutoFlags: vi.fn()
+    })
+
+    expect(screen.queryByTestId('auto-start-agent-toggle')).toBeNull()
+    expect(screen.queryByTestId('auto-complete-toggle')).toBeNull()
+  })
+
+  it('does not show toggles for recurring instances (with recurrence_parent_id)', () => {
+    renderDetailView({
+      task: {
+        is_recurring: false,
+        recurrence_parent_id: 'parent-template-id',
+        agent_id: 'agent-1'
+      },
+      agents: [makeAgent()],
+      onUpdateAutoFlags: vi.fn()
+    })
+
+    expect(screen.queryByTestId('auto-start-agent-toggle')).toBeNull()
+    expect(screen.queryByTestId('auto-complete-toggle')).toBeNull()
+  })
+
+  it('does not show toggles when no agent is assigned', () => {
+    renderDetailView({
+      task: {
+        is_recurring: true,
+        recurrence_parent_id: null,
+        recurrence_pattern: '0 9 * * 1-5',
+        agent_id: null
+      },
+      agents: [makeAgent()],
+      onUpdateAutoFlags: vi.fn()
+    })
+
+    expect(screen.queryByTestId('auto-start-agent-toggle')).toBeNull()
+    expect(screen.queryByTestId('auto-complete-toggle')).toBeNull()
+  })
+
+  it('does not show toggles when onUpdateAutoFlags is not provided', () => {
+    renderDetailView({
+      task: {
+        is_recurring: true,
+        recurrence_parent_id: null,
+        recurrence_pattern: '0 9 * * 1-5',
+        agent_id: 'agent-1'
+      },
+      agents: [makeAgent()]
+    })
+
+    expect(screen.queryByTestId('auto-start-agent-toggle')).toBeNull()
+    expect(screen.queryByTestId('auto-complete-toggle')).toBeNull()
+  })
+
+  it('calls onUpdateAutoFlags when auto-start toggle is clicked', () => {
+    const onUpdateAutoFlags = vi.fn()
+    renderDetailView({
+      task: {
+        is_recurring: true,
+        recurrence_parent_id: null,
+        recurrence_pattern: '0 9 * * 1-5',
+        agent_id: 'agent-1',
+        auto_start_agent: false,
+        auto_complete_without_review: false
+      },
+      agents: [makeAgent()],
+      onUpdateAutoFlags
+    })
+
+    const checkbox = screen.getByTestId('auto-start-agent-toggle').querySelector('input[type="checkbox"]')!
+    fireEvent.click(checkbox)
+
+    expect(onUpdateAutoFlags).toHaveBeenCalledWith({ auto_start_agent: true })
+  })
+
+  it('calls onUpdateAutoFlags when auto-complete toggle is clicked', () => {
+    const onUpdateAutoFlags = vi.fn()
+    renderDetailView({
+      task: {
+        is_recurring: true,
+        recurrence_parent_id: null,
+        recurrence_pattern: '0 9 * * 1-5',
+        agent_id: 'agent-1',
+        auto_start_agent: false,
+        auto_complete_without_review: false
+      },
+      agents: [makeAgent()],
+      onUpdateAutoFlags
+    })
+
+    const checkbox = screen.getByTestId('auto-complete-toggle').querySelector('input[type="checkbox"]')!
+    fireEvent.click(checkbox)
+
+    expect(onUpdateAutoFlags).toHaveBeenCalledWith({ auto_complete_without_review: true })
+  })
+
+  it('renders checkboxes as checked when flags are true', () => {
+    renderDetailView({
+      task: {
+        is_recurring: true,
+        recurrence_parent_id: null,
+        recurrence_pattern: '0 9 * * 1-5',
+        agent_id: 'agent-1',
+        auto_start_agent: true,
+        auto_complete_without_review: true
+      },
+      agents: [makeAgent()],
+      onUpdateAutoFlags: vi.fn()
+    })
+
+    const autoStartCheckbox = screen.getByTestId('auto-start-agent-toggle').querySelector('input[type="checkbox"]') as HTMLInputElement
+    const autoCompleteCheckbox = screen.getByTestId('auto-complete-toggle').querySelector('input[type="checkbox"]') as HTMLInputElement
+
+    expect(autoStartCheckbox.checked).toBe(true)
+    expect(autoCompleteCheckbox.checked).toBe(true)
   })
 })

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -367,6 +367,8 @@ interface TaskDetailViewProps {
   onEditAgent?: (agentId: string) => void
   /** Save an inline description edit. When provided, the description becomes editable. */
   onUpdateDescription?: (description: string) => void | Promise<void>
+  /** Update auto-start / auto-complete flags for recurring templates */
+  onUpdateAutoFlags?: (updates: { auto_start_agent?: boolean; auto_complete_without_review?: boolean }) => void
   subtasks?: WorkfloTask[]
   parentTask?: WorkfloTask | null
   onNavigateToTask?: (taskId: string) => void
@@ -374,7 +376,7 @@ interface TaskDetailViewProps {
   onReorderSubtasks?: (orderedIds: string[]) => void
 }
 
-export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onAddSkills, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage, onEditAgent, onUpdateDescription, subtasks, parentTask, onNavigateToTask, onAddSubtask, onReorderSubtasks }: TaskDetailViewProps) {
+export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onAddSkills, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage, onEditAgent, onUpdateDescription, onUpdateAutoFlags, subtasks, parentTask, onNavigateToTask, onAddSubtask, onReorderSubtasks }: TaskDetailViewProps) {
   const { skills, fetchSkills } = useSkillStore()
   const openTaskOnCanvas = useUIStore((s) => s.openTaskOnCanvas)
   const isActive = task.status !== TaskStatus.Completed
@@ -642,6 +644,30 @@ export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachm
                     </span>
                   )}
                 </div>
+              </>
+            )}
+            {task.is_recurring && !task.recurrence_parent_id && task.agent_id && onUpdateAutoFlags && (
+              <>
+                <span className="text-muted-foreground flex items-center gap-2"><Play className="h-3.5 w-3.5" /> Auto-start</span>
+                <label className="flex items-center gap-2 cursor-pointer" data-testid="auto-start-agent-toggle">
+                  <input
+                    type="checkbox"
+                    checked={task.auto_start_agent}
+                    onChange={(e) => onUpdateAutoFlags({ auto_start_agent: e.target.checked })}
+                    className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+                  />
+                  <span className="text-sm">Auto-start agent on new instances</span>
+                </label>
+                <span className="text-muted-foreground flex items-center gap-2"><Sparkles className="h-3.5 w-3.5" /> Auto-complete</span>
+                <label className="flex items-center gap-2 cursor-pointer" data-testid="auto-complete-toggle">
+                  <input
+                    type="checkbox"
+                    checked={task.auto_complete_without_review}
+                    onChange={(e) => onUpdateAutoFlags({ auto_complete_without_review: e.target.checked })}
+                    className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+                  />
+                  <span className="text-sm">Auto-complete without review</span>
+                </label>
               </>
             )}
             {task.recurrence_parent_id && (

--- a/src/renderer/src/components/tasks/TaskForm.test.tsx
+++ b/src/renderer/src/components/tasks/TaskForm.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { TaskForm } from './TaskForm'
+import { TaskStatus } from '@/types'
+import type { WorkfloTask } from '@/types'
+
+afterEach(cleanup)
+
+function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
+  return {
+    id: 'task-1',
+    title: 'Test Task',
+    description: '',
+    type: 'general',
+    priority: 'medium',
+    status: TaskStatus.NotStarted,
+    assignee: '',
+    due_date: null,
+    labels: [],
+    attachments: [],
+    repos: [],
+    output_fields: [],
+    agent_id: null,
+    session_id: null,
+    external_id: null,
+    source_id: null,
+    source: 'local',
+    skill_ids: null,
+    snoozed_until: null,
+    resolution: null,
+    feedback_rating: null,
+    feedback_comment: null,
+    is_recurring: false,
+    recurrence_pattern: null,
+    recurrence_parent_id: null,
+    last_occurrence_at: null,
+    next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
+    parent_task_id: null,
+    sort_order: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides
+  }
+}
+
+describe('TaskForm – auto-start / auto-complete toggles', () => {
+  it('does not show automation section when recurrence is disabled', () => {
+    render(<TaskForm onSubmit={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.queryByTestId('auto-flags-section')).toBeNull()
+    expect(screen.queryByText('Auto-start agent on new instances')).toBeNull()
+    expect(screen.queryByText('Auto-complete without review')).toBeNull()
+  })
+
+  it('shows automation section when editing a recurring task', () => {
+    const task = makeTask({
+      is_recurring: true,
+      recurrence_pattern: '0 9 * * 1-5',
+      agent_id: 'agent-1'
+    })
+
+    render(<TaskForm task={task} onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    expect(screen.getByTestId('auto-flags-section')).toBeDefined()
+    expect(screen.getByText('Auto-start agent on new instances')).toBeDefined()
+    expect(screen.getByText('Auto-complete without review')).toBeDefined()
+  })
+
+  it('initializes toggles from existing task values', () => {
+    const task = makeTask({
+      is_recurring: true,
+      recurrence_pattern: '0 9 * * 1-5',
+      agent_id: 'agent-1',
+      auto_start_agent: true,
+      auto_complete_without_review: true
+    })
+
+    render(<TaskForm task={task} onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    const autoStartCheckbox = screen.getByTestId('form-auto-start-toggle').querySelector('input[type="checkbox"]') as HTMLInputElement
+    const autoCompleteCheckbox = screen.getByTestId('form-auto-complete-toggle').querySelector('input[type="checkbox"]') as HTMLInputElement
+
+    expect(autoStartCheckbox.checked).toBe(true)
+    expect(autoCompleteCheckbox.checked).toBe(true)
+  })
+
+  it('initializes toggles as unchecked when task has them false', () => {
+    const task = makeTask({
+      is_recurring: true,
+      recurrence_pattern: '0 9 * * 1-5',
+      auto_start_agent: false,
+      auto_complete_without_review: false
+    })
+
+    render(<TaskForm task={task} onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    const autoStartCheckbox = screen.getByTestId('form-auto-start-toggle').querySelector('input[type="checkbox"]') as HTMLInputElement
+    const autoCompleteCheckbox = screen.getByTestId('form-auto-complete-toggle').querySelector('input[type="checkbox"]') as HTMLInputElement
+
+    expect(autoStartCheckbox.checked).toBe(false)
+    expect(autoCompleteCheckbox.checked).toBe(false)
+  })
+
+  it('toggles auto-start checkbox on click', () => {
+    const task = makeTask({
+      is_recurring: true,
+      recurrence_pattern: '0 9 * * 1-5'
+    })
+
+    render(<TaskForm task={task} onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    const checkbox = screen.getByTestId('form-auto-start-toggle').querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(true)
+
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(false)
+  })
+
+  it('toggles auto-complete checkbox on click', () => {
+    const task = makeTask({
+      is_recurring: true,
+      recurrence_pattern: '0 9 * * 1-5'
+    })
+
+    render(<TaskForm task={task} onSubmit={vi.fn()} onCancel={vi.fn()} />)
+
+    const checkbox = screen.getByTestId('form-auto-complete-toggle').querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(true)
+  })
+
+  it('includes auto flags in submit data when recurrence is enabled', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const task = makeTask({
+      is_recurring: true,
+      recurrence_pattern: '0 9 * * 1-5'
+    })
+
+    render(<TaskForm task={task} onSubmit={onSubmit} onCancel={vi.fn()} />)
+
+    // Enable auto-start
+    const autoStartCheckbox = screen.getByTestId('form-auto-start-toggle').querySelector('input[type="checkbox"]') as HTMLInputElement
+    fireEvent.click(autoStartCheckbox)
+
+    // Submit
+    fireEvent.click(screen.getByText('Save Changes'))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
+    const submitted = onSubmit.mock.calls[0][0]
+    expect(submitted.auto_start_agent).toBe(true)
+    expect(submitted.auto_complete_without_review).toBe(false)
+  })
+
+  it('resets auto flags to false in submit data when recurrence is disabled', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+
+    // Create the task form without an existing task (create mode)
+    // The RecurrenceEditor starts disabled so recurrencePattern is null
+    render(<TaskForm onSubmit={onSubmit} onCancel={vi.fn()} />)
+
+    // Fill required title
+    fireEvent.change(screen.getByPlaceholderText('What needs to be done?'), {
+      target: { value: 'My new task' }
+    })
+
+    // Submit without enabling recurrence
+    fireEvent.click(screen.getByText('Create Task'))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
+    const submitted = onSubmit.mock.calls[0][0]
+    expect(submitted.auto_start_agent).toBe(false)
+    expect(submitted.auto_complete_without_review).toBe(false)
+  })
+})

--- a/src/renderer/src/components/tasks/TaskForm.tsx
+++ b/src/renderer/src/components/tasks/TaskForm.tsx
@@ -180,31 +180,30 @@ export function TaskForm({ task, onSubmit, onCancel }: TaskFormProps) {
 
       <div className="rounded-md border p-4">
         <RecurrenceEditor value={recurrencePattern} onChange={setRecurrencePattern} />
+        {recurrencePattern && (
+          <div className="space-y-3 pt-4 mt-4 border-t border-border" data-testid="auto-flags-section">
+            <p className="text-sm font-medium text-muted-foreground">Automation</p>
+            <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
+              <input
+                type="checkbox"
+                checked={autoStartAgent}
+                onChange={(e) => setAutoStartAgent(e.target.checked)}
+                className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+              />
+              <span className="text-sm">Auto-start agent on new instances</span>
+            </label>
+            <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
+              <input
+                type="checkbox"
+                checked={autoCompleteWithoutReview}
+                onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
+                className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+              />
+              <span className="text-sm">Auto-complete without review</span>
+            </label>
+          </div>
+        )}
       </div>
-
-      {recurrencePattern && (
-        <div className="rounded-md border p-4 space-y-3" data-testid="auto-flags-section">
-          <p className="text-sm font-medium text-muted-foreground">Automation</p>
-          <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
-            <input
-              type="checkbox"
-              checked={autoStartAgent}
-              onChange={(e) => setAutoStartAgent(e.target.checked)}
-              className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
-            />
-            <span className="text-sm">Auto-start agent on new instances</span>
-          </label>
-          <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
-            <input
-              type="checkbox"
-              checked={autoCompleteWithoutReview}
-              onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
-              className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
-            />
-            <span className="text-sm">Auto-complete without review</span>
-          </label>
-        </div>
-      )}
 
       {submitError && (
         <p className="text-sm text-destructive">{submitError}</p>

--- a/src/renderer/src/components/tasks/TaskForm.tsx
+++ b/src/renderer/src/components/tasks/TaskForm.tsx
@@ -42,6 +42,8 @@ export function TaskForm({ task, onSubmit, onCancel }: TaskFormProps) {
   const [outputFields, setOutputFields] = useState<OutputField[]>([])
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([])
   const [recurrencePattern, setRecurrencePattern] = useState<RecurrencePattern | null>(null)
+  const [autoStartAgent, setAutoStartAgent] = useState(false)
+  const [autoCompleteWithoutReview, setAutoCompleteWithoutReview] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
@@ -58,6 +60,8 @@ export function TaskForm({ task, onSubmit, onCancel }: TaskFormProps) {
       setAttachments(task.attachments)
       setOutputFields(task.output_fields)
       setRecurrencePattern(task.recurrence_pattern)
+      setAutoStartAgent(task.auto_start_agent)
+      setAutoCompleteWithoutReview(task.auto_complete_without_review)
     }
   }, [task])
 
@@ -85,7 +89,9 @@ export function TaskForm({ task, onSubmit, onCancel }: TaskFormProps) {
         attachments,
         output_fields: outputFields,
         is_recurring: !!recurrencePattern,
-        recurrence_pattern: recurrencePattern
+        recurrence_pattern: recurrencePattern,
+        auto_start_agent: !!recurrencePattern && autoStartAgent,
+        auto_complete_without_review: !!recurrencePattern && autoCompleteWithoutReview
       }
 
       if (!task && pendingFiles.length > 0) {
@@ -175,6 +181,30 @@ export function TaskForm({ task, onSubmit, onCancel }: TaskFormProps) {
       <div className="rounded-md border p-4">
         <RecurrenceEditor value={recurrencePattern} onChange={setRecurrencePattern} />
       </div>
+
+      {recurrencePattern && (
+        <div className="rounded-md border p-4 space-y-3" data-testid="auto-flags-section">
+          <p className="text-sm font-medium text-muted-foreground">Automation</p>
+          <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
+            <input
+              type="checkbox"
+              checked={autoStartAgent}
+              onChange={(e) => setAutoStartAgent(e.target.checked)}
+              className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+            />
+            <span className="text-sm">Auto-start agent on new instances</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
+            <input
+              type="checkbox"
+              checked={autoCompleteWithoutReview}
+              onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
+              className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+            />
+            <span className="text-sm">Auto-complete without review</span>
+          </label>
+        </div>
+      )}
 
       {submitError && (
         <p className="text-sm text-destructive">{submitError}</p>

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -57,6 +57,8 @@ function makeRendererTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     recurrence_parent_id: null,
     last_occurrence_at: null,
     next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
     parent_task_id: null,

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -694,6 +694,14 @@ Update existing skills that were helpful or create new ones for patterns worth r
             onTriage={handleTriage}
             canTriage={!!canTriage}
             onEditAgent={handleEditAgent}
+            onUpdateAutoFlags={async (updates) => {
+              if (onUpdateTask) {
+                await onUpdateTask(task.id, updates)
+              } else {
+                await taskApi.update(task.id, updates)
+                updateTaskInStore(task.id, updates)
+              }
+            }}
             subtasks={subtasks}
             parentTask={parentTask}
             onNavigateToTask={onNavigateToTask}

--- a/src/renderer/src/hooks/use-agent-auto-start.test.tsx
+++ b/src/renderer/src/hooks/use-agent-auto-start.test.tsx
@@ -44,6 +44,8 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     recurrence_parent_id: null,
     last_occurrence_at: null,
     next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
     parent_task_id: null,
     sort_order: 0,
     created_at: '2026-01-01T00:00:00Z',

--- a/src/renderer/src/hooks/use-agent-auto-start.ts
+++ b/src/renderer/src/hooks/use-agent-auto-start.ts
@@ -608,7 +608,8 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
     return unsubscribe
   }, [isEnabled, isSnoozed, startTriage])
 
-  // Auto-start recurring instances with auto_start_agent flag (works independently of global scheduler)
+  // Auto-start recurring instances with auto_start_agent flag
+  // Runs regardless of global scheduler state — the session check prevents double-starts
   useEffect(() => {
     const unsubscribe = onTaskCreated((event) => {
       const task = event.task as WorkfloTask
@@ -617,9 +618,6 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
       if (task.status !== TaskStatus.NotStarted || !task.agent_id) return
       if (isSnoozed(task.snoozed_until)) return
       if (getSessionsSnapshot().has(task.id)) return
-
-      // If global scheduler is enabled, it will already handle this task — skip to avoid double starts
-      if (isEnabled) return
 
       const agentId = task.agent_id
       const agent = agents.find((a) => a.id === agentId)

--- a/src/renderer/src/hooks/use-agent-auto-start.ts
+++ b/src/renderer/src/hooks/use-agent-auto-start.ts
@@ -613,6 +613,17 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
   useEffect(() => {
     const unsubscribe = onTaskCreated((event) => {
       const task = event.task as WorkfloTask
+
+      // Log all recurring instances for debugging
+      if (task.recurrence_parent_id) {
+        console.log(`[AutoStart] Received task:created for recurring instance "${task.title}"`, {
+          auto_start_agent: task.auto_start_agent,
+          agent_id: task.agent_id,
+          status: task.status,
+          recurrence_parent_id: task.recurrence_parent_id
+        })
+      }
+
       // Only handle recurring instances (not templates) with auto_start_agent enabled
       if (!task.auto_start_agent || !task.recurrence_parent_id) return
       if (task.status !== TaskStatus.NotStarted || !task.agent_id) return
@@ -623,40 +634,60 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
       const agent = agents.find((a) => a.id === agentId)
       if (!agent) return
 
-      console.log(`[AutoStart] Recurring instance "${task.title}" has auto_start_agent, starting agent`)
+      console.log(`[AutoStart] Recurring instance "${task.title}" passed all checks, starting agent ${agent.name}`)
       const maxParallel = agent.config.max_parallel_sessions || 1
       const currentRunning = getRunningCount(agentId)
       if (currentRunning < maxParallel) {
-        setTimeout(() => startTasksForAgent(agentId, [task.id], agent), 200)
+        // Start directly — don't use startTasksForAgent because it looks up the
+        // task in the (stale) tasks array which doesn't include this new instance yet.
+        setTimeout(async () => {
+          try {
+            incrementRunningCount(agentId)
+            await start(agentId, task.id)
+            showToast(`Auto-started "${task.title}" with ${agent.name}`)
+          } catch (error) {
+            console.error(`[AutoStart] Failed to auto-start recurring instance ${task.id}:`, error)
+            decrementRunningCount(agentId)
+          }
+        }, 500)
       } else {
         addToQueue(agentId, task.id)
       }
     })
 
     return unsubscribe
-  }, [agents, isEnabled, isSnoozed, getSessionsSnapshot, getRunningCount, startTasksForAgent, addToQueue])
+  }, [agents, isSnoozed, getSessionsSnapshot, getRunningCount, incrementRunningCount, decrementRunningCount, start, showToast, addToQueue])
 
   // Auto-complete tasks with auto_complete_without_review flag when they reach ReadyForReview
   useEffect(() => {
     const unsubscribe = onTaskUpdated((event) => {
       if (event.updates?.status !== TaskStatus.ReadyForReview) return
 
-      const task = tasks.find((t) => t.id === event.taskId)
-      if (!task) return
+      // Try local tasks first, fall back to DB fetch for recently-created recurring instances
+      const localTask = tasks.find((t) => t.id === event.taskId)
 
-      // Merge event updates with stale task to get current state
-      const updatedTask = { ...task, ...event.updates } as WorkfloTask
-      if (!updatedTask.auto_complete_without_review) return
+      const doAutoComplete = async (baseTask: WorkfloTask) => {
+        const merged = { ...baseTask, ...event.updates } as WorkfloTask
+        if (!merged.auto_complete_without_review) return
 
-      console.log(`[AutoStart] Task "${updatedTask.title}" has auto_complete_without_review, auto-completing`)
-      setTimeout(async () => {
+        console.log(`[AutoStart] Task "${merged.title}" has auto_complete_without_review, auto-completing`)
         try {
           await taskApi.update(event.taskId, { status: TaskStatus.Completed })
-          showToast(`Auto-completed "${updatedTask.title}"`)
+          showToast(`Auto-completed "${merged.title}"`)
         } catch (error) {
           console.error(`[AutoStart] Failed to auto-complete task ${event.taskId}:`, error)
         }
-      }, 500)
+      }
+
+      if (localTask) {
+        setTimeout(() => doAutoComplete(localTask), 500)
+      } else {
+        // Task not in renderer yet — fetch from DB
+        setTimeout(async () => {
+          const freshTask = await taskApi.getById(event.taskId)
+          if (freshTask) doAutoComplete(freshTask)
+        }, 500)
+      }
     })
 
     return unsubscribe

--- a/src/renderer/src/hooks/use-agent-auto-start.ts
+++ b/src/renderer/src/hooks/use-agent-auto-start.ts
@@ -608,6 +608,62 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
     return unsubscribe
   }, [isEnabled, isSnoozed, startTriage])
 
+  // Auto-start recurring instances with auto_start_agent flag (works independently of global scheduler)
+  useEffect(() => {
+    const unsubscribe = onTaskCreated((event) => {
+      const task = event.task as WorkfloTask
+      // Only handle recurring instances (not templates) with auto_start_agent enabled
+      if (!task.auto_start_agent || !task.recurrence_parent_id) return
+      if (task.status !== TaskStatus.NotStarted || !task.agent_id) return
+      if (isSnoozed(task.snoozed_until)) return
+      if (getSessionsSnapshot().has(task.id)) return
+
+      // If global scheduler is enabled, it will already handle this task — skip to avoid double starts
+      if (isEnabled) return
+
+      const agentId = task.agent_id
+      const agent = agents.find((a) => a.id === agentId)
+      if (!agent) return
+
+      console.log(`[AutoStart] Recurring instance "${task.title}" has auto_start_agent, starting agent`)
+      const maxParallel = agent.config.max_parallel_sessions || 1
+      const currentRunning = getRunningCount(agentId)
+      if (currentRunning < maxParallel) {
+        setTimeout(() => startTasksForAgent(agentId, [task.id], agent), 200)
+      } else {
+        addToQueue(agentId, task.id)
+      }
+    })
+
+    return unsubscribe
+  }, [agents, isEnabled, isSnoozed, getSessionsSnapshot, getRunningCount, startTasksForAgent, addToQueue])
+
+  // Auto-complete tasks with auto_complete_without_review flag when they reach ReadyForReview
+  useEffect(() => {
+    const unsubscribe = onTaskUpdated((event) => {
+      if (event.updates?.status !== TaskStatus.ReadyForReview) return
+
+      const task = tasks.find((t) => t.id === event.taskId)
+      if (!task) return
+
+      // Merge event updates with stale task to get current state
+      const updatedTask = { ...task, ...event.updates } as WorkfloTask
+      if (!updatedTask.auto_complete_without_review) return
+
+      console.log(`[AutoStart] Task "${updatedTask.title}" has auto_complete_without_review, auto-completing`)
+      setTimeout(async () => {
+        try {
+          await taskApi.update(event.taskId, { status: TaskStatus.Completed })
+          showToast(`Auto-completed "${updatedTask.title}"`)
+        } catch (error) {
+          console.error(`[AutoStart] Failed to auto-complete task ${event.taskId}:`, error)
+        }
+      }, 500)
+    })
+
+    return unsubscribe
+  }, [tasks, showToast])
+
   // Listen to task updates (new tasks or reassignments)
   useEffect(() => {
     if (!isEnabled) return

--- a/src/renderer/src/hooks/use-tasks.test.tsx
+++ b/src/renderer/src/hooks/use-tasks.test.tsx
@@ -35,6 +35,8 @@ function makeWorkfloTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     recurrence_parent_id: null,
     last_occurrence_at: null,
     next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
     created_at: '2024-06-15T12:00:00Z',
     updated_at: '2024-06-15T12:00:00Z',
     parent_task_id: null,

--- a/src/renderer/src/stores/dashboard-store.test.ts
+++ b/src/renderer/src/stores/dashboard-store.test.ts
@@ -100,6 +100,8 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     recurrence_parent_id: null,
     last_occurrence_at: null,
     next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
     parent_task_id: null,
     sort_order: 0,
     created_at: new Date().toISOString(),

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -297,6 +297,8 @@ export interface WorkfloTask {
   heartbeat_interval_minutes?: number | null
   heartbeat_last_check_at?: string | null
   heartbeat_next_check_at?: string | null
+  auto_start_agent: boolean
+  auto_complete_without_review: boolean
   parent_task_id: string | null
   sort_order: number
   created_at: string
@@ -318,6 +320,8 @@ export interface CreateTaskDTO {
   is_recurring?: boolean
   recurrence_pattern?: RecurrencePattern | null
   recurrence_parent_id?: string | null
+  auto_start_agent?: boolean
+  auto_complete_without_review?: boolean
   parent_task_id?: string | null
 }
 
@@ -347,6 +351,8 @@ export interface UpdateTaskDTO {
   heartbeat_interval_minutes?: number | null
   heartbeat_last_check_at?: string | null
   heartbeat_next_check_at?: string | null
+  auto_start_agent?: boolean
+  auto_complete_without_review?: boolean
   parent_task_id?: string | null
   sort_order?: number
 }

--- a/test/helpers/db-test-helper.ts
+++ b/test/helpers/db-test-helper.ts
@@ -92,6 +92,8 @@ export function createTestDb(): { db: DatabaseManager; rawDb: InstanceType<typeo
       recurrence_parent_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
       last_occurrence_at TEXT DEFAULT NULL,
       next_occurrence_at TEXT DEFAULT NULL,
+      auto_start_agent INTEGER NOT NULL DEFAULT 0,
+      auto_complete_without_review INTEGER NOT NULL DEFAULT 0,
       parent_task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
       sort_order INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- Adds two new boolean fields to recurring task templates: `auto_start_agent` and `auto_complete_without_review`
- When an agent is assigned to a recurring task, toggle options appear in the task detail view (desktop + mobile)
- **Auto-start agent**: When a recurring instance is created, the agent automatically starts working on it (even if the global auto-start scheduler is disabled)
- **Auto-complete without review**: When an agent finishes and the task reaches "Ready for Review", it automatically transitions to "Completed" without requiring manual review

### Changes across the stack:
- **Database** (`database.ts`): New columns `auto_start_agent` and `auto_complete_without_review` with migration support
- **Recurrence Scheduler** (`recurrence-scheduler.ts`): Copies flags from template to created instances
- **Auto-start Hook** (`use-agent-auto-start.ts`): Two new effects — one to auto-start recurring instances with the flag, one to auto-complete tasks that reach ReadyForReview
- **Desktop UI** (`TaskDetailView.tsx`, `TaskWorkspace.tsx`): Toggle checkboxes shown for recurring templates with agent
- **Mobile UI** (`TaskDetailPage.tsx`): Same toggles mirrored for mobile
- **Types** updated across renderer, mobile, and test helpers (15 files total)

## Test plan
- [x] TypeScript build passes (`tsc --build --noEmit`)
- [x] All 1323 tests pass across 91 test files
- [x] 8 new tests for TaskDetailView covering toggle visibility and interaction
- [ ] Manual: Create recurring task with agent, enable auto-start, verify instances auto-start
- [ ] Manual: Enable auto-complete, verify tasks skip review step

🤖 Generated with [Claude Code](https://claude.com/claude-code)