### PR TITLE
feat: auto-open task and start triage after creation from dashboard/tasks view

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -90,11 +90,15 @@ export function registerIpcHandlers(
     return db.getTask(id)
   })
 
-  ipcMain.handle('db:createTask', (_, data: CreateTaskData) => {
+  ipcMain.handle('db:createTask', (event, data: CreateTaskData) => {
     const task = db.createTask(data)
     // Initialize recurring task if it has a recurrence pattern
     if (task && task.is_recurring && recurrenceScheduler) {
       recurrenceScheduler.initializeRecurringTask(task.id)
+    }
+    // Notify renderer so auto-start hook can trigger triage for UI-created tasks
+    if (task) {
+      event.sender.send('task:created', { task })
     }
     return task
   })

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -347,7 +347,11 @@ export function AppLayout() {
                   await updateTask(newTask.id, { attachments })
                 }
                 closeModal()
-                if (newTask) selectTask(newTask.id)
+                if (newTask) {
+                  selectTask(newTask.id)
+                  // Navigate to tasks view to show the newly created task
+                  setSidebarView('tasks')
+                }
               }}
               onCancel={closeModal}
             />


### PR DESCRIPTION
## Summary
- When creating a task from the dashboard or tasks view, the task is now automatically opened in the tasks detail view and triage is started
- Previously, UI-created tasks never triggered the auto-triage mechanism and the user stayed on the dashboard view after creation

## Changes
1. **src/main/ipc-handlers.ts**: The `db:createTask` IPC handler now emits `task:created` event to the renderer, which the `use-agent-auto-start` hook picks up and initiates triage for tasks without an agent assigned
2. **src/renderer/src/components/layout/AppLayout.tsx**: After task creation, `setSidebarView('tasks')` is now called to navigate to the tasks view and display the newly created task detail

## Why
The `task:created` IPC event was only emitted for tasks created via the MCP task API or mobile API, but not for tasks created through the UI dialog. The auto-start hook (`use-agent-auto-start.ts`) relies on this event to trigger automatic triage. Fixing this ensures UI-created tasks also benefit from auto-triage.

Additionally, `selectTask(newTask.id)` alone kept the user on the dashboard view without showing the task. Switching to tasks view ensures the user sees the new task open and can monitor triage progress.

## Test plan
- [ ] All 485 existing tests pass
- [ ] Typecheck passes with no errors
- [ ] Lint passes with 0 errors

Generated with opencode