### PR TITLE
fix: force https for github worktree clones

### DIFF
--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -260,7 +260,7 @@ export class AgentManager extends EventEmitter {
       let resolvedWorkspaceDir: string | undefined
 
       for (const [org, repoNames] of reposByOrg.entries()) {
-        let orgRepos: Array<{ fullName: string; defaultBranch: string }> = []
+        let orgRepos: Array<{ fullName: string; defaultBranch: string; cloneUrl?: string }> = []
 
         try {
           if (gitProvider === 'gitlab' && this.gitlabManager) {
@@ -273,9 +273,11 @@ export class AgentManager extends EventEmitter {
         }
 
         const branchByRepo = new Map(orgRepos.map((repo) => [repo.fullName, repo.defaultBranch]))
+        const cloneUrlByRepo = new Map(orgRepos.map((repo) => [repo.fullName, repo.cloneUrl]))
         const reposForSetup = repoNames.map((fullName) => ({
           fullName,
-          defaultBranch: branchByRepo.get(fullName) || 'main'
+          defaultBranch: branchByRepo.get(fullName) || 'main',
+          cloneUrl: cloneUrlByRepo.get(fullName)
         }))
 
         console.log(`[AgentManager] Setting up ${reposForSetup.length} repo(s) for org "${org}": ${reposForSetup.map((repo) => repo.fullName).join(', ')}`)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -484,7 +484,7 @@ export function registerIpcHandlers(
   })
 
   // Worktree handlers
-  ipcMain.handle('worktree:setup', async (_, taskId: string, repos: { fullName: string; defaultBranch: string }[], org: string, provider?: 'github' | 'gitlab') => {
+  ipcMain.handle('worktree:setup', async (_, taskId: string, repos: { fullName: string; defaultBranch: string; cloneUrl?: string }[], org: string, provider?: 'github' | 'gitlab') => {
     const resolvedProvider = provider || (db.getSetting('git_provider') as 'github' | 'gitlab' | null) || 'github'
     return await worktreeManager.setupWorkspaceForTask(taskId, repos, org, resolvedProvider)
   })

--- a/src/main/worktree-manager.test.ts
+++ b/src/main/worktree-manager.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, existsSyncMock, mkdirSyncMock } = vi.hoisted(() => {
+  const execFileMock = vi.fn()
+  const existsSyncMock = vi.fn()
+  const mkdirSyncMock = vi.fn()
+  const customPromisify = Symbol.for('nodejs.util.promisify.custom')
+
+  execFileMock[customPromisify] = (...args: unknown[]) => {
+    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      const callback = (error: Error | null, stdout = '', stderr = '') => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve({ stdout, stderr })
+      }
+
+      execFileMock(...args, callback)
+    })
+  }
+
+  return { execFileMock, existsSyncMock, mkdirSyncMock }
+})
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock
+}))
+
+vi.mock('fs', () => ({
+  existsSync: existsSyncMock,
+  mkdirSync: mkdirSyncMock,
+  rmSync: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/20x-user-data')
+  }
+}))
+
+import { WorktreeManager } from './worktree-manager'
+
+describe('WorktreeManager', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    existsSyncMock.mockReset()
+    mkdirSyncMock.mockReset()
+    existsSyncMock.mockReturnValue(false)
+    execFileMock.mockImplementation((file: string, args: string[], optionsOrCallback: unknown, maybeCallback?: (error: Error | null, stdout?: string, stderr?: string) => void) => {
+      const callback = typeof optionsOrCallback === 'function'
+        ? optionsOrCallback as (error: Error | null, stdout?: string, stderr?: string) => void
+        : maybeCallback as (error: Error | null, stdout?: string, stderr?: string) => void
+
+      if (file === 'gh' && args[0] === 'repo' && args[1] === 'clone') {
+        callback(null, '', '')
+        return
+      }
+
+      if (file === 'git' && args[0] === 'fetch') {
+        callback(null, '', '')
+        return
+      }
+
+      if (file === 'git' && args[0] === 'branch') {
+        callback(null, '', '')
+        return
+      }
+
+      if (file === 'git' && args[0] === 'rev-parse') {
+        callback(null, 'origin/main', '')
+        return
+      }
+
+      if (file === 'git' && args[0] === 'worktree' && args[1] === 'add') {
+        callback(null, '', '')
+        return
+      }
+
+      callback(new Error(`Unexpected command: ${file} ${args.join(' ')}`))
+    })
+  })
+
+  it('uses an explicit https clone URL for GitHub repos', async () => {
+    const manager = new WorktreeManager()
+
+    await manager.setupWorkspaceForTask(
+      'task-1',
+      [{ fullName: 'peakflo/20x', defaultBranch: 'main', cloneUrl: 'https://github.com/peakflo/20x.git' }],
+      'peakflo',
+      'github'
+    )
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'gh',
+      ['repo', 'clone', 'https://github.com/peakflo/20x.git', '/tmp/20x-user-data/repos/peakflo/20x.git', '--', '--bare'],
+      expect.objectContaining({ timeout: 300000 }),
+      expect.any(Function)
+    )
+  })
+
+  it('falls back to a derived https clone URL when repo metadata omits one', async () => {
+    const manager = new WorktreeManager()
+
+    await manager.setupWorkspaceForTask(
+      'task-2',
+      [{ fullName: 'peakflo/upload-functions', defaultBranch: 'main' }],
+      'peakflo',
+      'github'
+    )
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'gh',
+      ['repo', 'clone', 'https://github.com/peakflo/upload-functions.git', '/tmp/20x-user-data/repos/peakflo/upload-functions.git', '--', '--bare'],
+      expect.objectContaining({ timeout: 300000 }),
+      expect.any(Function)
+    )
+  })
+})

--- a/src/main/worktree-manager.ts
+++ b/src/main/worktree-manager.ts
@@ -13,6 +13,7 @@ const WORKSPACES_DIR = join(BASE_DIR, 'workspaces')
 export interface WorktreeRepo {
   fullName: string
   defaultBranch: string
+  cloneUrl?: string
 }
 
 export class WorktreeManager {
@@ -55,7 +56,7 @@ export class WorktreeManager {
       const repoName = repo.fullName.split('/').pop() || repo.fullName
       try {
         console.log(`[WorktreeManager] Processing repo: ${repo.fullName}`)
-        await this.ensureBareClone(org, repoName, repo.fullName, provider)
+        await this.ensureBareClone(org, repoName, repo.fullName, provider, repo.cloneUrl)
         await this.fetchBareClone(org, repoName)
         await this.createWorktree(taskId, org, repoName, repo.defaultBranch)
         this.sendProgress(taskId, repoName, 'done', true)
@@ -71,7 +72,13 @@ export class WorktreeManager {
     return taskDir
   }
 
-  private async ensureBareClone(org: string, repoName: string, fullName: string, provider?: string): Promise<void> {
+  private async ensureBareClone(
+    org: string,
+    repoName: string,
+    fullName: string,
+    provider?: string,
+    cloneUrl?: string
+  ): Promise<void> {
     const barePath = this.bareClonePath(org, repoName)
 
     if (existsSync(barePath)) {
@@ -97,8 +104,9 @@ export class WorktreeManager {
         'config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*'
       ], { cwd: barePath })
     } else {
-      console.log(`[WorktreeManager]   Executing: gh repo clone ${fullName} ${barePath} -- --bare`)
-      await execFileAsync('gh', ['repo', 'clone', fullName, barePath, '--', '--bare'], {
+      const githubCloneTarget = cloneUrl || `https://github.com/${fullName}.git`
+      console.log(`[WorktreeManager]   Executing: gh repo clone ${githubCloneTarget} ${barePath} -- --bare`)
+      await execFileAsync('gh', ['repo', 'clone', githubCloneTarget, barePath, '--', '--bare'], {
         timeout: 300000
       })
     }


### PR DESCRIPTION
## Summary
- force GitHub worktree provisioning to clone from an explicit HTTPS target instead of inheriting gh's SSH protocol setting
- thread optional clone URLs through worktree setup and fall back to a derived GitHub HTTPS URL when metadata is missing
- add focused coverage for the GitHub clone command selection

## Test plan
- not run locally; node_modules are missing in this workspace, so vitest and tsconfig dependencies are unavailable
