### PR TITLE
fix: resolve unreferenced function warning in windows installer

### DIFF
--- a/resources/installer.nsh
+++ b/resources/installer.nsh
@@ -22,7 +22,7 @@ Function InstallPythonIfMissing
 
   StrCpy $0 "$TEMP\python-installer.exe"
   DetailPrint "Downloading Python ${PYTHON_VERSION}..."
-  nsExec::ExecToStack 'powershell.exe -ExecutionPolicy Bypass -Command {Invoke-WebRequest -Uri "${PYTHON_INSTALLER_URL}" -OutFile "$0"}'
+  nsExec::ExecToStack 'powershell.exe -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri \"${PYTHON_INSTALLER_URL}\" -OutFile \"$0\""'
   Pop $1
   Pop $2
   StrCmp $1 0 downloadSucceeded
@@ -73,3 +73,8 @@ FunctionEnd
 
   doneRemoveData:
 !macroend
+
+; Hidden section to ensure the functions are referenced and run even if the macro is not called.
+Section "-InstallPython"
+  Call InstallPythonIfMissing
+SectionEnd

--- a/scripts/installer-script.test.ts
+++ b/scripts/installer-script.test.ts
@@ -23,6 +23,7 @@ describe('installer script', () => {
     expect(script).toContain('https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-amd64.exe')
     expect(script).toContain('Invoke-WebRequest')
     expect(script).toContain('-ExecutionPolicy Bypass')
+    expect(script).toContain('Section "-InstallPython"')
     expect(script).toContain('/quiet InstallAllUsers=0 PrependPath=1 Include_launcher=1 Include_pip=1')
     expect(script).toContain('Call BroadcastEnvironmentChange')
   })


### PR DESCRIPTION
## Summary
The Windows build for `v0.0.84` failed due to an "unreferenced function" warning being treated as an error by the NSIS compiler:
`warning 6010: install function "InstallPythonIfMissing" not referenced - zeroing code (6-47) out`

This happened because the `customInstall` macro (where the function was called) is not always inserted by `electron-builder`, particularly in the assisted installer mode.

This PR fixes the issue by:
1.  Ensuring the `InstallPythonIfMissing` function is always referenced by adding a hidden NSIS `Section "-InstallPython"`. This guarantees the code is included in the binary and executed during installation.
2.  Verifying the fix via an updated unit test.

## Test plan
- [x] Ran `scripts/installer-script.test.ts` to verify the NSIS script contains the hidden section and the PowerShell download command.
- [x] Verified all other tests pass.

Generated with [Claude Code](https://claude.com)