### PR TITLE
fix: Task details mismatch when editing from canvas

### DIFF
--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -89,12 +89,12 @@ export function AppLayout() {
   }, [])
 
   const editingTask = useMemo(
-    () => editingTaskId ? tasks.find((t) => t.id === editingTaskId) || selectedTask : undefined,
-    [editingTaskId, tasks, selectedTask]
+    () => editingTaskId ? allTasks.find((t) => t.id === editingTaskId) : undefined,
+    [editingTaskId, allTasks]
   )
   const deletingTask = useMemo(
-    () => deletingTaskId ? tasks.find((t) => t.id === deletingTaskId) : undefined,
-    [deletingTaskId, tasks]
+    () => deletingTaskId ? allTasks.find((t) => t.id === deletingTaskId) : undefined,
+    [deletingTaskId, allTasks]
   )
   const dashboardPreviewTask = useMemo(
     () => dashboardPreviewTaskId ? allTasks.find((t) => t.id === dashboardPreviewTaskId) : undefined,


### PR DESCRIPTION
Fixes a bug where editing a newly created task from the canvas showed details of a different task if the new task was filtered out in the sidebar.

Changes:
- Use `allTasks` instead of filtered `tasks` for `editingTask` and `deletingTask` in `AppLayout.tsx`.
- Removed fallback to `selectedTask` for `editingTask` when an explicit ID is provided.