### PR TITLE
[Tests] Make path assertions platform-agnostic

### DIFF
--- a/scripts/notarize-config.test.ts
+++ b/scripts/notarize-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import path from 'path'
 import { getMissingNotarizeEnv, shouldNotarize, getNotarizeOptions } from './notarize-config'
 
 function createContext(platform: string) {
@@ -71,7 +72,7 @@ describe('notarize-config', () => {
     expect(options).toEqual({
       tool: 'notarytool',
       appBundleId: 'com.20x.app',
-      appPath: '/tmp/out/20x.app',
+      appPath: path.join('/tmp/out', '20x.app'),
       appleId: 'dev@company.com',
       appleIdPassword: 'xxxx-xxxx-xxxx-xxxx',
       teamId: 'ABCD123456'

--- a/src/main/worktree-manager.test.ts
+++ b/src/main/worktree-manager.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import path from 'path'
 
 const { execFileMock, existsSyncMock, mkdirSyncMock } = vi.hoisted(() => {
   const execFileMock = vi.fn()
@@ -84,6 +85,7 @@ describe('WorktreeManager', () => {
 
   it('uses an explicit https clone URL for GitHub repos', async () => {
     const manager = new WorktreeManager()
+    const bareRepoPath = path.join('/tmp/20x-user-data', 'repos', 'peakflo', '20x.git')
 
     await manager.setupWorkspaceForTask(
       'task-1',
@@ -94,7 +96,7 @@ describe('WorktreeManager', () => {
 
     expect(execFileMock).toHaveBeenCalledWith(
       'gh',
-      ['repo', 'clone', 'https://github.com/peakflo/20x.git', '/tmp/20x-user-data/repos/peakflo/20x.git', '--', '--bare'],
+      ['repo', 'clone', 'https://github.com/peakflo/20x.git', bareRepoPath, '--', '--bare'],
       expect.objectContaining({ timeout: 300000 }),
       expect.any(Function)
     )
@@ -102,6 +104,7 @@ describe('WorktreeManager', () => {
 
   it('falls back to a derived https clone URL when repo metadata omits one', async () => {
     const manager = new WorktreeManager()
+    const bareRepoPath = path.join('/tmp/20x-user-data', 'repos', 'peakflo', 'upload-functions.git')
 
     await manager.setupWorkspaceForTask(
       'task-2',
@@ -112,7 +115,7 @@ describe('WorktreeManager', () => {
 
     expect(execFileMock).toHaveBeenCalledWith(
       'gh',
-      ['repo', 'clone', 'https://github.com/peakflo/upload-functions.git', '/tmp/20x-user-data/repos/peakflo/upload-functions.git', '--', '--bare'],
+      ['repo', 'clone', 'https://github.com/peakflo/upload-functions.git', bareRepoPath, '--', '--bare'],
       expect.objectContaining({ timeout: 300000 }),
       expect.any(Function)
     )


### PR DESCRIPTION
## Summary

This PR makes a small set of path assertions platform-agnostic so they pass on Windows as well as POSIX systems.

The affected tests were expecting hardcoded POSIX-style paths, while the implementation builds paths with Node’s `path.join(...)`. On Windows, those implementation paths correctly use backslashes, which caused the assertions to fail.


## Changes

- Use `path.join(...)` for the expected notarized app path in `scripts/notarize-config.test.ts`.
- Use `path.join(...)` for expected bare repository clone paths in `src/main/worktree-manager.test.ts`.


## Testing

Focused tests pass:

```powershell
$env:ELECTRON_RUN_AS_NODE='1'
.\node_modules\.bin\electron.cmd .\node_modules\vitest\vitest.mjs --project main scripts/notarize-config.test.ts src/main/worktree-manager.test.ts
```

**Results**

```
Test Files  2 passed (2)
Tests       8 passed (8)
```

## Checklist

- [X] `pnpm typecheck` passes
- [X] `pnpm build` succeeds
- [ ] `pnpm test:run` passes
- [X] No hardcoded color classes (use CSS variable tokens)

## Notes

Literal `pnpm test:run` fails on Windows because the package script uses Unix-style env syntax:

```
'ELECTRON_RUN_AS_NODE' is not recognized as an internal or external command
```

I ran the Windows-equivalent full test command instead:

```
$env:ELECTRON_RUN_AS_NODE='1'
.\node_modules\.bin\electron.cmd .\node_modules\vitest\vitest.mjs run
```

That completed with:

```
Test Files  2 failed | 93 passed (95)
Tests       9 failed | 1357 passed (1366)
```

The remaining failures are outside this PR’s scope:

- `src/main/agent-manager.test.ts`: additional Windows path separator assumptions. I left these for a separate PR because that file has several related expectations across skill file writing, agent docs, attachment syncing, and attachment preview behavior.
- `src/main/ipc-handlers.test.ts`: terminal kill mock expectation mismatch, likely related to the Windows terminal backend now using `node-pty` / ConPTY instead of the older child-process path.