### PR TITLE
fix: disable tillDone for orchestration sessions

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -137,6 +137,7 @@ describe('AgentManager skill file paths', () => {
 
       expect((manager as any).shouldEnableTillDone('heartbeat-task-1', null)).toBe(false)
       expect((manager as any).shouldEnableTillDone('task-1', { status: TaskStatus.Triaging })).toBe(false)
+      expect((manager as any).shouldEnableTillDone('task-1', { status: TaskStatus.NotStarted, agent_id: null })).toBe(false)
       expect((manager as any).shouldEnableTillDone('task-1', { status: TaskStatus.AgentLearning })).toBe(false)
     })
 
@@ -144,7 +145,7 @@ describe('AgentManager skill file paths', () => {
       const mockDb = createMockDb({ coding_agent: 'opencode' })
       manager = new AgentManager(mockDb)
 
-      expect((manager as any).shouldEnableTillDone('task-1', { status: TaskStatus.NotStarted })).toBe(true)
+      expect((manager as any).shouldEnableTillDone('task-1', { status: TaskStatus.NotStarted, agent_id: 'agent-1' })).toBe(true)
     })
   })
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -465,7 +465,7 @@ export class AgentManager extends EventEmitter {
 
     const isMastermind = taskId === 'mastermind-session'
     const task = this.db.getTask(taskId)
-    const isTriageSession = task?.status === TaskStatus.Triaging
+    const isTriageSession = this.isTriageSessionTask(taskId, task)
     const isSubtask = !!task?.parent_task_id
     const taskScope = isSubtask && task?.parent_task_id ? { taskId, parentTaskId: task.parent_task_id } : undefined
     const mcpServers = await this.buildMcpServersForAdapter(agentId, { ensureTaskManagement: isMastermind || isTriageSession || isSubtask, taskScope })
@@ -529,9 +529,17 @@ export class AgentManager extends EventEmitter {
   private shouldEnableTillDone(taskId: string, task?: TaskRecord | null): boolean {
     if (taskId === 'mastermind-session') return false
     if (taskId.startsWith('heartbeat-')) return false
-    if (task?.status === TaskStatus.Triaging) return false
+    if (this.isTriageSessionTask(taskId, task)) return false
     if (task?.status === TaskStatus.AgentLearning) return false
     return true
+  }
+
+  private isTriageSessionTask(taskId: string, task?: TaskRecord | null): boolean {
+    if (!task) return false
+    if (taskId === 'mastermind-session') return false
+    if (taskId.startsWith('heartbeat-')) return false
+    return task.status === TaskStatus.Triaging ||
+      (Object.prototype.hasOwnProperty.call(task, 'agent_id') && !task.agent_id)
   }
 
   /**
@@ -1092,7 +1100,7 @@ export class AgentManager extends EventEmitter {
 
     // Check if this is a triage session or subtask
     const task = this.db.getTask(taskId)
-    const isTriageSession = task?.status === TaskStatus.Triaging
+    const isTriageSession = this.isTriageSessionTask(taskId, task)
     const isSubtask = !!task?.parent_task_id
     const taskScope = isSubtask && task?.parent_task_id ? { taskId, parentTaskId: task.parent_task_id } : undefined
     await yieldEL()
@@ -1919,7 +1927,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     // Build MCP servers config
     const isMastermind = taskId === 'mastermind-session'
     const task = this.db.getTask(taskId)
-    const isTriageSession = task?.status === TaskStatus.Triaging
+    const isTriageSession = this.isTriageSessionTask(taskId, task)
     const isSubtask = !!task?.parent_task_id
     const taskScope = isSubtask && task?.parent_task_id ? { taskId, parentTaskId: task.parent_task_id } : undefined
     await yieldEL()


### PR DESCRIPTION
## Summary
- make triage detection status-independent for tillDone gating by also treating explicitly unassigned tasks as triage sessions
- keep tillDone disabled for Mastermind, heartbeat, triage, and AgentLearning sessions
- apply the shared triage detector in all AgentManager session config paths

## Test plan
- ./node_modules/.bin/tsc --noEmit --pretty false
- ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/vitest run src/main/agent-manager.test.ts --project main
