### PR TITLE
[Security] Avoid logging generated mobile auth token

### DIFF
--- a/src/main/mobile-api-server.test.ts
+++ b/src/main/mobile-api-server.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createTestDb } from '../../test/helpers/db-test-helper'
 import { makeTask } from '../../test/helpers/task-fixtures'
 import type { DatabaseManager } from './database'
+import { startMobileApiServer, stopMobileApiServer } from './mobile-api-server'
 
 // We test the database-level route logic for the create task feature,
 // which is the new functionality we're testing.
@@ -97,5 +98,34 @@ describe('mobile-api-server: route matching', () => {
     expect(updateRegex.test('/api/tasks')).toBe(false)
     expect(updateRegex.test('/api/tasks/')).toBe(false)
     expect(updateRegex.test('/api/tasks/some-id')).toBe(true)
+  })
+})
+
+describe('mobile-api-server: auth token logging', () => {
+  afterEach(() => {
+    stopMobileApiServer()
+    vi.restoreAllMocks()
+  })
+
+  it('does not log the generated mobile auth token', async () => {
+    const { db } = createTestDb()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await startMobileApiServer(
+      db,
+      {} as never,
+      {} as never,
+      0
+    )
+
+    const token = db.getSetting('mobile_auth_token')
+    expect(token).toBeTruthy()
+
+    const logs = logSpy.mock.calls
+      .map((call) => call.map(String).join(' '))
+      .join('\n')
+
+    expect(logs).toContain('generated new token')
+    expect(logs).not.toContain(token)
   })
 })

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -65,7 +65,7 @@ export function startMobileApiServer(
   if (!authToken) {
     authToken = randomUUID()
     db.setSetting('mobile_auth_token', authToken)
-    console.log(`[MobileAPI] No auth token configured — generated new token: ${authToken}`)
+    console.log('[MobileAPI] No auth token configured — generated new token')
   }
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

This PR removes raw mobile auth token logging during first-time token generation.

Previously, when the mobile API server generated a new auth token, the token value was included in the log message. Since that token is used as a bearer credential for mobile API access, it should not be emitted through logs.

The server still logs that a token was generated, but no longer prints the token value.

## Related Issue

Addresses item `#1` from #309.

## Changes

- Stop logging the generated mobile auth token value.
- Add a regression test to ensure the generated token is not present in `console.log` output.

## Testing

- `pnpm typecheck`
- `pnpm build`
- `pnpm exec electron ./node_modules/vitest/vitest.mjs --project main src/main/mobile-api-server.test.ts`

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [ ] `pnpm test:run` passes
- [x] No hardcoded color classes

## Notes

The focused mobile API server test passes.

I could not verify `pnpm test:run` cleanly on Windows because the script uses Unix-style environment variable syntax:

```text
ELECTRON_RUN_AS_NODE=1 electron ./node_modules/vitest/vitest.mjs run
```

The Windows-equivalent command ran, but failed in unrelated existing tests:

```powershell
$env:ELECTRON_RUN_AS_NODE='1'
pnpm exec electron ./node_modules/vitest/vitest.mjs run
```

Result:

```text
Test Files  3 failed | 91 passed (94)
Tests       11 failed | 1341 passed (1352)
```

The failures appear unrelated to this PR and are concentrated in Windows path/fixture mismatches:

- `scripts/notarize-config.test.ts`: path separator mismatch.
- `src/main/agent-manager.test.ts`: path separator mismatches and one attachment preview assertion.
- `src/main/worktree-manager.test.ts`: path separator mismatch in mocked git/gh calls.
