### PR TITLE
fix: surface HTTP-level prompt errors to prevent silent no-response sessions

### DIFF
--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -879,6 +879,15 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     }).catch((err: unknown) => {
       if (!(err instanceof Error) || err.name !== 'AbortError') {
         console.error('[OpencodeAdapter] prompt error:', err)
+        // Surface HTTP-level errors (network failures, 4xx/5xx, connection refused)
+        // via promptErrors so getStatus() returns ERROR instead of silent IDLE.
+        // Without this, the error is swallowed and the session appears to produce
+        // no response — the user sees idle with no feedback after the grace period.
+        const errorMsg = err instanceof Error ? err.message : String(err)
+        this.promptErrors.set(sessionId, errorMsg)
+        if (this.onDataAvailable) {
+          this.onDataAvailable(sessionId)
+        }
       }
     }).finally(() => {
       this.promptAborts.delete(sessionId)


### PR DESCRIPTION
## Summary
- **Bug:** OpenCode sessions with non-standard models (e.g., `peakflo/Deepseek v4 Flash`) could produce no response and no error — the session silently transitioned to IDLE after the 15-second grace period
- **Root cause:** The `.catch()` handler in `sendPrompt` logged HTTP-level errors (network failures, 4xx/5xx, connection refused) but did not store them in `promptErrors`, so `getStatus()` returned IDLE instead of ERROR
- **Fix:** Store caught HTTP errors in `promptErrors` and trigger `onDataAvailable` to ensure the polling coordinator picks up the error immediately — matching the existing pattern for provider errors in the `.then()` handler

## Test plan
- [ ] Verify sessions with valid models still work normally (prompt completes, response shown)
- [ ] Simulate a prompt HTTP failure (e.g., unreachable backend) and verify the error message is shown to the user instead of silent IDLE
- [ ] Verify intentional aborts (`AbortError`) are still silently ignored (no false error messages)
- [ ] Test with non-standard models (Deepseek, featherless) to confirm error surfacing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)