### PR TITLE
fix(windows): add guard for POSIX-only Python PTY backend in terminal

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1481,6 +1481,26 @@ export function registerIpcHandlers(
     id: string, shellPath: string, cols: number, rows: number,
     sender: Electron.WebContents, cwd?: string
   ): TerminalHandle {
+    if (process.platform === 'win32') {
+      const errorMsg = '\r\n\x1b[31m[Error] The built-in terminal is not yet supported on Windows.\x1b[0m\r\n' +
+        '\x1b[90mThe current PTY backend relies on POSIX APIs (pty, termios) not available on Windows.\x1b[0m\r\n\r\n'
+
+      // Delay sending the error to ensure the renderer has registered its listeners
+      setTimeout(() => {
+        if (!sender.isDestroyed()) {
+          sender.send('terminal:data', { id, data: errorMsg })
+          sender.send('terminal:exit', { id })
+        }
+      }, 100)
+
+      return {
+        write: () => {},
+        kill: () => {},
+        pid: 0,
+        outputBuffer: [errorMsg],
+      }
+    }
+
     const { spawn } = childProcess
 
     // Inline Python script that:


### PR DESCRIPTION
## Summary

This PR adds a platform guard to the built-in terminal backend to prevent it from crashing on Windows.

The current implementation uses Python's `pty` module and other POSIX-specific APIs (`termios`, `fcntl`, `os.fork()`) which are not available in standard Windows Python. This caused the terminal to exit immediately with a `ModuleNotFoundError: No module named 'termios'`.

## Changes

- Added a `process.platform === 'win32'` check in `createPythonPty`.
- When on Windows, it now returns a dummy handle that displays a descriptive error message to the user instead of spawning a failing Python process.
- The error message explains that the terminal is not yet supported on Windows due to POSIX dependencies.

## Related Issue

Addresses #319.

## Testing

- Verified that the logic correctly intercepts the call on Windows (simulated).
- Confirmed that it does not affect macOS/Linux execution paths.