### PR TITLE
fix: bump SCHEMA_VERSION to 8 so migration adds mcp_servers.source column

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -894,7 +894,7 @@ function deserializeInstalledPlugin(row: InstalledPluginRow): InstalledPluginRec
 
 // Bump this whenever new migrations are added so returning users skip
 // the full migration check on startup.
-const SCHEMA_VERSION = 7
+const SCHEMA_VERSION = 8
 
 export class DatabaseManager {
   public db!: Database.Database


### PR DESCRIPTION
## Summary
- **Root cause**: Commit `78f015e` added the `source` column migration to `runMigrations()` and the `source` field to `createMcpServer()`'s INSERT statement, but did NOT bump `SCHEMA_VERSION` (it was already 7 from a prior migration).
- Returning users whose database was already at version 7 skipped `runMigrations()` entirely, leaving `mcp_servers` without the `source` column.
- Any subsequent `createMcpServer()` call crashed with: `SqliteError: table mcp_servers has no column named source`
- **Fix**: Bump `SCHEMA_VERSION` from 7 → 8 so the migration runs on existing databases.

## Test plan
- [x] All 95 test files pass (1378 tests), including MCP server `source` column tests
- [x] Lint passes (0 errors)
- [ ] Verify on a machine that has an existing v7 database — after update, the `source` column should be added on next app start

🤖 Generated with [Claude Code](https://claude.com/claude-code)