### PR TITLE
feat: show current app version in general settings updates section

### DIFF
--- a/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
@@ -20,6 +20,7 @@ export function GeneralSettings() {
   const [updateVersion, setUpdateVersion] = useState<string | null>(null)
   const [updatePercent, setUpdatePercent] = useState(0)
   const [updateError, setUpdateError] = useState<string | null>(null)
+const [currentVersion, setCurrentVersion] = useState<string | null>(null)
 
   useEffect(() => {
     const cleanup = updaterApi.onStatus((data) => {
@@ -126,6 +127,14 @@ export function GeneralSettings() {
       } catch (error) {
         console.error('Failed to load mobile URL:', error)
         setMobileUrl('')
+      }
+
+      // Load current app version
+      try {
+        const version = await updaterApi.getVersion()
+        setCurrentVersion(version)
+      } catch (error) {
+        console.error('Failed to load app version:', error)
       }
     }
     loadSettings()
@@ -490,6 +499,11 @@ export function GeneralSettings() {
       description="Check for new versions and install updates"
     >
       <div className="flex items-center gap-3">
+        {currentVersion && (
+          <span className="text-xs text-muted-foreground flex items-center gap-1.5 mr-2">
+            Current version: v{currentVersion}
+          </span>
+        )}
         {updateStatus === 'idle' || updateStatus === 'up-to-date' || updateStatus === 'error' ? (
           <Button
             variant="outline"


### PR DESCRIPTION
## Summary
- The General Settings > Updates section previously did not display the current app version
- Added a `currentVersion` state that fetches the version via `updaterApi.getVersion()` on mount
- Displays the current version (e.g. "Current version: v0.0.84") inline before the action buttons in the Updates section

## Test plan
- [ ] Open Settings > General and verify the current version is displayed in the Updates section
- [ ] Version uses existing `updaterApi.getVersion()` IPC channel (same as used in UpdateDialog)

Generated with [Claude Code](https://claude.com/claude-code)