### PR TITLE
fix: use slack-user instead of slack for 20x Slack connector

### DIFF
--- a/src/renderer/src/components/settings/tabs/ConnectorsSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/ConnectorsSettings.tsx
@@ -54,7 +54,6 @@ const CONNECTOR_CATALOG: ConnectorType[] = [
   { id: 'notion', name: 'Notion', description: 'Connect to Notion REST API for database queries and task sync', iconName: 'FileText', category: 'Productivity' },
   // Communication
   { id: 'google-mail', name: 'Gmail', description: 'Connect to Gmail for email and calendar', iconName: 'Mail', category: 'Communication' },
-  { id: 'slack', name: 'Slack (Bot)', description: 'Connect to Slack with a bot token for automated messaging and channel management', iconName: 'MessageSquare', category: 'Communication' },
   { id: 'slack-user', name: 'Slack', description: 'Connect to Slack with user-level OAuth to post messages as yourself', iconName: 'MessageSquare', category: 'Communication' },
   { id: 'outlook', name: 'Outlook', description: 'Connect to Outlook for email and calendar', iconName: 'Mail', category: 'Communication' },
   { id: 'tldv', name: 'TLDV', description: 'Connect to TLDV for meeting recording and transcription', iconName: 'MessageSquare', category: 'Communication' },


### PR DESCRIPTION
## Summary
- Removed the `slack` (Bot) entry from the 20x connector catalog in `ConnectorsSettings.tsx`
- Users now only see the `slack-user` integration (user-level OAuth) which correctly opens `/settings/integrations/new/slack-user` in the workflow-builder web app
- The previous `slack` (Bot) entry opened `/settings/integrations/new/slack` which caused a client-side crash: `Cannot read properties of undefined (reading 'name')`
- This is consistent with the PresetupWizard mapping (`slack` → `slack-user`) and the `integration-key-map.ts` in workflow-builder

## Test plan
- [ ] Open 20x → Settings → Connectors → Communication section
- [ ] Verify only one "Slack" entry appears (not "Slack (Bot)")
- [ ] Click Connect on Slack → verify it opens `/settings/integrations/new/slack-user` in the browser
- [ ] Verify the Slack OAuth flow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)