### PR TITLE
fix: resolve MaxListenersExceededWarning on worktree:progress

### DIFF
--- a/src/renderer/src/components/github/WorktreeProgressOverlay.tsx
+++ b/src/renderer/src/components/github/WorktreeProgressOverlay.tsx
@@ -13,19 +13,24 @@ interface RepoProgress {
 interface WorktreeProgressOverlayProps {
   taskId: string | null
   visible: boolean
+  /** Called when worktree IPC events indicate setup started or finished for this task.
+   *  Lets the parent track visibility without a separate IPC listener (avoids exceeding
+   *  the 10-listener limit on the worktree:progress channel when many panels are open). */
+  onVisibilityChange?: (isActive: boolean) => void
 }
 
-export function WorktreeProgressOverlay({ taskId, visible }: WorktreeProgressOverlayProps) {
+export function WorktreeProgressOverlay({ taskId, visible, onVisibilityChange }: WorktreeProgressOverlayProps) {
   const [progress, setProgress] = useState<Map<string, RepoProgress>>(new Map())
 
   useEffect(() => {
-    if (!visible) {
-      setProgress(new Map())
-      return
-    }
+    if (!taskId) return
 
+    // Always listen — this is the SINGLE worktree:progress listener for this
+    // task (the parent no longer installs its own, preventing the
+    // MaxListenersExceededWarning when many task panels are open).
     const cleanup = onWorktreeProgress((event: WorktreeProgressEvent) => {
-      if (taskId && event.taskId && event.taskId !== taskId) return
+      if (event.taskId && event.taskId !== taskId) return
+
       setProgress((prev) => {
         const next = new Map(prev)
         next.set(event.repo, {
@@ -36,10 +41,27 @@ export function WorktreeProgressOverlay({ taskId, visible }: WorktreeProgressOve
         })
         return next
       })
+
+      // Notify parent of visibility changes
+      if (event.done) {
+        // Check if ALL repos are done before hiding
+        setProgress((current) => {
+          const updated = new Map(current)
+          updated.set(event.repo, { repo: event.repo, step: event.step, done: true, error: event.error })
+          const allDone = [...updated.values()].every((r) => r.done)
+          if (allDone) onVisibilityChange?.(false)
+          return updated
+        })
+      } else {
+        onVisibilityChange?.(true)
+      }
     })
 
-    return cleanup
-  }, [visible, taskId])
+    return () => {
+      cleanup()
+      setProgress(new Map())
+    }
+  }, [taskId, onVisibilityChange])
 
   if (!visible || progress.size === 0) return null
 

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -16,7 +16,7 @@ import { useAgentSession } from '@/hooks/use-agent-session'
 import { useAgentStore, SessionStatus } from '@/stores/agent-store'
 import { useSettingsStore, type GitProvider } from '@/stores/settings-store'
 import { useTaskStore } from '@/stores/task-store'
-import { taskApi, worktreeApi, taskSourceApi, onAgentIncompatibleSession, onWorktreeProgress, attachmentApi } from '@/lib/ipc-client'
+import { taskApi, worktreeApi, taskSourceApi, onAgentIncompatibleSession, attachmentApi } from '@/lib/ipc-client'
 import { useEffect, useCallback, useRef, useState, useMemo } from 'react'
 import { TaskStatus } from '@/types'
 import type { WorkfloTask, FileAttachment, OutputField, Agent, UpdateAgentDTO, CreateAgentDTO } from '@/types'
@@ -149,24 +149,14 @@ export function TaskWorkspace({
     }
   }, [task?.id])
 
-  // Drive worktree progress overlay from IPC events
-  useEffect(() => {
-    if (!task?.id) return
-
-    const unsubscribe = onWorktreeProgress((event) => {
-      if (event.taskId !== task.id) return
-      if (event.done) {
-        // Check if all repos are done — hide overlay
-        setIsSettingUpWorktree(false)
-      } else {
-        setIsSettingUpWorktree(true)
-      }
-    })
-
-    return () => {
-      unsubscribe()
-    }
-  }, [task?.id])
+  // Worktree progress IPC events are now handled by WorktreeProgressOverlay
+  // (single listener per task) which calls back via onVisibilityChange to
+  // update isSettingUpWorktree — avoids the MaxListenersExceededWarning that
+  // occurred when each TaskWorkspace + its child WorktreeProgressOverlay both
+  // registered their own worktree:progress listener.
+  const handleWorktreeVisibility = useCallback((isActive: boolean) => {
+    setIsSettingUpWorktree(isActive)
+  }, [])
 
   // Re-fetch tasks when agent status changes (status is updated in DB by agent-manager).
   // Debounced to 500ms to prevent cascading re-fetches when multiple canvas panels
@@ -739,7 +729,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
           </div>
         )}
 
-        <WorktreeProgressOverlay taskId={task.id} visible={isSettingUpWorktree} />
+        <WorktreeProgressOverlay taskId={task.id} visible={isSettingUpWorktree} onVisibilityChange={handleWorktreeVisibility} />
       </div>
 
       <GhCliSetupDialog


### PR DESCRIPTION
## Summary

Fixes the `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 worktree:progress listeners` error.

**Root cause:** Each `TaskWorkspace` (one per canvas task panel) registered its own `onWorktreeProgress` IPC listener, AND its child `WorktreeProgressOverlay` also registered one. With N task panels on the canvas, that's 2N listeners on the `worktree:progress` channel. At 6+ panels → 12+ listeners → exceeds Node's default limit of 10.

**Fix:**
- **`TaskWorkspace.tsx`** — Removed the duplicate `onWorktreeProgress` IPC listener. Now receives visibility updates via callback from the child component instead.
- **`WorktreeProgressOverlay.tsx`** — Serves as the single `worktree:progress` listener per task. Added `onVisibilityChange` callback prop to notify the parent when worktree setup starts/finishes. Listener is always active (not gated by `visible` prop) so it can detect externally-triggered worktree events.

## Test plan
- [x] TypeScript compiles cleanly (`pnpm exec tsc --noEmit`)
- [x] Production build succeeds (`pnpm build`)
- [ ] Open 6+ task panels on canvas — verify no MaxListenersExceededWarning in console
- [ ] Add repos to a task with active session — verify worktree progress overlay still appears and dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)