### PR TITLE
feat: install python during Windows setup

### DIFF
--- a/resources/installer.nsh
+++ b/resources/installer.nsh
@@ -1,5 +1,55 @@
+!include "WinMessages.nsh"
+
+!define PYTHON_VERSION "3.11.9"
+!define PYTHON_INSTALLER_URL "https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-amd64.exe"
+
+Function BroadcastEnvironmentChange
+  System::Call 'user32::SendMessageTimeoutW(p ${HWND_BROADCAST}, i ${WM_SETTINGCHANGE}, p 0, w "Environment", i 0, i 5000, *p .r0)'
+FunctionEnd
+
+Function InstallPythonIfMissing
+  DetailPrint "Checking for an existing Python installation..."
+
+  nsExec::ExecToStack '"$SYSDIR\where.exe" python.exe'
+  Pop $0
+  Pop $1
+  StrCmp $0 0 pythonAlreadyInstalled
+
+  nsExec::ExecToStack '"$SYSDIR\where.exe" py.exe'
+  Pop $0
+  Pop $1
+  StrCmp $0 0 pythonAlreadyInstalled
+
+  StrCpy $0 "$TEMP\python-installer.exe"
+  DetailPrint "Downloading Python ${PYTHON_VERSION}..."
+  inetc::get /SILENT "${PYTHON_INSTALLER_URL}" "$0"
+  Pop $1
+  StrCmp $1 "OK" downloadSucceeded
+
+  MessageBox MB_ICONEXCLAMATION|MB_OK "20x could not download Python automatically ($1). Installation will continue, but Python may need to be installed later from python.org."
+  Delete "$0"
+  Return
+
+  downloadSucceeded:
+  DetailPrint "Installing Python ${PYTHON_VERSION}..."
+  ExecWait '"$0" /quiet InstallAllUsers=0 PrependPath=1 Include_launcher=1 Include_pip=1 Include_test=0 Shortcuts=0 SimpleInstall=1' $1
+  Delete "$0"
+  StrCmp $1 0 pythonInstallSucceeded
+
+  MessageBox MB_ICONEXCLAMATION|MB_OK "Python installer exited with code $1. 20x will finish installing, but Python may not be available until you install it manually."
+  Return
+
+  pythonInstallSucceeded:
+  Call BroadcastEnvironmentChange
+  DetailPrint "Python installed successfully."
+  Return
+
+  pythonAlreadyInstalled:
+  DetailPrint "Python already detected. Skipping Python installation."
+FunctionEnd
+
 !macro customInstall
-  ; Reserved for post-install agent setup
+  Call InstallPythonIfMissing
 !macroend
 
 !macro customUnInstall

--- a/scripts/installer-script.test.ts
+++ b/scripts/installer-script.test.ts
@@ -13,4 +13,15 @@ describe('installer script', () => {
     expect(promptIndex).toBeGreaterThan(-1)
     expect(upgradeGuardIndex).toBeLessThan(promptIndex)
   })
+
+  it('bootstraps Python during Windows install when it is missing', () => {
+    const script = readFileSync(join(__dirname, '..', 'resources', 'installer.nsh'), 'utf8')
+
+    expect(script).toContain('Function InstallPythonIfMissing')
+    expect(script).toContain('where.exe" python.exe')
+    expect(script).toContain('where.exe" py.exe')
+    expect(script).toContain('https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-amd64.exe')
+    expect(script).toContain('/quiet InstallAllUsers=0 PrependPath=1 Include_launcher=1 Include_pip=1')
+    expect(script).toContain('Call BroadcastEnvironmentChange')
+  })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import { startMobileApiServer, stopMobileApiServer, broadcastToMobileClients, se
 import { registerUpdaterIpc, initAutoUpdater, isUpdateDownloaded, getPendingVersion } from './auto-updater'
 import { initCrashLogger } from './crash-logger'
 import { installProcessStreamErrorHandlers } from './process-stream-errors'
+import { getWindowsPathEntries, prependMissingWindowsPaths } from './windows-runtime-paths'
 
 /**
  * Validate that a URL is safe to open via shell.openExternal.
@@ -463,18 +464,13 @@ app.on('open-url', (event, url) => {
 // missing. We read the values from a login shell and apply them to process.env.
 function loadPlatformShellEnv(): Promise<void> {
   if (process.platform === 'win32') {
-    // On Windows, ensure common Node/npm/git paths are available
-    const home = process.env.USERPROFILE || process.env.HOME || ''
-    const winPaths = [
-      join(home, 'AppData', 'Roaming', 'npm'),
-      'C:\\Program Files\\nodejs',
-      'C:\\Program Files\\Git\\cmd'
-    ]
-    const existingPath = process.env.PATH || ''
-    const missing = winPaths.filter(p => !existingPath.includes(p))
-    if (missing.length > 0) {
-      process.env.PATH = [...missing, existingPath].join(';')
-    }
+    // On Windows, GUI apps can miss PATH updates from installers. Rehydrate the
+    // usual runtime locations, including the python.org user install path used
+    // by the NSIS bootstrap.
+    process.env.PATH = prependMissingWindowsPaths(
+      process.env.PATH || '',
+      getWindowsPathEntries(process.env)
+    )
     return Promise.resolve()
   }
   if (process.platform !== 'darwin') return Promise.resolve()

--- a/src/main/windows-runtime-paths.test.ts
+++ b/src/main/windows-runtime-paths.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockReaddirSync = vi.hoisted(() => vi.fn())
+
+vi.mock('fs', () => ({
+  readdirSync: mockReaddirSync
+}))
+
+import { getWindowsPathEntries, prependMissingWindowsPaths } from './windows-runtime-paths'
+
+describe('windows runtime paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('prepends discovered Python install directories ahead of the existing PATH', () => {
+    mockReaddirSync.mockReturnValue([
+      { name: 'Python311', isDirectory: () => true },
+      { name: 'Python39', isDirectory: () => true },
+      { name: 'not-python', isDirectory: () => true }
+    ])
+
+    const entries = getWindowsPathEntries({
+      USERPROFILE: 'C:\\Users\\alice',
+      LOCALAPPDATA: 'C:\\Users\\alice\\AppData\\Local'
+    })
+
+    expect(entries).toContain('C:\\Users\\alice\\AppData\\Local\\Programs\\Python\\Python311')
+    expect(entries).toContain('C:\\Users\\alice\\AppData\\Local\\Programs\\Python\\Python311\\Scripts')
+    expect(entries).toContain('C:\\Users\\alice\\AppData\\Local\\Programs\\Python\\Python39')
+    expect(entries).not.toContain('C:\\Users\\alice\\AppData\\Local\\Programs\\Python\\not-python')
+  })
+
+  it('does not duplicate path entries that already exist with different casing', () => {
+    const updatedPath = prependMissingWindowsPaths(
+      'C:\\Program Files\\Git\\cmd;C:\\Users\\alice\\AppData\\Local\\Programs\\Python\\Python311',
+      [
+        'c:\\program files\\git\\cmd',
+        'C:\\Users\\alice\\AppData\\Local\\Programs\\Python\\Python311',
+        'C:\\Users\\alice\\AppData\\Roaming\\npm'
+      ]
+    )
+
+    expect(updatedPath).toBe(
+      'C:\\Users\\alice\\AppData\\Roaming\\npm;C:\\Program Files\\Git\\cmd;C:\\Users\\alice\\AppData\\Local\\Programs\\Python\\Python311'
+    )
+  })
+})

--- a/src/main/windows-runtime-paths.ts
+++ b/src/main/windows-runtime-paths.ts
@@ -1,0 +1,43 @@
+import { readdirSync } from 'fs'
+import { win32 } from 'path'
+
+function normalizeWindowsPathSegment(entry: string): string {
+  return entry.replace(/[\\/]+$/, '').toLowerCase()
+}
+
+function getDiscoveredPythonPaths(localAppData: string): string[] {
+  const pythonRoot = win32.join(localAppData, 'Programs', 'Python')
+
+  try {
+    return readdirSync(pythonRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && /^Python\d+$/i.test(entry.name))
+      .map((entry) => win32.join(pythonRoot, entry.name))
+      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true, sensitivity: 'base' }))
+      .flatMap((pythonDir) => [pythonDir, win32.join(pythonDir, 'Scripts')])
+  } catch {
+    return []
+  }
+}
+
+export function getWindowsPathEntries(env: NodeJS.ProcessEnv = process.env): string[] {
+  const home = env.USERPROFILE || env.HOME || ''
+  const localAppData = env.LOCALAPPDATA || win32.join(home, 'AppData', 'Local')
+
+  return [
+    win32.join(home, 'AppData', 'Roaming', 'npm'),
+    'C:\\Program Files\\nodejs',
+    'C:\\Program Files\\Git\\cmd',
+    ...getDiscoveredPythonPaths(localAppData)
+  ]
+}
+
+export function prependMissingWindowsPaths(existingPath: string, candidates: string[]): string {
+  const existingEntries = existingPath.split(';').filter(Boolean)
+  const existingSet = new Set(existingEntries.map(normalizeWindowsPathSegment))
+  const missingEntries = candidates.filter((candidate) => {
+    if (!candidate) return false
+    return !existingSet.has(normalizeWindowsPathSegment(candidate))
+  })
+
+  return [...missingEntries, ...existingEntries].join(';')
+}


### PR DESCRIPTION
## Summary
- bootstrap Python 3.11 from the NSIS installer when Windows cannot already find python or the launcher
- prepend the standard python.org install directories into the Windows app PATH on startup so the first post-install run can find Python immediately
- cover the installer script and Windows PATH bootstrap with focused tests

## Test plan
- ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/vitest run scripts/installer-script.test.ts src/main/windows-runtime-paths.test.ts
- ./node_modules/.bin/eslint src/main/index.ts src/main/windows-runtime-paths.ts src/main/windows-runtime-paths.test.ts scripts/installer-script.test.ts

## Notes
- I verified the Python unattended install flags and electron-builder NSIS customInstall hook against the current official docs.
- I did not verify a full Windows installer build from this macOS environment.
