### PR TITLE
fix: migrate remaining per-panel IPC listeners to shared bus

### DIFF
--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -3,6 +3,7 @@ import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { useCanvasStore } from '@/stores/canvas-store'
+import { subscribe } from '@/lib/shared-ipc-listeners'
 import '@xterm/xterm/css/xterm.css'
 
 interface TerminalPanelContentProps {
@@ -131,20 +132,28 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
         window.electronAPI.terminal.write(terminalId, data)
       })
 
-      const removeDataListener = window.electronAPI.terminal.onData(({ id, data }) => {
-        if (id === terminalId) {
-          term.write(data)
+      const removeDataListener = subscribe<{ id: string; data: string }>(
+        'terminal:data',
+        (cb) => window.electronAPI.terminal.onData(cb),
+        ({ id, data }) => {
+          if (id === terminalId) {
+            term.write(data)
+          }
         }
-      })
+      )
 
       let processExited = false
 
-      const removeExitListener = window.electronAPI.terminal.onExit(({ id }) => {
-        if (id === terminalId) {
-          processExited = true
-          term.write('\r\n\x1b[90m[Process exited — press Enter to restart]\x1b[0m\r\n')
+      const removeExitListener = subscribe<{ id: string }>(
+        'terminal:exit',
+        (cb) => window.electronAPI.terminal.onExit(cb),
+        ({ id }) => {
+          if (id === terminalId) {
+            processExited = true
+            term.write('\r\n\x1b[90m[Process exited — press Enter to restart]\x1b[0m\r\n')
+          }
         }
-      })
+      )
 
       // Respawn the shell when the user presses Enter after exit
       const respawnDispose = term.onKey(({ domEvent }) => {

--- a/src/renderer/src/components/gitlab/GlabCliSetupDialog.tsx
+++ b/src/renderer/src/components/gitlab/GlabCliSetupDialog.tsx
@@ -3,6 +3,7 @@ import { CheckCircle, Loader2, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@/components/ui/Dialog'
 import { useSettingsStore } from '@/stores/settings-store'
+import { subscribe } from '@/lib/shared-ipc-listeners'
 
 interface GlabCliSetupDialogProps {
   open: boolean
@@ -25,9 +26,11 @@ export function GlabCliSetupDialog({ open, onOpenChange, onComplete }: GlabCliSe
   }, [open])
 
   useEffect(() => {
-    return window.electronAPI.onGitlabDeviceCode((code) => {
-      setDeviceCode(code)
-    })
+    return subscribe<string>(
+      'gitlab:deviceCode',
+      (cb) => window.electronAPI.onGitlabDeviceCode(cb),
+      (code) => setDeviceCode(code)
+    )
   }, [])
 
   const handleAuth = async () => {

--- a/src/renderer/src/components/tasks/HeartbeatSection.tsx
+++ b/src/renderer/src/components/tasks/HeartbeatSection.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/Badge'
 import { Textarea } from '@/components/ui/Textarea'
 import { Markdown } from '@/components/ui/Markdown'
 import { Dialog, DialogContent, DialogHeader, DialogBody, DialogTitle } from '@/components/ui/Dialog'
+import { subscribe } from '@/lib/shared-ipc-listeners'
 import type { WorkfloTask } from '@/types'
 import type { HeartbeatStatusResult } from '@/types/electron'
 import { HeartbeatStatus } from '@/types'
@@ -66,22 +67,28 @@ export function HeartbeatSection({ task, onTaskUpdated }: HeartbeatSectionProps)
     fetchLogs()
   }, [fetchStatus, fetchContent, fetchLogs])
 
-  // Listen for heartbeat events
+  // Listen for heartbeat events (shared listeners to avoid MaxListeners warning)
   useEffect(() => {
-    const unsubAlert = window.electronAPI.onHeartbeatAlert((event: unknown) => {
-      const alert = event as { taskId: string }
-      if (alert.taskId === task.id) {
-        fetchStatus()
-        fetchContent()
-        fetchLogs()
+    const unsubAlert = subscribe<{ taskId: string }>(
+      'heartbeat:alert',
+      (cb) => window.electronAPI.onHeartbeatAlert(cb as (event: unknown) => void),
+      (alert) => {
+        if (alert.taskId === task.id) {
+          fetchStatus()
+          fetchContent()
+          fetchLogs()
+        }
       }
-    })
-    const unsubDisabled = window.electronAPI.onHeartbeatDisabled((event: unknown) => {
-      const data = event as { taskId: string }
-      if (data.taskId === task.id) {
-        fetchStatus()
+    )
+    const unsubDisabled = subscribe<{ taskId: string }>(
+      'heartbeat:disabled',
+      (cb) => window.electronAPI.onHeartbeatDisabled(cb as (event: unknown) => void),
+      (data) => {
+        if (data.taskId === task.id) {
+          fetchStatus()
+        }
       }
-    })
+    )
     return () => { unsubAlert(); unsubDisabled() }
   }, [task.id, fetchStatus, fetchContent, fetchLogs])
 


### PR DESCRIPTION
## Summary

Follow-up to PR #347 — migrates the 5 remaining per-panel IPC channels that were not included before the merge:

| Channel | Component | Status |
|---------|-----------|--------|
| `heartbeat:alert` | HeartbeatSection | ✅ Fixed in this PR |
| `heartbeat:disabled` | HeartbeatSection | ✅ Fixed in this PR |
| `gitlab:deviceCode` | GlabCliSetupDialog | ✅ Fixed in this PR |
| `terminal:data` | TerminalPanelContent | ✅ Fixed in this PR |
| `terminal:exit` | TerminalPanelContent | ✅ Fixed in this PR |

All now use the `subscribe()` utility from `shared-ipc-listeners.ts` (introduced in PR #347) so each channel has a single `ipcRenderer.on()` listener regardless of how many canvas panels are open.

## Files Changed (3)

| File | Channels |
|------|----------|
| `HeartbeatSection.tsx` | `heartbeat:alert` + `heartbeat:disabled` |
| `GlabCliSetupDialog.tsx` | `gitlab:deviceCode` |
| `TerminalPanelContent.tsx` | `terminal:data` + `terminal:exit` |

## Test plan
- [x] TypeScript compiles cleanly
- [x] Production build succeeds
- [ ] Open 11+ task panels — no heartbeat MaxListeners warning
- [ ] Open 11+ terminal panels — no terminal MaxListeners warning
- [ ] Heartbeat alerts still appear per-task
- [ ] Terminal input/output still works per terminal
- [ ] GitLab auth device code still shows in dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)