### PR TITLE
feat: add ability to create task from canvas view via modal with center-screen placement

### DIFF
--- a/src/renderer/src/components/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/src/components/canvas/CanvasContextMenu.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef } from 'react'
-import { CheckSquare, MessageSquare, Monitor, AppWindow, Globe, TerminalSquare, X } from 'lucide-react'
+import { CheckSquare, MessageSquare, Monitor, AppWindow, Globe, TerminalSquare, Plus, X } from 'lucide-react'
 import { useTaskStore } from '@/stores/task-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useDashboardStore } from '@/stores/dashboard-store'
 import { useCanvasStore, DEFAULT_PANEL_WIDTH, DEFAULT_PANEL_HEIGHT } from '@/stores/canvas-store'
+import { useUIStore } from '@/stores/ui-store'
 import { TaskStatus } from '@/types'
 import type { CanvasPanelType } from '@/stores/canvas-store'
 
@@ -26,6 +27,7 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
   const applications = useDashboardStore((s) => s.applications)
   const addPanel = useCanvasStore((s) => s.addPanel)
   const panels = useCanvasStore((s) => s.panels)
+  const openCreateModal = useUIStore((s) => s.openCreateModal)
 
   // Close on click outside
   useEffect(() => {
@@ -107,6 +109,18 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
       </div>
 
       <div className="py-1 max-h-[400px] overflow-y-auto custom-scrollbar">
+        {/* Create Task — always at top */}
+        <MenuItem
+          icon={<Plus className="h-3.5 w-3.5 text-green-400" />}
+          label="Create Task"
+          sublabel="New task placed at center of canvas"
+          onClick={() => {
+            openCreateModal()
+            onClose()
+          }}
+        />
+        <div className="mx-3 my-1 border-t border-border/20" />
+
         {/* Browser & Terminal — always available */}
         <MenuSection title="Tools">
           <MenuItem

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -50,6 +50,7 @@ export function AppLayout() {
   const openDeleteModal = useUIStore((s) => s.openDeleteModal)
   const openSettings = useUIStore((s) => s.openSettings)
   const closeModal = useUIStore((s) => s.closeModal)
+  const setCanvasPendingTaskId = useUIStore((s) => s.setCanvasPendingTaskId)
   const dashboardPreviewTaskId = useUIStore((s) => s.dashboardPreviewTaskId)
   const closeDashboardPreview = useUIStore((s) => s.closeDashboardPreview)
 
@@ -348,9 +349,13 @@ export function AppLayout() {
                 }
                 closeModal()
                 if (newTask) {
-                  selectTask(newTask.id)
-                  // Navigate to tasks view to show the newly created task
-                  setSidebarView('tasks')
+                  if (sidebarView === 'canvas') {
+                    setCanvasPendingTaskId(newTask.id)
+                  } else {
+                    selectTask(newTask.id)
+                    // Navigate to tasks view to show the newly created task
+                    setSidebarView('tasks')
+                  }
                 }
               }}
               onCancel={closeModal}

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -44,6 +44,8 @@ interface UIState {
   closeDashboardPreview: () => void
   /** Switch to canvas view and queue a task to be added as a panel */
   openTaskOnCanvas: (taskId: string) => void
+  /** Set a pending task ID to be added as a panel on the canvas (without switching views) */
+  setCanvasPendingTaskId: (taskId: string) => void
   clearCanvasPendingTask: () => void
   /** Switch to canvas view and queue an app to be added as a panel */
   openAppOnCanvas: (workflowId: string, name: string) => void
@@ -96,6 +98,7 @@ export const useUIStore = create<UIState>((set) => ({
   openDashboardPreview: (taskId) => set({ dashboardPreviewTaskId: taskId }),
   closeDashboardPreview: () => set({ dashboardPreviewTaskId: null }),
   openTaskOnCanvas: (taskId) => set({ sidebarView: 'canvas', canvasPendingTaskId: taskId, dashboardPreviewTaskId: null }),
+  setCanvasPendingTaskId: (taskId) => set({ canvasPendingTaskId: taskId, dashboardPreviewTaskId: null }),
   clearCanvasPendingTask: () => set({ canvasPendingTaskId: null }),
   openAppOnCanvas: (workflowId, name) => set({ sidebarView: 'canvas', canvasPendingApp: { workflowId, name }, dashboardPreviewTaskId: null }),
   clearCanvasPendingApp: () => set({ canvasPendingApp: null })


### PR DESCRIPTION
## Summary
- Added "Create Task" option to the canvas context menu so users can create tasks directly from the canvas view
- When a task is created from the canvas, it is automatically placed as a panel at the center of the current viewport
- The existing TaskForm dialog is reused, keeping the UI consistent

## Changes
- **CanvasContextMenu.tsx**: Added "Create Task" menu item at the top of the context menu with a Plus icon
- **AppLayout.tsx**: Modified create task submit handler to route new tasks as centered canvas panels when on the canvas view (otherwise selects the task in tasks view)
- **ui-store.ts**: Added `setCanvasPendingTaskId` action to set a pending task for canvas panel placement without switching sidebar views

## Test plan
- [ ] CI lint check passes
- [ ] CI typecheck passes
- [ ] All 485 renderer tests pass

Generated with Claude Code