### PR TITLE
fix(windows): detect claude.exe in addition to claude.cmd

### DIFF
--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -87,7 +87,7 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
 
       // Try to find claude in PATH
       const whichCmd = isWin ? 'where' : 'which'
-      const binaryName = isWin ? 'claude.cmd' : 'claude'
+      const binaryName = 'claude'
       const { stdout } = await execFileAsync(whichCmd, [binaryName])
       let found = stdout.trim().split(/\r?\n/)[0]
 
@@ -111,7 +111,9 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
         ? [
             `${home}\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\cli.js`,
             `${home}\\AppData\\Roaming\\npm\\claude.cmd`,
-            `${home}\\.local\\bin\\claude.cmd`
+            `${home}\\AppData\\Roaming\\npm\\claude.exe`,
+            `${home}\\.local\\bin\\claude.cmd`,
+            `${home}\\.local\\bin\\claude.exe`
           ]
         : [
             '/usr/local/bin/claude',


### PR DESCRIPTION
## Overview
This PR resolves an issue on Windows where the app fails to detect the Claude Code CLI if it is installed as `claude.exe` rather than the `claude.cmd` wrapper (e.g., when installed via standalone packages or modern npm global setups).
## The Issue
In `src/main/adapters/claude-code-adapter.ts`, the `findClaudeExecutable()` helper was restricted to searching for `'claude.cmd'` on Windows systems:
```ts
const binaryName = isWin ? 'claude.cmd' : 'claude'
This caused the OS where command search to completely miss claude.exe installations. Additionally, the list of fallback search paths for Windows was missing .exe entries.

The Solution
Extensionless Lookup: Changed the binaryName search key on Windows from 'claude.cmd' to 'claude'. The Windows where command automatically consults the %PATHEXT% environment variable list (which includes .exe, .cmd, .bat, etc.) to find the executable. Passing the extensionless name is the standard, most robust way to find binaries on Windows.
Added Fallbacks: Expanded the common paths fallback list to search for claude.exe in both npm's global directory (AppData\Roaming\npm\claude.exe) and the user's .local\bin\ folder.
Verification & Testing
Run pnpm typecheck ✅ (Passed)
Run pnpm build ✅ (Passed)
Verified that Windows platforms now successfully find claude.exe in the PATH without failing.
macOS/Linux code paths remain completely untouched and backward-compatible.