### PR TITLE
fix: subtasks run in parent task's workspace instead of creating their own

### DIFF
--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -2103,9 +2103,19 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       throw new Error(`Agent not found: ${agentId}`)
     }
 
+    // Subtasks should run in the same workspace as their parent task
+    // so they share worktrees, skill files, and other filesystem context.
+    const task = this.db.getTask(taskId)
+    const effectiveTaskId = task?.parent_task_id ? task.parent_task_id : taskId
+
     // Auto-setup worktrees if caller didn't provide a workspaceDir
     if (!workspaceDir) {
-      workspaceDir = await this.setupWorktreeIfNeeded(taskId)
+      workspaceDir = await this.setupWorktreeIfNeeded(effectiveTaskId)
+    }
+
+    // Always use a dedicated workspace directory
+    if (!workspaceDir) {
+      workspaceDir = this.db.getWorkspaceDir(effectiveTaskId)
     }
 
     const adapter = this.getAdapter(agentId)


### PR DESCRIPTION
## Summary
- Subtask agent sessions now resolve workspace to their parent task's directory instead of creating a new one
- Previously each subtask created `<userData>/workspaces/<subtaskId>` with duplicate worktrees
- Now subtasks share the parent's workspace at `<userData>/workspaces/<parentTaskId>`

## Details
Modified `AgentManager.startSession()` in `src/main/agent-manager.ts`:
1. Looks up the task to check if it is a subtask (`task.parent_task_id`)
2. Computes `effectiveTaskId` — uses parent's taskId for subtasks, own taskId otherwise
3. Routes `setupWorktreeIfNeeded()` to the effective taskId (avoids duplicate worktrees)
4. Falls back to `getWorkspaceDir(effectiveTaskId)` when no repos are configured (ensures the workspace directory always resolves to the parent)

## Why this matters
- Prevents redundant git worktree checkouts for the same repos
- Subtask agents can see artifacts, AGENTS.md, and SKILL.md files from the parent workspace
- Eliminates isolated workspace silos between parent and subtask agents