### PR TITLE
fix: set tsconfigRootDir in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,11 @@ export default tseslint.config(
   })),
   {
     files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname
+      }
+    },
     rules: {
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }]


### PR DESCRIPTION
Sets tsconfigRootDir in ESLint configuration to resolve parsing errors when multiple tsconfig candidates are present. This specifically fixes the issue in vitest.config.ts.