### PR TITLE
[Alignment] Align task update contract for `resolution` field

### DIFF
--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -34,6 +34,24 @@ describe('Task CRUD', () => {
     expect(updated!.priority).toBe('high')
   })
 
+  it('updates task resolution', () => {
+    const task = db.createTask(makeTask())!
+    const updated = db.updateTask(task.id, { resolution: 'Fixed by adding a regression test.' })
+
+    expect(updated!.resolution).toBe('Fixed by adding a regression test.')
+    expect(db.getTask(task.id)!.resolution).toBe('Fixed by adding a regression test.')
+  })
+
+  it('clears task resolution', () => {
+    const task = db.createTask(makeTask())!
+    db.updateTask(task.id, { resolution: 'No longer needed.' })
+
+    const updated = db.updateTask(task.id, { resolution: null })
+
+    expect(updated!.resolution).toBeNull()
+    expect(db.getTask(task.id)!.resolution).toBeNull()
+  })
+
   it('does not update non-updatable fields', () => {
     const task = db.createTask(makeTask())!
     const updated = db.updateTask(task.id, { title: 'New' } as unknown as Parameters<typeof db.updateTask>[1])

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -368,6 +368,7 @@ export interface UpdateTaskData {
   skill_ids?: string[] | null
   session_id?: string | null
   snoozed_until?: string | null
+  resolution?: string | null
   feedback_rating?: number | null
   feedback_comment?: string | null
   is_recurring?: boolean
@@ -401,6 +402,7 @@ const UPDATABLE_COLUMNS = new Set([
   'skill_ids',
   'session_id',
   'snoozed_until',
+  'resolution',
   'feedback_rating',
   'feedback_comment',
   'is_recurring',


### PR DESCRIPTION
## Summary

This PR aligns the main task update contract with the existing task model for the `resolution` field.

The renderer task update type and agent-facing task API already treat `resolution` as an updatable task field, but the main `DatabaseManager.updateTask` path did not include it in `UpdateTaskData` or the update whitelist. This meant normal main-process task updates could ignore `resolution` while other task mutation paths exposed it.


## Related Issue

Addresses item `#3` from #309.

## Changes

- Add `resolution?: string | null` to `UpdateTaskData`.
- Add `resolution` to the `UPDATABLE_COLUMNS` whitelist.
- Add regression coverage for setting and clearing task resolution through `DatabaseManager.updateTask`.

## Testing

- `pnpm exec electron ./node_modules/vitest/vitest.mjs --project main src/main/database.test.ts`

## Checklist

- [X] `pnpm typecheck` passes
- [X] `pnpm build` succeeds
- [ ] `pnpm test:run` passes
- [X] No hardcoded color classes (use CSS variable tokens)

---

## Notes 

The focused Database test passes.

Literal `pnpm test:run` fails because the script uses Unix-style env syntax:

```
'ELECTRON_RUN_AS_NODE' is not recognized as an internal or external command
```

Windows-equivalent full run completed, but failed in unrelated existing tests:

```
Test Files  3 failed | 92 passed (95)
Tests       11 failed | 1346 passed (1357)
```

The failures are due to Windows path/fixture mismatches:

- `scripts/notarize-config.test.ts`: path separator mismatch.
- `src/main/agent-manager.test.ts`: path separator mismatches and one attachment preview assertion.
- `src/main/worktree-manager.test.ts`: path separator mismatch in mocked git/gh calls.