### PR TITLE
fix: canonicalize Workflo MCP dev routing

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -766,6 +766,46 @@ describe('AgentManager implicit resume behavior', () => {
   })
 })
 
+describe('AgentManager MCP server routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('canonicalizes Workflo MCP dev server URLs to the active enterprise API URL', async () => {
+    const mockDb = {
+      getAgent: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'OPS L2',
+        config: {
+          mcp_servers: ['workflo-stage-server']
+        }
+      })),
+      getMcpServer: vi.fn(() => ({
+        id: 'workflo-stage-server',
+        name: 'pf-workflo-integrations',
+        type: 'remote',
+        url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
+        headers: { Authorization: 'Bearer stale-stage-key' },
+        oauth_metadata: {},
+      })),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+
+    const manager = new AgentManager(mockDb)
+    manager.setEnterpriseAuth({
+      getApiUrl: vi.fn(() => 'https://api.peakflo.ai'),
+      getJwt: vi.fn(async () => 'fresh-prod-jwt'),
+    } as any)
+
+    const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
+
+    expect(mcpServers['pf-workflo-integrations']).toMatchObject({
+      type: 'http',
+      url: 'https://api.peakflo.ai/api/mcp/dev/mcp',
+      headers: { Authorization: 'Bearer fresh-prod-jwt' },
+    })
+  })
+})
+
 describe('AgentManager transitionToIdle — enterprise task completion after feedback', () => {
   function createEnterpriseTaskDb(taskOverrides: Record<string, unknown> = {}) {
     const task = {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -29,6 +29,8 @@ enum CodingAgentType {
 
 // Default OpenCode server URL (matches database default)
 const DEFAULT_SERVER_URL = 'http://localhost:4096'
+const WORKFLO_MCP_DEV_SERVER_NAME = '[Workflo] MCP Dev Server'
+const WORKFLO_MCP_DEV_PATH = '/api/mcp/dev/mcp'
 
 interface AgentSession {
   id: string
@@ -46,6 +48,41 @@ interface AgentSession {
   adapter?: CodingAgentAdapter
   secretSessionToken?: string
   pollingStarted?: boolean
+}
+
+function normalizeUrlPath(pathname: string): string {
+  return pathname.replace(/\/+$/, '') || '/'
+}
+
+function isWorkfloMcpDevServerUrl(serverUrl?: string): boolean {
+  if (!serverUrl) return false
+
+  try {
+    return normalizeUrlPath(new URL(serverUrl).pathname) === WORKFLO_MCP_DEV_PATH
+  } catch {
+    return false
+  }
+}
+
+function isEnterpriseWorkfloMcpServer(name: string, serverUrl?: string): boolean {
+  return name === WORKFLO_MCP_DEV_SERVER_NAME ||
+    (name.toLowerCase().includes('workflo') && isWorkfloMcpDevServerUrl(serverUrl))
+}
+
+function resolveEnterpriseMcpDevUrl(currentUrl: string | undefined, enterpriseApiUrl: string): string {
+  if (!currentUrl) return `${enterpriseApiUrl}${WORKFLO_MCP_DEV_PATH}`
+
+  try {
+    const current = new URL(currentUrl)
+    const enterprise = new URL(enterpriseApiUrl)
+    if (normalizeUrlPath(current.pathname) === WORKFLO_MCP_DEV_PATH && current.origin !== enterprise.origin) {
+      return `${enterpriseApiUrl}${WORKFLO_MCP_DEV_PATH}`
+    }
+  } catch {
+    return currentUrl
+  }
+
+  return currentUrl
 }
 
 /** Entry tracked by the centralized polling coordinator */
@@ -357,14 +394,18 @@ export class AgentManager extends EventEmitter {
 
         // Inject enterprise JWT for Workflo MCP Dev Server — route through auth proxy
         let finalUrl = mcpServer.url
-        if (mcpServer.name === '[Workflo] MCP Dev Server' && this.enterpriseAuth) {
+        if (
+          this.enterpriseAuth &&
+          isEnterpriseWorkfloMcpServer(mcpServer.name, mcpServer.url)
+        ) {
+          finalUrl = resolveEnterpriseMcpDevUrl(mcpServer.url, this.enterpriseAuth.getApiUrl())
           const proxyPort = getMcpAuthProxyPort()
-          const proxyUrl = proxyPort ? registerMcpProxyTarget(mcpServer.url, mcpServer.name) : null
+          const proxyUrl = proxyPort ? registerMcpProxyTarget(finalUrl, mcpServer.name) : null
           if (proxyUrl) {
             finalUrl = proxyUrl
             // Don't send static Authorization — proxy injects fresh JWT per request
             delete finalHeaders['Authorization']
-            console.log(`[AgentManager] MCP Dev Server routed through auth proxy: ${proxyUrl}`)
+            console.log(`[AgentManager] MCP Dev Server routed through auth proxy: ${proxyUrl} -> ${resolveEnterpriseMcpDevUrl(mcpServer.url, this.enterpriseAuth.getApiUrl())}`)
           } else {
             // Fallback: static JWT (proxy not running)
             try {


### PR DESCRIPTION
## Summary
- Canonicalize Workflo MCP dev server URLs to the active enterprise API URL before auth proxy registration.
- Preserve proxy/JWT auth behavior for stale Workflo-named MCP records instead of relying on the exact server display name.
- Add regression coverage for a stale stage Workflo MCP entry routing to prod.

## Test plan
- pnpm vitest run src/main/agent-manager.test.ts (blocked locally: missing @electron-toolkit/tsconfig dependency resolution)
- pnpm exec tsc --noEmit --project tsconfig.node.json (blocked locally: missing @electron-toolkit/tsconfig and electron-vite/node dependency resolution)