### PR TITLE
fix(mcp): identify enterprise MCP by provenance, fix tenant leak

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -805,7 +805,7 @@ describe('AgentManager MCP server routing', () => {
     vi.clearAllMocks()
   })
 
-  it('canonicalizes Workflo MCP dev server URLs to the active enterprise API URL when no Authorization header is provided', async () => {
+  it('canonicalizes Workflo MCP dev server URLs to the active enterprise API URL for enterprise-sourced servers', async () => {
     const mockDb = {
       getAgent: vi.fn(() => ({
         id: 'agent-1',
@@ -816,11 +816,12 @@ describe('AgentManager MCP server routing', () => {
       })),
       getMcpServer: vi.fn(() => ({
         id: 'workflo-stage-server',
-        name: 'pf-workflo-integrations',
+        name: '[Workflo] MCP Dev Server',
         type: 'remote',
         url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
         headers: {},
         oauth_metadata: {},
+        source: 'enterprise',
       })),
     } as unknown as ConstructorParameters<typeof AgentManager>[0]
 
@@ -832,17 +833,59 @@ describe('AgentManager MCP server routing', () => {
 
     const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
 
-    expect(mcpServers['pf-workflo-integrations']).toMatchObject({
+    expect(mcpServers['[Workflo] MCP Dev Server']).toMatchObject({
       type: 'http',
       url: 'https://api.peakflo.ai/api/mcp/dev/mcp',
       headers: { Authorization: 'Bearer fresh-prod-jwt' },
     })
   })
 
-  it('respects a user-supplied Authorization header on a Workflo-shaped MCP URL — does not rewrite URL or substitute JWT', async () => {
-    // Regression: a developer API key (pfwf_...) created in tenant A and added
-    // as an MCP server in 20x must NOT be replaced by 20x's enterprise JWT
-    // (which would resolve to whichever tenant 20x is currently logged into).
+  it('does NOT auto-manage a user-sourced MCP, even when name and URL look like the enterprise one (provenance check)', async () => {
+    // Regression — the primary tenant-leak fix.
+    // A user-added MCP whose `source` is 'user' must never be hijacked, no
+    // matter what its name or URL looks like. Before Phase 1 this was a
+    // name/path heuristic and any "*workflo*" name + /api/mcp/dev/mcp path
+    // got auto-managed → tenant leak. Now identification is provenance-only.
+    const mockDb = {
+      getAgent: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'OPS L2',
+        config: {
+          mcp_servers: ['tan-insurance-workflo'],
+        },
+      })),
+      getMcpServer: vi.fn(() => ({
+        id: 'tan-insurance-workflo',
+        name: '[Workflo] MCP Dev Server',  // user copied the canonical name
+        type: 'remote',
+        url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',  // and the canonical URL
+        headers: {},
+        oauth_metadata: {},
+        source: 'user',  // but it was added by the user, not by enterprise sync
+      })),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+
+    const manager = new AgentManager(mockDb)
+    manager.setEnterpriseAuth({
+      getApiUrl: vi.fn(() => 'https://api.peakflo.ai'),
+      getJwt: vi.fn(async () => 'fresh-prod-jwt-for-tenant-b'),
+    } as any)
+
+    const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
+
+    expect(mcpServers['[Workflo] MCP Dev Server']).toMatchObject({
+      type: 'http',
+      // URL is NOT rewritten — user pointed at stage, request goes to stage
+      url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
+    })
+    // No Authorization injected — user didn't set one and the proxy is not invoked
+    expect(mcpServers['[Workflo] MCP Dev Server'].headers).not.toHaveProperty('Authorization')
+  })
+
+  it('respects a user-supplied Authorization header even when an enterprise-sourced row carries one (defence-in-depth)', async () => {
+    // Defence-in-depth: even if a row is somehow mislabelled as 'enterprise'
+    // but the user/sync wrote an Authorization header, honour their explicit
+    // credential and skip the auto-manage path.
     const mockDb = {
       getAgent: vi.fn(() => ({
         id: 'agent-1',
@@ -858,6 +901,7 @@ describe('AgentManager MCP server routing', () => {
         url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
         headers: { Authorization: 'Bearer pfwf_tenant_a_key' },
         oauth_metadata: {},
+        source: 'enterprise',
       })),
     } as unknown as ConstructorParameters<typeof AgentManager>[0]
 

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -805,7 +805,7 @@ describe('AgentManager MCP server routing', () => {
     vi.clearAllMocks()
   })
 
-  it('canonicalizes Workflo MCP dev server URLs to the active enterprise API URL', async () => {
+  it('canonicalizes Workflo MCP dev server URLs to the active enterprise API URL when no Authorization header is provided', async () => {
     const mockDb = {
       getAgent: vi.fn(() => ({
         id: 'agent-1',
@@ -819,7 +819,7 @@ describe('AgentManager MCP server routing', () => {
         name: 'pf-workflo-integrations',
         type: 'remote',
         url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
-        headers: { Authorization: 'Bearer stale-stage-key' },
+        headers: {},
         oauth_metadata: {},
       })),
     } as unknown as ConstructorParameters<typeof AgentManager>[0]
@@ -836,6 +836,43 @@ describe('AgentManager MCP server routing', () => {
       type: 'http',
       url: 'https://api.peakflo.ai/api/mcp/dev/mcp',
       headers: { Authorization: 'Bearer fresh-prod-jwt' },
+    })
+  })
+
+  it('respects a user-supplied Authorization header on a Workflo-shaped MCP URL — does not rewrite URL or substitute JWT', async () => {
+    // Regression: a developer API key (pfwf_...) created in tenant A and added
+    // as an MCP server in 20x must NOT be replaced by 20x's enterprise JWT
+    // (which would resolve to whichever tenant 20x is currently logged into).
+    const mockDb = {
+      getAgent: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'OPS L2',
+        config: {
+          mcp_servers: ['tan-insurance-workflo'],
+        },
+      })),
+      getMcpServer: vi.fn(() => ({
+        id: 'tan-insurance-workflo',
+        name: 'Tan Insurance MCP workflo',
+        type: 'remote',
+        url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
+        headers: { Authorization: 'Bearer pfwf_tenant_a_key' },
+        oauth_metadata: {},
+      })),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+
+    const manager = new AgentManager(mockDb)
+    manager.setEnterpriseAuth({
+      getApiUrl: vi.fn(() => 'https://api.peakflo.ai'),
+      getJwt: vi.fn(async () => 'fresh-prod-jwt-for-tenant-b'),
+    } as any)
+
+    const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
+
+    expect(mcpServers['Tan Insurance MCP workflo']).toMatchObject({
+      type: 'http',
+      url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
+      headers: { Authorization: 'Bearer pfwf_tenant_a_key' },
     })
   })
 })

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -5,7 +5,7 @@ import { existsSync, copyFileSync, mkdirSync, readFileSync, readdirSync, statSyn
 import { mkdir, writeFile } from 'fs/promises'
 import { Notification } from 'electron'
 import type { BrowserWindow } from 'electron'
-import type { DatabaseManager, AgentMcpServerEntry, OutputFieldRecord, SecretRecord, SkillRecord, TaskRecord } from './database'
+import type { DatabaseManager, AgentMcpServerEntry, McpServerSource, OutputFieldRecord, SecretRecord, SkillRecord, TaskRecord } from './database'
 import { TaskStatus, SessionStatus, PluginActionId } from '../shared/constants'
 import type { WorktreeManager } from './worktree-manager'
 import type { GitHubManager } from './github-manager'
@@ -29,7 +29,6 @@ enum CodingAgentType {
 
 // Default OpenCode server URL (matches database default)
 const DEFAULT_SERVER_URL = 'http://localhost:4096'
-const WORKFLO_MCP_DEV_SERVER_NAME = '[Workflo] MCP Dev Server'
 const WORKFLO_MCP_DEV_PATH = '/api/mcp/dev/mcp'
 
 interface AgentSession {
@@ -72,20 +71,29 @@ function hasUserSuppliedAuthHeader(headers?: Record<string, string>): boolean {
   return false
 }
 
-function isEnterpriseWorkfloMcpServer(
-  name: string,
-  serverUrl?: string,
+/**
+ * The MCP server that 20x should auto-manage (URL canonicalisation + JWT
+ * injection via mcp-auth-proxy) is exactly: an enterprise-sourced row whose
+ * URL points at the Workflo MCP Dev endpoint.
+ *
+ * Identification is by the `source` column (set by EnterpriseSyncManager
+ * when the row is created — see enterprise-sync.ts and database.ts). This
+ * is deterministic and immune to user-chosen names, name collisions, or
+ * future renames of the canonical entry.
+ *
+ * The header-based defence-in-depth (`hasUserSuppliedAuthHeader`) is kept
+ * for the unusual case where a row gets mislabelled as 'enterprise' but
+ * the user has manually pasted in their own credential — we still honour
+ * their explicit intent.
+ */
+function isEnterpriseMcpDevServer(mcpServer: {
+  source?: McpServerSource
+  url?: string | null
   headers?: Record<string, string>
-): boolean {
-  // If the user supplied their own Authorization header (e.g. a pfwf_ API key
-  // bound to a specific tenant), respect it — do NOT treat this as the
-  // auto-managed enterprise MCP server. Otherwise 20x would clobber the
-  // header with a fresh JWT for whichever tenant 20x is currently logged
-  // into, silently leaking the request to the wrong tenant.
-  if (hasUserSuppliedAuthHeader(headers)) return false
-
-  return name === WORKFLO_MCP_DEV_SERVER_NAME ||
-    (name.toLowerCase().includes('workflo') && isWorkfloMcpDevServerUrl(serverUrl))
+}): boolean {
+  if (mcpServer.source !== 'enterprise') return false
+  if (hasUserSuppliedAuthHeader(mcpServer.headers)) return false
+  return isWorkfloMcpDevServerUrl(mcpServer.url ?? undefined)
 }
 
 function resolveEnterpriseMcpDevUrl(currentUrl: string | undefined, enterpriseApiUrl: string): string {
@@ -417,7 +425,7 @@ export class AgentManager extends EventEmitter {
         let finalUrl = mcpServer.url
         if (
           this.enterpriseAuth &&
-          isEnterpriseWorkfloMcpServer(mcpServer.name, mcpServer.url, finalHeaders)
+          isEnterpriseMcpDevServer({ source: mcpServer.source, url: mcpServer.url, headers: finalHeaders })
         ) {
           finalUrl = resolveEnterpriseMcpDevUrl(mcpServer.url, this.enterpriseAuth.getApiUrl())
           const proxyPort = getMcpAuthProxyPort()

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -64,7 +64,26 @@ function isWorkfloMcpDevServerUrl(serverUrl?: string): boolean {
   }
 }
 
-function isEnterpriseWorkfloMcpServer(name: string, serverUrl?: string): boolean {
+function hasUserSuppliedAuthHeader(headers?: Record<string, string>): boolean {
+  if (!headers) return false
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === 'authorization' && headers[key]) return true
+  }
+  return false
+}
+
+function isEnterpriseWorkfloMcpServer(
+  name: string,
+  serverUrl?: string,
+  headers?: Record<string, string>
+): boolean {
+  // If the user supplied their own Authorization header (e.g. a pfwf_ API key
+  // bound to a specific tenant), respect it — do NOT treat this as the
+  // auto-managed enterprise MCP server. Otherwise 20x would clobber the
+  // header with a fresh JWT for whichever tenant 20x is currently logged
+  // into, silently leaking the request to the wrong tenant.
+  if (hasUserSuppliedAuthHeader(headers)) return false
+
   return name === WORKFLO_MCP_DEV_SERVER_NAME ||
     (name.toLowerCase().includes('workflo') && isWorkfloMcpDevServerUrl(serverUrl))
 }
@@ -398,7 +417,7 @@ export class AgentManager extends EventEmitter {
         let finalUrl = mcpServer.url
         if (
           this.enterpriseAuth &&
-          isEnterpriseWorkfloMcpServer(mcpServer.name, mcpServer.url)
+          isEnterpriseWorkfloMcpServer(mcpServer.name, mcpServer.url, finalHeaders)
         ) {
           finalUrl = resolveEnterpriseMcpDevUrl(mcpServer.url, this.enterpriseAuth.getApiUrl())
           const proxyPort = getMcpAuthProxyPort()

--- a/src/main/claude-plugin-manager.ts
+++ b/src/main/claude-plugin-manager.ts
@@ -848,7 +848,8 @@ export class ClaudePluginManager {
                 command: config.command || '',
                 args: config.args || [],
                 url: config.url,
-                environment: config.env || config.environment || {}
+                environment: config.env || config.environment || {},
+                source: 'plugin'
               })
             } catch (err) {
               console.warn(`[ClaudePluginManager] Failed to create MCP server "${serverName}" from plugin:`, err)
@@ -899,7 +900,8 @@ export class ClaudePluginManager {
             name: `${plugin.name}:${serverName}`,
             command: serverConfig.command || '',
             args: serverConfig.args || [],
-            environment: serverConfig.env || {}
+            environment: serverConfig.env || {},
+            source: 'plugin'
           })
         } catch (err) {
           console.warn(`[ClaudePluginManager] Failed to create MCP server from manifest:`, err)

--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -243,6 +243,32 @@ describe('MCP Server CRUD', () => {
     expect(db.deleteMcpServer(server.id)).toBe(true)
     expect(db.getMcpServer(server.id)).toBeUndefined()
   })
+
+  it("defaults `source` to 'user' when not specified", () => {
+    const server = db.createMcpServer({ name: 'User-added MCP' })!
+    expect(server.source).toBe('user')
+  })
+
+  it("persists `source: 'enterprise'` when set explicitly (used by EnterpriseSyncManager)", () => {
+    const server = db.createMcpServer({
+      name: '[Workflo] MCP Dev Server',
+      type: 'remote',
+      url: 'https://api.peakflo.ai/api/mcp/dev/mcp',
+      source: 'enterprise'
+    })!
+    expect(server.source).toBe('enterprise')
+
+    const refetched = db.getMcpServer(server.id)!
+    expect(refetched.source).toBe('enterprise')
+  })
+
+  it("persists `source: 'plugin'` when set explicitly (used by ClaudePluginManager)", () => {
+    const server = db.createMcpServer({
+      name: 'my-plugin:some-server',
+      source: 'plugin'
+    })!
+    expect(server.source).toBe('plugin')
+  })
 })
 
 describe('TaskSource CRUD', () => {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -80,6 +80,18 @@ export interface McpOAuthRegistration {
 /** @deprecated Use McpOAuthRegistration instead */
 export type McpOAuthMetadata = McpOAuthRegistration
 
+/**
+ * Provenance of an MCP server row:
+ * - 'user'       — added by the user through the 20x UI / IPC.
+ * - 'enterprise' — synced from a Workflo org node by EnterpriseSyncManager.
+ * - 'plugin'     — materialised from a Claude plugin (.mcp.json or manifest).
+ *
+ * This is the authoritative signal for "is this an enterprise-managed MCP?"
+ * Do NOT rely on name prefixes or URL heuristics — those are display details
+ * that the user can edit. `source` is set at create time and never changes.
+ */
+export type McpServerSource = 'user' | 'enterprise' | 'plugin'
+
 export interface McpServerRow {
   id: string
   name: string
@@ -91,6 +103,7 @@ export interface McpServerRow {
   environment: string
   tools: string
   oauth_metadata: string
+  source: string
   created_at: string
   updated_at: string
 }
@@ -106,6 +119,7 @@ export interface McpServerRecord {
   environment: Record<string, string>
   tools: McpServerToolRecord[]
   oauth_metadata: McpOAuthRegistration | Record<string, never>
+  source: McpServerSource
   created_at: string
   updated_at: string
 }
@@ -119,6 +133,8 @@ export interface CreateMcpServerData {
   headers?: Record<string, string>
   environment?: Record<string, string>
   oauth_metadata?: McpOAuthRegistration
+  /** Defaults to 'user' when omitted — see McpServerSource. */
+  source?: McpServerSource
 }
 
 export interface UpdateMcpServerData {
@@ -130,6 +146,11 @@ export interface UpdateMcpServerData {
   headers?: Record<string, string>
   environment?: Record<string, string>
   oauth_metadata?: McpOAuthRegistration
+  /**
+   * Provenance is set at create time and generally immutable. This field is
+   * exposed for migrations and tests only — UI/IPC paths should never write it.
+   */
+  source?: McpServerSource
 }
 
 export interface CreateAgentData {
@@ -492,6 +513,9 @@ function deserializeTaskSource(row: TaskSourceRow): TaskSourceRecord {
 }
 
 function deserializeMcpServer(row: McpServerRow): McpServerRecord {
+  const source: McpServerSource = row.source === 'enterprise' || row.source === 'plugin'
+    ? row.source
+    : 'user'
   return {
     ...row,
     type: (row.type as 'local' | 'remote') || 'local',
@@ -500,7 +524,8 @@ function deserializeMcpServer(row: McpServerRow): McpServerRecord {
     headers: JSON.parse(row.headers || '{}') as Record<string, string>,
     environment: JSON.parse(row.environment || '{}') as Record<string, string>,
     tools: JSON.parse(row.tools || '[]') as McpServerToolRecord[],
-    oauth_metadata: JSON.parse(row.oauth_metadata || '{}') as McpOAuthRegistration | Record<string, never>
+    oauth_metadata: JSON.parse(row.oauth_metadata || '{}') as McpOAuthRegistration | Record<string, never>,
+    source
   }
 }
 
@@ -984,6 +1009,7 @@ export class DatabaseManager {
         url TEXT,
         headers TEXT NOT NULL DEFAULT '{}',
         environment TEXT NOT NULL DEFAULT '{}',
+        source TEXT NOT NULL DEFAULT 'user',
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       );
@@ -1250,6 +1276,20 @@ export class DatabaseManager {
     }
     if (!mcpColumnNames.has('oauth_metadata')) {
       this.db.exec(`ALTER TABLE mcp_servers ADD COLUMN oauth_metadata TEXT NOT NULL DEFAULT '{}'`)
+    }
+    if (!mcpColumnNames.has('source')) {
+      // Provenance column. Defaults to 'user'.
+      this.db.exec(`ALTER TABLE mcp_servers ADD COLUMN source TEXT NOT NULL DEFAULT 'user'`)
+      // One-time backfill for rows seeded by EnterpriseSyncManager before this
+      // column existed. Those rows have a hardcoded "[Workflo] " name prefix
+      // (see mapMcpServer in enterprise-sync.ts). This is the ONLY place that
+      // prefix is treated as a signal — going forward `source` is the truth.
+      //
+      // Plugin-materialised rows are intentionally NOT backfilled by name
+      // heuristic — "<plugin>:<server>" could collide with a user-chosen
+      // name. They'll be tagged correctly on the next plugin reload (every
+      // app start re-materialises plugin MCPs).
+      this.db.exec(`UPDATE mcp_servers SET source = 'enterprise' WHERE name LIKE '[Workflo] %'`)
     }
 
     // Migrate oauth_tokens: make source_id nullable and add mcp_server_id
@@ -2204,8 +2244,9 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
     const id = createId()
     const now = new Date().toISOString()
     const type = data.type ?? 'local'
+    const source: McpServerSource = data.source ?? 'user'
     this.db.prepare(
-      'INSERT INTO mcp_servers (id, name, type, command, args, url, headers, environment, oauth_metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+      'INSERT INTO mcp_servers (id, name, type, command, args, url, headers, environment, oauth_metadata, source, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
     ).run(
       id,
       data.name,
@@ -2216,6 +2257,7 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
       JSON.stringify(data.headers ?? {}),
       JSON.stringify(data.environment ?? {}),
       JSON.stringify(data.oauth_metadata ?? {}),
+      source,
       now,
       now
     )
@@ -2234,6 +2276,7 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
     if (data.headers !== undefined) { setClauses.push('headers = ?'); values.push(JSON.stringify(data.headers)) }
     if (data.environment !== undefined) { setClauses.push('environment = ?'); values.push(JSON.stringify(data.environment)) }
     if (data.oauth_metadata !== undefined) { setClauses.push('oauth_metadata = ?'); values.push(JSON.stringify(data.oauth_metadata)) }
+    if (data.source !== undefined) { setClauses.push('source = ?'); values.push(data.source) }
 
     if (setClauses.length === 0) return this.getMcpServer(id)
 

--- a/src/main/enterprise-sync.ts
+++ b/src/main/enterprise-sync.ts
@@ -806,6 +806,7 @@ export class EnterpriseSyncManager {
     url: string
     headers: Record<string, string>
     environment: Record<string, string>
+    source: 'enterprise'
   } {
     if (server.type === 'remote') {
       const config = server.config as { url?: string; headers?: Record<string, string> }
@@ -816,7 +817,8 @@ export class EnterpriseSyncManager {
         args: [],
         url: config.url || '',
         headers: config.headers || {},
-        environment: {}
+        environment: {},
+        source: 'enterprise'
       }
     } else {
       const config = server.config as {
@@ -831,7 +833,8 @@ export class EnterpriseSyncManager {
         args: config.args || [],
         url: '',
         headers: {},
-        environment: config.environment || {}
+        environment: config.environment || {},
+        source: 'enterprise'
       }
     }
   }

--- a/src/main/mcp-tool-caller.test.ts
+++ b/src/main/mcp-tool-caller.test.ts
@@ -14,6 +14,7 @@ function makeServer(overrides: Partial<McpServerRecord> = {}): McpServerRecord {
     environment: {},
     tools: [],
     oauth_metadata: {},
+    source: 'user',
     created_at: '',
     updated_at: '',
     ...overrides

--- a/src/main/plugins/peakflo-plugin.test.ts
+++ b/src/main/plugins/peakflo-plugin.test.ts
@@ -27,6 +27,7 @@ function makeContext(overrides: Partial<PluginContext> = {}): PluginContext {
       environment: {},
       tools: [],
       oauth_metadata: {},
+      source: 'user',
       created_at: '',
       updated_at: ''
     } as McpServerRecord,

--- a/test/helpers/db-test-helper.ts
+++ b/test/helpers/db-test-helper.ts
@@ -42,6 +42,7 @@ export function createTestDb(): { db: DatabaseManager; rawDb: InstanceType<typeo
       environment TEXT NOT NULL DEFAULT '{}',
       tools TEXT NOT NULL DEFAULT '[]',
       oauth_metadata TEXT NOT NULL DEFAULT '{}',
+      source TEXT NOT NULL DEFAULT 'user',
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );


### PR DESCRIPTION
## What this PR does

Closes the tenant-leak where a `pfwf_` developer API key (bound to **Workflow Builder tenant A**) added as an MCP in 20x got silently replaced by a fresh JWT for **whichever tenant 20x was logged into** — every tool call landed in the wrong tenant.

The fix is in two layers:

### Layer 1 — Provenance (primary fix, commit 2)
Adds a `source` column to `mcp_servers`: `'user' | 'enterprise' | 'plugin'`. Set at create time by whichever subsystem owns the row:

- `'enterprise'` — `EnterpriseSyncManager.mapMcpServer` (rows pulled from Workflo org nodes)
- `'plugin'`     — `ClaudePluginManager` (rows materialised from `.mcp.json` / manifest)
- `'user'`       — default for UI/IPC additions

`isEnterpriseMcpDevServer` (renamed from `isEnterpriseWorkfloMcpServer`) now identifies the auto-managed MCP **only** by `source === 'enterprise' && URL path === /api/mcp/dev/mcp`. The previous heuristic — `name.toLowerCase().includes('workflo')` + path match — meant any user-added MCP named `Tan Insurance MCP workflo` (or anything containing "workflo") pointing at the canonical path was misclassified, had its URL rewritten to the active enterprise host, had its `Authorization` header stripped, and was routed through `mcp-auth-proxy`, which unconditionally injects a fresh JWT for the logged-in 20x tenant.

After this PR, **a user can name an MCP server `[Workflo] MCP Dev Server` and point it at the canonical URL — it still won't be hijacked**, because its `source` is `'user'`.

### Layer 2 — Header defence-in-depth (commit 1)
If a row is ever mislabelled as `'enterprise'` but the caller has supplied an explicit `Authorization` header, honour their credential and skip the proxy. Belt and braces.

## No server-side change required
`packages/workflow-api/src/middleware/developer-api-key-auth.ts` was already correct — it derives `tenantId` strictly from `apiKey.tenantId` when a `pfwf_` token is presented. The bug was entirely 20x silently swapping out the credential before the request left the desktop app.

## Schema migration
- `ALTER TABLE mcp_servers ADD COLUMN source TEXT NOT NULL DEFAULT 'user'`
- One-time backfill: `UPDATE … SET source = 'enterprise' WHERE name LIKE '[Workflo] %'` — this is the **only** place the legacy name prefix is treated as a signal; going forward `source` is the truth.
- Plugin rows are intentionally **not** backfilled by name heuristic (collision risk with user-chosen names). They'll be tagged correctly on the next plugin reload; `'user'` is the safe default in the meantime.

## Files changed
- `src/main/database.ts` — column, types, INSERT/UPDATE, deserialise, migration.
- `src/main/enterprise-sync.ts` — writes `source: 'enterprise'`.
- `src/main/claude-plugin-manager.ts` — writes `source: 'plugin'`.
- `src/main/agent-manager.ts` — replaces heuristic with provenance check; drops `WORKFLO_MCP_DEV_SERVER_NAME` exact-match constant (covered by `source`).
- `test/helpers/db-test-helper.ts` — adds column to test schema.
- Tests: provenance defaults, enterprise routing path, user-sourced-not-hijacked regression, defence-in-depth case, two existing fixtures updated.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test -- --run` — **1371/1371 passing**
- [x] `pnpm lint` — 0 errors in changed files
- [ ] Manual: in a 20x build, log into tenant B, add a `pfwf_` MCP key created in tenant A, invoke a tool, verify the response reflects tenant A data
- [ ] Manual: the built-in `[Workflo] MCP Dev Server` (synced via enterprise) still gets JWT refresh and works
- [ ] Manual: name a user-added MCP `[Workflo] MCP Dev Server` exactly, point at canonical URL — confirm it is NOT hijacked (its `source` is `'user'`)

## Commits
1. `0815866` — Layer 2: respect user-supplied Authorization header (defence-in-depth).
2. `95b8baf` — Layer 1: provenance column + heuristic replacement (primary fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)