### PR TITLE
fix: disable tillDone for learning sessions

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -137,6 +137,7 @@ describe('AgentManager skill file paths', () => {
 
       expect((manager as any).shouldEnableTillDone('heartbeat-task-1', null)).toBe(false)
       expect((manager as any).shouldEnableTillDone('task-1', { status: TaskStatus.Triaging })).toBe(false)
+      expect((manager as any).shouldEnableTillDone('task-1', { status: TaskStatus.AgentLearning })).toBe(false)
     })
 
     it('enables tillDone for regular task sessions', () => {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -530,6 +530,7 @@ export class AgentManager extends EventEmitter {
     if (taskId === 'mastermind-session') return false
     if (taskId.startsWith('heartbeat-')) return false
     if (task?.status === TaskStatus.Triaging) return false
+    if (task?.status === TaskStatus.AgentLearning) return false
     return true
   }
 


### PR DESCRIPTION
## Summary
- keep tillDone disabled for existing orchestration sessions like triage, Mastermind, and heartbeat
- also disable tillDone when a task is in AgentLearning feedback mode
- add regression coverage for the AgentLearning opt-out

## Test plan
- ./node_modules/.bin/tsc --noEmit --pretty false
- ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/vitest run src/main/agent-manager.test.ts --project main
- ./node_modules/.bin/eslint src/main/agent-manager.ts src/main/agent-manager.test.ts (warnings only: existing agent-manager warnings)
