### PR TITLE
feat: new dashboard layout with hero, command input, and quick chips

### DIFF
--- a/src/renderer/src/components/dashboard/ApplicationsList.tsx
+++ b/src/renderer/src/components/dashboard/ApplicationsList.tsx
@@ -122,7 +122,7 @@ function CardsView() {
 
   return (
     <section>
-      <h2 className="text-sm font-semibold mb-3">Applications</h2>
+      <h2 className="text-sm font-semibold mb-3">Launch an application</h2>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
         {applications.map((app) => {
           const tab = openTabs.find((t) => t.workflowId === app.workflowId)

--- a/src/renderer/src/components/dashboard/CommandInput.tsx
+++ b/src/renderer/src/components/dashboard/CommandInput.tsx
@@ -1,0 +1,173 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { Paperclip, AtSign, Plus, ArrowUp, ChevronDown, Settings } from 'lucide-react'
+import { agentApi } from '@/lib/ipc-client'
+import type { Agent } from '@/types'
+
+interface CommandInputProps {
+  onSendToMastermind: (message: string) => void
+  onCreateTask: (text: string) => void
+}
+
+export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputProps) {
+  const [text, setText] = useState('')
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null)
+  const [showAgentDropdown, setShowAgentDropdown] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  // Load agents on mount
+  useEffect(() => {
+    agentApi.getAll().then((allAgents) => {
+      setAgents(allAgents)
+      const defaultAgent = allAgents.find((a) => a.is_default) || allAgents[0]
+      if (defaultAgent) setSelectedAgentId(defaultAgent.id)
+    })
+  }, [])
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setShowAgentDropdown(false)
+      }
+    }
+    if (showAgentDropdown) {
+      document.addEventListener('mousedown', handleClickOutside)
+      return () => document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [showAgentDropdown])
+
+  // Auto-resize textarea
+  const handleInput = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value)
+    const el = e.target
+    el.style.height = 'auto'
+    el.style.height = Math.min(el.scrollHeight, 120) + 'px'
+  }, [])
+
+  const handleSend = useCallback(() => {
+    const trimmed = text.trim()
+    if (!trimmed) return
+    onSendToMastermind(trimmed)
+    setText('')
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'
+    }
+  }, [text, onSendToMastermind])
+
+  const handleCreateTask = useCallback(() => {
+    onCreateTask(text.trim())
+    setText('')
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'
+    }
+  }, [text, onCreateTask])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }, [handleSend])
+
+  const selectedAgent = agents.find((a) => a.id === selectedAgentId)
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-card/80 backdrop-blur-sm overflow-hidden transition-all duration-200 focus-within:border-border focus-within:shadow-lg focus-within:shadow-black/5">
+      {/* Text area */}
+      <div className="px-4 pt-3 pb-2">
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={handleInput}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask Mastermind or describe a task..."
+          rows={1}
+          className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/60 resize-none outline-none leading-relaxed"
+        />
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-1 px-3 pb-2.5 pt-0.5">
+        {/* Agent selector pill */}
+        <div className="relative" ref={dropdownRef}>
+          <button
+            onClick={() => setShowAgentDropdown(!showAgentDropdown)}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+          >
+            <Settings className="h-3 w-3" />
+            <span className="max-w-[120px] truncate">{selectedAgent?.name || 'Select agent'}</span>
+            <ChevronDown className="h-3 w-3" />
+          </button>
+
+          {showAgentDropdown && (
+            <div className="absolute bottom-full left-0 mb-1 w-48 rounded-lg border border-border bg-popover shadow-lg py-1 z-50">
+              {agents.map((agent) => (
+                <button
+                  key={agent.id}
+                  onClick={() => {
+                    setSelectedAgentId(agent.id)
+                    setShowAgentDropdown(false)
+                  }}
+                  className={`w-full text-left px-3 py-1.5 text-xs transition-colors cursor-pointer ${
+                    agent.id === selectedAgentId
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-foreground hover:bg-muted/50'
+                  }`}
+                >
+                  {agent.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Separator */}
+        <div className="w-px h-4 bg-border/50 mx-1" />
+
+        {/* Attach file */}
+        <button
+          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+          title="Attach file"
+        >
+          <Paperclip className="h-3.5 w-3.5" />
+        </button>
+
+        {/* Mention */}
+        <button
+          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+          title="Mention"
+        >
+          <AtSign className="h-3.5 w-3.5" />
+        </button>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Create task button */}
+        <button
+          onClick={handleCreateTask}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Create task
+        </button>
+
+        {/* Send button */}
+        <button
+          onClick={handleSend}
+          disabled={!text.trim()}
+          className={`p-1.5 rounded-md transition-all duration-150 cursor-pointer ${
+            text.trim()
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm'
+              : 'text-muted-foreground/40 cursor-not-allowed'
+          }`}
+          title="Send to Mastermind"
+        >
+          <ArrowUp className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/CommandInput.tsx
+++ b/src/renderer/src/components/dashboard/CommandInput.tsx
@@ -27,15 +27,14 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
 
   // Close dropdown when clicking outside
   useEffect(() => {
+    if (!showAgentDropdown) return undefined
     const handleClickOutside = (e: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
         setShowAgentDropdown(false)
       }
     }
-    if (showAgentDropdown) {
-      document.addEventListener('mousedown', handleClickOutside)
-      return () => document.removeEventListener('mousedown', handleClickOutside)
-    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [showAgentDropdown])
 
   // Auto-resize textarea

--- a/src/renderer/src/components/dashboard/CommandInput.tsx
+++ b/src/renderer/src/components/dashboard/CommandInput.tsx
@@ -73,7 +73,7 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
   const selectedAgent = agents.find((a) => a.id === selectedAgentId)
 
   return (
-    <div className="rounded-xl border border-border/50 bg-card/80 backdrop-blur-sm overflow-hidden transition-all duration-200 focus-within:border-border focus-within:shadow-lg focus-within:shadow-black/5">
+    <div className="rounded-lg border border-border bg-muted/50 overflow-hidden transition-all duration-200 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/30">
       {/* Text area */}
       <div className="px-4 pt-3 pb-2">
         <textarea
@@ -83,17 +83,17 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
           onKeyDown={handleKeyDown}
           placeholder="Ask Mastermind or describe a task..."
           rows={1}
-          className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/60 resize-none outline-none leading-relaxed"
+          className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground resize-none outline-none leading-relaxed max-h-32 min-h-[32px]"
         />
       </div>
 
       {/* Toolbar */}
-      <div className="flex items-center gap-1 px-3 pb-2.5 pt-0.5">
+      <div className="flex items-center gap-1 px-3 pb-2.5 pt-0.5 border-t border-border/40">
         {/* Agent selector pill */}
         <div className="relative" ref={dropdownRef}>
           <button
             onClick={() => setShowAgentDropdown(!showAgentDropdown)}
-            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-background/60 transition-colors cursor-pointer"
           >
             <Settings className="h-3 w-3" />
             <span className="max-w-[120px] truncate">{selectedAgent?.name || 'Select agent'}</span>
@@ -123,11 +123,11 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
         </div>
 
         {/* Separator */}
-        <div className="w-px h-4 bg-border/50 mx-1" />
+        <div className="w-px h-4 bg-border mx-1" />
 
         {/* Attach file */}
         <button
-          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-background/60 transition-colors cursor-pointer"
           title="Attach file"
         >
           <Paperclip className="h-3.5 w-3.5" />
@@ -135,7 +135,7 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
 
         {/* Mention */}
         <button
-          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-background/60 transition-colors cursor-pointer"
           title="Mention"
         >
           <AtSign className="h-3.5 w-3.5" />
@@ -147,7 +147,7 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
         {/* Create task button */}
         <button
           onClick={handleCreateTask}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-background/60 border border-border/60 transition-colors cursor-pointer"
         >
           <Plus className="h-3.5 w-3.5" />
           Create task
@@ -157,10 +157,10 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
         <button
           onClick={handleSend}
           disabled={!text.trim()}
-          className={`p-1.5 rounded-md transition-all duration-150 cursor-pointer ${
+          className={`p-1.5 rounded-lg transition-all duration-150 cursor-pointer ${
             text.trim()
               ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm'
-              : 'text-muted-foreground/40 cursor-not-allowed'
+              : 'bg-muted text-muted-foreground/40 cursor-not-allowed'
           }`}
           title="Send to Mastermind"
         >

--- a/src/renderer/src/components/dashboard/CommandInput.tsx
+++ b/src/renderer/src/components/dashboard/CommandInput.tsx
@@ -73,7 +73,7 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
   const selectedAgent = agents.find((a) => a.id === selectedAgentId)
 
   return (
-    <div className="rounded-lg border border-border bg-muted/50 overflow-hidden transition-all duration-200 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/30">
+    <div className="rounded-lg border border-border/80 bg-muted overflow-hidden shadow-sm transition-all duration-200 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/30">
       {/* Text area */}
       <div className="px-4 pt-3 pb-2">
         <textarea

--- a/src/renderer/src/components/dashboard/CommandInput.tsx
+++ b/src/renderer/src/components/dashboard/CommandInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { Paperclip, AtSign, Plus, ArrowUp, ChevronDown, Settings } from 'lucide-react'
+import { Paperclip, Plus, ArrowUp, ChevronDown, Settings } from 'lucide-react'
 import { agentApi } from '@/lib/ipc-client'
 import type { Agent } from '@/types'
 
@@ -131,14 +131,6 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
           title="Attach file"
         >
           <Paperclip className="h-4 w-4" />
-        </button>
-
-        {/* Mention */}
-        <button
-          className="p-1.5 rounded-md text-foreground/60 hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
-          title="Mention"
-        >
-          <AtSign className="h-4 w-4" />
         </button>
 
         {/* Spacer */}

--- a/src/renderer/src/components/dashboard/CommandInput.tsx
+++ b/src/renderer/src/components/dashboard/CommandInput.tsx
@@ -88,14 +88,14 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
       </div>
 
       {/* Toolbar */}
-      <div className="flex items-center gap-1 px-3 pb-2.5 pt-0.5 border-t border-border/40">
+      <div className="flex items-center gap-1 px-3 pb-2.5 pt-1.5 border-t border-border">
         {/* Agent selector pill */}
         <div className="relative" ref={dropdownRef}>
           <button
             onClick={() => setShowAgentDropdown(!showAgentDropdown)}
-            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-background/60 transition-colors cursor-pointer"
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs text-foreground/70 hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
           >
-            <Settings className="h-3 w-3" />
+            <Settings className="h-3.5 w-3.5" />
             <span className="max-w-[120px] truncate">{selectedAgent?.name || 'Select agent'}</span>
             <ChevronDown className="h-3 w-3" />
           </button>
@@ -112,7 +112,7 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
                   className={`w-full text-left px-3 py-1.5 text-xs transition-colors cursor-pointer ${
                     agent.id === selectedAgentId
                       ? 'bg-primary/10 text-primary'
-                      : 'text-foreground hover:bg-muted/50'
+                      : 'text-foreground hover:bg-accent'
                   }`}
                 >
                   {agent.name}
@@ -127,18 +127,18 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
 
         {/* Attach file */}
         <button
-          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-background/60 transition-colors cursor-pointer"
+          className="p-1.5 rounded-md text-foreground/60 hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
           title="Attach file"
         >
-          <Paperclip className="h-3.5 w-3.5" />
+          <Paperclip className="h-4 w-4" />
         </button>
 
         {/* Mention */}
         <button
-          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-background/60 transition-colors cursor-pointer"
+          className="p-1.5 rounded-md text-foreground/60 hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
           title="Mention"
         >
-          <AtSign className="h-3.5 w-3.5" />
+          <AtSign className="h-4 w-4" />
         </button>
 
         {/* Spacer */}
@@ -147,7 +147,7 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
         {/* Create task button */}
         <button
           onClick={handleCreateTask}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-background/60 border border-border/60 transition-colors cursor-pointer"
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-foreground/70 hover:text-foreground hover:bg-accent border border-border transition-colors cursor-pointer"
         >
           <Plus className="h-3.5 w-3.5" />
           Create task
@@ -160,11 +160,11 @@ export function CommandInput({ onSendToMastermind, onCreateTask }: CommandInputP
           className={`p-1.5 rounded-lg transition-all duration-150 cursor-pointer ${
             text.trim()
               ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm'
-              : 'bg-muted text-muted-foreground/40 cursor-not-allowed'
+              : 'bg-accent text-muted-foreground cursor-not-allowed'
           }`}
           title="Send to Mastermind"
         >
-          <ArrowUp className="h-3.5 w-3.5" />
+          <ArrowUp className="h-4 w-4" />
         </button>
       </div>
     </div>

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
@@ -134,6 +134,10 @@ beforeEach(() => {
     isLoading: false,
     error: null
   })
+  useUIStore.setState({
+    showOrchestrator: false,
+    createTaskPrefill: null
+  })
 })
 
 describe('DashboardWorkspace', () => {
@@ -143,77 +147,33 @@ describe('DashboardWorkspace', () => {
     expect(screen.getByText('Connect')).toBeDefined() // CTA button
   })
 
-  it('always shows stats section even when not authenticated', () => {
-    useDashboardStore.setState({
-      localStats: {
-        totalTasks: 5,
-        tasksByStatus: { not_started: 3, completed: 2 },
-        tasksCreatedInWindow: 5,
-        tasksCompletedInWindow: 2,
-        avgTaskCompletionTimeHours: null,
-        p50CompletionTimeHours: null,
-        p90CompletionTimeHours: null,
-        totalAgentRuns: 0,
-        agentSuccessRate: null,
-        autonomousTasksCompleted: 0,
-        humanReviewedTasksCompleted: 2,
-        aiAutonomyRate: 0,
-        activeUsers: 1,
-        totalUsers: 1,
-        adoptionRate: null
-      }
+  it('renders hero section with rotating title', () => {
+    render(<DashboardWorkspace />)
+    // One of the rotating titles should be visible
+    expect(screen.getByText('What do you want to finish today?')).toBeDefined()
+  })
+
+  it('renders command input', () => {
+    render(<DashboardWorkspace />)
+    expect(screen.getByPlaceholderText('Ask Mastermind or describe a task...')).toBeDefined()
+  })
+
+  it('renders quick chips', () => {
+    render(<DashboardWorkspace />)
+    expect(screen.getByText('Summarize this week')).toBeDefined()
+    expect(screen.getByText('Draft outreach email')).toBeDefined()
+  })
+
+  it('renders task board with status columns', () => {
+    useTaskStore.setState({
+      tasks: [
+        makeTask({ id: 'task-1', title: 'Some task', status: TaskStatus.NotStarted })
+      ]
     })
-
     render(<DashboardWorkspace />)
-    expect(screen.getByText('Stats Overview')).toBeDefined()
-    expect(screen.getByText('5')).toBeDefined() // tasksCreatedInWindow
     expect(screen.getByText('Task Board')).toBeDefined()
-  })
-
-  it('always shows time window selector', () => {
-    render(<DashboardWorkspace />)
-    expect(screen.getByText('24h')).toBeDefined()
-    expect(screen.getByText('7d')).toBeDefined()
-    expect(screen.getByText('30d')).toBeDefined()
-    expect(screen.getByText('All')).toBeDefined()
-  })
-
-  it('renders dashboard sections when authenticated', () => {
-    useEnterpriseStore.setState({ isAuthenticated: true })
-
-    render(<DashboardWorkspace />)
-    expect(screen.getByText('Dashboard')).toBeDefined()
-    expect(screen.getByText('Stats Overview')).toBeDefined()
-    expect(screen.getByText('Task Board')).toBeDefined()
-  })
-
-  it('shows stats values when cloud data is loaded', () => {
-    useEnterpriseStore.setState({ isAuthenticated: true })
-    useDashboardStore.setState({
-      stats: {
-        totalTasks: 150,
-        tasksByStatus: { pending: 30, completed: 80 },
-        tasksCreatedInWindow: 25,
-        tasksCompletedInWindow: 18,
-        avgTaskCompletionTimeHours: 4.5,
-        p50CompletionTimeHours: 3.0,
-        p90CompletionTimeHours: 8.2,
-        totalAgentRuns: 200,
-        agentSuccessRate: 92.5,
-        autonomousTasksCompleted: 60,
-        humanReviewedTasksCompleted: 20,
-        aiAutonomyRate: 75.0,
-        activeUsers: 5,
-        totalUsers: 12,
-        adoptionRate: 41.7
-      }
-    })
-
-    render(<DashboardWorkspace />)
-    expect(screen.getByText('75.0%')).toBeDefined() // AI Autonomy
-    expect(screen.getByText('92.5%')).toBeDefined() // Agent Success
-    expect(screen.getByText('25')).toBeDefined() // Tasks Created (tasksCreatedInWindow)
-    expect(screen.getByText('18')).toBeDefined() // Completed (tasksCompletedInWindow)
+    expect(screen.getByText('Not Started')).toBeDefined()
+    expect(screen.getByText('Agent Working')).toBeDefined()
   })
 
   it('hides applications section when no data', () => {
@@ -366,15 +326,6 @@ describe('DashboardWorkspace', () => {
     expect(screen.getByText('Expired snooze task')).toBeDefined()
   })
 
-  it('shows "New Task" button that opens create modal', () => {
-    render(<DashboardWorkspace />)
-    const newTaskBtn = screen.getByText('New Task')
-    expect(newTaskBtn).toBeDefined()
-
-    fireEvent.click(newTaskBtn)
-    expect(useUIStore.getState().activeModal).toBe('create')
-  })
-
   it('resets hasFetchedOnce and errors when isAuthenticated goes false (re-login scenario)', () => {
     // Simulate: previous fetch failed and set hasFetchedOnce + errors
     useDashboardStore.setState({
@@ -412,5 +363,15 @@ describe('DashboardWorkspace', () => {
 
     // Should set the preview task ID in the UI store (dialog rendered by AppLayout)
     expect(useUIStore.getState().dashboardPreviewTaskId).toBe('task-abc')
+  })
+
+  it('quick chip click for task opens create modal with prefill', () => {
+    render(<DashboardWorkspace />)
+    fireEvent.click(screen.getByText('Draft outreach email'))
+
+    const state = useUIStore.getState()
+    expect(state.activeModal).toBe('create')
+    expect(state.createTaskPrefill).toBeDefined()
+    expect(state.createTaskPrefill?.title).toBe('Draft outreach email')
   })
 })

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -1,23 +1,18 @@
 import { useEffect, useCallback, useState } from 'react'
-import { RefreshCw, Cloud, Plus, ExternalLink } from 'lucide-react'
+import { Cloud, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
-import { useDashboardStore, type TimeWindow } from '@/stores/dashboard-store'
+import { useDashboardStore } from '@/stores/dashboard-store'
 import { useEnterpriseStore } from '@/stores/enterprise-store'
 import { useTaskStore } from '@/stores/task-store'
 import { useUIStore } from '@/stores/ui-store'
 import { SettingsTab } from '@/types'
-import { StatsSection } from './StatsSection'
+import { HeroSection } from './HeroSection'
+import { CommandInput } from './CommandInput'
+import { QuickChips } from './QuickChips'
 import { PresetupSection } from './PresetupSection'
 import { ApplicationsList } from './ApplicationsList'
 import { TaskBoard } from './TaskBoard'
 import { EnterpriseLoginModal } from '@/components/settings/tabs/EnterpriseLoginModal'
-
-const TIME_WINDOW_LABELS: Record<TimeWindow, string> = {
-  '24h': '24h',
-  '7d': '7d',
-  '30d': '30d',
-  all: 'All'
-}
 
 export function DashboardWorkspace() {
   const {
@@ -50,7 +45,7 @@ export function DashboardWorkspace() {
     }
   }, [availableTenants, isAuthenticated])
 
-  // Listen for sync completion from main process (also needed when connecting from dashboard)
+  // Listen for sync completion from main process
   useEffect(() => {
     const unsubscribe = window.electronAPI?.enterprise?.onSyncComplete?.((data) => {
       setSyncing(false)
@@ -64,19 +59,16 @@ export function DashboardWorkspace() {
     return () => unsubscribe?.()
   }, [setSyncing, setSyncResult])
 
-  // Use individual selectors to prevent re-renders from unrelated store changes
   const tasks = useTaskStore((s) => s.tasks)
   const openSettings = useUIStore((s) => s.openSettings)
   const setSettingsTab = useUIStore((s) => s.setSettingsTab)
-  const openCreateModal = useUIStore((s) => s.openCreateModal)
+  const openCreateWithPrefill = useUIStore((s) => s.openCreateWithPrefill)
+  const setShowOrchestrator = useUIStore((s) => s.setShowOrchestrator)
   const timeWindow = useDashboardStore((s) => s.timeWindow)
-  const setTimeWindow = useDashboardStore((s) => s.setTimeWindow)
-  const fetchAll = useDashboardStore((s) => s.fetchAll)
   const fetchAllIfNeeded = useDashboardStore((s) => s.fetchAllIfNeeded)
   const startPeriodicRefresh = useDashboardStore((s) => s.startPeriodicRefresh)
   const stopPeriodicRefresh = useDashboardStore((s) => s.stopPeriodicRefresh)
   const updateLocalStats = useDashboardStore((s) => s.updateLocalStats)
-  const isRefreshing = useDashboardStore((s) => s.isRefreshing)
 
   // Restore saved enterprise session on mount
   useEffect(() => {
@@ -88,10 +80,7 @@ export function DashboardWorkspace() {
     updateLocalStats(tasks)
   }, [tasks, timeWindow])
 
-  // Fetch cloud data when authenticated — only on first load, then periodically.
-  // When isAuthenticated goes false (logout / session expiry), reset dashboard
-  // fetch state so the next login triggers a fresh data load instead of being
-  // short-circuited by the stale hasFetchedOnce flag.
+  // Fetch cloud data when authenticated
   useEffect(() => {
     if (isAuthenticated) {
       fetchAllIfNeeded()
@@ -106,147 +95,131 @@ export function DashboardWorkspace() {
     return () => stopPeriodicRefresh()
   }, [isAuthenticated])
 
+  // Handler: send message to Mastermind and open the drawer
+  const handleSendToMastermind = useCallback((message: string) => {
+    // Open the orchestrator panel — the panel itself handles sending messages
+    setShowOrchestrator(true)
+    // We dispatch a custom event so the OrchestratorPanel can pick up the message
+    window.dispatchEvent(new CustomEvent('mastermind-prefill', { detail: { message } }))
+  }, [setShowOrchestrator])
+
+  // Handler: create task from command input text
+  const handleCreateTask = useCallback((text: string) => {
+    if (text) {
+      openCreateWithPrefill(text)
+    } else {
+      openCreateWithPrefill('')
+    }
+  }, [openCreateWithPrefill])
+
+  // Handler: open Mastermind drawer from hero "See full conversation"
+  const handleSeeFullConversation = useCallback(() => {
+    setShowOrchestrator(true)
+  }, [setShowOrchestrator])
+
   return (
     <div className="h-full overflow-y-auto">
-      <div className="p-6 space-y-6">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-xl font-bold tracking-tight">Dashboard</h1>
-            <p className="text-sm text-muted-foreground">
-              {isAuthenticated
-                ? 'Applications, stats, and task overview'
-                : 'Stats and task overview'}
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="default"
-              size="sm"
-              onClick={openCreateModal}
-              title="Create new task"
-            >
-              <Plus className="h-3.5 w-3.5 mr-1" />
-              New Task
-            </Button>
-            {/* Time window selector — always available */}
-            <div className="flex rounded-md border border-border bg-muted/30 p-0.5">
-              {(Object.keys(TIME_WINDOW_LABELS) as TimeWindow[]).map((w) => (
-                <button
-                  key={w}
-                  onClick={() => setTimeWindow(w)}
-                  className={`rounded px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer ${
-                    timeWindow === w
-                      ? 'bg-background text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground'
-                  }`}
-                >
-                  {TIME_WINDOW_LABELS[w]}
-                </button>
-              ))}
-            </div>
-            {isAuthenticated && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={fetchAll}
-                disabled={isRefreshing}
-                title="Refresh all"
-              >
-                <RefreshCw className={`h-3.5 w-3.5 transition-transform ${isRefreshing ? 'animate-spin' : ''}`} />
-              </Button>
-            )}
-          </div>
-        </div>
+      <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+        {/* 1. Hero — Recent Mastermind Messages */}
+        <HeroSection onSeeFullConversation={handleSeeFullConversation} />
 
-        {/* Stats — always available (local data fallback when not connected) */}
-        <StatsSection />
+        {/* 2. Command Input */}
+        <CommandInput
+          onSendToMastermind={handleSendToMastermind}
+          onCreateTask={handleCreateTask}
+        />
 
-        {/* Presetups + Applications — cloud only, shows connect prompt when not authenticated */}
-        {isAuthenticated ? (
+        {/* 3. Quick Task Chips */}
+        <QuickChips
+          onAskMastermind={handleSendToMastermind}
+          onCreateTask={(text) => openCreateWithPrefill(text)}
+        />
+
+        {/* Cloud connect prompt — when not authenticated */}
+        {!isAuthenticated && (
           <>
-            <PresetupSection />
-            <ApplicationsList />
-          </>
-        ) : (
-          <>
-          <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex items-center gap-3">
-                <Cloud className="h-5 w-5 text-muted-foreground shrink-0" />
-                <div>
-                  <p className="text-sm font-medium">Connect to 20x Cloud</p>
-                  <p className="text-xs text-muted-foreground">
-                    See application workflows and enhanced stats.
-                  </p>
+            <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <Cloud className="h-5 w-5 text-muted-foreground shrink-0" />
+                  <div>
+                    <p className="text-sm font-medium">Connect to 20x Cloud</p>
+                    <p className="text-xs text-muted-foreground">
+                      See application workflows and enhanced stats.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={handleSignupInBrowser}
+                    disabled={signupPending || enterpriseLoading}
+                  >
+                    {signupPending ? (
+                      <span className="flex items-center gap-1.5">
+                        <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                        </svg>
+                        Waiting...
+                      </span>
+                    ) : (
+                      <>
+                        <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                        Connect
+                      </>
+                    )}
+                  </Button>
                 </div>
               </div>
+              {signupPending && (
+                <p className="text-xs text-muted-foreground">
+                  Complete sign up in your browser, then you'll be connected automatically.
+                </p>
+              )}
+              {enterpriseError && (
+                <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 flex items-center justify-between">
+                  <p className="text-xs text-destructive">{enterpriseError}</p>
+                  <button
+                    onClick={clearError}
+                    className="text-xs text-destructive/70 hover:text-destructive underline ml-2 shrink-0 cursor-pointer"
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              )}
               <div className="flex items-center gap-2">
-                <Button
-                  variant="default"
-                  size="sm"
-                  onClick={handleSignupInBrowser}
-                  disabled={signupPending || enterpriseLoading}
-                >
-                  {signupPending ? (
-                    <span className="flex items-center gap-1.5">
-                      <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
-                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                      </svg>
-                      Waiting...
-                    </span>
-                  ) : (
-                    <>
-                      <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
-                      Connect
-                    </>
-                  )}
-                </Button>
-              </div>
-            </div>
-            {signupPending && (
-              <p className="text-xs text-muted-foreground">
-                Complete sign up in your browser, then you'll be connected automatically.
-              </p>
-            )}
-            {enterpriseError && (
-              <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 flex items-center justify-between">
-                <p className="text-xs text-destructive">{enterpriseError}</p>
+                <span className="text-xs text-muted-foreground">Already have an account?</span>
                 <button
-                  onClick={clearError}
-                  className="text-xs text-destructive/70 hover:text-destructive underline ml-2 shrink-0 cursor-pointer"
+                  className="text-xs text-primary hover:underline cursor-pointer"
+                  onClick={() => {
+                    setSettingsTab(SettingsTab.ENTERPRISE)
+                    openSettings()
+                  }}
                 >
-                  Dismiss
+                  Sign in
                 </button>
               </div>
-            )}
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground">Already have an account?</span>
-              <button
-                className="text-xs text-primary hover:underline cursor-pointer"
-                onClick={() => {
-                  setSettingsTab(SettingsTab.ENTERPRISE)
-                  openSettings()
-                }}
-              >
-                Sign in
-              </button>
             </div>
-          </div>
 
-          {/* Tenant selection modal — shown after browser signup when multiple orgs exist */}
-          <EnterpriseLoginModal
-            open={showLoginModal}
-            onClose={() => {
-              setShowLoginModal(false)
-              loadSession()
-            }}
-          />
+            <EnterpriseLoginModal
+              open={showLoginModal}
+              onClose={() => {
+                setShowLoginModal(false)
+                loadSession()
+              }}
+            />
           </>
         )}
 
-        {/* Task Kanban Board — always available (local data) */}
+        {/* 4. Launch an Application — cloud only */}
+        {isAuthenticated && <ApplicationsList />}
+
+        {/* 5. Start with a Template — cloud only */}
+        {isAuthenticated && <PresetupSection />}
+
+        {/* 6. Task Board (Kanban) */}
         <TaskBoard />
       </div>
     </div>

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -137,8 +137,8 @@ export function DashboardWorkspace() {
         />
       </div>
 
-      {/* Full-width sections below */}
-      <div className="px-6 space-y-6 pb-8">
+      {/* Full-width sections below — constrained + centered to align with kanban */}
+      <div className="max-w-screen-xl mx-auto px-6 space-y-6 pb-8">
         {/* Cloud connect prompt — when not authenticated */}
         {!isAuthenticated && (
           <>

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -119,7 +119,8 @@ export function DashboardWorkspace() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="px-6 py-8 space-y-6">
+      {/* Command center — centered narrow column */}
+      <div className="max-w-2xl mx-auto px-6 pt-8 pb-6 space-y-5">
         {/* 1. Hero — Recent Mastermind Messages */}
         <HeroSection onSeeFullConversation={handleSeeFullConversation} />
 
@@ -134,11 +135,14 @@ export function DashboardWorkspace() {
           onAskMastermind={handleSendToMastermind}
           onCreateTask={(text) => openCreateWithPrefill(text)}
         />
+      </div>
 
+      {/* Full-width sections below */}
+      <div className="px-6 space-y-6 pb-8">
         {/* Cloud connect prompt — when not authenticated */}
         {!isAuthenticated && (
           <>
-            <div className="rounded-lg border border-border/50 bg-card p-4 space-y-3">
+            <div className="max-w-2xl mx-auto rounded-lg border border-border/50 bg-card p-4 space-y-3">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-3">
                   <Cloud className="h-5 w-5 text-muted-foreground shrink-0" />
@@ -213,13 +217,13 @@ export function DashboardWorkspace() {
           </>
         )}
 
-        {/* 4. Launch an Application — cloud only */}
+        {/* 4. Launch an Application — cloud only, full width */}
         {isAuthenticated && <ApplicationsList />}
 
-        {/* 5. Start with a Template — cloud only */}
+        {/* 5. Start with a Template — cloud only, full width */}
         {isAuthenticated && <PresetupSection />}
 
-        {/* 6. Task Board (Kanban) */}
+        {/* 6. Task Board (Kanban) — full width */}
         <TaskBoard />
       </div>
     </div>

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -119,7 +119,7 @@ export function DashboardWorkspace() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+      <div className="px-6 py-8 space-y-6">
         {/* 1. Hero — Recent Mastermind Messages */}
         <HeroSection onSeeFullConversation={handleSeeFullConversation} />
 

--- a/src/renderer/src/components/dashboard/HeroSection.tsx
+++ b/src/renderer/src/components/dashboard/HeroSection.tsx
@@ -70,15 +70,15 @@ export function HeroSection({ onSeeFullConversation }: HeroSectionProps) {
 
       {/* Recent messages */}
       {recentMessages.length > 0 && (
-        <div className="rounded-lg border border-border/30 bg-card/50 px-4 py-3">
-          <div className="space-y-0 divide-y divide-border/20">
+        <div className="rounded-lg border border-border/60 bg-card/80 px-4 py-3">
+          <div className="space-y-0 divide-y divide-border/30">
             {recentMessages.map((msg: AgentMessage) => (
               <MessageRow key={msg.id} message={msg} />
             ))}
           </div>
           <button
             onClick={onSeeFullConversation}
-            className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground hover:text-primary transition-colors cursor-pointer"
+            className="mt-3 flex items-center gap-1.5 text-xs text-foreground/60 hover:text-primary transition-colors cursor-pointer"
           >
             <span className="tracking-wider">&middot; &middot; &middot;</span>
             <span>See full conversation</span>

--- a/src/renderer/src/components/dashboard/HeroSection.tsx
+++ b/src/renderer/src/components/dashboard/HeroSection.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect, useMemo } from 'react'
+import { useAgentStore, type AgentMessage } from '@/stores/agent-store'
+import { Bot, User } from 'lucide-react'
+
+const MASTERMIND_SESSION_ID = 'mastermind-session'
+
+const ROTATING_TITLES = [
+  'What do you want to finish today?',
+  'What should we tackle next?',
+  'Ready to get things done?',
+  'What’s on your mind?'
+]
+
+function MessageRow({ message }: { message: AgentMessage }) {
+  const isAssistant = message.role === 'assistant'
+  const content = message.content?.replace(/\n/g, ' ').trim()
+  if (!content) return null
+
+  return (
+    <div className="flex items-start gap-3 py-2 first:pt-0 last:pb-0">
+      <div className={`mt-0.5 h-6 w-6 rounded-full flex items-center justify-center shrink-0 ${
+        isAssistant
+          ? 'bg-primary/10 text-primary'
+          : 'bg-muted text-muted-foreground'
+      }`}>
+        {isAssistant ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+      </div>
+      <p className="text-sm text-foreground/80 line-clamp-1 leading-6 min-w-0">
+        {content}
+      </p>
+    </div>
+  )
+}
+
+interface HeroSectionProps {
+  onSeeFullConversation: () => void
+}
+
+export function HeroSection({ onSeeFullConversation }: HeroSectionProps) {
+  const [titleIndex, setTitleIndex] = useState(0)
+
+  const session = useAgentStore((s) => s.sessions.get(MASTERMIND_SESSION_ID))
+  const messages = session?.messages || []
+
+  // Rotate title every 5 seconds
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTitleIndex((i) => (i + 1) % ROTATING_TITLES.length)
+    }, 5000)
+    return () => clearInterval(interval)
+  }, [])
+
+  // Get last 3 text messages (user + assistant with content, skip tool/system messages)
+  const recentMessages = useMemo(() => {
+    const textMessages = messages.filter(
+      (m: AgentMessage) =>
+        (m.role === 'user' || m.role === 'assistant') &&
+        m.content?.trim() &&
+        !m.partType
+    )
+    return textMessages.slice(-3)
+  }, [messages])
+
+  return (
+    <div className="space-y-3">
+      {/* Rotating title */}
+      <h1 className="text-xl font-semibold tracking-tight text-foreground transition-opacity duration-500">
+        {ROTATING_TITLES[titleIndex]}
+      </h1>
+
+      {/* Recent messages */}
+      {recentMessages.length > 0 && (
+        <div className="rounded-lg border border-border/30 bg-card/50 px-4 py-3">
+          <div className="space-y-0 divide-y divide-border/20">
+            {recentMessages.map((msg: AgentMessage) => (
+              <MessageRow key={msg.id} message={msg} />
+            ))}
+          </div>
+          <button
+            onClick={onSeeFullConversation}
+            className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground hover:text-primary transition-colors cursor-pointer"
+          >
+            <span className="tracking-wider">&middot; &middot; &middot;</span>
+            <span>See full conversation</span>
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/PresetupSection.test.tsx
+++ b/src/renderer/src/components/dashboard/PresetupSection.test.tsx
@@ -46,7 +46,7 @@ describe('PresetupSection', () => {
   it('renders templates when expanded (default)', async () => {
     render(<PresetupSection />)
     await waitFor(() => {
-      expect(screen.getByText('Get Started')).toBeDefined()
+      expect(screen.getByText('Start with a template')).toBeDefined()
       expect(screen.getByText('Test Template')).toBeDefined()
     })
   })
@@ -55,7 +55,7 @@ describe('PresetupSection', () => {
     render(<PresetupSection />)
     await waitFor(() => expect(screen.getByText('Test Template')).toBeDefined())
 
-    fireEvent.click(screen.getByText('Get Started'))
+    fireEvent.click(screen.getByText('Start with a template'))
 
     expect(screen.queryByText('Test Template')).toBeNull()
     expect(mockSettingsSet).toHaveBeenCalledWith('dashboard_presetup_collapsed', 'true')
@@ -66,11 +66,11 @@ describe('PresetupSection', () => {
     await waitFor(() => expect(screen.getByText('Test Template')).toBeDefined())
 
     // Collapse
-    fireEvent.click(screen.getByText('Get Started'))
+    fireEvent.click(screen.getByText('Start with a template'))
     expect(screen.queryByText('Test Template')).toBeNull()
 
     // Expand
-    fireEvent.click(screen.getByText('Get Started'))
+    fireEvent.click(screen.getByText('Start with a template'))
     expect(screen.getByText('Test Template')).toBeDefined()
     expect(mockSettingsSet).toHaveBeenCalledWith('dashboard_presetup_collapsed', 'false')
   })
@@ -81,7 +81,7 @@ describe('PresetupSection', () => {
     render(<PresetupSection />)
 
     await waitFor(() => {
-      expect(screen.getByText('Get Started')).toBeDefined()
+      expect(screen.getByText('Start with a template')).toBeDefined()
       expect(screen.queryByText('Test Template')).toBeNull()
     })
   })
@@ -129,7 +129,7 @@ describe('PresetupSection', () => {
     useDashboardStore.setState({ presetupLoading: true })
 
     render(<PresetupSection />)
-    expect(screen.getByText('Get Started')).toBeDefined()
+    expect(screen.getByText('Start with a template')).toBeDefined()
     // Template cards should not be rendered during loading
     expect(screen.queryByText('Test Template')).toBeNull()
   })

--- a/src/renderer/src/components/dashboard/PresetupSection.tsx
+++ b/src/renderer/src/components/dashboard/PresetupSection.tsx
@@ -123,7 +123,7 @@ export function PresetupSection() {
   if ((presetupLoading && presetupTemplates.length === 0) || !loaded) {
     return (
       <section>
-        <h2 className="text-sm font-semibold mb-3">Get Started</h2>
+        <h2 className="text-sm font-semibold mb-3">Start with a template</h2>
         <div className="grid grid-cols-2 gap-3">
           {[1, 2].map((i) => (
             <div
@@ -154,7 +154,7 @@ export function PresetupSection() {
           ) : (
             <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
           )}
-          <h2 className="text-sm font-semibold">Get Started</h2>
+          <h2 className="text-sm font-semibold">Start with a template</h2>
           {collapsed && provisionedCount > 0 && (
             <span className="text-[11px] text-muted-foreground font-normal">
               {provisionedCount}/{presetupTemplates.length} set up

--- a/src/renderer/src/components/dashboard/QuickChips.tsx
+++ b/src/renderer/src/components/dashboard/QuickChips.tsx
@@ -1,0 +1,54 @@
+import { MessageSquare, ListPlus } from 'lucide-react'
+
+interface QuickChip {
+  label: string
+  type: 'mastermind' | 'task'
+}
+
+const CHIPS: QuickChip[] = [
+  // Ask -> Mastermind
+  { label: 'Summarize this week', type: 'mastermind' },
+  { label: 'What needs my attention', type: 'mastermind' },
+  { label: 'Pipeline status', type: 'mastermind' },
+  { label: 'Overdue payments', type: 'mastermind' },
+  // Task -> modal
+  { label: 'Draft outreach email', type: 'task' },
+  { label: 'Process invoices', type: 'task' },
+  { label: 'Run reconciliation', type: 'task' },
+  { label: 'Run a workflow', type: 'task' }
+]
+
+interface QuickChipsProps {
+  onAskMastermind: (text: string) => void
+  onCreateTask: (text: string) => void
+}
+
+export function QuickChips({ onAskMastermind, onCreateTask }: QuickChipsProps) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {CHIPS.map((chip) => {
+        const isMastermind = chip.type === 'mastermind'
+        return (
+          <button
+            key={chip.label}
+            onClick={() => {
+              if (isMastermind) {
+                onAskMastermind(chip.label)
+              } else {
+                onCreateTask(chip.label)
+              }
+            }}
+            className="group flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs text-muted-foreground border border-border/30 bg-card/30 hover:border-border/60 hover:text-foreground hover:bg-card/80 transition-all duration-150 cursor-pointer"
+          >
+            {isMastermind ? (
+              <MessageSquare className="h-3 w-3 opacity-50 group-hover:opacity-80 transition-opacity" />
+            ) : (
+              <ListPlus className="h-3 w-3 opacity-50 group-hover:opacity-80 transition-opacity" />
+            )}
+            {chip.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/QuickChips.tsx
+++ b/src/renderer/src/components/dashboard/QuickChips.tsx
@@ -38,12 +38,12 @@ export function QuickChips({ onAskMastermind, onCreateTask }: QuickChipsProps) {
                 onCreateTask(chip.label)
               }
             }}
-            className="group flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs text-muted-foreground border border-border/30 bg-card/30 hover:border-border/60 hover:text-foreground hover:bg-card/80 transition-all duration-150 cursor-pointer"
+            className="group flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs text-foreground/70 border border-border bg-card/50 hover:border-border hover:text-foreground hover:bg-card transition-all duration-150 cursor-pointer"
           >
             {isMastermind ? (
-              <MessageSquare className="h-3 w-3 opacity-50 group-hover:opacity-80 transition-opacity" />
+              <MessageSquare className="h-3 w-3 opacity-70 group-hover:opacity-100 transition-opacity" />
             ) : (
-              <ListPlus className="h-3 w-3 opacity-50 group-hover:opacity-80 transition-opacity" />
+              <ListPlus className="h-3 w-3 opacity-70 group-hover:opacity-100 transition-opacity" />
             )}
             {chip.label}
           </button>

--- a/src/renderer/src/components/dashboard/TaskBoard.tsx
+++ b/src/renderer/src/components/dashboard/TaskBoard.tsx
@@ -365,7 +365,7 @@ export function TaskBoard() {
       </div>
 
       {isLoading ? (
-        <div className="flex gap-3 pb-2 justify-center">
+        <div className="flex gap-3 pb-2">
           {COLUMNS.map((col) => (
             <div key={col.key} className={`min-w-[230px] max-w-[280px] flex-1 rounded-xl ${col.columnBg} border border-border/15`}>
               <div className="px-3 py-2.5 border-b border-border/15">
@@ -393,7 +393,7 @@ export function TaskBoard() {
           </p>
         </div>
       ) : (
-        <div className="flex gap-3 pb-2 justify-center">
+        <div className="flex gap-3 pb-2">
           {COLUMNS.map((col) => (
             <BoardColumn
               key={col.key}

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -149,6 +149,22 @@ export function AppLayout() {
     showToast
   })
 
+  // ── Track zoom factor so macOS traffic-light margin stays constant in physical pixels ──
+  useEffect(() => {
+    const update = () => {
+      // outerWidth is in device-independent screen px (stable); innerWidth shrinks/grows with zoom
+      const factor = window.outerWidth && window.innerWidth
+        ? window.outerWidth / window.innerWidth
+        : 1
+      if (factor > 0) {
+        document.documentElement.style.setProperty('--zoom-factor', String(factor))
+      }
+    }
+    update()
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
+
   const NAV_ITEMS: { key: SidebarView; label: string; icon: typeof LayoutDashboard }[] = [
     { key: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { key: 'canvas', label: 'Canvas', icon: Layers },

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -338,7 +338,6 @@ export function AppLayout() {
           <DialogBody>
             <TaskForm
               prefill={createTaskPrefill}
-              compact={!!createTaskPrefill}
               onSubmit={async (data) => {
                 const formData = data as TaskFormSubmitData
                 const pendingFiles = formData._pendingFiles

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -52,6 +52,11 @@ export function AppLayout() {
   const closeModal = useUIStore((s) => s.closeModal)
   const dashboardPreviewTaskId = useUIStore((s) => s.dashboardPreviewTaskId)
   const closeDashboardPreview = useUIStore((s) => s.closeDashboardPreview)
+  const showOrchestrator = useUIStore((s) => s.showOrchestrator)
+  const setShowOrchestrator = useUIStore((s) => s.setShowOrchestrator)
+  const toggleOrchestrator = useUIStore((s) => s.toggleOrchestrator)
+  const createTaskPrefill = useUIStore((s) => s.createTaskPrefill)
+  const clearCreateTaskPrefill = useUIStore((s) => s.clearCreateTaskPrefill)
 
   // ── Update indicator state ──
   const [updateAvailableVersion, setUpdateAvailableVersion] = useState<string | null>(null)
@@ -114,7 +119,6 @@ export function AppLayout() {
     setTimeout(() => setToast(null), isError ? 5000 : 3000)
   }, [])
 
-  const [showOrchestrator, setShowOrchestrator] = useState(false)
   const [onboardingOpen, setOnboardingOpen] = useState(false)
 
   // Auto-open onboarding on first launch or major/minor version bumps
@@ -209,7 +213,7 @@ export function AppLayout() {
           <Button
             variant={showOrchestrator ? 'default' : 'ghost'}
             size="sm"
-            onClick={() => setShowOrchestrator(!showOrchestrator)}
+            onClick={toggleOrchestrator}
             className="h-7 px-2"
           >
             <MessageSquare className="h-3.5 w-3.5 mr-1" />
@@ -218,7 +222,7 @@ export function AppLayout() {
         </div>
       </div>
 
-      {/* ── Content area: optional sidebar + workspace ── */}
+      {/* ── Content area: optional sidebar + workspace + orchestrator ── */}
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Sidebar — only for tasks and skills views */}
         {sidebarView !== 'dashboard' && sidebarView !== 'canvas' && (
@@ -231,8 +235,8 @@ export function AppLayout() {
           />
         )}
 
-        {/* Workspace */}
-        <main className="flex flex-col flex-1 min-w-0 overflow-hidden bg-background">
+        {/* Workspace — shrinks when orchestrator is open */}
+        <main className="flex flex-col flex-1 min-w-0 overflow-hidden bg-background transition-all duration-200">
           <div className="flex-1 h-0 overflow-hidden relative">
             {/* Canvas — always mounted so iframes/terminals survive navigation */}
             <div
@@ -308,30 +312,33 @@ export function AppLayout() {
               onNavigateToTask={(taskId) => selectTask(taskId)}
             />
           ) : null}
+          </div>
+        </main>
 
-          {/* Orchestrator slide-in panel */}
-          <div
-            className={`absolute top-0 right-0 bottom-0 w-96 transition-transform duration-200 ${
-              showOrchestrator ? 'translate-x-0' : 'translate-x-full'
-            }`}
-            style={{ zIndex: 10 }}
-          >
+        {/* Mastermind drawer — sits beside the workspace, shifts main content left */}
+        <div
+          className={`flex-shrink-0 transition-all duration-200 ease-in-out overflow-hidden ${
+            showOrchestrator ? 'w-[340px]' : 'w-0'
+          }`}
+        >
+          <div className="w-[340px] h-full">
             <Suspense fallback={null}>
               <OrchestratorPanel onClose={() => setShowOrchestrator(false)} />
             </Suspense>
           </div>
-          </div>
-        </main>
+        </div>
       </div>
 
-      {/* Create Task Dialog */}
-      <Dialog open={activeModal === 'create'} onOpenChange={(open) => !open && closeModal()}>
+      {/* Create Task Dialog — dismiss on outside click */}
+      <Dialog open={activeModal === 'create'} onOpenChange={(open) => { if (!open) { closeModal(); clearCreateTaskPrefill() } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Create Task</DialogTitle>
           </DialogHeader>
           <DialogBody>
             <TaskForm
+              prefill={createTaskPrefill}
+              compact={!!createTaskPrefill}
               onSubmit={async (data) => {
                 const formData = data as TaskFormSubmitData
                 const pendingFiles = formData._pendingFiles
@@ -347,9 +354,10 @@ export function AppLayout() {
                   await updateTask(newTask.id, { attachments })
                 }
                 closeModal()
+                clearCreateTaskPrefill()
                 if (newTask) selectTask(newTask.id)
               }}
-              onCancel={closeModal}
+              onCancel={() => { closeModal(); clearCreateTaskPrefill() }}
             />
           </DialogBody>
         </DialogContent>

--- a/src/renderer/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/renderer/src/components/orchestrator/OrchestratorPanel.tsx
@@ -33,21 +33,6 @@ export function OrchestratorPanel({ onClose }: OrchestratorPanelProps) {
     })
   }, [])
 
-  // Listen for pre-fill messages from the dashboard command input
-  useEffect(() => {
-    const handlePrefill = (e: Event) => {
-      const detail = (e as CustomEvent).detail
-      if (detail?.message && typeof detail.message === 'string') {
-        // Small delay to ensure the panel is mounted and agent is selected
-        setTimeout(() => {
-          handleSendMessage(detail.message)
-        }, 200)
-      }
-    }
-    window.addEventListener('mastermind-prefill', handlePrefill)
-    return () => window.removeEventListener('mastermind-prefill', handlePrefill)
-  }, [handleSendMessage])
-
   // Switch agent
   const handleAgentChange = async (newAgentId: string) => {
     if (currentSession?.sessionId) {
@@ -94,6 +79,21 @@ export function OrchestratorPanel({ onClose }: OrchestratorPanelProps) {
     },
     [selectedAgentId, currentSession, start, sendMessage, approve, removeSession]
   )
+
+  // Listen for pre-fill messages from the dashboard command input
+  useEffect(() => {
+    const handlePrefill = (e: Event) => {
+      const detail = (e as CustomEvent).detail
+      if (detail?.message && typeof detail.message === 'string') {
+        // Small delay to ensure the panel is mounted and agent is selected
+        setTimeout(() => {
+          handleSendMessage(detail.message)
+        }, 200)
+      }
+    }
+    window.addEventListener('mastermind-prefill', handlePrefill)
+    return () => window.removeEventListener('mastermind-prefill', handlePrefill)
+  }, [handleSendMessage])
 
   return (
     <div className="h-full flex flex-col bg-background border-l border-border">

--- a/src/renderer/src/components/orchestrator/OrchestratorPanel.tsx
+++ b/src/renderer/src/components/orchestrator/OrchestratorPanel.tsx
@@ -33,6 +33,21 @@ export function OrchestratorPanel({ onClose }: OrchestratorPanelProps) {
     })
   }, [])
 
+  // Listen for pre-fill messages from the dashboard command input
+  useEffect(() => {
+    const handlePrefill = (e: Event) => {
+      const detail = (e as CustomEvent).detail
+      if (detail?.message && typeof detail.message === 'string') {
+        // Small delay to ensure the panel is mounted and agent is selected
+        setTimeout(() => {
+          handleSendMessage(detail.message)
+        }, 200)
+      }
+    }
+    window.addEventListener('mastermind-prefill', handlePrefill)
+    return () => window.removeEventListener('mastermind-prefill', handlePrefill)
+  }, [handleSendMessage])
+
   // Switch agent
   const handleAgentChange = async (newAgentId: string) => {
     if (currentSession?.sessionId) {

--- a/src/renderer/src/components/tasks/TaskForm.tsx
+++ b/src/renderer/src/components/tasks/TaskForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { ChevronRight } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/Input'
 import { Select } from '@/components/ui/Select'
@@ -26,13 +27,13 @@ export interface TaskFormSubmitData extends CreateTaskDTO {
 interface TaskFormProps {
   task?: WorkfloTask
   prefill?: { title: string; description: string } | null
-  /** When true, hide non-essential fields (labels, output fields, recurrence, etc.) */
+  /** @deprecated Use collapsible section instead — kept for backward compat, ignored */
   compact?: boolean
   onSubmit: (data: TaskFormSubmitData | UpdateTaskDTO) => Promise<void>
   onCancel: () => void
 }
 
-export function TaskForm({ task, prefill, compact, onSubmit, onCancel }: TaskFormProps) {
+export function TaskForm({ task, prefill, onSubmit, onCancel }: TaskFormProps) {
   const [title, setTitle] = useState(prefill?.title || '')
   const [description, setDescription] = useState(prefill?.description || '')
   const [type, setType] = useState<TaskType>('general')
@@ -50,6 +51,9 @@ export function TaskForm({ task, prefill, compact, onSubmit, onCancel }: TaskFor
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
+  // Collapsible "Additional fields" — collapsed by default, auto-expands on edit with values
+  const [showMore, setShowMore] = useState(false)
+
   useEffect(() => {
     if (task) {
       setTitle(task.title)
@@ -65,8 +69,22 @@ export function TaskForm({ task, prefill, compact, onSubmit, onCancel }: TaskFor
       setRecurrencePattern(task.recurrence_pattern)
       setAutoStartAgent(task.auto_start_agent)
       setAutoCompleteWithoutReview(task.auto_complete_without_review)
+
+      // Auto-expand if task has non-default values in optional fields
+      if (
+        task.type !== 'general' ||
+        task.priority !== 'medium' ||
+        task.due_date ||
+        task.labels.length > 0 ||
+        task.output_fields.length > 0 ||
+        task.recurrence_pattern
+      ) {
+        setShowMore(true)
+      }
     }
   }, [task])
+
+  const hasOptionalValues = type !== 'general' || priority !== 'medium' || dueDate || labels || outputFields.length > 0 || !!recurrencePattern
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -135,42 +153,6 @@ export function TaskForm({ task, prefill, compact, onSubmit, onCancel }: TaskFor
         />
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="type">Type</Label>
-          <Select id="type" value={type} onChange={(e) => setType(e.target.value as TaskType)} options={TASK_TYPES} />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="priority">Priority</Label>
-          <Select id="priority" value={priority} onChange={(e) => setPriority(e.target.value as TaskPriority)} options={TASK_PRIORITIES} />
-        </div>
-        {!compact && (
-          <div className="space-y-2">
-            <Label htmlFor="status">Status</Label>
-            <Select id="status" value={status} onChange={(e) => setStatus(e.target.value as TaskStatus)} options={TASK_STATUSES} />
-          </div>
-        )}
-        {!compact && task?.source_id && (
-          <div className="space-y-2">
-            <Label htmlFor="assignee">Assignee</Label>
-            <p className="text-sm text-muted-foreground py-1">{assignee || 'Unassigned'}</p>
-          </div>
-        )}
-      </div>
-
-      {!compact && (
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="dueDate">Due Date</Label>
-            <Input id="dueDate" type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="labels">Labels</Label>
-            <Input id="labels" value={labels} onChange={(e) => setLabels(e.target.value)} placeholder="bug, feature..." />
-          </div>
-        </div>
-      )}
-
       <div className="rounded-md border p-4">
         <TaskAttachments
           items={attachments}
@@ -181,38 +163,83 @@ export function TaskForm({ task, prefill, compact, onSubmit, onCancel }: TaskFor
         />
       </div>
 
-      {!compact && (
-        <div className="rounded-md border p-4">
-          <OutputFieldsEditor fields={outputFields} onChange={setOutputFields} />
-        </div>
-      )}
+      {/* Collapsible additional fields — same pattern as mobile */}
+      <button
+        type="button"
+        onClick={() => setShowMore(!showMore)}
+        className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors py-1 cursor-pointer"
+      >
+        <ChevronRight className={`h-3 w-3 transition-transform ${showMore ? 'rotate-90' : ''}`} />
+        Additional fields
+        {!showMore && hasOptionalValues && (
+          <span className="text-primary text-[10px]">(has values)</span>
+        )}
+      </button>
 
-      {!compact && (
-        <div className="rounded-md border p-4">
-          <RecurrenceEditor value={recurrencePattern} onChange={setRecurrencePattern} />
-          {recurrencePattern && (
-            <div className="space-y-3 pt-4 mt-4 border-t border-border" data-testid="auto-flags-section">
-              <p className="text-sm font-medium text-muted-foreground">Automation</p>
-              <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
-                <input
-                  type="checkbox"
-                  checked={autoStartAgent}
-                  onChange={(e) => setAutoStartAgent(e.target.checked)}
-                  className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
-                />
-                <span className="text-sm">Auto-start agent on new instances</span>
-              </label>
-              <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
-                <input
-                  type="checkbox"
-                  checked={autoCompleteWithoutReview}
-                  onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
-                  className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
-                />
-                <span className="text-sm">Auto-complete without review</span>
-              </label>
+      {showMore && (
+        <div className="space-y-5 pl-1">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="type">Type</Label>
+              <Select id="type" value={type} onChange={(e) => setType(e.target.value as TaskType)} options={TASK_TYPES} />
             </div>
-          )}
+            <div className="space-y-2">
+              <Label htmlFor="priority">Priority</Label>
+              <Select id="priority" value={priority} onChange={(e) => setPriority(e.target.value as TaskPriority)} options={TASK_PRIORITIES} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="status">Status</Label>
+              <Select id="status" value={status} onChange={(e) => setStatus(e.target.value as TaskStatus)} options={TASK_STATUSES} />
+            </div>
+            {task?.source_id && (
+              <div className="space-y-2">
+                <Label htmlFor="assignee">Assignee</Label>
+                <p className="text-sm text-muted-foreground py-1">{assignee || 'Unassigned'}</p>
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="dueDate">Due Date</Label>
+              <Input id="dueDate" type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="labels">Labels</Label>
+              <Input id="labels" value={labels} onChange={(e) => setLabels(e.target.value)} placeholder="bug, feature..." />
+            </div>
+          </div>
+
+          <div className="rounded-md border p-4">
+            <OutputFieldsEditor fields={outputFields} onChange={setOutputFields} />
+          </div>
+
+          <div className="rounded-md border p-4">
+            <RecurrenceEditor value={recurrencePattern} onChange={setRecurrencePattern} />
+            {recurrencePattern && (
+              <div className="space-y-3 pt-4 mt-4 border-t border-border" data-testid="auto-flags-section">
+                <p className="text-sm font-medium text-muted-foreground">Automation</p>
+                <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
+                  <input
+                    type="checkbox"
+                    checked={autoStartAgent}
+                    onChange={(e) => setAutoStartAgent(e.target.checked)}
+                    className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+                  />
+                  <span className="text-sm">Auto-start agent on new instances</span>
+                </label>
+                <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
+                  <input
+                    type="checkbox"
+                    checked={autoCompleteWithoutReview}
+                    onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
+                    className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+                  />
+                  <span className="text-sm">Auto-complete without review</span>
+                </label>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/renderer/src/components/tasks/TaskForm.tsx
+++ b/src/renderer/src/components/tasks/TaskForm.tsx
@@ -25,13 +25,16 @@ export interface TaskFormSubmitData extends CreateTaskDTO {
 
 interface TaskFormProps {
   task?: WorkfloTask
+  prefill?: { title: string; description: string } | null
+  /** When true, hide non-essential fields (labels, output fields, recurrence, etc.) */
+  compact?: boolean
   onSubmit: (data: TaskFormSubmitData | UpdateTaskDTO) => Promise<void>
   onCancel: () => void
 }
 
-export function TaskForm({ task, onSubmit, onCancel }: TaskFormProps) {
-  const [title, setTitle] = useState('')
-  const [description, setDescription] = useState('')
+export function TaskForm({ task, prefill, compact, onSubmit, onCancel }: TaskFormProps) {
+  const [title, setTitle] = useState(prefill?.title || '')
+  const [description, setDescription] = useState(prefill?.description || '')
   const [type, setType] = useState<TaskType>('general')
   const [priority, setPriority] = useState<TaskPriority>('medium')
   const [status, setStatus] = useState<TaskStatus>(TaskStatus.NotStarted)
@@ -141,11 +144,13 @@ export function TaskForm({ task, onSubmit, onCancel }: TaskFormProps) {
           <Label htmlFor="priority">Priority</Label>
           <Select id="priority" value={priority} onChange={(e) => setPriority(e.target.value as TaskPriority)} options={TASK_PRIORITIES} />
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="status">Status</Label>
-          <Select id="status" value={status} onChange={(e) => setStatus(e.target.value as TaskStatus)} options={TASK_STATUSES} />
-        </div>
-        {task?.source_id && (
+        {!compact && (
+          <div className="space-y-2">
+            <Label htmlFor="status">Status</Label>
+            <Select id="status" value={status} onChange={(e) => setStatus(e.target.value as TaskStatus)} options={TASK_STATUSES} />
+          </div>
+        )}
+        {!compact && task?.source_id && (
           <div className="space-y-2">
             <Label htmlFor="assignee">Assignee</Label>
             <p className="text-sm text-muted-foreground py-1">{assignee || 'Unassigned'}</p>
@@ -153,16 +158,18 @@ export function TaskForm({ task, onSubmit, onCancel }: TaskFormProps) {
         )}
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="dueDate">Due Date</Label>
-          <Input id="dueDate" type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} />
+      {!compact && (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="dueDate">Due Date</Label>
+            <Input id="dueDate" type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="labels">Labels</Label>
+            <Input id="labels" value={labels} onChange={(e) => setLabels(e.target.value)} placeholder="bug, feature..." />
+          </div>
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="labels">Labels</Label>
-          <Input id="labels" value={labels} onChange={(e) => setLabels(e.target.value)} placeholder="bug, feature..." />
-        </div>
-      </div>
+      )}
 
       <div className="rounded-md border p-4">
         <TaskAttachments
@@ -174,36 +181,40 @@ export function TaskForm({ task, onSubmit, onCancel }: TaskFormProps) {
         />
       </div>
 
-      <div className="rounded-md border p-4">
-        <OutputFieldsEditor fields={outputFields} onChange={setOutputFields} />
-      </div>
+      {!compact && (
+        <div className="rounded-md border p-4">
+          <OutputFieldsEditor fields={outputFields} onChange={setOutputFields} />
+        </div>
+      )}
 
-      <div className="rounded-md border p-4">
-        <RecurrenceEditor value={recurrencePattern} onChange={setRecurrencePattern} />
-        {recurrencePattern && (
-          <div className="space-y-3 pt-4 mt-4 border-t border-border" data-testid="auto-flags-section">
-            <p className="text-sm font-medium text-muted-foreground">Automation</p>
-            <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
-              <input
-                type="checkbox"
-                checked={autoStartAgent}
-                onChange={(e) => setAutoStartAgent(e.target.checked)}
-                className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
-              />
-              <span className="text-sm">Auto-start agent on new instances</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
-              <input
-                type="checkbox"
-                checked={autoCompleteWithoutReview}
-                onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
-                className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
-              />
-              <span className="text-sm">Auto-complete without review</span>
-            </label>
-          </div>
-        )}
-      </div>
+      {!compact && (
+        <div className="rounded-md border p-4">
+          <RecurrenceEditor value={recurrencePattern} onChange={setRecurrencePattern} />
+          {recurrencePattern && (
+            <div className="space-y-3 pt-4 mt-4 border-t border-border" data-testid="auto-flags-section">
+              <p className="text-sm font-medium text-muted-foreground">Automation</p>
+              <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-start-toggle">
+                <input
+                  type="checkbox"
+                  checked={autoStartAgent}
+                  onChange={(e) => setAutoStartAgent(e.target.checked)}
+                  className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+                />
+                <span className="text-sm">Auto-start agent on new instances</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer" data-testid="form-auto-complete-toggle">
+                <input
+                  type="checkbox"
+                  checked={autoCompleteWithoutReview}
+                  onChange={(e) => setAutoCompleteWithoutReview(e.target.checked)}
+                  className="h-4 w-4 rounded border-border bg-background text-primary cursor-pointer"
+                />
+                <span className="text-sm">Auto-complete without review</span>
+              </label>
+            </div>
+          )}
+        </div>
+      )}
 
       {submitError && (
         <p className="text-sm text-destructive">{submitError}</p>

--- a/src/renderer/src/stores/ui-store.test.ts
+++ b/src/renderer/src/stores/ui-store.test.ts
@@ -17,7 +17,9 @@ describe('useUIStore', () => {
       activeModal: null,
       editingTaskId: null,
       deletingTaskId: null,
-      settingsTab: SettingsTab.GENERAL
+      settingsTab: SettingsTab.GENERAL,
+      createTaskPrefill: null,
+      showOrchestrator: false
     })
   })
 

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -25,6 +25,10 @@ interface UIState {
   canvasPendingTaskId: string | null
   /** App to add to canvas when switching to canvas view */
   canvasPendingApp: { workflowId: string; name: string } | null
+  /** Pre-fill text for the create task modal (from dashboard command input / quick chips) */
+  createTaskPrefill: { title: string; description: string } | null
+  /** Whether the Mastermind drawer is open (global) */
+  showOrchestrator: boolean
 
   setSidebarView: (view: SidebarView) => void
   setStatusFilter: (filter: TaskStatus | 'all') => void
@@ -48,6 +52,13 @@ interface UIState {
   /** Switch to canvas view and queue an app to be added as a panel */
   openAppOnCanvas: (workflowId: string, name: string) => void
   clearCanvasPendingApp: () => void
+  /** Open create modal with pre-filled text from command input */
+  openCreateWithPrefill: (text: string) => void
+  /** Clear prefill data after the form has consumed it */
+  clearCreateTaskPrefill: () => void
+  /** Toggle the Mastermind orchestrator drawer */
+  setShowOrchestrator: (show: boolean) => void
+  toggleOrchestrator: () => void
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -66,6 +77,8 @@ export const useUIStore = create<UIState>((set) => ({
   dashboardPreviewTaskId: null,
   canvasPendingTaskId: null,
   canvasPendingApp: null,
+  createTaskPrefill: null,
+  showOrchestrator: false,
 
   setSidebarView: (sidebarView) => set({ sidebarView }),
   setStatusFilter: (statusFilter) => set({ statusFilter }),
@@ -98,5 +111,28 @@ export const useUIStore = create<UIState>((set) => ({
   openTaskOnCanvas: (taskId) => set({ sidebarView: 'canvas', canvasPendingTaskId: taskId, dashboardPreviewTaskId: null }),
   clearCanvasPendingTask: () => set({ canvasPendingTaskId: null }),
   openAppOnCanvas: (workflowId, name) => set({ sidebarView: 'canvas', canvasPendingApp: { workflowId, name }, dashboardPreviewTaskId: null }),
-  clearCanvasPendingApp: () => set({ canvasPendingApp: null })
+  clearCanvasPendingApp: () => set({ canvasPendingApp: null }),
+  openCreateWithPrefill: (text: string) => {
+    // Split text: first sentence becomes title, rest becomes description
+    const firstSentenceMatch = text.match(/^(.+?[.!?])\s+([\s\S]+)$/)
+    if (firstSentenceMatch) {
+      set({
+        activeModal: 'create',
+        editingTaskId: null,
+        createTaskPrefill: {
+          title: firstSentenceMatch[1].trim(),
+          description: firstSentenceMatch[2].trim()
+        }
+      })
+    } else {
+      set({
+        activeModal: 'create',
+        editingTaskId: null,
+        createTaskPrefill: { title: text.trim(), description: '' }
+      })
+    }
+  },
+  clearCreateTaskPrefill: () => set({ createTaskPrefill: null }),
+  setShowOrchestrator: (showOrchestrator) => set({ showOrchestrator }),
+  toggleOrchestrator: () => set((s) => ({ showOrchestrator: !s.showOrchestrator }))
 }))

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -81,8 +81,9 @@ html, body, #root {
 .drag-region { -webkit-app-region: drag; }
 .no-drag { -webkit-app-region: no-drag; }
 
-/* ── macOS: push left-pinned elements past the traffic lights (≈ 70px) ── */
-[data-platform="darwin"] .macos-titlebar-pad { margin-left: 56px; }
+/* ── macOS: push left-pinned elements past the traffic lights (≈ 78px physical).
+   Use a generous value so moderate zoom-out (≥ 80%) still clears them. ── */
+[data-platform="darwin"] .macos-titlebar-pad { margin-left: 76px; }
 
 /* ── Windows: push content left of the title-bar overlay (min/max/close ≈ 140px) ── */
 [data-platform="win32"] .windows-titlebar-pad { padding-right: 150px; }

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -81,9 +81,12 @@ html, body, #root {
 .drag-region { -webkit-app-region: drag; }
 .no-drag { -webkit-app-region: no-drag; }
 
-/* ── macOS: push left-pinned elements past the traffic lights (≈ 78px physical).
-   Use a generous value so moderate zoom-out (≥ 80%) still clears them. ── */
-[data-platform="darwin"] .macos-titlebar-pad { margin-left: 76px; }
+/* ── macOS: push left-pinned elements past the traffic lights (≈ 70px physical).
+   Divides by --zoom-factor (set by AppLayout) so the gap stays constant
+   regardless of Cmd+/Cmd- page zoom.  Fallback: 80px at zoom 1×. ── */
+[data-platform="darwin"] .macos-titlebar-pad {
+  margin-left: calc(80px / var(--zoom-factor, 1));
+}
 
 /* ── Windows: push content left of the title-bar overlay (min/max/close ≈ 140px) ── */
 [data-platform="win32"] .windows-titlebar-pad { padding-right: 150px; }


### PR DESCRIPTION
## Summary

Redesigns the 20x dashboard with a conversational, task-oriented layout:

- **Hero section**: Shows the last 3 Mastermind conversation messages with rotating title prompts ("What do you want to finish today?", etc.)
- **Unified command input**: Single text box with agent selector, attach file, create task, and send-to-Mastermind buttons — toolbar is part of the unified box
- **Quick task chips**: Subtle pill row with pre-built prompts split between "Ask Mastermind" (sends to drawer) and "Task" (opens create modal with pre-fill)
- **Mastermind drawer shift**: Drawer now pushes main content left (340px) instead of overlaying — Kanban board compresses, nothing is hidden
- **Task modal pre-fill**: When creating a task from the command input or quick chips, the first sentence becomes the title, the rest becomes description; non-essential fields are hidden (compact mode, similar to mobile)
- **Global orchestrator state**: `showOrchestrator` moved from AppLayout local state to UIStore so the dashboard can open the drawer on send
- **Apps & Templates sections**: Kept as-is, rendered when authenticated
- **Stats section**: Removed from dashboard layout (component file preserved for future use)
- **Task Board (Kanban)**: No changes

### Files changed

| File | Change |
|------|--------|
| `HeroSection.tsx` | New — rotating title + recent Mastermind messages |
| `CommandInput.tsx` | New — unified command box with agent selector & toolbar |
| `QuickChips.tsx` | New — hardcoded quick action pills |
| `DashboardWorkspace.tsx` | Rewritten — new centered layout with all sections |
| `AppLayout.tsx` | Drawer shifts content left; passes prefill to TaskForm |
| `OrchestratorPanel.tsx` | Listens for `mastermind-prefill` custom event |
| `TaskForm.tsx` | Accepts `prefill` and `compact` props |
| `ui-store.ts` | Added `showOrchestrator`, `createTaskPrefill`, `openCreateWithPrefill()` |
| Tests | Updated to match new layout |

## Test plan
- [x] All 485 renderer tests pass
- [x] Zero lint errors (all warnings pre-existing)
- [ ] Manual: Hero shows rotating titles, recent messages appear after Mastermind conversation
- [ ] Manual: Command input sends to Mastermind drawer and opens it
- [ ] Manual: Create task button opens modal with pre-filled text
- [ ] Manual: Quick chips work for both Mastermind and task creation
- [ ] Manual: Drawer shifts content left (not overlay)
- [ ] Manual: Kanban board still works, task card clicks open preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)