### PR TITLE
[Local API Hardening] Require bearer auth for local task API

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -44,7 +44,11 @@ vi.mock('electron', () => {
 vi.mock('./adapters/opencode-adapter', () => ({ OpencodeAdapter: vi.fn() }))
 vi.mock('./adapters/claude-code-adapter', () => ({ ClaudeCodeAdapter: vi.fn() }))
 vi.mock('./adapters/acp-adapter', () => ({ AcpAdapter: vi.fn() }))
-vi.mock('./task-api-server', () => ({ getTaskApiPort: vi.fn(), waitForTaskApiServer: vi.fn() }))
+vi.mock('./task-api-server', () => ({
+  getTaskApiAuthToken: vi.fn(),
+  getTaskApiPort: vi.fn(),
+  waitForTaskApiServer: vi.fn()
+}))
 vi.mock('./secret-broker', () => ({
   registerSecretSession: vi.fn(),
   unregisterSecretSession: vi.fn(),
@@ -54,6 +58,7 @@ vi.mock('./secret-broker', () => ({
 
 import { mkdir as mkdirAsync, writeFile as writeFileAsync } from 'fs/promises'
 import { existsSync, copyFileSync, mkdirSync, readFileSync } from 'fs'
+import { getTaskApiAuthToken, getTaskApiPort, waitForTaskApiServer } from './task-api-server'
 
 const mockedMkdirAsync = vi.mocked(mkdirAsync)
 const mockedWriteFileAsync = vi.mocked(writeFileAsync)
@@ -802,6 +807,45 @@ describe('AgentManager implicit resume behavior', () => {
 describe('AgentManager MCP server routing', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it('injects task API URL and bearer token into the task-management MCP server', async () => {
+    vi.mocked(waitForTaskApiServer).mockResolvedValue(43210)
+    vi.mocked(getTaskApiPort).mockReturnValue(43210)
+    vi.mocked(getTaskApiAuthToken).mockReturnValue('task-api-token')
+
+    const mockDb = {
+      getAgent: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'Local Agent',
+        config: {
+          mcp_servers: ['task-management-server']
+        }
+      })),
+      getMcpServer: vi.fn(() => ({
+        id: 'task-management-server',
+        name: 'task-management',
+        type: 'local',
+        command: 'node',
+        args: ['task-management-mcp.js'],
+        environment: { EXISTING_ENV: 'kept' },
+      })),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+
+    const manager = new AgentManager(mockDb)
+
+    const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
+
+    expect(mcpServers['task-management']).toMatchObject({
+      type: 'stdio',
+      command: 'node',
+      args: ['task-management-mcp.js'],
+      env: {
+        EXISTING_ENV: 'kept',
+        TASK_API_URL: 'http://127.0.0.1:43210',
+        TASK_API_TOKEN: 'task-api-token',
+      },
+    })
   })
 
   it('canonicalizes Workflo MCP dev server URLs to the active enterprise API URL', async () => {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -15,7 +15,7 @@ import { ClaudeCodeAdapter } from './adapters/claude-code-adapter'
 import { AcpAdapter } from './adapters/acp-adapter'
 import type { CodingAgentAdapter, SessionConfig, MessagePart, SessionMessage, McpServerConfig } from './adapters/coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './adapters/coding-agent-adapter'
-import { getTaskApiPort, waitForTaskApiServer } from './task-api-server'
+import { getTaskApiAuthToken, getTaskApiPort, waitForTaskApiServer } from './task-api-server'
 import { randomUUID } from 'crypto'
 import { registerSecretSession, unregisterSecretSession, getSecretBrokerPort, writeSecretShellWrapper } from './secret-broker'
 import { registerMcpProxyTarget, getMcpAuthProxyPort } from './mcp-auth-proxy'
@@ -357,21 +357,33 @@ export class AgentManager extends EventEmitter {
     // loop can process rendering before we enter the MCP server loop.
     await new Promise<void>((r) => setImmediate(r))
 
+    const getTaskApiEnv = (): Record<string, string> => {
+      const apiPort = getTaskApiPort()
+      const apiToken = getTaskApiAuthToken()
+      const env: Record<string, string> = {}
+      if (apiPort) {
+        env.TASK_API_URL = `http://127.0.0.1:${apiPort}`
+      } else {
+        console.warn('[AgentManager] buildMcpServersForAdapter - task API port is null for task-management server')
+      }
+      if (apiToken) {
+        env.TASK_API_TOKEN = apiToken
+      } else {
+        console.warn('[AgentManager] buildMcpServersForAdapter - task API token is null for task-management server')
+      }
+      return env
+    }
+
     for (const entry of mcpEntries) {
       const serverId = typeof entry === 'string' ? entry : (entry as AgentMcpServerEntry).serverId
       const mcpServer = this.db.getMcpServer(serverId)
       if (!mcpServer) continue
 
       if (mcpServer.type === 'local') {
-        // Inject TASK_API_URL for the task-management MCP server
+        // Inject task API connection details for the task-management MCP server.
         let env = { ...mcpServer.environment }
         if (mcpServer.name === 'task-management') {
-          const apiPort = getTaskApiPort()
-          if (apiPort) {
-            env = { ...env, TASK_API_URL: `http://127.0.0.1:${apiPort}` }
-          } else {
-            console.warn(`[AgentManager] buildMcpServersForAdapter - task API port is null for task-management server`)
-          }
+          env = { ...env, ...getTaskApiEnv() }
           // Inject task scope for subtask agents (restricts access to parent + siblings only)
           if (opts?.taskScope) {
             env = { ...env, TASK_SCOPE_PARENT_ID: opts.taskScope.parentTaskId, TASK_SCOPE_TASK_ID: opts.taskScope.taskId }
@@ -433,11 +445,7 @@ export class AgentManager extends EventEmitter {
       const allServers = this.db.getMcpServers()
       const tmServer = allServers.find(s => s.name === 'task-management')
       if (tmServer && tmServer.type === 'local') {
-        const apiPort = getTaskApiPort()
-        if (!apiPort) {
-          console.warn('[AgentManager] buildMcpServersForAdapter - task API port is null! MCP server may fail to start')
-        }
-        const env: Record<string, string> = { ...tmServer.environment, ...(apiPort ? { TASK_API_URL: `http://127.0.0.1:${apiPort}` } : {}) }
+        const env: Record<string, string> = { ...tmServer.environment, ...getTaskApiEnv() }
         if (opts?.taskScope) {
           env.TASK_SCOPE_PARENT_ID = opts.taskScope.parentTaskId
           env.TASK_SCOPE_TASK_ID = opts.taskScope.taskId
@@ -3166,9 +3174,19 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     return this.testLocalMcpServer(serverData)
   }
 
-  private testLocalMcpServer(serverData: { name: string; command?: string; args?: string[]; environment?: Record<string, string> }): Promise<{ status: 'connected' | 'failed'; error?: string; errorDetail?: string; toolCount?: number; tools?: { name: string; description: string }[] }> {
+  private async testLocalMcpServer(serverData: { name: string; command?: string; args?: string[]; environment?: Record<string, string> }): Promise<{ status: 'connected' | 'failed'; error?: string; errorDetail?: string; toolCount?: number; tools?: { name: string; description: string }[] }> {
     if (!serverData.command) {
       return Promise.resolve({ status: 'failed', error: 'No command specified' })
+    }
+
+    // Inject TASK_API_URL and TASK_API_TOKEN for the built-in task-management server.
+    const extraEnv: Record<string, string> = {}
+    if (serverData.name === 'task-management') {
+      await waitForTaskApiServer()
+      const apiPort = getTaskApiPort()
+      const apiToken = getTaskApiAuthToken()
+      if (apiPort) extraEnv.TASK_API_URL = `http://127.0.0.1:${apiPort}`
+      if (apiToken) extraEnv.TASK_API_TOKEN = apiToken
     }
 
     return new Promise((resolve) => {
@@ -3184,13 +3202,6 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       const timer = setTimeout(() => {
         finish({ status: 'failed', error: 'Connection timeout (30s)' })
       }, 30000)
-
-      // Inject TASK_API_URL for the built-in task-management server
-      const extraEnv: Record<string, string> = {}
-      if (serverData.name === 'task-management') {
-        const apiPort = getTaskApiPort()
-        if (apiPort) extraEnv.TASK_API_URL = `http://127.0.0.1:${apiPort}`
-      }
 
       // Spawn directly with args array (no shell quoting) to avoid Windows single-quote issues.
       // Only use shell mode for commands that need it (npx, .cmd/.bat wrappers).

--- a/src/main/mcp-servers/task-management-mcp.js
+++ b/src/main/mcp-servers/task-management-mcp.js
@@ -10,6 +10,10 @@ const apiUrl = process.env.TASK_API_URL
 if (!apiUrl) {
   throw new Error('TASK_API_URL environment variable is required')
 }
+const apiToken = process.env.TASK_API_TOKEN
+if (!apiToken) {
+  throw new Error('TASK_API_TOKEN environment variable is required')
+}
 
 // Scope: if set, this MCP server is running for a subtask agent
 // and can only access the parent task + its subtasks
@@ -22,7 +26,10 @@ async function callApi(route, params = {}) {
   try {
     const res = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiToken}`
+      },
       body: JSON.stringify(params)
     })
     return res.json()

--- a/src/main/mcp-servers/task-management-mcp.ts
+++ b/src/main/mcp-servers/task-management-mcp.ts
@@ -10,6 +10,10 @@ const apiUrl = process.env.TASK_API_URL
 if (!apiUrl) {
   throw new Error('TASK_API_URL environment variable is required')
 }
+const apiToken = process.env.TASK_API_TOKEN
+if (!apiToken) {
+  throw new Error('TASK_API_TOKEN environment variable is required')
+}
 
 // Scope: if set, this MCP server is running for a subtask agent
 // and can only access the parent task + its subtasks
@@ -22,7 +26,10 @@ async function callApi(route: string, params: Record<string, unknown> = {}): Pro
   try {
     const res = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiToken}`
+      },
       body: JSON.stringify(params)
     })
     return res.json()

--- a/src/main/task-api-server.test.ts
+++ b/src/main/task-api-server.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createTestDb } from '../../test/helpers/db-test-helper'
 import { makeTask, makeAgent } from '../../test/helpers/task-fixtures'
 import type { DatabaseManager } from './database'
-import { setTaskApiAgentController, startTaskApiServer, stopTaskApiServer } from './task-api-server'
+import { getTaskApiAuthToken, setTaskApiAgentController, startTaskApiServer, stopTaskApiServer } from './task-api-server'
 import { TaskStatus } from '../shared/constants'
 
 /**
@@ -21,6 +21,65 @@ beforeEach(() => {
 afterEach(() => {
   setTaskApiAgentController(null)
   stopTaskApiServer()
+})
+
+function authorizedJsonHeaders(): Record<string, string> {
+  const token = getTaskApiAuthToken()
+  expect(token).toEqual(expect.any(String))
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`
+  }
+}
+
+describe('Task API authentication', () => {
+  it('rejects requests without a bearer token', async () => {
+    const task = db.createTask(makeTask({ title: 'Auth protected task' }))!
+    const port = await startTaskApiServer(db)
+
+    const res = await fetch(`http://127.0.0.1:${port}/get_task`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ task_id: task.id })
+    })
+
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('rejects requests with an invalid bearer token', async () => {
+    const task = db.createTask(makeTask({ title: 'Invalid auth task' }))!
+    const port = await startTaskApiServer(db)
+
+    const res = await fetch(`http://127.0.0.1:${port}/get_task`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer wrong-token'
+      },
+      body: JSON.stringify({ task_id: task.id })
+    })
+
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('accepts requests with the generated bearer token', async () => {
+    const task = db.createTask(makeTask({ title: 'Valid auth task' }))!
+    const port = await startTaskApiServer(db)
+
+    const res = await fetch(`http://127.0.0.1:${port}/get_task`, {
+      method: 'POST',
+      headers: authorizedJsonHeaders(),
+      body: JSON.stringify({ task_id: task.id })
+    })
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({
+      id: task.id,
+      title: 'Valid auth task'
+    })
+  })
 })
 
 describe('/update_task - triage status guard', () => {
@@ -326,7 +385,7 @@ describe('/start_task', () => {
     const port = await startTaskApiServer(db)
     const response = await fetch(`http://127.0.0.1:${port}/start_task`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authorizedJsonHeaders(),
       body: JSON.stringify({ task_id: task.id })
     })
     const result = await response.json() as Record<string, unknown>
@@ -356,7 +415,7 @@ describe('/wait_for_subtasks', () => {
     const port = await startTaskApiServer(db)
     const response = await fetch(`http://127.0.0.1:${port}/wait_for_subtasks`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authorizedJsonHeaders(),
       body: JSON.stringify({ parent_task_id: parent.id, subtask_ids: [subtask.id], timeout_ms: 5_000 })
     })
     const result = await response.json() as Record<string, unknown>

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -5,6 +5,7 @@
  * endpoints via fetch, avoiding the native module version mismatch.
  */
 import { createServer, type Server as HttpServer } from 'http'
+import { randomBytes, timingSafeEqual } from 'crypto'
 import { CronExpressionParser } from 'cron-parser'
 import type { DatabaseManager } from './database'
 import { TaskStatus } from '../shared/constants'
@@ -12,6 +13,7 @@ import type { AgentManager } from './agent-manager'
 
 let server: HttpServer | null = null
 let port: number | null = null
+let authToken: string | null = null
 let startupPromise: Promise<number> | null = null
 let notifyRenderer: ((channel: string, data: unknown) => void) | null = null
 let transcriptProvider: ((taskId: string) => Promise<Array<{ role: string; text: string }>>) | null = null
@@ -19,6 +21,29 @@ let agentController: Pick<AgentManager, 'startTask'> | null = null
 
 export function getTaskApiPort(): number | null {
   return port
+}
+
+export function getTaskApiAuthToken(): string | null {
+  return authToken
+}
+
+function ensureAuthToken(): string {
+  if (!authToken) {
+    authToken = randomBytes(32).toString('base64url')
+  }
+  return authToken
+}
+
+function isAuthorized(authorizationHeader: string | string[] | undefined, expectedToken: string): boolean {
+  const header = Array.isArray(authorizationHeader) ? authorizationHeader[0] : authorizationHeader
+  const match = header?.match(/^Bearer\s+(.+)$/i)
+  if (!match) return false
+
+  const actual = Buffer.from(match[1])
+  const expected = Buffer.from(expectedToken)
+  if (actual.length !== expected.length) return false
+
+  return timingSafeEqual(actual, expected)
 }
 
 /**
@@ -55,10 +80,19 @@ export function startTaskApiServer(db: DatabaseManager): Promise<number> {
   if (server && port) return Promise.resolve(port)
   if (startupPromise) return startupPromise
 
+  const expectedToken = ensureAuthToken()
+
   startupPromise = new Promise((resolve, reject) => {
     server = createServer((req, res) => {
       // CORS not needed — local only
       res.setHeader('Content-Type', 'application/json')
+
+      if (!isAuthorized(req.headers.authorization, expectedToken)) {
+        res.writeHead(401)
+        res.end(JSON.stringify({ error: 'Unauthorized' }))
+        req.resume()
+        return
+      }
 
       let body = ''
       req.on('data', (chunk) => { body += chunk })
@@ -111,9 +145,10 @@ export function startTaskApiServer(db: DatabaseManager): Promise<number> {
 export function stopTaskApiServer(): void {
   if (server) {
     server.close()
-    server = null
-    port = null
   }
+  server = null
+  port = null
+  authToken = null
   startupPromise = null
 }
 


### PR DESCRIPTION
## Summary

This PR adds bearer-token authentication to the local task API used by the built-in task-management MCP server.

Previously, the task API listened on `127.0.0.1` with a random port and passed `TASK_API_URL` to the MCP process. Loopback binding and random ports reduce exposure, but they do not authenticate the caller. This PR makes the trust relationship explicit by generating a per-server token in the main process, requiring it on task API requests, and passing it only to the built-in MCP process.

## Related Issue

Addresses item `#2` from #309.

## Changes

- Generate a high-entropy task API auth token when the task API server starts.
- Require `Authorization: Bearer <token>` for task API requests.
- Use timing-safe token comparison for bearer-token validation.
- Pass `TASK_API_TOKEN` alongside `TASK_API_URL` to the built-in `task-management` MCP server.
- Update the task-management MCP server to include the bearer token on task API requests.
- Add regression tests for missing, invalid, and valid task API tokens.
- Add coverage ensuring the built-in task-management MCP server receives both the task API URL and auth token.

## Testing

- Focused tests pass:

```powershell
$env:ELECTRON_RUN_AS_NODE='1'
.\node_modules\.bin\electron.cmd .\node_modules\vitest\vitest.mjs --project main src/main/task-api-server.test.ts

$env:ELECTRON_RUN_AS_NODE='1'
.\node_modules\.bin\electron.cmd .\node_modules\vitest\vitest.mjs --project main src/main/agent-manager.test.ts -t "injects task API URL and bearer token"

$env:ELECTRON_RUN_AS_NODE='1'
.\node_modules\.bin\electron.cmd .\node_modules\vitest\vitest.mjs --project main src/main/mcp-servers/task-management-mcp-schema.test.ts
```

## Checklist

- [X] `pnpm typecheck` passes
- [X] `pnpm build` succeeds
- [ ] `pnpm test:run` passes
- [X] No hardcoded color classes (use CSS variable tokens)

## Notes

Literal `pnpm test:run` fails because the script uses Unix-style env syntax:

```
'ELECTRON_RUN_AS_NODE' is not recognized as an internal or external command
```
I ran the Windows-equivalent full test command instead:

```
$env:ELECTRON_RUN_AS_NODE='1'
.\node_modules\.bin\electron.cmd .\node_modules\vitest\vitest.mjs run
```
That completed, but failed in unrelated existing tests:

```
Test Files  4 failed | 91 passed (95)
Tests       12 failed | 1348 passed (1360)
```
Failures were in:

- `scripts/notarize-config.test.ts`: Windows path separator mismatch.
- `src/main/agent-manager.test.ts`: Windows path separator expectations, including an attachment-preview mock that checks for POSIX-style paths.
- `src/main/worktree-manager.test.ts`: Windows path separator expectations in mocked `gh`/`git` calls.
- `src/main/ipc-handlers.test.ts`: terminal kill mock expectation mismatch, likely because Windows terminal creation now uses `node-pty` / ConPTY rather than the old child-process path.

