### PR TITLE
feat: add claude-opus-4-8 model

### DIFF
--- a/src/renderer/src/types/index.test.ts
+++ b/src/renderer/src/types/index.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { CLAUDE_MODELS, ClaudeModel, CODEX_MODELS, CodexModel } from './index'
 
 describe('CLAUDE_MODELS', () => {
+  it('includes Claude Opus 4.8', () => {
+    expect(CLAUDE_MODELS).toContainEqual({
+      id: ClaudeModel.OPUS_4_8,
+      name: 'claude-opus-4-8'
+    })
+  })
+
   it('includes Claude Opus 4.7', () => {
     expect(CLAUDE_MODELS).toContainEqual({
       id: ClaudeModel.OPUS_4_7,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -41,6 +41,7 @@ export const CODING_AGENTS: { value: CodingAgentType; label: string }[] = [
 ]
 
 export enum ClaudeModel {
+  OPUS_4_8 = 'claude-opus-4-8',
   OPUS_4_7 = 'claude-opus-4-7',
   SONNET_4_6 = 'claude-sonnet-4-6',
   SONNET_4_5 = 'claude-sonnet-4-5',
@@ -52,6 +53,7 @@ export enum ClaudeModel {
 }
 
 export const CLAUDE_MODELS: { id: ClaudeModel; name: string }[] = [
+  { id: ClaudeModel.OPUS_4_8, name: 'claude-opus-4-8' },
   { id: ClaudeModel.OPUS_4_7, name: 'Claude Opus 4.7' },
   { id: ClaudeModel.SONNET_4_6, name: 'Claude Sonnet 4.6' },
   { id: ClaudeModel.SONNET_4_5, name: 'Claude Sonnet 4.5' },


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-8` to the `ClaudeModel` enum and `CLAUDE_MODELS` array
- Add corresponding test for the new model

## Test plan
- [ ] CI lint check passes
- [ ] All 6 tests pass (including new Opus 4.8 test)

Generated with [Claude Code](https://claude.com/claude-code)