### PR TITLE
fix: disable stale tillDone plugins

### DIFF
--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -49,6 +49,13 @@ describe('OpencodeAdapter', () => {
         expect(tillDoneCode).toContain('isTillDoneEnabled(sessionId)')
         expect(tillDoneCode).toContain('parsed.sessions[sessionId]')
         expect(tillDoneCode).toContain('return false;')
+        expect(tillDoneCode).toContain([
+          '  } catch (e) {',
+          '    return false;',
+          '  }',
+          '}',
+          ''
+        ].join('\n'))
         expect(tillDoneCode).toContain('INITIAL_TODO_PROMPT')
 
         const tillDoneConfigPath = supportPaths.find(path => path.endsWith('.20x-tilldone-config.json'))!

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -1470,7 +1470,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       '    }',
       '    return parsed?.enabled !== false;',
       '  } catch (e) {',
-      '    return true;',
+      '    return false;',
       '  }',
       '}',
       '',

--- a/src/main/utils/opencode-config.test.ts
+++ b/src/main/utils/opencode-config.test.ts
@@ -114,6 +114,41 @@ describe('buildMergedOpencodeConfig', () => {
     expect(config.plugin).toEqual(['/path/to/plugin.js'])
   })
 
+  it('removes missing generated 20x runtime plugins from stored config', () => {
+    const existingPlugin = '/home/testuser/workspace/.opencode/plugins/20x-tilldone.js'
+    const missingPlugin = 'file:///home/testuser/missing/.opencode/plugins/20x-secret-injector.js'
+    const userPlugin = '/home/testuser/custom-plugin.js'
+
+    mockExistsSync.mockImplementation((path) => {
+      if (path === '/home/testuser/.config/opencode/opencode.json') return true
+      if (path === '/home/testuser/.local/share/opencode/auth.json') return true
+      return path === existingPlugin
+    })
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify({
+        plugin: [existingPlugin, missingPlugin, userPlugin]
+      }))
+      .mockReturnValueOnce(JSON.stringify({}))
+
+    const config = buildMergedOpencodeConfig()
+    expect(config.plugin).toEqual([existingPlugin, userPlugin])
+  })
+
+  it('keeps extra plugin config even when stored generated plugins are stale', () => {
+    mockExistsSync.mockImplementation((path) => {
+      return path === '/home/testuser/.config/opencode/opencode.json' ||
+        path === '/home/testuser/.local/share/opencode/auth.json'
+    })
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify({
+        plugin: ['/home/testuser/missing/.opencode/plugins/20x-tilldone.js']
+      }))
+      .mockReturnValueOnce(JSON.stringify({}))
+
+    const config = buildMergedOpencodeConfig({ plugin: ['/home/testuser/current/.opencode/plugins/20x-tilldone.js'] })
+    expect(config.plugin).toEqual(['/home/testuser/current/.opencode/plugins/20x-tilldone.js'])
+  })
+
   it('handles missing config and auth files gracefully', () => {
     mockExistsSync.mockReturnValue(false)
     const config = buildMergedOpencodeConfig({ plugin: ['/path/to/plugin.js'] })

--- a/src/main/utils/opencode-config.ts
+++ b/src/main/utils/opencode-config.ts
@@ -9,6 +9,7 @@
  * config via `OPENCODE_CONFIG_CONTENT` so every provider has its key.
  */
 import { existsSync, readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
 import { join } from 'path'
 import { homedir } from 'os'
 
@@ -60,6 +61,35 @@ export function readOpencodeAuth(): Record<string, OpencodeAuthEntry> {
   return {}
 }
 
+function is20xRuntimePluginPath(value: unknown): value is string {
+  return typeof value === 'string' &&
+    (value.endsWith('/.opencode/plugins/20x-tilldone.js') ||
+      value.endsWith('/.opencode/plugins/20x-secret-injector.js'))
+}
+
+function pluginPathExists(pluginPath: string): boolean {
+  try {
+    return existsSync(pluginPath.startsWith('file://') ? fileURLToPath(pluginPath) : pluginPath)
+  } catch {
+    return false
+  }
+}
+
+function removeMissing20xRuntimePlugins(config: Record<string, unknown>): void {
+  if (!Array.isArray(config.plugin)) return
+
+  const plugins = config.plugin.filter((pluginPath) => {
+    if (!is20xRuntimePluginPath(pluginPath)) return true
+    return pluginPathExists(pluginPath)
+  })
+
+  if (plugins.length > 0) {
+    config.plugin = plugins
+  } else {
+    delete config.plugin
+  }
+}
+
 /**
  * Builds a complete config object suitable for `OPENCODE_CONFIG_CONTENT`.
  *
@@ -78,6 +108,7 @@ export function buildMergedOpencodeConfig(
 ): Record<string, unknown> {
   const config = readOpencodeConfig()
   const auth = readOpencodeAuth()
+  removeMissing20xRuntimePlugins(config)
 
   // Inject auth keys into providers that lack an inline apiKey
   const providers = config.provider as Record<string, Record<string, unknown>> | undefined


### PR DESCRIPTION
## Summary
- Fixes stale globally registered tillDone plugins blocking unrelated OpenCode sessions when their workspace config file has been removed.
- Changes generated tillDone plugin config-read failures to disable enforcement instead of defaulting on.
- Removes missing generated 20x runtime plugin paths from stored OpenCode config before pushing merged config to the server, while preserving user plugins and current session plugin config.
- Adds regression coverage for both generated plugin fallback behavior and stale persisted plugin cleanup.

## Root cause
The affected task `test multiple grep + glob tool calls with opencode` had a disabled per-session tillDone config, but OpenCode logs showed it also loaded an orphaned plugin from workspace `yocsjwy2sy85b6sjyk7ve7c8`. That plugin path remained in global OpenCode config while the workspace `.opencode` config file no longer existed, so the generated plugin's old catch fallback returned `true` and blocked tools globally.

## Test plan
- `ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/vitest run src/main/adapters/opencode-adapter.test.ts src/main/agent-manager.test.ts src/main/utils/opencode-config.test.ts --project main`
- `./node_modules/.bin/tsc --build --noEmit --pretty false`
- `./node_modules/.bin/eslint src/main/adapters/opencode-adapter.ts src/main/adapters/opencode-adapter.test.ts src/main/utils/opencode-config.ts src/main/utils/opencode-config.test.ts` (passes with existing no-explicit-any warnings in the adapter test file)