### PR TITLE
Fix Claude Code thinking message updates

### DIFF
--- a/src/main/adapters/claude-code-adapter.test.ts
+++ b/src/main/adapters/claude-code-adapter.test.ts
@@ -519,7 +519,8 @@ describe('ClaudeCodeAdapter task_progress handling', () => {
     const msg = {
       type: 'system',
       subtype: ClaudeSystemSubtype.THINKING_TOKENS,
-      text: 'Considering the next edit',
+      estimated_tokens: 128,
+      estimated_tokens_delta: 32,
       uuid: 'tt-1',
       session_id: 's1',
     }
@@ -531,9 +532,43 @@ describe('ClaudeCodeAdapter task_progress handling', () => {
 
     expect(parts).toHaveLength(1)
     expect(parts[0].type).toBe(MessagePartType.REASONING)
-    expect(parts[0].id).toBe('thinking-tokens-tt-1')
-    expect(parts[0].text).toBe('Considering the next edit')
+    expect(parts[0].id).toBe('thinking-tokens-s1')
+    expect(parts[0].text).toBe('Estimated thinking tokens: 128')
     expect(parts[0].role).toBe('assistant')
+  })
+
+  it('updates one thinking_tokens reasoning part instead of appending messages', async () => {
+    const messages = [
+      {
+        type: 'system',
+        subtype: ClaudeSystemSubtype.THINKING_TOKENS,
+        estimated_tokens: 128,
+        estimated_tokens_delta: 32,
+        uuid: 'tt-1',
+        session_id: 's1',
+      },
+      {
+        type: 'system',
+        subtype: ClaudeSystemSubtype.THINKING_TOKENS,
+        estimated_tokens: 256,
+        estimated_tokens_delta: 128,
+        uuid: 'tt-2',
+        session_id: 's1',
+      },
+    ]
+
+    const { adapter } = createAdapterWithSession('s1', messages)
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+    const parts = await adapter.pollMessages('s1', new Set(), seenPartIds, partContentLengths, {} as any)
+
+    expect(parts).toHaveLength(2)
+    expect(parts[0].id).toBe('thinking-tokens-s1')
+    expect(parts[0].update).toBe(false)
+    expect(parts[0].text).toBe('Estimated thinking tokens: 128')
+    expect(parts[1].id).toBe('thinking-tokens-s1')
+    expect(parts[1].update).toBe(true)
+    expect(parts[1].text).toBe('Estimated thinking tokens: 256')
   })
 
   it('converts task_started to TASK_PROGRESS part', async () => {
@@ -758,6 +793,32 @@ describe('ClaudeCodeAdapter loadSessionHistory stable IDs (regression)', () => {
     expect(parts2).toHaveLength(1)
     expect(parts2[0].update).toBe(true)
     expect(parts2[0].text).toBe('Full response text')
+  })
+
+  it('converts assistant thinking content blocks to reasoning parts', () => {
+    const adapter = new ClaudeCodeAdapter()
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+
+    const msg = {
+      type: 'assistant',
+      uuid: 'uuid-thinking',
+      message: {
+        id: 'msg_01THINK',
+        content: [
+          { type: 'thinking', thinking: 'I should inspect the adapter mapping first.', signature: 'sig' },
+          { type: 'text', text: 'I found the issue.' },
+        ]
+      }
+    }
+
+    const parts = (adapter as any).convertSDKMessageToParts(msg, seenPartIds, partContentLengths)
+    const thinkingPart = parts.find((p: any) => p.type === MessagePartType.REASONING)
+
+    expect(thinkingPart).toBeDefined()
+    expect(thinkingPart!.id).toBe('msg_01THINK-thinking-0')
+    expect(thinkingPart!.text).toBe('I should inspect the adapter mapping first.')
+    expect(thinkingPart!.role).toBe('assistant')
   })
 
   it('surfaces non-error result text when no assistant text was emitted', () => {

--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -459,6 +459,15 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
                 text: contentPart.text,
                 content: contentPart.text
               })
+            } else if (contentPart.type === 'thinking') {
+              if (!contentPart.thinking || contentPart.thinking.trim() === '') continue
+
+              message.parts.push({
+                id: `${stableId}-thinking-${blockIdx}`,
+                type: MessagePartType.REASONING,
+                text: contentPart.thinking,
+                content: contentPart.thinking
+              })
             } else if (contentPart.type === 'tool_use') {
               const rawInput = contentPart.input as Record<string, unknown> | undefined
               const toolName = contentPart.name || 'unknown'
@@ -1188,6 +1197,10 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
       // SDKToolProgressMessage fields
       elapsed_time_seconds?: number
       parent_tool_use_id?: string | null
+      // SDKThinkingTokensMessage fields
+      estimated_tokens?: number
+      estimated_tokens_delta?: number
+      session_id?: string
       // SDKTaskNotificationMessage / SDKTaskProgressMessage / SDKTaskStartedMessage fields
       task_id?: string
       summary?: string
@@ -1222,7 +1235,7 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
 
       for (let blockIdx = 0; blockIdx < content.length; blockIdx++) {
         const block = content[blockIdx]
-        const blockWithProps = block as { type?: string; text?: string; name?: string; input?: unknown; id?: string }
+        const blockWithProps = block as { type?: string; text?: string; thinking?: string; name?: string; input?: unknown; id?: string }
         // For text blocks (no id), use stable message ID + block index for consistent dedup.
         // For tool_use blocks, blockWithProps.id is the tool_use_id which is already stable.
         const partId = `${stableId}-${blockWithProps.type}-${blockWithProps.id || blockIdx}`
@@ -1252,6 +1265,30 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
             id: partId,
             type: MessagePartType.TEXT,
             text,
+          })
+        } else if (blockWithProps.type === 'thinking') {
+          const thinking = blockWithProps.thinking || ''
+          if (seenPartIds.has(partId)) {
+            const previousLength = partContentLengths.get(partId)
+            if (previousLength !== undefined && String(thinking.length) !== previousLength && thinking.length > 0) {
+              partContentLengths.set(partId, String(thinking.length))
+              parts.push({
+                id: partId,
+                type: MessagePartType.REASONING,
+                text: thinking,
+                role: 'assistant',
+                update: true,
+              })
+            }
+            continue
+          }
+          seenPartIds.add(partId)
+          partContentLengths.set(partId, String(thinking.length))
+          parts.push({
+            id: partId,
+            type: MessagePartType.REASONING,
+            text: thinking,
+            role: 'assistant',
           })
         } else if (seenPartIds.has(partId)) {
           continue
@@ -1645,18 +1682,26 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
 
       // SDKThinkingTokensMessage — reasoning/thinking token updates from Claude Code
       if (msgWithProps.subtype === ClaudeSystemSubtype.THINKING_TOKENS) {
-        const partId = `thinking-tokens-${msgWithProps.uuid || Date.now()}`
-        if (!seenPartIds.has(partId)) {
+        const partId = `thinking-tokens-${msgWithProps.session_id || 'session'}`
+        const alreadySeen = seenPartIds.has(partId)
+        const estimatedTokens = typeof msgWithProps.estimated_tokens === 'number'
+          ? msgWithProps.estimated_tokens
+          : undefined
+        const content = estimatedTokens !== undefined
+          ? `Estimated thinking tokens: ${estimatedTokens}`
+          : 'Estimating thinking tokens...'
+
+        if (!alreadySeen) {
           seenPartIds.add(partId)
-          const content = msgWithProps.text || msgWithProps.summary || 'Thinking'
-          partContentLengths.set(partId, String(content.length))
-          parts.push({
-            id: partId,
-            type: MessagePartType.REASONING,
-            text: content,
-            role: 'assistant',
-          })
         }
+        partContentLengths.set(partId, String(content.length))
+        parts.push({
+          id: partId,
+          type: MessagePartType.REASONING,
+          text: content,
+          role: 'assistant',
+          update: alreadySeen,
+        })
         return parts
       }
 


### PR DESCRIPTION
## Summary
- Update Claude Code thinking_tokens handling to reuse one stable reasoning part per session instead of appending one message per token frame
- Render thinking_tokens content as an estimated token count based on the SDK payload
- Add support for assistant content blocks with type thinking so summarized thinking text appears in the existing reasoning box when Claude sends it
- Preserve thinking blocks during Claude session-history replay

## SDK notes
- @anthropic-ai/claude-agent-sdk SDKThinkingTokensMessage only exposes estimated_tokens and estimated_tokens_delta; it does not include actual thinking text
- Actual visible thinking text is represented by Anthropic BetaThinkingBlock content with type thinking and thinking: string

## Tests
- pnpm test:run src/main/adapters/claude-code-adapter.test.ts