### PR TITLE
fix: 'Switch organization' modal not showing when already connected

### DIFF
--- a/src/renderer/src/components/settings/tabs/EnterpriseSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/EnterpriseSettings.tsx
@@ -89,10 +89,11 @@ export function EnterpriseSettings() {
   // ── Connected view ─────────────────────────────────────────────
   if (isAuthenticated && currentTenant) {
     return (
-      <SettingsSection
-        title="20x Cloud"
-        description="Connected to your organization's 20x Cloud"
-      >
+      <>
+        <SettingsSection
+          title="20x Cloud"
+          description="Connected to your organization's 20x Cloud"
+        >
         <div className="space-y-4">
           {/* Connected status */}
           <div className="flex items-center gap-2 py-2">
@@ -296,6 +297,15 @@ export function EnterpriseSettings() {
           </div>
         </div>
       </SettingsSection>
+
+      <EnterpriseLoginModal
+        open={showLoginModal}
+        onClose={() => {
+          setShowLoginModal(false)
+          loadSession()
+        }}
+      />
+    </>
     )
   }
 


### PR DESCRIPTION
## Root Cause

The `EnterpriseSettings` component conditionally renders two branches based on auth state:
- **Connected view**: Renders when `isAuthenticated && currentTenant` is true
- **Not connected view**: Renders otherwise

The `EnterpriseLoginModal` component was **only** included in the "Not connected" branch. When a connected user clicked "Switch organization", the `handleSwitchOrg` callback correctly populated `availableTenants` and set `showLoginModal = true`, but the modal never rendered because the connected branch didn't include it.

## Fix

Added the `EnterpriseLoginModal` component to the connected branch's render tree, wrapping the return in a React Fragment to accommodate both the `SettingsSection` and the modal.

Now when a connected user clicks "Switch organization", the modal appears with the tenant selection list, exactly as it does for the login flow.
