### PR TITLE
fix: restore opencode session replies during polling

### DIFF
--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -124,6 +124,39 @@ describe('OpencodeAdapter', () => {
     expect(replayed.flatMap((message) => message.parts.map((part) => part.id))).toEqual(['msg-1:part-1', 'msg-2:part-1'])
   })
 
+  it('falls back to message-scoped part indexes during polling when part ids are missing', async () => {
+    const adapter = new OpencodeAdapter()
+    const mockClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            {
+              info: { id: 'msg-1', role: 'assistant' },
+              parts: [
+                { type: 'text', text: 'First chunk' },
+                { type: 'tool', tool: 'bash', state: { status: 'completed', input: { command: 'pwd' }, output: '/tmp' } }
+              ]
+            }
+          ]
+        })
+      }
+    }
+
+    ;(adapter as any).clients.set('session-1', mockClient)
+
+    const polled = await adapter.pollMessages(
+      'session-1',
+      new Set<string>(),
+      new Set<string>(),
+      new Map<string, string>(),
+      { agentId: 'agent-1', taskId: 'task-1', workspaceDir: '/tmp/ws' }
+    )
+
+    expect(polled).toHaveLength(2)
+    expect(polled.map((part) => part.id)).toEqual(['msg-1:part-0', 'msg-1:part-1'])
+    expect(polled.map((part) => part.type)).toEqual(['text', 'tool'])
+  })
+
   describe('getStatus', () => {
     it('returns BUSY when prompt is still in-flight', async () => {
       const adapter = new OpencodeAdapter()

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -1080,8 +1080,8 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       }
 
       const parts = msg.parts && Array.isArray(msg.parts) ? msg.parts : []
-      for (const part of parts) {
-        const partId = this.getScopedPartId(String(msgId), part.id as string | undefined)
+      for (const [partIndex, part] of parts.entries()) {
+        const partId = this.getScopedPartId(String(msgId), part.id as string | undefined, partIndex)
         if (!partId) continue
         // Cast part to a loose record for uniform property access across SDK Part union members
         const p = part as unknown as Record<string, unknown>


### PR DESCRIPTION
## Summary
- preserve live OpenCode polling updates when message parts arrive without a part id
- reuse the same message-scoped fallback id scheme already used by resume and transcript replay
- add a regression test covering polling of text and tool parts without ids

## Test plan
- 
> 20x@0.0.80 test:main /Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/hzjur500hx30c63qxue86vp1/20x
> ELECTRON_RUN_AS_NODE=1 electron ./node_modules/vitest/vitest.mjs --project main "--" "opencode-adapter.test.ts"

 ELIFECYCLE  Command failed with exit code 1.
 WARN   Local package.json exists, but node_modules missing, did you mean to install? *(blocked locally:  is missing in this workspace)*
