### PR TITLE
feat: revamp & simplify 20x onboarding

### DIFF
--- a/src/main/agent-installer/install.js
+++ b/src/main/agent-installer/install.js
@@ -694,6 +694,22 @@ export async function installAgent(agentName, onProgress) {
     }
   }
 
+  // OpenCode — prefer standalone install (no npm dependency) when npm is not available
+  if (agentName === 'opencode') {
+    let hasNpm = false
+    try {
+      const { promisify } = await import('util')
+      const execFileAsync = promisify(execFile)
+      await execFileAsync(isWin ? 'npm.cmd' : 'npm', ['--version'], { timeout: 5000, shell: isWin, windowsHide: true })
+      hasNpm = true
+    } catch { /* npm not available */ }
+
+    if (!hasNpm) {
+      return installOpencodeStandalone(onProgress)
+    }
+    // Fall through to npm install if npm is available
+  }
+
   const info = INSTALL_COMMANDS[agentName]
   if (!info) {
     return {
@@ -1067,6 +1083,67 @@ async function installGlabLinux(onProgress) {
   }
 
   return installLinuxBinaryFromTarball({ tarUrl, archiveName, binName: 'glab', onProgress })
+}
+
+/**
+ * Install OpenCode via standalone methods (no npm required).
+ * macOS/Linux: curl installer script from opencode.ai
+ * Windows: scoop or direct download
+ */
+async function installOpencodeStandalone(onProgress) {
+  const isWin = process.platform === 'win32'
+
+  if (isWin) {
+    // Try scoop first, fall back to error with manual instructions
+    onProgress({ stage: 'starting', output: 'Installing OpenCode via scoop...\n', percent: 5 })
+    try {
+      return await spawnInstall('scoop', ['install', 'opencode'], 'opencode', onProgress)
+    } catch {
+      onProgress({ stage: 'error', output: 'scoop not found. Install OpenCode manually: https://opencode.ai/download\n', percent: 100 })
+      return {
+        success: false,
+        error: 'Install OpenCode from https://opencode.ai/download or run: scoop install opencode',
+        newStatus: await detectInstalledAgents()
+      }
+    }
+  }
+
+  // macOS / Linux — use the official curl installer
+  onProgress({ stage: 'starting', output: '$ curl -fsSL https://opencode.ai/install | bash\n', percent: 5 })
+  return new Promise((resolve) => {
+    const proc = spawn('bash', ['-c', 'curl -fsSL https://opencode.ai/install | bash'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env }
+    })
+
+    proc.stdout.on('data', (chunk) => {
+      onProgress({ stage: 'installing', output: chunk.toString(), percent: 50 })
+    })
+
+    proc.stderr.on('data', (chunk) => {
+      onProgress({ stage: 'installing', output: chunk.toString(), percent: 50 })
+    })
+
+    proc.on('error', async (err) => {
+      onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
+      resolve({ success: false, error: err.message, newStatus: await detectInstalledAgents() })
+    })
+
+    proc.on('close', async (code) => {
+      // The installer may place the binary in ~/.local/bin or similar — ensure it's on PATH
+      const localBin = join(homedir(), '.local', 'bin')
+      ensureOnPath(localBin)
+
+      const newStatus = await detectInstalledAgents()
+      if (code === 0 || newStatus.opencode?.installed) {
+        onProgress({ stage: 'complete', output: 'OpenCode installed successfully!\n', percent: 100 })
+        resolve({ success: true, error: null, newStatus })
+      } else {
+        onProgress({ stage: 'error', output: `Install script exited with code ${code}\n`, percent: 100 })
+        resolve({ success: false, error: `Install failed with exit code ${code}`, newStatus })
+      }
+    })
+  })
 }
 
 /**

--- a/src/main/agent-installer/install.js
+++ b/src/main/agent-installer/install.js
@@ -694,20 +694,39 @@ export async function installAgent(agentName, onProgress) {
     }
   }
 
-  // OpenCode — prefer standalone install (no npm dependency) when npm is not available
+  // Coding agents — prefer standalone installers (no npm dependency)
   if (agentName === 'opencode') {
-    let hasNpm = false
-    try {
-      const { promisify } = await import('util')
-      const execFileAsync = promisify(execFile)
-      await execFileAsync(isWin ? 'npm.cmd' : 'npm', ['--version'], { timeout: 5000, shell: isWin, windowsHide: true })
-      hasNpm = true
-    } catch { /* npm not available */ }
+    return installStandaloneAgent(agentName, {
+      curlUrl: 'https://opencode.ai/install',
+      curlShell: 'bash',
+      winCmd: 'scoop',
+      winArgs: ['install', 'opencode'],
+      winFallback: 'Install OpenCode from https://opencode.ai/download or run: scoop install opencode',
+      successMsg: 'OpenCode installed successfully!\n',
+      detectKey: 'opencode'
+    }, onProgress)
+  }
 
-    if (!hasNpm) {
-      return installOpencodeStandalone(onProgress)
-    }
-    // Fall through to npm install if npm is available
+  if (agentName === 'claudeCode') {
+    return installStandaloneAgent(agentName, {
+      curlUrl: 'https://claude.ai/install.sh',
+      curlShell: 'sh',
+      winPowershell: 'irm https://claude.ai/install.ps1 | iex',
+      winFallback: 'Install Claude Code from https://claude.ai/download',
+      successMsg: 'Claude Code installed successfully!\n',
+      detectKey: 'claudeCode'
+    }, onProgress)
+  }
+
+  if (agentName === 'codex') {
+    return installStandaloneAgent(agentName, {
+      curlUrl: 'https://chatgpt.com/codex/install.sh',
+      curlShell: 'sh',
+      winPowershell: 'irm https://chatgpt.com/codex/install.ps1 | iex',
+      winFallback: 'Install Codex from https://openai.com/codex',
+      successMsg: 'Codex installed successfully!\n',
+      detectKey: 'codex'
+    }, onProgress)
   }
 
   const info = INSTALL_COMMANDS[agentName]
@@ -719,7 +738,7 @@ export async function installAgent(agentName, onProgress) {
     }
   }
 
-  // Check if npm is available before attempting npm installs
+  // Check if npm is available before attempting npm installs (pnpm etc.)
   try {
     const { promisify } = await import('util')
     const execFileAsync = promisify(execFile)
@@ -1086,32 +1105,71 @@ async function installGlabLinux(onProgress) {
 }
 
 /**
- * Install OpenCode via standalone methods (no npm required).
- * macOS/Linux: curl installer script from opencode.ai
- * Windows: scoop or direct download
+ * Install a coding agent via standalone methods (no npm required).
+ * macOS/Linux: curl installer script
+ * Windows: PowerShell installer or scoop
+ *
+ * @param {string} agentName
+ * @param {{ curlUrl: string, curlShell: string, winCmd?: string, winArgs?: string[], winPowershell?: string, winFallback: string, successMsg: string, detectKey: string }} opts
+ * @param {(progress: { stage: string, output: string, percent: number }) => void} onProgress
  */
-async function installOpencodeStandalone(onProgress) {
+async function installStandaloneAgent(agentName, opts, onProgress) {
   const isWin = process.platform === 'win32'
 
   if (isWin) {
-    // Try scoop first, fall back to error with manual instructions
-    onProgress({ stage: 'starting', output: 'Installing OpenCode via scoop...\n', percent: 5 })
-    try {
-      return await spawnInstall('scoop', ['install', 'opencode'], 'opencode', onProgress)
-    } catch {
-      onProgress({ stage: 'error', output: 'scoop not found. Install OpenCode manually: https://opencode.ai/download\n', percent: 100 })
-      return {
-        success: false,
-        error: 'Install OpenCode from https://opencode.ai/download or run: scoop install opencode',
-        newStatus: await detectInstalledAgents()
-      }
+    if (opts.winPowershell) {
+      // Use PowerShell installer (Claude Code, Codex)
+      onProgress({ stage: 'starting', output: `$ powershell -c "${opts.winPowershell}"\n`, percent: 5 })
+      return new Promise((resolve) => {
+        const proc = spawn('powershell', ['-ExecutionPolicy', 'ByPass', '-Command', opts.winPowershell], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true
+        })
+
+        proc.stdout.on('data', (chunk) => {
+          onProgress({ stage: 'installing', output: chunk.toString(), percent: 50 })
+        })
+        proc.stderr.on('data', (chunk) => {
+          onProgress({ stage: 'installing', output: chunk.toString(), percent: 50 })
+        })
+        proc.on('error', async (err) => {
+          onProgress({ stage: 'error', output: `Error: ${err.message}\n`, percent: 100 })
+          resolve({ success: false, error: err.message, newStatus: await detectInstalledAgents() })
+        })
+        proc.on('close', async (code) => {
+          const newStatus = await detectInstalledAgents()
+          if (code === 0 || newStatus[opts.detectKey]?.installed) {
+            onProgress({ stage: 'complete', output: opts.successMsg, percent: 100 })
+            resolve({ success: true, error: null, newStatus })
+          } else {
+            onProgress({ stage: 'error', output: `Installer exited with code ${code}\n`, percent: 100 })
+            resolve({ success: false, error: `Install failed with exit code ${code}`, newStatus })
+          }
+        })
+      })
+    }
+
+    if (opts.winCmd && opts.winArgs) {
+      // Use scoop/winget (OpenCode)
+      onProgress({ stage: 'starting', output: `$ ${opts.winCmd} ${opts.winArgs.join(' ')}\n`, percent: 5 })
+      try {
+        return await spawnInstall(opts.winCmd, opts.winArgs, agentName, onProgress)
+      } catch { /* fall through */ }
+    }
+
+    onProgress({ stage: 'error', output: `${opts.winFallback}\n`, percent: 100 })
+    return {
+      success: false,
+      error: opts.winFallback,
+      newStatus: await detectInstalledAgents()
     }
   }
 
   // macOS / Linux — use the official curl installer
-  onProgress({ stage: 'starting', output: '$ curl -fsSL https://opencode.ai/install | bash\n', percent: 5 })
+  const curlCmd = `curl -fsSL ${opts.curlUrl} | ${opts.curlShell}`
+  onProgress({ stage: 'starting', output: `$ ${curlCmd}\n`, percent: 5 })
   return new Promise((resolve) => {
-    const proc = spawn('bash', ['-c', 'curl -fsSL https://opencode.ai/install | bash'], {
+    const proc = spawn('bash', ['-c', curlCmd], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env }
     })
@@ -1130,13 +1188,13 @@ async function installOpencodeStandalone(onProgress) {
     })
 
     proc.on('close', async (code) => {
-      // The installer may place the binary in ~/.local/bin or similar — ensure it's on PATH
+      // Ensure common binary install paths are on PATH
       const localBin = join(homedir(), '.local', 'bin')
       ensureOnPath(localBin)
 
       const newStatus = await detectInstalledAgents()
-      if (code === 0 || newStatus.opencode?.installed) {
-        onProgress({ stage: 'complete', output: 'OpenCode installed successfully!\n', percent: 100 })
+      if (code === 0 || newStatus[opts.detectKey]?.installed) {
+        onProgress({ stage: 'complete', output: opts.successMsg, percent: 100 })
         resolve({ success: true, error: null, newStatus })
       } else {
         onProgress({ stage: 'error', output: `Install script exited with code ${code}\n`, percent: 100 })

--- a/src/renderer/src/components/onboarding/OnboardingWizard.test.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.test.tsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { OnboardingWizard, shouldShowOnboarding, isForceOnboarding } from './OnboardingWizard'
+
+// Access mock electronAPI from test/setup-renderer.ts
+const mockAgentInstaller = window.electronAPI.agentInstaller as unknown as {
+  detect: Mock
+  install: Mock
+  onProgress: Mock
+}
+
+const mockAgents = window.electronAPI.agents as unknown as {
+  getAll: Mock
+  create: Mock
+  update: Mock
+}
+
+const mockSettings = window.electronAPI.settings as unknown as {
+  get: Mock
+  set: Mock
+  getAll: Mock
+}
+
+const mockEnterprise = window.electronAPI.enterprise as unknown as {
+  getSession: Mock
+}
+
+describe('shouldShowOnboarding', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('should return true when no completed version exists', () => {
+    expect(shouldShowOnboarding(null, '1.0.0')).toBe(true)
+    expect(shouldShowOnboarding(undefined, '1.0.0')).toBe(true)
+  })
+
+  it('should return false when major.minor matches', () => {
+    expect(shouldShowOnboarding('1.2.0', '1.2.5')).toBe(false)
+  })
+
+  it('should return true when major version changes', () => {
+    expect(shouldShowOnboarding('1.2.0', '2.2.0')).toBe(true)
+  })
+
+  it('should return true when minor version changes', () => {
+    expect(shouldShowOnboarding('1.2.0', '1.3.0')).toBe(true)
+  })
+
+  it('should return true when force-onboarding flag is set', () => {
+    localStorage.setItem('force-onboarding', 'true')
+    expect(shouldShowOnboarding('1.2.0', '1.2.0')).toBe(true)
+  })
+
+  it('should return true when debug:onboarding flag is set', () => {
+    localStorage.setItem('debug:onboarding', 'true')
+    expect(shouldShowOnboarding('1.2.0', '1.2.0')).toBe(true)
+  })
+})
+
+describe('isForceOnboarding', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('should return false by default', () => {
+    expect(isForceOnboarding()).toBe(false)
+  })
+
+  it('should return true when force-onboarding is set', () => {
+    localStorage.setItem('force-onboarding', 'true')
+    expect(isForceOnboarding()).toBe(true)
+  })
+
+  it('should return true when debug:onboarding is set', () => {
+    localStorage.setItem('debug:onboarding', 'true')
+    expect(isForceOnboarding()).toBe(true)
+  })
+})
+
+describe('OnboardingWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+
+    mockAgentInstaller.detect.mockResolvedValue({
+      nodejs: { installed: true, version: '20.0.0' },
+      npm: { installed: true, version: '10.0.0' },
+      git: { installed: true, version: '2.40.0' },
+      claudeCode: { installed: true, version: '1.0.0' },
+      opencode: { installed: false, version: null },
+      codex: { installed: false, version: null }
+    })
+    mockAgentInstaller.onProgress.mockImplementation(() => vi.fn())
+    mockAgents.getAll.mockResolvedValue([])
+    mockSettings.getAll.mockResolvedValue({})
+    mockEnterprise.getSession.mockResolvedValue({
+      isAuthenticated: false,
+      userEmail: null,
+      userId: null,
+      currentTenant: null
+    })
+  })
+
+  it('should not render when open is false', () => {
+    render(<OnboardingWizard open={false} onOpenChange={vi.fn()} />)
+    expect(screen.queryByText('Welcome to 20x')).not.toBeInTheDocument()
+  })
+
+  it('should render welcome title when open', () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    // Radix Dialog may render duplicate nodes
+    expect(screen.getAllByText('Welcome to 20x').length).toBeGreaterThan(0)
+  })
+
+  it('should display Peakflo option prominently', () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    expect(screen.getAllByText('Peakflo').length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/Managed agents, workflows/i).length).toBeGreaterThan(0)
+  })
+
+  it('should display all three BYO coding agent options', () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    expect(screen.getAllByText('Claude Code').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('OpenCode').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Codex').length).toBeGreaterThan(0)
+  })
+
+  it('should show button disabled when no agent is selected', () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    const btns = screen.getAllByRole('button', { name: /get started|sign up/i })
+    expect(btns.some((b) => b.hasAttribute('disabled'))).toBe(true)
+  })
+
+  it('should show "Sign up / Log in" when Peakflo is selected', async () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    const peakfloButtons = screen.getAllByText('Peakflo')
+    fireEvent.click(peakfloButtons[0])
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Sign up \/ Log in/i).length).toBeGreaterThan(0)
+    })
+  })
+
+  it('should show "Get Started" when a BYO agent is selected', async () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    const agents = screen.getAllByText('Claude Code')
+    fireEvent.click(agents[0])
+
+    await waitFor(() => {
+      // Button contains "Get Started" text alongside icon elements
+      const btns = screen.getAllByText('Get Started')
+      expect(btns.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('should call onOpenChange(false) when Skip is clicked', () => {
+    const onOpenChange = vi.fn()
+    render(<OnboardingWizard open={true} onOpenChange={onOpenChange} />)
+    const skipBtns = screen.getAllByRole('button', { name: /skip/i })
+    fireEvent.click(skipBtns[0])
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('should detect tools on mount', async () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    await waitFor(() => {
+      expect(mockAgentInstaller.detect).toHaveBeenCalled()
+    })
+  })
+
+  it('should show git provider options when BYO agent is selected', async () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    const agents = screen.getAllByText('OpenCode')
+    fireEvent.click(agents[0])
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Where are your repos/i).length).toBeGreaterThan(0)
+      expect(screen.getAllByText('GitHub').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('GitLab').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('should NOT show git provider when Peakflo is selected', async () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    const peakflo = screen.getAllByText('Peakflo')
+    fireEvent.click(peakflo[0])
+
+    // Git provider row should not appear for Peakflo
+    await waitFor(() => {
+      expect(screen.queryByText(/Where are your repos/i)).not.toBeInTheDocument()
+    })
+  })
+
+  it('should enable Get Started button when BYO agent is selected and not blocked', async () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+
+    // Select Claude Code (which is installed per mock)
+    const agents = screen.getAllByText('Claude Code')
+    fireEvent.click(agents[0])
+
+    // The Get Started button should appear and be enabled (agent is installed, no blocking)
+    await waitFor(() => {
+      const getStarted = screen.getAllByText('Get Started')
+      const btn = getStarted[0].closest('button')
+      expect(btn).toBeTruthy()
+      expect(btn!.hasAttribute('disabled')).toBe(false)
+    })
+  })
+
+  it('should show agent taglines', () => {
+    render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
+    expect(screen.getAllByText('Anthropic').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Open-source, free models').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('OpenAI').length).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -151,14 +151,16 @@ type ProviderChoice = GitProvider | 'none'
 
 function GitProviderRow({
   selected,
-  onSelect
+  onSelect,
+  toolStatus
 }: {
   selected: ProviderChoice | null
   onSelect: (p: ProviderChoice) => void
+  toolStatus: Record<string, ToolStatus> | null
 }) {
-  const options: { value: ProviderChoice; label: string }[] = [
-    { value: 'github', label: 'GitHub' },
-    { value: 'gitlab', label: 'GitLab' }
+  const options: { value: ProviderChoice; label: string; cliKey: string; cliName: string }[] = [
+    { value: 'github', label: 'GitHub', cliKey: 'gh', cliName: 'gh' },
+    { value: 'gitlab', label: 'GitLab', cliKey: 'glab', cliName: 'glab' }
   ]
 
   return (
@@ -167,21 +169,30 @@ function GitProviderRow({
         Where are your repos? <span className="opacity-60">(optional)</span>
       </p>
       <div className="flex gap-2">
-        {options.map((opt) => (
-          <button
-            key={opt.value}
-            type="button"
-            onClick={() => onSelect(selected === opt.value ? 'none' : opt.value)}
-            className={`px-3 py-1.5 rounded-md border text-xs font-medium transition-all cursor-pointer ${
-              selected === opt.value
-                ? 'border-primary bg-primary/5 text-foreground'
-                : 'border-border text-muted-foreground hover:border-muted-foreground/40'
-            }`}
-          >
-            {opt.label}
-            {selected === opt.value && <Check className="inline size-3 ml-1" />}
-          </button>
-        ))}
+        {options.map((opt) => {
+          const cli = toolStatus?.[opt.cliKey]
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onSelect(selected === opt.value ? 'none' : opt.value)}
+              className={`px-3 py-1.5 rounded-md border text-xs font-medium transition-all cursor-pointer flex items-center gap-1.5 ${
+                selected === opt.value
+                  ? 'border-primary bg-primary/5 text-foreground'
+                  : 'border-border text-muted-foreground hover:border-muted-foreground/40'
+              }`}
+            >
+              {opt.label}
+              {selected === opt.value && <Check className="inline size-3" />}
+              {toolStatus && cli?.installed && (
+                <span className="text-emerald-400 text-[10px] font-normal flex items-center gap-0.5">
+                  <Check className="size-2.5" />
+                  {opt.cliName}
+                </span>
+              )}
+            </button>
+          )
+        })}
       </div>
     </div>
   )
@@ -572,6 +583,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
               <GitProviderRow
                 selected={providerChoice}
                 onSelect={handleProviderSelect}
+                toolStatus={toolStatus}
               />
             )}
 

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -524,7 +524,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
           <DialogHeader>
             <DialogTitle>Welcome to 20x</DialogTitle>
             <DialogDescription>
-              AI-powered task management for software teams
+              Get 20x more done with AI agents
             </DialogDescription>
           </DialogHeader>
 

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -300,14 +300,6 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
     return cleanup
   }, [open])
 
-  // After enterprise login completes, fetch templates
-  useEffect(() => {
-    if (isAuthenticated && !wasAuthenticated) {
-      fetchPresetups()
-    }
-    setWasAuthenticated(isAuthenticated)
-  }, [isAuthenticated, wasAuthenticated, fetchPresetups])
-
   const handleInstall = useCallback(async (toolKey: string) => {
     setInstalling(toolKey)
     try {
@@ -401,6 +393,17 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
       setCreating(false)
     }
   }, [createDefaultAgent, fetchPresetups, onOpenChange])
+
+  // When auth completes while login modal is open, auto-close it and run post-auth flow.
+  // This handles the browser signup flow where login/tenant-select happens in the background
+  // and isAuthenticated flips to true while the modal is still showing.
+  useEffect(() => {
+    if (isAuthenticated && !wasAuthenticated && loginModalOpen) {
+      setLoginModalOpen(false)
+      runPostAuthFlow()
+    }
+    setWasAuthenticated(isAuthenticated)
+  }, [isAuthenticated, wasAuthenticated, loginModalOpen, runPostAuthFlow])
 
   const handleStart = async () => {
     if (!selectedAgent) return

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -512,6 +512,9 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
               <div className="grid grid-cols-3 gap-2.5">
                 {AGENT_OPTIONS.map((agent) => {
                   const isSelected = selectedAgent === agent.type
+                  const toolKey = getAgentToolKey(agent.type as CodingAgentType)
+                  const detected = toolStatus?.[toolKey]
+                  const isInstalled = detected?.installed === true
                   return (
                     <button
                       key={agent.type}
@@ -538,6 +541,21 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
                           {agent.tagline}
                         </p>
                       </div>
+                      {/* Detected status */}
+                      {toolStatus && (
+                        <span className={`text-[10px] flex items-center gap-0.5 ${
+                          isInstalled ? 'text-emerald-400' : 'text-muted-foreground/50'
+                        }`}>
+                          {isInstalled ? (
+                            <>
+                              <Check className="size-2.5" />
+                              {detected?.version ? `v${detected.version}` : 'Installed'}
+                            </>
+                          ) : (
+                            'Not installed'
+                          )}
+                        </span>
+                      )}
                       {isSelected && (
                         <div className="absolute top-1.5 right-1.5">
                           <Check className="size-3.5 text-primary" />
@@ -557,41 +575,29 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
               />
             )}
 
-            {/* ── Agent CLI status (BYO only) ── */}
-            {toolStatus && selectedCodingAgent && (
+            {/* ── Install prompt (only when selected agent is not installed) ── */}
+            {toolStatus && selectedCodingAgent && agentInstalled === false && (
               <div className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-muted/20 text-xs">
-                {agentInstalled ? (
-                  <Check className="size-4 text-emerald-400 shrink-0" />
-                ) : (
-                  <AlertTriangle className="size-4 text-amber-400 shrink-0" />
-                )}
+                <AlertTriangle className="size-4 text-amber-400 shrink-0" />
                 <span className="text-muted-foreground flex-1">
-                  {agentInstalled
-                    ? `${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} CLI ready${
-                        toolStatus[getAgentToolKey(selectedCodingAgent)]?.version
-                          ? ` (v${toolStatus[getAgentToolKey(selectedCodingAgent)]?.version})`
-                          : ''
-                      }`
-                    : `${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} will be installed automatically`}
+                  {AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} will be installed automatically
                 </span>
-                {agentInstalled === false && (
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="h-5 px-1.5 text-[10px]"
-                    disabled={!!installing}
-                    onClick={() => handleInstall(getAgentToolKey(selectedCodingAgent))}
-                  >
-                    {installing === getAgentToolKey(selectedCodingAgent) ? (
-                      <Loader2 className="size-3 animate-spin" />
-                    ) : (
-                      <>
-                        <Download className="size-2.5 mr-0.5" />
-                        Install now
-                      </>
-                    )}
-                  </Button>
-                )}
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-5 px-1.5 text-[10px]"
+                  disabled={!!installing}
+                  onClick={() => handleInstall(getAgentToolKey(selectedCodingAgent))}
+                >
+                  {installing === getAgentToolKey(selectedCodingAgent) ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <>
+                      <Download className="size-2.5 mr-0.5" />
+                      Install now
+                    </>
+                  )}
+                </Button>
               </div>
             )}
 

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -1,20 +1,16 @@
-import { useEffect, useState, useRef, useCallback } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import {
   Check,
-  Download,
   Loader2,
-  Terminal,
-  RefreshCw,
-  X,
   AlertTriangle,
   ArrowRight,
-  Bot,
-  Rocket,
-  FolderOpen
+  ChevronDown,
+  ChevronUp,
+  Download,
+  Sparkles,
+  Zap
 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
-import { Input } from '@/components/ui/Input'
-import { Label } from '@/components/ui/Label'
 import {
   Dialog,
   DialogContent,
@@ -25,21 +21,14 @@ import {
 } from '@/components/ui/Dialog'
 import { useAgentStore } from '@/stores/agent-store'
 import { useSettingsStore, type GitProvider } from '@/stores/settings-store'
-import { agentConfigApi, depsApi } from '@/lib/ipc-client'
-import { CodingAgentType, CODING_AGENTS, CLAUDE_MODELS, CODEX_MODELS } from '@/types'
+import { useEnterpriseStore } from '@/stores/enterprise-store'
+import { useDashboardStore } from '@/stores/dashboard-store'
+import { EnterpriseLoginModal } from '@/components/settings/tabs/EnterpriseLoginModal'
+import { PresetupWizard } from '@/components/dashboard/PresetupWizard'
+import { CodingAgentType, CLAUDE_MODELS, CODEX_MODELS } from '@/types'
+import { agentConfigApi } from '@/lib/ipc-client'
 import type { ToolStatus } from '@/types/electron'
-
-/* ─── Types ─── */
-
-type OnboardingStep = 'welcome' | 'provider' | 'tools' | 'agent'
-type OnboardingProviderChoice = GitProvider | 'none'
-
-interface ProgressEvent {
-  agentName: string
-  stage: string
-  output: string
-  percent: number
-}
+import type { PresetupTemplate } from '@/stores/dashboard-store'
 
 /* ─── Force-onboarding flag ─── */
 
@@ -62,793 +51,104 @@ export function shouldShowOnboarding(
   return cMaj !== sMaj || cMin !== sMin
 }
 
-/* ─── Tool metadata ─── */
+/* ─── Agent card metadata ─── */
 
-const TOOL_META: Record<
-  string,
+type AgentChoice = CodingAgentType | 'peakflo'
+
+interface AgentOption {
+  type: AgentChoice
+  label: string
+  tagline: string
+  color: string
+  letter: string
+}
+
+const AGENT_OPTIONS: AgentOption[] = [
   {
-    label: string
-    color: string
-    letter: string
-    required?: boolean
-    description: string
-    category: 'prerequisite' | 'agent' | 'tool'
-  }
-> = {
-  nodejs: {
-    label: 'Node.js',
-    color: 'bg-green-600',
-    letter: 'N',
-    required: true,
-    description: 'JavaScript runtime (required for all agents)',
-    category: 'prerequisite'
-  },
-  npm: {
-    label: 'npm',
-    color: 'bg-red-600',
-    letter: 'n',
-    required: true,
-    description: 'Package manager (included with Node.js)',
-    category: 'prerequisite'
-  },
-  git: {
-    label: 'Git',
-    color: 'bg-orange-600',
-    letter: 'G',
-    description: 'Version control system',
-    category: 'prerequisite'
-  },
-  gh: {
-    label: 'GitHub CLI',
-    color: 'bg-gray-600',
-    letter: 'gh',
-    description: 'GitHub command-line tool',
-    category: 'tool'
-  },
-  glab: {
-    label: 'GitLab CLI',
-    color: 'bg-orange-500',
-    letter: 'gl',
-    description: 'GitLab command-line tool',
-    category: 'tool'
-  },
-  claudeCode: {
+    type: CodingAgentType.CLAUDE_CODE,
     label: 'Claude Code',
+    tagline: 'Anthropic',
     color: 'bg-amber-600',
-    letter: 'C',
-    description: "Anthropic's coding agent",
-    category: 'agent'
+    letter: 'C'
   },
-  opencode: {
+  {
+    type: CodingAgentType.OPENCODE,
     label: 'OpenCode',
+    tagline: 'Open-source, free models',
     color: 'bg-blue-600',
-    letter: 'O',
-    description: 'Open-source coding agent (free models)',
-    category: 'agent'
+    letter: 'O'
   },
-  codex: {
+  {
+    type: CodingAgentType.CODEX,
     label: 'Codex',
+    tagline: 'OpenAI',
     color: 'bg-purple-600',
-    letter: 'X',
-    description: "OpenAI's coding agent",
-    category: 'agent'
+    letter: 'X'
+  }
+]
+
+/* ─── Tool status helpers ─── */
+
+interface ToolCheck {
+  key: string
+  label: string
+}
+
+const CORE_TOOLS: ToolCheck[] = [
+  { key: 'nodejs', label: 'Node.js' },
+  { key: 'npm', label: 'npm' },
+  { key: 'git', label: 'Git' }
+]
+
+function getAgentToolKey(type: CodingAgentType): string {
+  switch (type) {
+    case CodingAgentType.CLAUDE_CODE:
+      return 'claudeCode'
+    case CodingAgentType.OPENCODE:
+      return 'opencode'
+    case CodingAgentType.CODEX:
+      return 'codex'
   }
 }
 
-const INSTALLABLE = ['nodejs', 'npm', 'git', 'gh', 'glab', 'claudeCode', 'opencode', 'codex', 'pnpm']
-const INSTALL_ORDER = ['nodejs', 'git', 'gh', 'glab', 'claudeCode', 'opencode', 'codex']
+/* ─── Auto-select best default model ─── */
 
-function isVisibleToolForProvider(key: string, provider: OnboardingProviderChoice | null): boolean {
-  if (key === 'gh') return provider === 'github'
-  if (key === 'glab') return provider === 'gitlab'
-  return true
-}
-
-function getVisibleInstallOrder(provider: OnboardingProviderChoice | null): string[] {
-  return INSTALL_ORDER.filter((key) => isVisibleToolForProvider(key, provider))
-}
-
-function getVisibleToolKeys(provider: OnboardingProviderChoice | null): string[] {
-  return Object.keys(TOOL_META).filter((key) => isVisibleToolForProvider(key, provider))
-}
-
-/* ─── Step 1: Welcome ─── */
-
-function WelcomeStep({ onNext }: { onNext: () => void }) {
-  return (
-    <div className="flex flex-col items-center text-center py-4">
-      <div className="rounded-full bg-primary/10 p-4 mb-6">
-        <Rocket className="size-8 text-primary" />
-      </div>
-
-      <h2 className="text-2xl font-bold text-foreground mb-2">Welcome to 20x</h2>
-      <p className="text-sm text-muted-foreground mb-8 leading-relaxed max-w-sm">
-        AI-powered task management for software teams. Let&apos;s get your environment set up in a
-        few quick steps.
-      </p>
-
-      <ul className="text-left text-sm text-muted-foreground space-y-3 mb-8 w-full max-w-xs">
-        <li className="flex items-start gap-2.5">
-          <Check className="size-4 text-primary mt-0.5 shrink-0" />
-          <span>Detect &amp; install required CLI tools</span>
-        </li>
-        <li className="flex items-start gap-2.5">
-          <Check className="size-4 text-primary mt-0.5 shrink-0" />
-          <span>Configure your first coding agent</span>
-        </li>
-      </ul>
-
-      <Button onClick={onNext} className="w-full max-w-xs">
-        Get Started
-        <ArrowRight className="size-4 ml-1.5" />
-      </Button>
-    </div>
-  )
-}
-
-/* ─── Step 1b: Git Provider Choice ─── */
-
-function ProviderChoiceStep({
-  onNext,
-  selectedProvider,
-  onSelectProvider
-}: {
-  onNext: () => void
-  selectedProvider: OnboardingProviderChoice | null
-  onSelectProvider: (provider: OnboardingProviderChoice) => void
-}) {
-  const { setGitProvider } = useSettingsStore()
-
-  const handleSelect = async (provider: OnboardingProviderChoice) => {
-    onSelectProvider(provider)
-    await setGitProvider(provider === 'none' ? null : provider)
+async function getDefaultModel(type: CodingAgentType): Promise<string> {
+  if (type === CodingAgentType.CLAUDE_CODE) {
+    return CLAUDE_MODELS[0]?.id || ''
   }
-
-  return (
-    <div className="flex flex-col items-center text-center py-4">
-      <h2 className="text-2xl font-bold text-foreground mb-2">Choose your workspace</h2>
-      <p className="text-sm text-muted-foreground mb-6 leading-relaxed max-w-sm">
-        Select the platform where your repositories are hosted, or continue without repo tools.
-      </p>
-
-      <div className="grid grid-cols-3 gap-3 w-full max-w-xl mb-8">
-        {/* GitHub option */}
-        <button
-          type="button"
-          onClick={() => handleSelect('github')}
-          className={`flex flex-col items-center gap-3 rounded-xl border-2 p-6 transition-all ${
-            selectedProvider === 'github'
-              ? 'border-primary bg-primary/5 shadow-md'
-              : 'border-border hover:border-muted-foreground/50 hover:bg-muted/30'
-          }`}
-        >
-          <div className="bg-gray-600 rounded-full size-12 flex items-center justify-center text-white text-sm font-bold">
-            gh
-          </div>
-          <div>
-            <p className="text-sm font-semibold text-foreground">GitHub</p>
-            <p className="text-xs text-muted-foreground mt-0.5">github.com</p>
-          </div>
-          {selectedProvider === 'github' && (
-            <Check className="size-5 text-primary" />
-          )}
-        </button>
-
-        {/* GitLab option */}
-        <button
-          type="button"
-          onClick={() => handleSelect('gitlab')}
-          className={`flex flex-col items-center gap-3 rounded-xl border-2 p-6 transition-all ${
-            selectedProvider === 'gitlab'
-              ? 'border-primary bg-primary/5 shadow-md'
-              : 'border-border hover:border-muted-foreground/50 hover:bg-muted/30'
-          }`}
-        >
-          <div className="bg-orange-500 rounded-full size-12 flex items-center justify-center text-white text-sm font-bold">
-            gl
-          </div>
-          <div>
-            <p className="text-sm font-semibold text-foreground">GitLab</p>
-            <p className="text-xs text-muted-foreground mt-0.5">gitlab.com</p>
-          </div>
-          {selectedProvider === 'gitlab' && (
-            <Check className="size-5 text-primary" />
-          )}
-        </button>
-
-        {/* No repo tools option */}
-        <button
-          type="button"
-          onClick={() => handleSelect('none')}
-          className={`flex flex-col items-center gap-3 rounded-xl border-2 p-6 transition-all ${
-            selectedProvider === 'none'
-              ? 'border-primary bg-primary/5 shadow-md'
-              : 'border-border hover:border-muted-foreground/50 hover:bg-muted/30'
-          }`}
-        >
-          <div className="bg-muted rounded-full size-12 flex items-center justify-center text-muted-foreground text-sm font-bold">
-            <X className="size-5" />
-          </div>
-          <div>
-            <p className="text-sm font-semibold text-foreground">I don&apos;t use them</p>
-            <p className="text-xs text-muted-foreground mt-0.5">Skip repo tools</p>
-          </div>
-          {selectedProvider === 'none' && (
-            <Check className="size-5 text-primary" />
-          )}
-        </button>
-      </div>
-
-      <Button onClick={onNext} disabled={!selectedProvider} className="w-full max-w-xs">
-        Continue
-        <ArrowRight className="size-4 ml-1.5" />
-      </Button>
-    </div>
-  )
-}
-
-/* ─── Step 2: Tools & Agents ─── */
-
-function ToolsAndAgentsStep({
-  onNext,
-  onSkip,
-  selectedProvider
-}: {
-  onNext: () => void
-  onSkip: () => void
-  selectedProvider: OnboardingProviderChoice | null
-}) {
-  const [status, setStatus] = useState<Record<string, ToolStatus> | null>(null)
-  const [installing, setInstalling] = useState<string | null>(null)
-  const [terminalOutput, setTerminalOutput] = useState('')
-  const [loading, setLoading] = useState(true)
-  const [customOpencodePath, setCustomOpencodePath] = useState('')
-  const [savingPath, setSavingPath] = useState(false)
-  const [pathError, setPathError] = useState<string | null>(null)
-  const termRef = useRef<HTMLDivElement>(null)
-
-  const detect = useCallback(async () => {
-    setLoading(true)
-    try {
-      const result = await window.electronAPI.agentInstaller.detect()
-      setStatus(result)
-    } catch (err) {
-      console.error('Failed to detect agents:', err)
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    detect()
-    setTerminalOutput('')
-  }, [detect])
-
-  useEffect(() => {
-    const cleanup = window.electronAPI.agentInstaller.onProgress((data: ProgressEvent) => {
-      setTerminalOutput((prev) => prev + data.output)
-      if (data.stage === 'complete' || data.stage === 'error') {
-        setInstalling(null)
-        detect()
-      }
-    })
-    return cleanup
-  }, [detect])
-
-  useEffect(() => {
-    if (termRef.current) {
-      termRef.current.scrollTop = termRef.current.scrollHeight
-    }
-  }, [terminalOutput])
-
-  const handleInstall = async (agentName: string) => {
-    setInstalling(agentName)
-    setTerminalOutput(
-      (prev) =>
-        prev + `\n── Installing ${TOOL_META[agentName]?.label || agentName} ──\n`
-    )
-    try {
-      const result = await window.electronAPI.agentInstaller.install(agentName) as { success: boolean; error: string | null; newStatus: Record<string, ToolStatus> }
-      // On some platforms the install returns immediately without progress events
-      // (e.g. glab/gh on macOS), so we must clear the installing state here.
-      if (result && !result.success) {
-        setTerminalOutput((prev) => prev + `${result.error || 'Installation not available on this platform.'}\n`)
-        setInstalling(null)
-        if (result.newStatus) setStatus(result.newStatus)
-      }
-    } catch (err) {
-      setTerminalOutput((prev) => prev + `Error: ${err}\n`)
-      setInstalling(null)
-    }
+  if (type === CodingAgentType.CODEX) {
+    return CODEX_MODELS[0]?.id || ''
   }
-
-  const handleInstallAll = async () => {
-    if (!status) return
-    const missing = getVisibleInstallOrder(selectedProvider).filter((key) => {
-      const s = status[key]
-      return s && !s.installed
-    })
-
-    for (const agentName of missing) {
-      const freshStatus = await window.electronAPI.agentInstaller.detect()
-      setStatus(freshStatus)
-      if (freshStatus[agentName]?.installed) continue
-
-      setInstalling(agentName)
-      setTerminalOutput(
-        (prev) =>
-          prev + `\n── Installing ${TOOL_META[agentName]?.label || agentName} ──\n`
-      )
-      try {
-        const result = await window.electronAPI.agentInstaller.install(agentName) as { success: boolean; error: string | null; newStatus: Record<string, ToolStatus> }
-        if (result && !result.success) {
-          setTerminalOutput((prev) => prev + `${result.error || 'Installation not available on this platform.'}\n`)
-          if (result.newStatus) setStatus(result.newStatus)
-        }
-      } catch (err) {
-        setTerminalOutput((prev) => prev + `Error: ${err}\n`)
-      }
-      await new Promise((r) => setTimeout(r, 500))
-    }
-    setInstalling(null)
-    await detect()
-  }
-
-  const handleSetOpencodePath = async () => {
-    if (!customOpencodePath.trim()) {
-      setPathError('Please enter the directory path containing the binary.')
-      return
-    }
-    setSavingPath(true)
-    setPathError(null)
-    try {
-      const result = await depsApi.setOpencodePath(customOpencodePath.trim())
-      if (result.success) {
-        await detect()
-      } else {
-        setPathError(result.error || 'Binary not found at that path.')
-      }
-    } catch {
-      setPathError('Failed to save path.')
-    } finally {
-      setSavingPath(false)
-    }
-  }
-
-  const visibleInstallOrder = getVisibleInstallOrder(selectedProvider)
-  const visibleToolKeys = getVisibleToolKeys(selectedProvider)
-
-  const missingCount = status
-    ? visibleInstallOrder.filter((key) => status[key] && !status[key].installed).length
-    : 0
-
-  const installedCount = status
-    ? visibleToolKeys.filter((key) => status[key]?.installed).length
-    : 0
-  const totalCount = status ? visibleToolKeys.filter((key) => status[key]).length : 0
-
-  const hasPrerequisites = status?.nodejs?.installed && status?.npm?.installed
-
-  const renderCategory = (
-    category: 'prerequisite' | 'agent' | 'tool',
-    title: string
-  ) => {
-    const items = Object.entries(TOOL_META).filter(([key, meta]) => {
-      if (meta.category !== category) return false
-      return isVisibleToolForProvider(key, selectedProvider)
-    })
-    if (items.length === 0) return null
-
-    return (
-      <div className="mb-3">
-        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5 px-1">
-          {title}
-        </p>
-        <div className="grid gap-1.5">
-          {items.map(([key, meta]) => {
-            const toolStatus = status?.[key]
-            if (!toolStatus) return null
-            const isInstalling = installing === key
-            const canInstall = INSTALLABLE.includes(key)
-            const needsPrereq =
-              !hasPrerequisites && meta.category === 'agent' && !toolStatus.installed
-
-            return (
-              <div
-                key={key}
-                className={`flex items-center gap-3 rounded-lg border border-border p-2.5 bg-background ${
-                  needsPrereq ? 'opacity-60' : ''
-                }`}
-              >
-                <div
-                  className={`${meta.color} rounded-full size-8 flex items-center justify-center text-white text-xs font-bold shrink-0`}
-                >
-                  {meta.letter}
-                </div>
-
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-foreground leading-tight">
-                    {meta.label}
-                    {meta.required && <span className="text-red-400 ml-1">*</span>}
-                  </p>
-                  <p className="text-xs text-muted-foreground truncate">
-                    {toolStatus.installed && toolStatus.version
-                      ? `v${toolStatus.version}`
-                      : meta.description}
-                  </p>
-                </div>
-
-                {isInstalling ? (
-                  <span className="flex items-center gap-1.5 text-xs text-yellow-400 shrink-0">
-                    <Loader2 className="size-3.5 animate-spin" />
-                    Installing...
-                  </span>
-                ) : toolStatus.installed ? (
-                  <span className="flex items-center gap-1.5 text-xs text-emerald-400 shrink-0">
-                    <Check className="size-3.5" />
-                    Installed
-                  </span>
-                ) : (
-                  <span className="text-xs text-red-400 shrink-0">Missing</span>
-                )}
-
-                {!toolStatus.installed && canInstall && !isInstalling && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => handleInstall(key)}
-                    disabled={!!installing || needsPrereq}
-                    className="ml-1 h-7 px-2.5 text-xs shrink-0"
-                    title={needsPrereq ? 'Install Node.js first' : undefined}
-                  >
-                    <Download className="size-3 mr-1" />
-                    Install
-                  </Button>
-                )}
-              </div>
-            )
-          })}
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <>
-      {loading && !status ? (
-        <div className="flex items-center justify-center py-8 gap-3 text-muted-foreground">
-          <Loader2 className="size-5 animate-spin" />
-          <span>Detecting installed tools...</span>
-        </div>
-      ) : (
-        <>
-          {/* Prerequisites warning */}
-          {status && !hasPrerequisites && (
-            <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-3 mb-4 text-sm">
-              <AlertTriangle className="size-4 text-yellow-400 shrink-0 mt-0.5" />
-              <div>
-                <p className="font-medium text-yellow-400">Prerequisites missing</p>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  Node.js and npm are required before installing coding agents. Install them first,
-                  or click &quot;Install All&quot; to set up everything in order.
-                </p>
-              </div>
-            </div>
-          )}
-
-          {/* Status grid */}
-          {renderCategory('prerequisite', 'Prerequisites')}
-          {renderCategory('tool', 'Tools')}
-          {renderCategory('agent', 'Coding Agents')}
-
-          {/* Custom OpenCode path */}
-          {status && !status.opencode?.installed && (
-            <div className="mt-3 pt-3 border-t border-border">
-              <p className="text-xs font-medium text-muted-foreground mb-2 uppercase tracking-wide">
-                Custom OpenCode path
-              </p>
-              <div className="flex gap-2">
-                <Input
-                  value={customOpencodePath}
-                  onChange={(e) => setCustomOpencodePath(e.target.value)}
-                  placeholder="e.g. /home/user/.opencode/bin"
-                  className="flex-1"
-                />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleSetOpencodePath}
-                  disabled={savingPath || !customOpencodePath.trim()}
-                >
-                  {savingPath ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <FolderOpen className="size-4" />
-                  )}
-                  Set
-                </Button>
-              </div>
-              {pathError && <p className="text-xs text-destructive mt-1.5">{pathError}</p>}
-            </div>
-          )}
-
-          {/* Actions */}
-          <div className="flex items-center gap-3 mt-4 mb-4">
-            {missingCount > 0 && (
-              <Button size="sm" onClick={handleInstallAll} disabled={!!installing}>
-                {installing ? (
-                  <Loader2 className="size-3.5 animate-spin mr-1.5" />
-                ) : (
-                  <Download className="size-3.5 mr-1.5" />
-                )}
-                Install All Missing ({missingCount})
-              </Button>
-            )}
-            <Button variant="ghost" size="sm" onClick={detect} disabled={!!installing}>
-              <RefreshCw className={`size-3.5 mr-1 ${loading ? 'animate-spin' : ''}`} />
-              Refresh
-            </Button>
-            {missingCount === 0 && status && (
-              <span className="text-xs text-emerald-400 flex items-center gap-1.5">
-                <Check className="size-3.5" />
-                All tools are installed!
-              </span>
-            )}
-          </div>
-
-          {/* Terminal output */}
-          {terminalOutput && (
-            <div>
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <Terminal className="size-3.5" />
-                  Installation output
-                </div>
-                <button
-                  onClick={() => setTerminalOutput('')}
-                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <X className="size-3.5" />
-                </button>
-              </div>
-              <div
-                ref={termRef}
-                className="bg-black/80 border border-border rounded-lg p-3 max-h-40 overflow-y-auto font-mono text-xs text-green-400 whitespace-pre-wrap"
-              >
-                {terminalOutput}
-              </div>
-            </div>
-          )}
-
-          {/* Navigation */}
-          <div className="flex items-center gap-3 mt-4 border-t border-border pt-4">
-            <Button onClick={onNext}>
-              Continue
-              <ArrowRight className="size-4 ml-1.5" />
-            </Button>
-            <Button variant="ghost" onClick={onSkip}>
-              Skip setup
-            </Button>
-            <span className="ml-auto text-xs text-muted-foreground">
-              {installedCount}/{totalCount} installed
-            </span>
-          </div>
-        </>
-      )}
-    </>
-  )
-}
-
-/* ─── Step 4: Agent Configuration ─── */
-
-interface ModelOption {
-  id: string
-  name: string
-}
-
-function AgentConfigStep({
-  onCreated,
-  error,
-  setError
-}: {
-  onCreated: () => void
-  error: string | null
-  setError: (e: string | null) => void
-}) {
-  const [name, setName] = useState('Robo')
-  const [codingAgent, setCodingAgent] = useState<CodingAgentType>(CodingAgentType.OPENCODE)
-  const [model, setModel] = useState('')
-  const [models, setModels] = useState<ModelOption[]>([])
-  const [loadingModels, setLoadingModels] = useState(true)
-  const [creating, setCreating] = useState(false)
-  const { agents, createAgent, updateAgent } = useAgentStore()
-
-  useEffect(() => {
-    let cancelled = false
-    setLoadingModels(true)
-    setModel('')
-
-    if (codingAgent === CodingAgentType.CLAUDE_CODE) {
-      const list = CLAUDE_MODELS.map((m) => ({ id: m.id, name: m.name }))
-      setModels(list)
-      if (list.length > 0) setModel(list[0].id)
-      setLoadingModels(false)
-      return
-    }
-
-    if (codingAgent === CodingAgentType.CODEX) {
-      const list = CODEX_MODELS.map((m) => ({ id: m.id, name: m.name }))
-      setModels(list)
-      if (list.length > 0) setModel(list[0].id)
-      setLoadingModels(false)
-      return
-    }
-
-    // OpenCode — fetch from server
-    agentConfigApi
-      .getProviders(undefined, CodingAgentType.OPENCODE)
-      .then((result) => {
-        if (cancelled) return
-        if (result?.providers) {
-          const list: ModelOption[] = []
-          const providers = Array.isArray(result.providers) ? result.providers : []
-          for (const p of providers) {
-            if (Array.isArray(p.models)) {
-              for (const m of p.models as { id?: string; name?: string }[]) {
-                if (m?.id)
-                  list.push({ id: `${p.id}/${m.id}`, name: `${p.name} – ${m.name || m.id}` })
-              }
-            } else if (p.models && typeof p.models === 'object') {
-              // Use Object.entries so the map key serves as fallback model ID
-              // (custom providers like routerAI may not have id on the value)
-              for (const [key, m] of Object.entries(p.models as Record<string, { id?: string; name?: string }>)) {
-                const modelId = m?.id || key
-                if (modelId)
-                  list.push({ id: `${p.id}/${modelId}`, name: `${p.name} – ${m?.name || modelId}` })
-              }
+  // OpenCode — try to fetch, fall back gracefully
+  try {
+    const result = await agentConfigApi.getProviders(undefined, CodingAgentType.OPENCODE)
+    if (result?.providers) {
+      const providers = Array.isArray(result.providers) ? result.providers : []
+      for (const p of providers) {
+        if (Array.isArray(p.models)) {
+          for (const m of p.models as { id?: string; name?: string }[]) {
+            if (m?.id) {
+              const name = (m.name || '').toLowerCase()
+              if (name.includes('free')) return `${p.id}/${m.id}`
             }
           }
-          setModels(list)
-          if (list.length > 0) {
-            const zenFree = list.find((m) => m.name.toLowerCase().includes('free'))
-            setModel(zenFree?.id || list[0].id)
+          const first = (p.models as { id?: string }[])[0]
+          if (first?.id) return `${p.id}/${first.id}`
+        } else if (p.models && typeof p.models === 'object') {
+          for (const [key, m] of Object.entries(
+            p.models as Record<string, { id?: string; name?: string }>
+          )) {
+            const modelId = m?.id || key
+            if (modelId) return `${p.id}/${modelId}`
           }
         }
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (!cancelled) setLoadingModels(false)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [codingAgent])
-
-  const handleCreate = async () => {
-    if (!name.trim()) {
-      setError('Agent name is required')
-      return
-    }
-    setCreating(true)
-    setError(null)
-    try {
-      const existingDefault = agents.find(
-        (a) => a.is_default && (!a.config.coding_agent || !a.config.model)
-      )
-      if (existingDefault) {
-        await updateAgent(existingDefault.id, {
-          name: name.trim(),
-          config: {
-            ...existingDefault.config,
-            coding_agent: codingAgent,
-            model: model || undefined
-          }
-        })
-      } else {
-        await createAgent({
-          name: name.trim(),
-          config: {
-            coding_agent: codingAgent,
-            model: model || undefined
-          },
-          is_default: true
-        })
       }
-      onCreated()
-    } catch {
-      setError('Failed to create agent')
-    } finally {
-      setCreating(false)
     }
+  } catch {
+    // Silently fail — user can configure model later in settings
   }
-
-  return (
-    <>
-      <div className="rounded-full bg-primary/10 p-2.5 w-fit mb-4">
-        <Bot className="size-5 text-primary" />
-      </div>
-
-      <h2 className="text-2xl font-bold text-foreground mb-2">Set up your agent</h2>
-      <p className="text-sm text-muted-foreground mb-6 leading-relaxed">
-        Configure your AI coding agent to work on tasks.
-      </p>
-
-      <div className="space-y-4">
-        <div className="space-y-1.5">
-          <Label htmlFor="setup-agent-name">Agent name</Label>
-          <Input
-            id="setup-agent-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Robo"
-          />
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="setup-coding-agent">Coding agent</Label>
-          <select
-            id="setup-coding-agent"
-            value={codingAgent}
-            onChange={(e) => setCodingAgent(e.target.value as CodingAgentType)}
-            className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm cursor-pointer"
-          >
-            {CODING_AGENTS.map((a) => (
-              <option key={a.value} value={a.value}>
-                {a.label}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="setup-agent-model">Model</Label>
-          {loadingModels ? (
-            <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground border border-input rounded-md">
-              <Loader2 className="size-4 animate-spin" />
-              Loading models...
-            </div>
-          ) : models.length > 0 ? (
-            <select
-              id="setup-agent-model"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm cursor-pointer"
-            >
-              <option value="">Select a model...</option>
-              {models.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.name}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <Input
-              id="setup-agent-model"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              placeholder="provider/model-id"
-            />
-          )}
-          {!loadingModels && models.length === 0 && codingAgent === CodingAgentType.OPENCODE && (
-            <p className="text-xs text-muted-foreground">
-              Could not load models from OpenCode server. You can configure this later in settings.
-            </p>
-          )}
-        </div>
-      </div>
-
-      {error && <p className="mt-3 text-xs text-destructive">{error}</p>}
-
-      <div className="flex items-center gap-3 mt-6">
-        <Button onClick={handleCreate} disabled={creating || !name.trim()}>
-          {creating ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
-          {agents.find((a) => a.is_default && (!a.config.coding_agent || !a.config.model))
-            ? 'Update agent'
-            : 'Create agent'}
-        </Button>
-      </div>
-    </>
-  )
+  return ''
 }
 
 /* ─── Helpers ─── */
@@ -858,6 +158,52 @@ function hasCompleteDefaultAgent(): boolean {
   return agents.some((a) => a.is_default && !!a.config.coding_agent && !!a.config.model)
 }
 
+/* ─── Git Provider Choice (inline, optional) ─── */
+
+type ProviderChoice = GitProvider | 'none'
+
+function GitProviderRow({
+  selected,
+  onSelect
+}: {
+  selected: ProviderChoice | null
+  onSelect: (p: ProviderChoice) => void
+}) {
+  const options: { value: ProviderChoice; label: string }[] = [
+    { value: 'github', label: 'GitHub' },
+    { value: 'gitlab', label: 'GitLab' }
+  ]
+
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground mb-2">
+        Where are your repos? <span className="opacity-60">(optional)</span>
+      </p>
+      <div className="flex gap-2">
+        {options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onSelect(selected === opt.value ? 'none' : opt.value)}
+            className={`px-3 py-1.5 rounded-md border text-xs font-medium transition-all cursor-pointer ${
+              selected === opt.value
+                ? 'border-primary bg-primary/5 text-foreground'
+                : 'border-border text-muted-foreground hover:border-muted-foreground/40'
+            }`}
+          >
+            {opt.label}
+            {selected === opt.value && <Check className="inline size-3 ml-1" />}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/* ─── Onboarding step type ─── */
+
+type OnboardingScreen = 'main' | 'templates'
+
 /* ─── Main OnboardingWizard ─── */
 
 interface OnboardingWizardProps {
@@ -866,110 +212,528 @@ interface OnboardingWizardProps {
 }
 
 export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) {
-  const [currentStep, setCurrentStep] = useState(0)
-  const [steps, setSteps] = useState<OnboardingStep[]>([])
+  const [screen, setScreen] = useState<OnboardingScreen>('main')
+  const [selectedAgent, setSelectedAgent] = useState<AgentChoice | null>(null)
+  const [providerChoice, setProviderChoice] = useState<ProviderChoice | null>(null)
+  const [toolStatus, setToolStatus] = useState<Record<string, ToolStatus> | null>(null)
+  const [toolsExpanded, setToolsExpanded] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [installing, setInstalling] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [selectedProvider, setSelectedProvider] = useState<OnboardingProviderChoice | null>(null)
-  const { fetchAgents } = useAgentStore()
-  const { fetchSettings, gitProvider } = useSettingsStore()
+  const [loginModalOpen, setLoginModalOpen] = useState(false)
+  const [wizardTemplate, setWizardTemplate] = useState<PresetupTemplate | null>(null)
+  const [wasAuthenticated, setWasAuthenticated] = useState(false)
 
-  // Build step list on open
+  const { fetchAgents, agents, createAgent, updateAgent } = useAgentStore()
+  const { fetchSettings, setGitProvider } = useSettingsStore()
+  const { isAuthenticated, loadSession } = useEnterpriseStore()
+  const { presetupTemplates, fetchPresetups } = useDashboardStore()
+
+  // Initialize state on open
   useEffect(() => {
     if (!open) return
-
-    const force = isForceOnboarding()
-
-    Promise.all([fetchAgents(), fetchSettings()]).then(() => {
-      const stepList: OnboardingStep[] = ['welcome', 'provider', 'tools']
-
-      // Agent config step — skip if default agent is fully configured
-      if (force || !hasCompleteDefaultAgent()) {
-        stepList.push('agent')
-      }
-
-      setSteps(stepList)
-      setCurrentStep(0)
-      setError(null)
-      // Restore previously saved provider choice
-      if (gitProvider) {
-        setSelectedProvider(gitProvider)
-      }
-    })
-  }, [open, fetchAgents, fetchSettings])
-
-  const advance = useCallback(() => {
     setError(null)
-    if (currentStep >= steps.length - 1) {
-      onOpenChange(false)
-    } else {
-      setCurrentStep((s) => s + 1)
+    setScreen('main')
+
+    Promise.all([fetchAgents(), fetchSettings(), loadSession()]).then(() => {
+      // Pre-select agent if one is already configured
+      const existing = useAgentStore.getState().agents.find(
+        (a) => a.is_default && a.config.coding_agent
+      )
+      if (existing?.config.coding_agent) {
+        setSelectedAgent(existing.config.coding_agent as CodingAgentType)
+      }
+      // Restore git provider choice
+      const gp = useSettingsStore.getState().gitProvider
+      if (gp) setProviderChoice(gp)
+    })
+
+    // Detect tools in background
+    window.electronAPI.agentInstaller
+      .detect()
+      .then(setToolStatus)
+      .catch(() => {})
+  }, [open, fetchAgents, fetchSettings, loadSession])
+
+  // Listen for install progress events
+  useEffect(() => {
+    if (!open) return
+    const cleanup = window.electronAPI.agentInstaller.onProgress(
+      (data: { stage: string }) => {
+        if (data.stage === 'complete' || data.stage === 'error') {
+          setInstalling(null)
+          window.electronAPI.agentInstaller
+            .detect()
+            .then(setToolStatus)
+            .catch(() => {})
+        }
+      }
+    )
+    return cleanup
+  }, [open])
+
+  // After enterprise login completes, fetch templates
+  useEffect(() => {
+    if (isAuthenticated && !wasAuthenticated) {
+      fetchPresetups()
     }
-  }, [currentStep, steps.length, onOpenChange])
+    setWasAuthenticated(isAuthenticated)
+  }, [isAuthenticated, wasAuthenticated, fetchPresetups])
 
-  const dismiss = useCallback(() => {
+  const handleInstall = useCallback(async (toolKey: string) => {
+    setInstalling(toolKey)
+    try {
+      const result = (await window.electronAPI.agentInstaller.install(toolKey)) as {
+        success: boolean
+        error: string | null
+        newStatus: Record<string, ToolStatus>
+      }
+      if (result?.newStatus) {
+        setToolStatus(result.newStatus)
+      } else {
+        const fresh = await window.electronAPI.agentInstaller.detect()
+        setToolStatus(fresh)
+      }
+    } catch {
+      const fresh = await window.electronAPI.agentInstaller.detect()
+      setToolStatus(fresh)
+    } finally {
+      setInstalling(null)
+    }
+  }, [])
+
+  const handleProviderSelect = useCallback(
+    async (p: ProviderChoice) => {
+      setProviderChoice(p)
+      await setGitProvider(p === 'none' ? null : p)
+    },
+    [setGitProvider]
+  )
+
+  const createDefaultAgent = useCallback(
+    async (agentType: CodingAgentType) => {
+      const model = await getDefaultModel(agentType)
+
+      const existingDefault = agents.find(
+        (a) => a.is_default && (!a.config.coding_agent || !a.config.model)
+      )
+
+      if (existingDefault) {
+        await updateAgent(existingDefault.id, {
+          name: existingDefault.name || 'Robo',
+          config: {
+            ...existingDefault.config,
+            coding_agent: agentType,
+            model: model || undefined
+          }
+        })
+      } else if (!hasCompleteDefaultAgent()) {
+        await createAgent({
+          name: 'Robo',
+          config: {
+            coding_agent: agentType,
+            model: model || undefined
+          },
+          is_default: true
+        })
+      }
+    },
+    [agents, createAgent, updateAgent]
+  )
+
+  const handleStart = async () => {
+    if (!selectedAgent) return
+    setCreating(true)
+    setError(null)
+
+    try {
+      if (selectedAgent === 'peakflo') {
+        // Open login modal — after auth, handleLoginClose transitions forward
+        setLoginModalOpen(true)
+        setCreating(false)
+        return
+      }
+
+      // BYO agent path — create default agent and close
+      await createDefaultAgent(selectedAgent)
+      onOpenChange(false)
+    } catch {
+      setError('Failed to set up agent. You can configure it later in Settings.')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  // After enterprise login modal closes
+  const handleLoginClose = useCallback(async () => {
+    setLoginModalOpen(false)
+    const auth = useEnterpriseStore.getState().isAuthenticated
+    if (!auth) return // User cancelled
+
+    // Auto-install OpenCode + create default agent
+    setCreating(true)
+    try {
+      if (!hasCompleteDefaultAgent()) {
+        const status = await window.electronAPI.agentInstaller.detect()
+        setToolStatus(status)
+        if (!status.opencode?.installed) {
+          setInstalling('opencode')
+          await window.electronAPI.agentInstaller.install('opencode')
+          setInstalling(null)
+        }
+        await createDefaultAgent(CodingAgentType.OPENCODE)
+      }
+
+      // Fetch templates and show them if available
+      await fetchPresetups()
+      const templates = useDashboardStore.getState().presetupTemplates
+      if (templates.length > 0) {
+        setScreen('templates')
+      } else {
+        onOpenChange(false)
+      }
+    } catch {
+      const templates = useDashboardStore.getState().presetupTemplates
+      if (templates.length > 0) {
+        setScreen('templates')
+      } else {
+        onOpenChange(false)
+      }
+    } finally {
+      setCreating(false)
+    }
+  }, [createDefaultAgent, fetchPresetups, onOpenChange])
+
+  const handleSkip = () => {
     onOpenChange(false)
-  }, [onOpenChange])
+  }
 
-  const current = steps[currentStep]
+  // Compute tool health for the selected BYO agent
+  const selectedCodingAgent =
+    selectedAgent && selectedAgent !== 'peakflo' ? selectedAgent : null
+
+  const agentInstalled =
+    selectedCodingAgent && toolStatus
+      ? toolStatus[getAgentToolKey(selectedCodingAgent)]?.installed
+      : null
+
+  // Claude Code & Codex need npm; OpenCode can install standalone
+  const needsNpm =
+    selectedCodingAgent === CodingAgentType.CLAUDE_CODE ||
+    selectedCodingAgent === CodingAgentType.CODEX
+  const npmAvailable = toolStatus?.npm?.installed ?? false
+  const canInstallAgent = !needsNpm || npmAvailable
+
+  // Block when agent isn't installed and we can't install it
+  const agentBlocked =
+    selectedCodingAgent && agentInstalled === false && !canInstallAgent
+
+  /* ─── Render: Templates screen ─── */
+
+  if (screen === 'templates') {
+    return (
+      <>
+        <Dialog open={open} onOpenChange={(o) => !o && handleSkip()}>
+          <DialogContent className="max-w-lg">
+            <DialogHeader>
+              <DialogTitle>Start with a template</DialogTitle>
+              <DialogDescription>
+                Set up pre-built workflows for your team, or do it later from the Dashboard.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogBody className="space-y-4">
+              <div className="grid grid-cols-2 gap-3">
+                {presetupTemplates.map((template) => (
+                  <button
+                    key={template.slug}
+                    type="button"
+                    onClick={() => setWizardTemplate(template)}
+                    className="rounded-lg border border-border bg-card p-4 text-left transition-all hover:border-primary/40 hover:bg-secondary/30 cursor-pointer group"
+                  >
+                    <p className="text-sm font-medium text-foreground group-hover:text-primary transition-colors">
+                      {template.name}
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                      {template.description}
+                    </p>
+                    <span className="inline-flex items-center gap-1 text-xs text-primary mt-2 font-medium">
+                      Set up <ArrowRight className="size-3" />
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="flex items-center gap-3 pt-2">
+                <Button onClick={() => onOpenChange(false)} className="flex-1">
+                  Done
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => onOpenChange(false)}
+                  className="text-muted-foreground"
+                >
+                  Set up later
+                </Button>
+              </div>
+            </DialogBody>
+          </DialogContent>
+        </Dialog>
+
+        {wizardTemplate && (
+          <PresetupWizard
+            template={wizardTemplate}
+            onClose={() => setWizardTemplate(null)}
+          />
+        )}
+      </>
+    )
+  }
+
+  /* ─── Render: Main screen ─── */
 
   return (
-    <Dialog open={open} onOpenChange={(o) => !o && dismiss()}>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>
-            {current === 'welcome'
-              ? 'Welcome'
-              : current === 'provider'
-                ? 'Git Provider'
-                : current === 'tools'
-                  ? 'Agent & Tool Setup'
-                  : current === 'agent'
-                    ? 'Agent Configuration'
-                    : 'Setup'}
-          </DialogTitle>
-          <DialogDescription>
-            {steps.length > 1 && (
-              <span className="text-xs">
-                Step {currentStep + 1} of {steps.length}
-              </span>
-            )}
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open && !loginModalOpen} onOpenChange={(o) => !o && handleSkip()}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Welcome to 20x</DialogTitle>
+            <DialogDescription>
+              AI-powered task management for software teams
+            </DialogDescription>
+          </DialogHeader>
 
-        {/* Step indicator */}
-        {steps.length > 1 && (
-          <div className="flex items-center gap-1.5 px-6">
-            {steps.map((_, i) => (
-              <div
-                key={i}
-                className={`h-1 rounded-full transition-colors ${
-                  i <= currentStep ? 'w-6 bg-primary' : 'w-6 bg-border'
+          <DialogBody className="space-y-5">
+            {/* ── Peakflo option ── */}
+            <div>
+              <button
+                type="button"
+                onClick={() => setSelectedAgent('peakflo')}
+                className={`w-full flex items-center gap-3 rounded-xl border-2 p-4 transition-all cursor-pointer ${
+                  selectedAgent === 'peakflo'
+                    ? 'border-primary bg-primary/5 shadow-md'
+                    : 'border-border hover:border-muted-foreground/40 hover:bg-muted/20'
                 }`}
-              />
-            ))}
-          </div>
-        )}
-
-        <DialogBody>
-          {current === 'welcome' && <WelcomeStep onNext={advance} />}
-
-          {current === 'provider' && (
-            <ProviderChoiceStep
-              onNext={advance}
-              selectedProvider={selectedProvider}
-              onSelectProvider={setSelectedProvider}
-            />
-          )}
-
-          {current === 'tools' && <ToolsAndAgentsStep onNext={advance} onSkip={dismiss} selectedProvider={selectedProvider} />}
-
-          {current === 'agent' && (
-            <div className="px-2 pt-2 pb-2">
-              <AgentConfigStep error={error} setError={setError} onCreated={advance} />
+              >
+                <div className="bg-gradient-to-br from-primary to-primary/70 rounded-full size-10 flex items-center justify-center text-white shrink-0">
+                  <Zap className="size-5" />
+                </div>
+                <div className="text-left flex-1">
+                  <p className="text-sm font-semibold text-foreground">Peakflo</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Managed agents, workflows &amp; integrations
+                  </p>
+                </div>
+                {selectedAgent === 'peakflo' && (
+                  <Check className="size-4 text-primary shrink-0" />
+                )}
+              </button>
             </div>
-          )}
-        </DialogBody>
-      </DialogContent>
-    </Dialog>
+
+            {/* ── BYO agent options ── */}
+            <div>
+              <p className="text-xs text-muted-foreground mb-2">
+                Or bring your own agent:
+              </p>
+              <div className="grid grid-cols-3 gap-2.5">
+                {AGENT_OPTIONS.map((agent) => {
+                  const isSelected = selectedAgent === agent.type
+                  return (
+                    <button
+                      key={agent.type}
+                      type="button"
+                      onClick={() => setSelectedAgent(agent.type)}
+                      className={`group relative flex flex-col items-center gap-2 rounded-xl border-2 p-3 transition-all cursor-pointer ${
+                        isSelected
+                          ? 'border-primary bg-primary/5 shadow-md'
+                          : 'border-border hover:border-muted-foreground/40 hover:bg-muted/20'
+                      }`}
+                    >
+                      <div
+                        className={`${agent.color} rounded-full size-9 flex items-center justify-center text-white text-sm font-bold transition-transform ${
+                          isSelected ? 'scale-110' : 'group-hover:scale-105'
+                        }`}
+                      >
+                        {agent.letter}
+                      </div>
+                      <div className="text-center">
+                        <p className="text-xs font-semibold text-foreground leading-tight">
+                          {agent.label}
+                        </p>
+                        <p className="text-[10px] text-muted-foreground mt-0.5">
+                          {agent.tagline}
+                        </p>
+                      </div>
+                      {isSelected && (
+                        <div className="absolute top-1.5 right-1.5">
+                          <Check className="size-3.5 text-primary" />
+                        </div>
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            {/* ── Git provider (optional, BYO only) ── */}
+            {selectedAgent && selectedAgent !== 'peakflo' && (
+              <GitProviderRow
+                selected={providerChoice}
+                onSelect={handleProviderSelect}
+              />
+            )}
+
+            {/* ── Tool health (collapsed, BYO only) ── */}
+            {toolStatus && selectedCodingAgent && (
+              <div className="rounded-lg border border-border bg-muted/20 overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => setToolsExpanded((v) => !v)}
+                  className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left cursor-pointer hover:bg-muted/30 transition-colors"
+                >
+                  {agentInstalled ? (
+                    <Check className="size-4 text-emerald-400 shrink-0" />
+                  ) : agentBlocked ? (
+                    <AlertTriangle className="size-4 text-red-400 shrink-0" />
+                  ) : (
+                    <AlertTriangle className="size-4 text-amber-400 shrink-0" />
+                  )}
+                  <span className="text-xs text-muted-foreground flex-1">
+                    {agentInstalled
+                      ? `${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} ready`
+                      : agentBlocked
+                        ? `Install Node.js first to set up ${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label}`
+                        : `${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} not installed — will be set up automatically`}
+                  </span>
+                  {toolsExpanded ? (
+                    <ChevronUp className="size-3.5 text-muted-foreground" />
+                  ) : (
+                    <ChevronDown className="size-3.5 text-muted-foreground" />
+                  )}
+                </button>
+
+                {toolsExpanded && (
+                  <div className="border-t border-border px-3 py-2.5 space-y-1.5">
+                    {/* Agent CLI */}
+                    <div className="flex items-center gap-2 text-xs">
+                      {agentInstalled ? (
+                        <Check className="size-3 text-emerald-400 shrink-0" />
+                      ) : (
+                        <span className="size-3 rounded-full border border-amber-400 shrink-0" />
+                      )}
+                      <span className="text-muted-foreground flex-1">
+                        {AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} CLI
+                        {agentInstalled &&
+                          toolStatus[getAgentToolKey(selectedCodingAgent)]?.version && (
+                            <span className="ml-1 opacity-60">
+                              v{toolStatus[getAgentToolKey(selectedCodingAgent)]?.version}
+                            </span>
+                          )}
+                      </span>
+                      {agentInstalled === false && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-5 px-1.5 text-[10px]"
+                          disabled={!!installing || !canInstallAgent}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            handleInstall(getAgentToolKey(selectedCodingAgent))
+                          }}
+                        >
+                          {installing === getAgentToolKey(selectedCodingAgent) ? (
+                            <Loader2 className="size-3 animate-spin" />
+                          ) : (
+                            <>
+                              <Download className="size-2.5 mr-0.5" />
+                              Install
+                            </>
+                          )}
+                        </Button>
+                      )}
+                    </div>
+
+                    {/* Core tools */}
+                    <div className="border-t border-border/50 pt-1.5 mt-1.5">
+                      {CORE_TOOLS.map((tool) => {
+                        const st = toolStatus[tool.key]
+                        const isInstalling = installing === tool.key
+                        return (
+                          <div key={tool.key} className="flex items-center gap-2 text-xs py-0.5">
+                            {st?.installed ? (
+                              <Check className="size-3 text-emerald-400 shrink-0" />
+                            ) : (
+                              <span className="size-3 rounded-full border border-muted-foreground/40 shrink-0" />
+                            )}
+                            <span className="text-muted-foreground flex-1">
+                              {tool.label}
+                              {st?.installed && st.version && (
+                                <span className="ml-1 opacity-60">v{st.version}</span>
+                              )}
+                            </span>
+                            {!st?.installed && (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="h-5 px-1.5 text-[10px]"
+                                disabled={!!installing}
+                                onClick={(e) => {
+                                  e.stopPropagation()
+                                  handleInstall(tool.key)
+                                }}
+                              >
+                                {isInstalling ? (
+                                  <Loader2 className="size-3 animate-spin" />
+                                ) : (
+                                  <>
+                                    <Download className="size-2.5 mr-0.5" />
+                                    Install
+                                  </>
+                                )}
+                              </Button>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* ── Error ── */}
+            {error && <p className="text-xs text-destructive">{error}</p>}
+
+            {/* ── Actions ── */}
+            <div className="flex items-center gap-3">
+              <Button
+                onClick={handleStart}
+                disabled={!selectedAgent || creating || !!agentBlocked}
+                className="flex-1"
+              >
+                {creating ? (
+                  <Loader2 className="size-4 animate-spin mr-1.5" />
+                ) : selectedAgent === 'peakflo' ? (
+                  <Zap className="size-4 mr-1.5" />
+                ) : (
+                  <Sparkles className="size-4 mr-1.5" />
+                )}
+                {selectedAgent === 'peakflo' ? 'Sign up / Log in' : 'Get Started'}
+                {!creating && <ArrowRight className="size-4 ml-1.5" />}
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={handleSkip}
+                className="text-muted-foreground"
+              >
+                Skip
+              </Button>
+            </div>
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+
+      {/* Enterprise login modal — opens when user picks Peakflo */}
+      <EnterpriseLoginModal open={loginModalOpen} onClose={handleLoginClose} />
+    </>
   )
 }

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -4,8 +4,6 @@ import {
   Loader2,
   AlertTriangle,
   ArrowRight,
-  ChevronDown,
-  ChevronUp,
   Download,
   Sparkles,
   Zap
@@ -88,17 +86,6 @@ const AGENT_OPTIONS: AgentOption[] = [
 ]
 
 /* ─── Tool status helpers ─── */
-
-interface ToolCheck {
-  key: string
-  label: string
-}
-
-const CORE_TOOLS: ToolCheck[] = [
-  { key: 'nodejs', label: 'Node.js' },
-  { key: 'npm', label: 'npm' },
-  { key: 'git', label: 'Git' }
-]
 
 function getAgentToolKey(type: CodingAgentType): string {
   switch (type) {
@@ -216,7 +203,6 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
   const [selectedAgent, setSelectedAgent] = useState<AgentChoice | null>(null)
   const [providerChoice, setProviderChoice] = useState<ProviderChoice | null>(null)
   const [toolStatus, setToolStatus] = useState<Record<string, ToolStatus> | null>(null)
-  const [toolsExpanded, setToolsExpanded] = useState(false)
   const [creating, setCreating] = useState(false)
   const [installing, setInstalling] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -417,17 +403,6 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
       ? toolStatus[getAgentToolKey(selectedCodingAgent)]?.installed
       : null
 
-  // Claude Code & Codex need npm; OpenCode can install standalone
-  const needsNpm =
-    selectedCodingAgent === CodingAgentType.CLAUDE_CODE ||
-    selectedCodingAgent === CodingAgentType.CODEX
-  const npmAvailable = toolStatus?.npm?.installed ?? false
-  const canInstallAgent = !needsNpm || npmAvailable
-
-  // Block when agent isn't installed and we can't install it
-  const agentBlocked =
-    selectedCodingAgent && agentInstalled === false && !canInstallAgent
-
   /* ─── Render: Templates screen ─── */
 
   if (screen === 'templates') {
@@ -582,120 +557,40 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
               />
             )}
 
-            {/* ── Tool health (collapsed, BYO only) ── */}
+            {/* ── Agent CLI status (BYO only) ── */}
             {toolStatus && selectedCodingAgent && (
-              <div className="rounded-lg border border-border bg-muted/20 overflow-hidden">
-                <button
-                  type="button"
-                  onClick={() => setToolsExpanded((v) => !v)}
-                  className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left cursor-pointer hover:bg-muted/30 transition-colors"
-                >
-                  {agentInstalled ? (
-                    <Check className="size-4 text-emerald-400 shrink-0" />
-                  ) : agentBlocked ? (
-                    <AlertTriangle className="size-4 text-red-400 shrink-0" />
-                  ) : (
-                    <AlertTriangle className="size-4 text-amber-400 shrink-0" />
-                  )}
-                  <span className="text-xs text-muted-foreground flex-1">
-                    {agentInstalled
-                      ? `${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} ready`
-                      : agentBlocked
-                        ? `Install Node.js first to set up ${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label}`
-                        : `${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} not installed — will be set up automatically`}
-                  </span>
-                  {toolsExpanded ? (
-                    <ChevronUp className="size-3.5 text-muted-foreground" />
-                  ) : (
-                    <ChevronDown className="size-3.5 text-muted-foreground" />
-                  )}
-                </button>
-
-                {toolsExpanded && (
-                  <div className="border-t border-border px-3 py-2.5 space-y-1.5">
-                    {/* Agent CLI */}
-                    <div className="flex items-center gap-2 text-xs">
-                      {agentInstalled ? (
-                        <Check className="size-3 text-emerald-400 shrink-0" />
-                      ) : (
-                        <span className="size-3 rounded-full border border-amber-400 shrink-0" />
-                      )}
-                      <span className="text-muted-foreground flex-1">
-                        {AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} CLI
-                        {agentInstalled &&
-                          toolStatus[getAgentToolKey(selectedCodingAgent)]?.version && (
-                            <span className="ml-1 opacity-60">
-                              v{toolStatus[getAgentToolKey(selectedCodingAgent)]?.version}
-                            </span>
-                          )}
-                      </span>
-                      {agentInstalled === false && (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="h-5 px-1.5 text-[10px]"
-                          disabled={!!installing || !canInstallAgent}
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleInstall(getAgentToolKey(selectedCodingAgent))
-                          }}
-                        >
-                          {installing === getAgentToolKey(selectedCodingAgent) ? (
-                            <Loader2 className="size-3 animate-spin" />
-                          ) : (
-                            <>
-                              <Download className="size-2.5 mr-0.5" />
-                              Install
-                            </>
-                          )}
-                        </Button>
-                      )}
-                    </div>
-
-                    {/* Core tools */}
-                    <div className="border-t border-border/50 pt-1.5 mt-1.5">
-                      {CORE_TOOLS.map((tool) => {
-                        const st = toolStatus[tool.key]
-                        const isInstalling = installing === tool.key
-                        return (
-                          <div key={tool.key} className="flex items-center gap-2 text-xs py-0.5">
-                            {st?.installed ? (
-                              <Check className="size-3 text-emerald-400 shrink-0" />
-                            ) : (
-                              <span className="size-3 rounded-full border border-muted-foreground/40 shrink-0" />
-                            )}
-                            <span className="text-muted-foreground flex-1">
-                              {tool.label}
-                              {st?.installed && st.version && (
-                                <span className="ml-1 opacity-60">v{st.version}</span>
-                              )}
-                            </span>
-                            {!st?.installed && (
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                className="h-5 px-1.5 text-[10px]"
-                                disabled={!!installing}
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  handleInstall(tool.key)
-                                }}
-                              >
-                                {isInstalling ? (
-                                  <Loader2 className="size-3 animate-spin" />
-                                ) : (
-                                  <>
-                                    <Download className="size-2.5 mr-0.5" />
-                                    Install
-                                  </>
-                                )}
-                              </Button>
-                            )}
-                          </div>
-                        )
-                      })}
-                    </div>
-                  </div>
+              <div className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-muted/20 text-xs">
+                {agentInstalled ? (
+                  <Check className="size-4 text-emerald-400 shrink-0" />
+                ) : (
+                  <AlertTriangle className="size-4 text-amber-400 shrink-0" />
+                )}
+                <span className="text-muted-foreground flex-1">
+                  {agentInstalled
+                    ? `${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} CLI ready${
+                        toolStatus[getAgentToolKey(selectedCodingAgent)]?.version
+                          ? ` (v${toolStatus[getAgentToolKey(selectedCodingAgent)]?.version})`
+                          : ''
+                      }`
+                    : `${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} will be installed automatically`}
+                </span>
+                {agentInstalled === false && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-5 px-1.5 text-[10px]"
+                    disabled={!!installing}
+                    onClick={() => handleInstall(getAgentToolKey(selectedCodingAgent))}
+                  >
+                    {installing === getAgentToolKey(selectedCodingAgent) ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : (
+                      <>
+                        <Download className="size-2.5 mr-0.5" />
+                        Install now
+                      </>
+                    )}
+                  </Button>
                 )}
               </div>
             )}
@@ -707,7 +602,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
             <div className="flex items-center gap-3">
               <Button
                 onClick={handleStart}
-                disabled={!selectedAgent || creating || !!agentBlocked}
+                disabled={!selectedAgent || creating}
                 className="flex-1"
               >
                 {creating ? (

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -369,6 +369,39 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
     [agents, createAgent, updateAgent]
   )
 
+  const runPostAuthFlow = useCallback(async () => {
+    setCreating(true)
+    try {
+      if (!hasCompleteDefaultAgent()) {
+        const status = await window.electronAPI.agentInstaller.detect()
+        setToolStatus(status)
+        if (!status.opencode?.installed) {
+          setInstalling(DetectKey.OPENCODE)
+          await window.electronAPI.agentInstaller.install(DetectKey.OPENCODE)
+          setInstalling(null)
+        }
+        await createDefaultAgent(CodingAgentType.OPENCODE)
+      }
+
+      await fetchPresetups()
+      const templates = useDashboardStore.getState().presetupTemplates
+      if (templates.length > 0) {
+        setScreen(OnboardingScreen.TEMPLATES)
+      } else {
+        onOpenChange(false)
+      }
+    } catch {
+      const templates = useDashboardStore.getState().presetupTemplates
+      if (templates.length > 0) {
+        setScreen(OnboardingScreen.TEMPLATES)
+      } else {
+        onOpenChange(false)
+      }
+    } finally {
+      setCreating(false)
+    }
+  }, [createDefaultAgent, fetchPresetups, onOpenChange])
+
   const handleStart = async () => {
     if (!selectedAgent) return
     setCreating(true)
@@ -376,7 +409,12 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
 
     try {
       if (selectedAgent === AgentChoiceType.PEAKFLO) {
-        // Open login modal — after auth, handleLoginClose transitions forward
+        // Already authenticated — skip login, go straight to post-auth flow
+        if (isAuthenticated) {
+          await runPostAuthFlow()
+          return
+        }
+        // Not authenticated — open login modal
         setLoginModalOpen(true)
         setCreating(false)
         return
@@ -397,40 +435,8 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
     setLoginModalOpen(false)
     const auth = useEnterpriseStore.getState().isAuthenticated
     if (!auth) return // User cancelled
-
-    // Auto-install OpenCode + create default agent
-    setCreating(true)
-    try {
-      if (!hasCompleteDefaultAgent()) {
-        const status = await window.electronAPI.agentInstaller.detect()
-        setToolStatus(status)
-        if (!status.opencode?.installed) {
-          setInstalling(DetectKey.OPENCODE)
-          await window.electronAPI.agentInstaller.install(DetectKey.OPENCODE)
-          setInstalling(null)
-        }
-        await createDefaultAgent(CodingAgentType.OPENCODE)
-      }
-
-      // Fetch templates and show them if available
-      await fetchPresetups()
-      const templates = useDashboardStore.getState().presetupTemplates
-      if (templates.length > 0) {
-        setScreen(OnboardingScreen.TEMPLATES)
-      } else {
-        onOpenChange(false)
-      }
-    } catch {
-      const templates = useDashboardStore.getState().presetupTemplates
-      if (templates.length > 0) {
-        setScreen(OnboardingScreen.TEMPLATES)
-      } else {
-        onOpenChange(false)
-      }
-    } finally {
-      setCreating(false)
-    }
-  }, [createDefaultAgent, fetchPresetups, onOpenChange])
+    await runPostAuthFlow()
+  }, [runPostAuthFlow])
 
   const handleSkip = () => {
     onOpenChange(false)

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -25,6 +25,7 @@ import { EnterpriseLoginModal } from '@/components/settings/tabs/EnterpriseLogin
 import { PresetupWizard } from '@/components/dashboard/PresetupWizard'
 import { CodingAgentType, CLAUDE_MODELS, CODEX_MODELS } from '@/types'
 import { agentConfigApi } from '@/lib/ipc-client'
+import { AnthropicLogo, OpenCodeLogo, OpenAILogo } from '@/components/icons/AgentLogos'
 import type { ToolStatus } from '@/types/electron'
 import type { PresetupTemplate } from '@/stores/dashboard-store'
 
@@ -87,8 +88,7 @@ interface AgentOption {
   type: AgentChoice
   label: string
   tagline: string
-  color: string
-  letter: string
+  Logo: React.ComponentType<{ className?: string }>
 }
 
 const AGENT_OPTIONS: AgentOption[] = [
@@ -96,22 +96,19 @@ const AGENT_OPTIONS: AgentOption[] = [
     type: CodingAgentType.CLAUDE_CODE,
     label: 'Claude Code',
     tagline: 'Anthropic',
-    color: 'bg-amber-600',
-    letter: 'C'
+    Logo: AnthropicLogo
   },
   {
     type: CodingAgentType.OPENCODE,
     label: 'OpenCode',
     tagline: 'Open-source, free models',
-    color: 'bg-blue-600',
-    letter: 'O'
+    Logo: OpenCodeLogo
   },
   {
     type: CodingAgentType.CODEX,
     label: 'Codex',
     tagline: 'OpenAI',
-    color: 'bg-purple-600',
-    letter: 'X'
+    Logo: OpenAILogo
   }
 ]
 
@@ -571,13 +568,11 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
                           : 'border-border hover:border-muted-foreground/40 hover:bg-muted/20'
                       }`}
                     >
-                      <div
-                        className={`${agent.color} rounded-full size-9 flex items-center justify-center text-white text-sm font-bold transition-transform ${
+                      <agent.Logo
+                        className={`size-9 transition-transform ${
                           isSelected ? 'scale-110' : 'group-hover:scale-105'
                         }`}
-                      >
-                        {agent.letter}
-                      </div>
+                      />
                       <div className="text-center">
                         <p className="text-xs font-semibold text-foreground leading-tight">
                           {agent.label}

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -28,12 +28,42 @@ import { agentConfigApi } from '@/lib/ipc-client'
 import type { ToolStatus } from '@/types/electron'
 import type { PresetupTemplate } from '@/stores/dashboard-store'
 
+/* ─── Enums & Constants ─── */
+
+enum OnboardingScreen {
+  MAIN = 'main',
+  TEMPLATES = 'templates'
+}
+
+enum AgentChoiceType {
+  PEAKFLO = 'peakflo'
+}
+
+enum DetectKey {
+  CLAUDE_CODE = 'claudeCode',
+  OPENCODE = 'opencode',
+  CODEX = 'codex',
+  GH = 'gh',
+  GLAB = 'glab'
+}
+
+enum ProviderChoiceValue {
+  NONE = 'none'
+}
+
+const STORAGE_KEYS = {
+  DEBUG_ONBOARDING: 'debug:onboarding',
+  FORCE_ONBOARDING: 'force-onboarding'
+} as const
+
+const DEFAULT_AGENT_NAME = 'Robo'
+
 /* ─── Force-onboarding flag ─── */
 
 export function isForceOnboarding(): boolean {
   return (
-    localStorage.getItem('debug:onboarding') === 'true' ||
-    localStorage.getItem('force-onboarding') === 'true'
+    localStorage.getItem(STORAGE_KEYS.DEBUG_ONBOARDING) === 'true' ||
+    localStorage.getItem(STORAGE_KEYS.FORCE_ONBOARDING) === 'true'
   )
 }
 
@@ -51,7 +81,7 @@ export function shouldShowOnboarding(
 
 /* ─── Agent card metadata ─── */
 
-type AgentChoice = CodingAgentType | 'peakflo'
+type AgentChoice = CodingAgentType | AgentChoiceType.PEAKFLO
 
 interface AgentOption {
   type: AgentChoice
@@ -87,14 +117,14 @@ const AGENT_OPTIONS: AgentOption[] = [
 
 /* ─── Tool status helpers ─── */
 
-function getAgentToolKey(type: CodingAgentType): string {
+function getAgentToolKey(type: CodingAgentType): DetectKey {
   switch (type) {
     case CodingAgentType.CLAUDE_CODE:
-      return 'claudeCode'
+      return DetectKey.CLAUDE_CODE
     case CodingAgentType.OPENCODE:
-      return 'opencode'
+      return DetectKey.OPENCODE
     case CodingAgentType.CODEX:
-      return 'codex'
+      return DetectKey.CODEX
   }
 }
 
@@ -147,7 +177,19 @@ function hasCompleteDefaultAgent(): boolean {
 
 /* ─── Git Provider Choice (inline, optional) ─── */
 
-type ProviderChoice = GitProvider | 'none'
+type ProviderChoice = GitProvider | ProviderChoiceValue.NONE
+
+interface GitProviderOption {
+  value: ProviderChoice
+  label: string
+  cliKey: DetectKey
+  cliName: string
+}
+
+const GIT_PROVIDER_OPTIONS: GitProviderOption[] = [
+  { value: 'github', label: 'GitHub', cliKey: DetectKey.GH, cliName: 'gh' },
+  { value: 'gitlab', label: 'GitLab', cliKey: DetectKey.GLAB, cliName: 'glab' }
+]
 
 function GitProviderRow({
   selected,
@@ -158,10 +200,6 @@ function GitProviderRow({
   onSelect: (p: ProviderChoice) => void
   toolStatus: Record<string, ToolStatus> | null
 }) {
-  const options: { value: ProviderChoice; label: string; cliKey: string; cliName: string }[] = [
-    { value: 'github', label: 'GitHub', cliKey: 'gh', cliName: 'gh' },
-    { value: 'gitlab', label: 'GitLab', cliKey: 'glab', cliName: 'glab' }
-  ]
 
   return (
     <div>
@@ -169,13 +207,13 @@ function GitProviderRow({
         Where are your repos? <span className="opacity-60">(optional)</span>
       </p>
       <div className="flex gap-2">
-        {options.map((opt) => {
+        {GIT_PROVIDER_OPTIONS.map((opt) => {
           const cli = toolStatus?.[opt.cliKey]
           return (
             <button
               key={opt.value}
               type="button"
-              onClick={() => onSelect(selected === opt.value ? 'none' : opt.value)}
+              onClick={() => onSelect(selected === opt.value ? ProviderChoiceValue.NONE : opt.value)}
               className={`px-3 py-1.5 rounded-md border text-xs font-medium transition-all cursor-pointer flex items-center gap-1.5 ${
                 selected === opt.value
                   ? 'border-primary bg-primary/5 text-foreground'
@@ -198,10 +236,6 @@ function GitProviderRow({
   )
 }
 
-/* ─── Onboarding step type ─── */
-
-type OnboardingScreen = 'main' | 'templates'
-
 /* ─── Main OnboardingWizard ─── */
 
 interface OnboardingWizardProps {
@@ -210,7 +244,7 @@ interface OnboardingWizardProps {
 }
 
 export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) {
-  const [screen, setScreen] = useState<OnboardingScreen>('main')
+  const [screen, setScreen] = useState(OnboardingScreen.MAIN)
   const [selectedAgent, setSelectedAgent] = useState<AgentChoice | null>(null)
   const [providerChoice, setProviderChoice] = useState<ProviderChoice | null>(null)
   const [toolStatus, setToolStatus] = useState<Record<string, ToolStatus> | null>(null)
@@ -230,7 +264,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
   useEffect(() => {
     if (!open) return
     setError(null)
-    setScreen('main')
+    setScreen(OnboardingScreen.MAIN)
 
     Promise.all([fetchAgents(), fetchSettings(), loadSession()]).then(() => {
       // Pre-select agent if one is already configured
@@ -302,7 +336,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
   const handleProviderSelect = useCallback(
     async (p: ProviderChoice) => {
       setProviderChoice(p)
-      await setGitProvider(p === 'none' ? null : p)
+      await setGitProvider(p === ProviderChoiceValue.NONE ? null : p)
     },
     [setGitProvider]
   )
@@ -317,7 +351,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
 
       if (existingDefault) {
         await updateAgent(existingDefault.id, {
-          name: existingDefault.name || 'Robo',
+          name: existingDefault.name || DEFAULT_AGENT_NAME,
           config: {
             ...existingDefault.config,
             coding_agent: agentType,
@@ -326,7 +360,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
         })
       } else if (!hasCompleteDefaultAgent()) {
         await createAgent({
-          name: 'Robo',
+          name: DEFAULT_AGENT_NAME,
           config: {
             coding_agent: agentType,
             model: model || undefined
@@ -344,7 +378,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
     setError(null)
 
     try {
-      if (selectedAgent === 'peakflo') {
+      if (selectedAgent === AgentChoiceType.PEAKFLO) {
         // Open login modal — after auth, handleLoginClose transitions forward
         setLoginModalOpen(true)
         setCreating(false)
@@ -374,8 +408,8 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
         const status = await window.electronAPI.agentInstaller.detect()
         setToolStatus(status)
         if (!status.opencode?.installed) {
-          setInstalling('opencode')
-          await window.electronAPI.agentInstaller.install('opencode')
+          setInstalling(DetectKey.OPENCODE)
+          await window.electronAPI.agentInstaller.install(DetectKey.OPENCODE)
           setInstalling(null)
         }
         await createDefaultAgent(CodingAgentType.OPENCODE)
@@ -385,14 +419,14 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
       await fetchPresetups()
       const templates = useDashboardStore.getState().presetupTemplates
       if (templates.length > 0) {
-        setScreen('templates')
+        setScreen(OnboardingScreen.TEMPLATES)
       } else {
         onOpenChange(false)
       }
     } catch {
       const templates = useDashboardStore.getState().presetupTemplates
       if (templates.length > 0) {
-        setScreen('templates')
+        setScreen(OnboardingScreen.TEMPLATES)
       } else {
         onOpenChange(false)
       }
@@ -407,7 +441,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
 
   // Compute tool health for the selected BYO agent
   const selectedCodingAgent =
-    selectedAgent && selectedAgent !== 'peakflo' ? selectedAgent : null
+    selectedAgent && selectedAgent !== AgentChoiceType.PEAKFLO ? selectedAgent : null
 
   const agentInstalled =
     selectedCodingAgent && toolStatus
@@ -416,7 +450,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
 
   /* ─── Render: Templates screen ─── */
 
-  if (screen === 'templates') {
+  if (screen === OnboardingScreen.TEMPLATES) {
     return (
       <>
         <Dialog open={open} onOpenChange={(o) => !o && handleSkip()}>
@@ -493,9 +527,9 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
             <div>
               <button
                 type="button"
-                onClick={() => setSelectedAgent('peakflo')}
+                onClick={() => setSelectedAgent(AgentChoiceType.PEAKFLO)}
                 className={`w-full flex items-center gap-3 rounded-xl border-2 p-4 transition-all cursor-pointer ${
-                  selectedAgent === 'peakflo'
+                  selectedAgent === AgentChoiceType.PEAKFLO
                     ? 'border-primary bg-primary/5 shadow-md'
                     : 'border-border hover:border-muted-foreground/40 hover:bg-muted/20'
                 }`}
@@ -509,7 +543,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
                     Managed agents, workflows &amp; integrations
                   </p>
                 </div>
-                {selectedAgent === 'peakflo' && (
+                {selectedAgent === AgentChoiceType.PEAKFLO && (
                   <Check className="size-4 text-primary shrink-0" />
                 )}
               </button>
@@ -579,7 +613,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
             </div>
 
             {/* ── Git provider (optional, BYO only) ── */}
-            {selectedAgent && selectedAgent !== 'peakflo' && (
+            {selectedAgent && selectedAgent !== AgentChoiceType.PEAKFLO && (
               <GitProviderRow
                 selected={providerChoice}
                 onSelect={handleProviderSelect}
@@ -625,12 +659,12 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
               >
                 {creating ? (
                   <Loader2 className="size-4 animate-spin mr-1.5" />
-                ) : selectedAgent === 'peakflo' ? (
+                ) : selectedAgent === AgentChoiceType.PEAKFLO ? (
                   <Zap className="size-4 mr-1.5" />
                 ) : (
                   <Sparkles className="size-4 mr-1.5" />
                 )}
-                {selectedAgent === 'peakflo' ? 'Sign up / Log in' : 'Get Started'}
+                {selectedAgent === AgentChoiceType.PEAKFLO ? 'Sign up / Log in' : 'Get Started'}
                 {!creating && <ArrowRight className="size-4 ml-1.5" />}
               </Button>
               <Button

--- a/test/setup-renderer.ts
+++ b/test/setup-renderer.ts
@@ -65,7 +65,25 @@ const mockElectronAPI = {
   shell: {
     openPath: vi.fn().mockResolvedValue(undefined),
     showItemInFolder: vi.fn().mockResolvedValue(undefined),
-    readTextFile: vi.fn().mockResolvedValue(null)
+    readTextFile: vi.fn().mockResolvedValue(null),
+    openExternal: vi.fn().mockResolvedValue(undefined)
+  },
+  enterprise: {
+    login: vi.fn().mockResolvedValue({ userId: 'u1', email: 'test@test.com', companies: [] }),
+    signupInBrowser: vi.fn().mockResolvedValue({ userId: 'u1', email: 'test@test.com', companies: [] }),
+    selectTenant: vi.fn().mockResolvedValue({ token: 'jwt', tenant: { id: 't1', name: 'Test' } }),
+    logout: vi.fn().mockResolvedValue(undefined),
+    getSession: vi.fn().mockResolvedValue({ isAuthenticated: false, userEmail: null, userId: null, currentTenant: null }),
+    listCompanies: vi.fn().mockResolvedValue([]),
+    syncResources: vi.fn().mockResolvedValue({}),
+    apiRequest: vi.fn().mockResolvedValue({}),
+    getJwt: vi.fn().mockResolvedValue(null),
+    refreshToken: vi.fn().mockResolvedValue(undefined),
+    getAuthTokens: vi.fn().mockResolvedValue({ accessToken: '', refreshToken: '', tenantId: '' }),
+    getAiGatewayStatus: vi.fn().mockResolvedValue(null),
+    getApiUrl: vi.fn().mockResolvedValue('https://api.peakflo.ai'),
+    enableIframeAuth: vi.fn().mockResolvedValue(undefined),
+    disableIframeAuth: vi.fn().mockResolvedValue(undefined)
   },
   notifications: {
     show: vi.fn().mockResolvedValue(undefined)
@@ -170,6 +188,15 @@ const mockElectronAPI = {
   onTasksRefresh: vi.fn((_cb: () => void) => {
     return vi.fn()
   }),
+  agentInstaller: {
+    detect: vi.fn().mockResolvedValue({}),
+    install: vi.fn().mockResolvedValue({ success: true, error: null, newStatus: {} }),
+    getCommand: vi.fn().mockResolvedValue(''),
+    onProgress: vi.fn((_cb: (data: unknown) => void) => vi.fn())
+  },
+  app: {
+    getVersion: vi.fn().mockResolvedValue('0.0.1')
+  },
   updater: {
     check: vi.fn().mockResolvedValue({ success: true }),
     download: vi.fn().mockResolvedValue({ success: true }),


### PR DESCRIPTION
## Summary
- **Replaces 4-step wizard with single-screen onboarding** — users pick their agent and start using the app immediately
- **Peakflo as first option** — sign up/login opens existing EnterpriseLoginModal, then auto-installs OpenCode and shows workflow templates
- **BYO agent cards** (Claude Code, OpenCode, Codex) with auto-model selection and collapsed tool health
- **Standalone OpenCode install** via `curl -fsSL https://opencode.ai/install | bash` — no Node.js/npm dependency required
- **Optional inline git provider** (GitHub/GitLab) shown only for BYO agents
- **Post-auth template screen** reuses existing PresetupWizard for workflow setup

### Before (4 steps)
1. Welcome splash → click "Get Started"
2. Git Provider choice (GitHub/GitLab/None)
3. Tool & Agent detection matrix (8 tools, install buttons, terminal output)
4. Agent configuration (name, type, model dropdowns)

### After (1 screen)
1. Pick Peakflo **or** a BYO agent → one click → done

### Files changed
| File | Change |
|------|--------|
| `OnboardingWizard.tsx` | Full rewrite: 976→496 lines. Single screen + conditional templates screen |
| `install.js` | +77 lines: standalone OpenCode install via curl/scoop (no npm needed) |
| `setup-renderer.ts` | Added `agentInstaller`, `app`, `enterprise`, `shell.openExternal` mocks |
| `OnboardingWizard.test.tsx` | New: 22 unit tests covering both flows |

## Test plan
- [ ] 22 new unit tests pass (`vitest run --project renderer`)
- [ ] All 509 existing renderer tests pass (0 regressions)
- [ ] TypeScript build clean (`tsc --build --noEmit`)
- [ ] Manual: open app fresh → onboarding shows single screen
- [ ] Manual: select Peakflo → login modal opens → after auth, templates screen shows
- [ ] Manual: select Claude Code → "Get Started" → agent created, onboarding closes
- [ ] Manual: click Skip → onboarding closes, setup_completed_version saved

Generated with [Claude Code](https://claude.com/claude-code)