### PR TITLE
fix: chunk sync events into batches of 100 to respect server limit

### DIFF
--- a/src/main/enterprise-state-sync.test.ts
+++ b/src/main/enterprise-state-sync.test.ts
@@ -190,6 +190,70 @@ describe('EnterpriseStateSync', () => {
 
       expect(stateSync.pendingCount).toBe(0)
     })
+
+    it('sends events in batches of at most 100', async () => {
+      const task = makeTask()
+      // Record 250 events
+      for (let i = 0; i < 250; i++) {
+        stateSync.recordTaskStatusChange(
+          task,
+          'not_started',
+          'agent_working'
+        )
+      }
+
+      mockApiClient.sendSyncEvents.mockImplementation((events: unknown[]) =>
+        Promise.resolve({ ok: true, inserted: events.length })
+      )
+
+      await stateSync.flush()
+
+      // Should have been called 3 times (100 + 100 + 50)
+      expect(mockApiClient.sendSyncEvents).toHaveBeenCalledTimes(3)
+      const calls = mockApiClient.sendSyncEvents.mock.calls
+      expect(calls[0][0]).toHaveLength(100)
+      expect(calls[1][0]).toHaveLength(100)
+      expect(calls[2][0]).toHaveLength(50)
+    })
+
+    it('sends single batch when <= 100 events pending', async () => {
+      const task = makeTask()
+      for (let i = 0; i < 50; i++) {
+        stateSync.recordTaskCreated(task)
+      }
+
+      mockApiClient.sendSyncEvents.mockImplementation((events: unknown[]) =>
+        Promise.resolve({ ok: true, inserted: events.length })
+      )
+
+      await stateSync.flush()
+
+      expect(mockApiClient.sendSyncEvents).toHaveBeenCalledTimes(1)
+      expect(mockApiClient.sendSyncEvents.mock.calls[0][0]).toHaveLength(50)
+    })
+
+    it('re-queues all events when a batch fails', async () => {
+      const task = makeTask()
+      for (let i = 0; i < 150; i++) {
+        stateSync.recordTaskCreated(task)
+      }
+
+      let callCount = 0
+      mockApiClient.sendSyncEvents.mockImplementation(() => {
+        callCount++
+        if (callCount === 2) {
+          return Promise.reject(new Error('network error'))
+        }
+        return Promise.resolve({ ok: true, inserted: 100 })
+      })
+
+      await stateSync.flush()
+
+      // All 150 events should be re-queued
+      expect(stateSync.pendingCount).toBe(150)
+      // First batch succeeded, second failed
+      expect(mockApiClient.sendSyncEvents).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('entity ID resolution', () => {

--- a/src/main/enterprise-state-sync.ts
+++ b/src/main/enterprise-state-sync.ts
@@ -20,6 +20,11 @@ import { TaskStatus } from '../shared/constants'
 // ── Event queue ─────────────────────────────────────────────────────────
 
 export class EnterpriseStateSync {
+  /**
+   * Maximum number of events per sync request (server Zod schema uses .max(100)).
+   */
+  private static readonly SYNC_EVENTS_MAX_BATCH_SIZE = 100
+
   private pendingEvents: WorkfloSyncEvent[] = []
   private apiClient: WorkfloApiClient
   private userName: string | null = null
@@ -196,10 +201,22 @@ export class EnterpriseStateSync {
         this.pendingEvents = []
 
         try {
-          const result = await this.apiClient.sendSyncEvents(events)
-          console.log(`[EnterpriseStateSync] Sent ${result.inserted} events`)
+          let totalInserted = 0
+          for (
+            let i = 0;
+            i < events.length;
+            i += EnterpriseStateSync.SYNC_EVENTS_MAX_BATCH_SIZE
+          ) {
+            const chunk = events.slice(
+              i,
+              i + EnterpriseStateSync.SYNC_EVENTS_MAX_BATCH_SIZE
+            )
+            const result = await this.apiClient.sendSyncEvents(chunk)
+            totalInserted += result.inserted
+          }
+          console.log(`[EnterpriseStateSync] Sent ${totalInserted} events`)
         } catch (err) {
-          // Re-queue events on failure (they'll be sent next flush)
+          // Re-queue ALL events on any batch failure to preserve order
           this.pendingEvents.unshift(...events)
           const msg = err instanceof Error ? err.message : String(err)
           console.warn(`[EnterpriseStateSync] Failed to send events (domain: ${this.domain}): ${msg}`)


### PR DESCRIPTION
## Summary
- `EnterpriseStateSync.flush()` was sending all pending events in a single API call to `POST /api/20x/sync/events`
- The server-side (workflow-builder) Zod schema validates `.max(100)` events per request
- When >100 events accumulated before a flush, the server rejected with 400 `"too_big"` error, breaking sync
- Fix: chunk events into batches of at most 100 before sending, matching the existing `EnterpriseSyncManager.batchSyncSkills()` pattern

## Test plan
- [x] All 23 tests pass (20 existing + 3 new chunking tests)
- [x] Chunking of 250 events → 3 batches (100, 100, 50)
- [x] Single batch when ≤100 events
- [x] All events re-queued on any batch failure

Generated with [OpenCode](https://opencode.ai)