### PR TITLE
feat: ask to include AI subscription on signup

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -816,7 +816,7 @@ export function registerIpcHandlers(
 
   // Enterprise auth handlers
 
-  ipcMain.handle('enterprise:signupInBrowser', async (_, mode: 'register' | 'login') => {
+  ipcMain.handle('enterprise:signupInBrowser', async (_, mode: 'register' | 'login', options?: { includeAiSubscription?: boolean }) => {
     if (!enterpriseAuth) throw new Error('Enterprise auth not available')
 
     const { AuthCallbackServer } = await import('./oauth/auth-callback-server')
@@ -839,10 +839,14 @@ export function registerIpcHandlers(
       }
 
       const path = mode === 'register' ? '/register' : '/login'
-      const signupUrl = `${frontendOrigin}${path}?redirect_uri=${encodeURIComponent(redirectUri)}`
+      const signupUrl = new URL(`${frontendOrigin}${path}`)
+      signupUrl.searchParams.set('redirect_uri', redirectUri)
+      if (mode === 'register' && options?.includeAiSubscription) {
+        signupUrl.searchParams.set('include_ai_subscription', 'true')
+      }
 
       // Open the URL in the user's default browser
-      await shell.openExternal(signupUrl)
+      await shell.openExternal(signupUrl.toString())
 
       // Wait for the callback with tokens
       const tokens = await callbackServer.waitForCallback()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -346,11 +346,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('mobile:getInfo')
   },
   enterprise: {
-    signupInBrowser: (mode: 'register' | 'login'): Promise<{
+    signupInBrowser: (mode: 'register' | 'login', options?: { includeAiSubscription?: boolean }): Promise<{
       userId: string
       email: string
       companies: { id: string; name: string; isPrimary: boolean }[]
-    }> => ipcRenderer.invoke('enterprise:signupInBrowser', mode),
+    }> => ipcRenderer.invoke('enterprise:signupInBrowser', mode, options),
     login: (email: string, password: string): Promise<{
       userId: string
       email: string

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import { DashboardWorkspace } from './DashboardWorkspace'
 import { useDashboardStore } from '@/stores/dashboard-store'
 import { useEnterpriseStore } from '@/stores/enterprise-store'
@@ -22,6 +22,7 @@ vi.mock('@/lib/ipc-client', () => ({
     logout: vi.fn(),
     getSession: vi.fn().mockResolvedValue({ isAuthenticated: false }),
     refreshToken: vi.fn(),
+    signupInBrowser: vi.fn(),
     getApiUrl: vi.fn().mockResolvedValue('http://localhost:2000'),
     getJwt: vi.fn().mockResolvedValue('mock-jwt-token'),
     enableIframeAuth: vi.fn().mockResolvedValue({ apiUrl: 'http://localhost:2000' }),
@@ -146,6 +147,16 @@ describe('DashboardWorkspace', () => {
     render(<DashboardWorkspace />)
     expect(screen.getByText('Connect to 20x Cloud')).toBeDefined()
     expect(screen.getByText('Connect')).toBeDefined() // CTA button
+  })
+
+  it('opens the cloud signup modal from the connect CTA', async () => {
+    render(<DashboardWorkspace />)
+    const connectButton = screen.getByText('Connect').closest('button') as HTMLButtonElement
+
+    await waitFor(() => expect(connectButton.disabled).toBe(false))
+    fireEvent.click(connectButton)
+
+    expect(screen.getByText('Include AI subscription')).toBeDefined()
   })
 
   it('renders hero section with rotating title', () => {

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -20,23 +20,12 @@ export function DashboardWorkspace() {
     isLoading: enterpriseLoading,
     error: enterpriseError,
     availableTenants,
-    signupInBrowser,
     loadSession,
     clearError,
     setSyncing,
     setSyncResult
   } = useEnterpriseStore()
-  const [signupPending, setSignupPending] = useState(false)
   const [showLoginModal, setShowLoginModal] = useState(false)
-
-  const handleSignupInBrowser = useCallback(async () => {
-    setSignupPending(true)
-    try {
-      await signupInBrowser('register')
-    } finally {
-      setSignupPending(false)
-    }
-  }, [signupInBrowser])
 
   // After browser signup returns companies that need tenant selection, open the modal
   useEffect(() => {
@@ -157,31 +146,14 @@ export function DashboardWorkspace() {
                   <Button
                     variant="default"
                     size="sm"
-                    onClick={handleSignupInBrowser}
-                    disabled={signupPending || enterpriseLoading}
+                    onClick={() => setShowLoginModal(true)}
+                    disabled={enterpriseLoading}
                   >
-                    {signupPending ? (
-                      <span className="flex items-center gap-1.5">
-                        <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                        </svg>
-                        Waiting...
-                      </span>
-                    ) : (
-                      <>
-                        <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
-                        Connect
-                      </>
-                    )}
+                    <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                    Connect
                   </Button>
                 </div>
               </div>
-              {signupPending && (
-                <p className="text-xs text-muted-foreground">
-                  Complete sign up in your browser, then you'll be connected automatically.
-                </p>
-              )}
               {enterpriseError && (
                 <div className="rounded-md bg-destructive/10 border border-destructive/20 px-3 py-2 flex items-center justify-between">
                   <p className="text-xs text-destructive">{enterpriseError}</p>

--- a/src/renderer/src/components/settings/tabs/EnterpriseLoginModal.test.tsx
+++ b/src/renderer/src/components/settings/tabs/EnterpriseLoginModal.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { enterpriseApi } from '@/lib/ipc-client'
+import { useEnterpriseStore } from '@/stores/enterprise-store'
+import { EnterpriseLoginModal } from './EnterpriseLoginModal'
+
+vi.mock('@/lib/ipc-client', () => ({
+  enterpriseApi: {
+    apiRequest: vi.fn().mockResolvedValue({}),
+    getSession: vi.fn().mockResolvedValue({ isAuthenticated: false }),
+    login: vi.fn(),
+    signupInBrowser: vi.fn(),
+    selectTenant: vi.fn(),
+    logout: vi.fn(),
+    refreshToken: vi.fn()
+  },
+  onTaskDeleted: vi.fn(() => vi.fn())
+}))
+
+afterEach(cleanup)
+
+describe('EnterpriseLoginModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(enterpriseApi.signupInBrowser).mockResolvedValue({
+      userId: 'user-1',
+      email: 'new@example.com',
+      companies: []
+    })
+    useEnterpriseStore.setState({
+      isAuthenticated: false,
+      isLoading: false,
+      isSyncing: false,
+      error: null,
+      userEmail: null,
+      userId: null,
+      currentTenant: null,
+      availableTenants: null,
+      lastSyncStats: null,
+      lastSyncMs: null
+    })
+  })
+
+  it('includes the AI subscription by default for browser signup', async () => {
+    render(<EnterpriseLoginModal open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Sign up in browser'))
+
+    await waitFor(() => {
+      expect(enterpriseApi.signupInBrowser).toHaveBeenCalledWith('register', {
+        includeAiSubscription: true
+      })
+    })
+  })
+
+  it('can opt out of including the AI subscription for browser signup', async () => {
+    render(<EnterpriseLoginModal open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Include AI subscription'))
+    fireEvent.click(screen.getByText('Sign up in browser'))
+
+    await waitFor(() => {
+      expect(enterpriseApi.signupInBrowser).toHaveBeenCalledWith('register', {
+        includeAiSubscription: false
+      })
+    })
+  })
+
+  it('does not send an AI subscription preference for browser login', async () => {
+    render(<EnterpriseLoginModal open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Sign in via browser instead'))
+
+    await waitFor(() => {
+      expect(enterpriseApi.signupInBrowser).toHaveBeenCalledWith('login', undefined)
+    })
+  })
+})

--- a/src/renderer/src/components/settings/tabs/EnterpriseLoginModal.tsx
+++ b/src/renderer/src/components/settings/tabs/EnterpriseLoginModal.tsx
@@ -10,8 +10,9 @@ import {
 import { Label } from '@/components/ui/Label'
 import { Input } from '@/components/ui/Input'
 import { Button } from '@/components/ui/Button'
+import { Checkbox } from '@/components/ui/Checkbox'
 import { useEnterpriseStore } from '@/stores/enterprise-store'
-import { ExternalLink } from 'lucide-react'
+import { CreditCard, ExternalLink } from 'lucide-react'
 
 interface EnterpriseLoginModalProps {
   open: boolean
@@ -33,6 +34,7 @@ export function EnterpriseLoginModal({ open, onClose }: EnterpriseLoginModalProp
 
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [includeAiSubscription, setIncludeAiSubscription] = useState(true)
 
   // After login, we may have tenants to select — show that step in the same modal
   const showTenantSelection = availableTenants && availableTenants.length > 0
@@ -45,8 +47,11 @@ export function EnterpriseLoginModal({ open, onClose }: EnterpriseLoginModalProp
   }, [email, password, login])
 
   const handleBrowserSignup = useCallback(async (mode: 'register' | 'login') => {
-    await signupInBrowser(mode)
-  }, [signupInBrowser])
+    await signupInBrowser(
+      mode,
+      mode === 'register' ? { includeAiSubscription } : undefined
+    )
+  }, [includeAiSubscription, signupInBrowser])
 
   const handleSelectTenant = useCallback(async (tenantId: string) => {
     // Close modal immediately — sync runs in the background via IPC
@@ -72,6 +77,7 @@ export function EnterpriseLoginModal({ open, onClose }: EnterpriseLoginModalProp
     }
     setEmail('')
     setPassword('')
+    setIncludeAiSubscription(true)
     clearError()
     onClose()
   }, [showTenantSelection, isAuthenticated, clearError, onClose])
@@ -83,12 +89,12 @@ export function EnterpriseLoginModal({ open, onClose }: EnterpriseLoginModalProp
           <DialogTitle>
             {showTenantSelection
               ? (isAuthenticated ? 'Switch Organization' : 'Select Organization')
-              : 'Sign in to 20x Cloud'}
+              : 'Connect to 20x Cloud'}
           </DialogTitle>
           <DialogDescription>
             {showTenantSelection
               ? `Signed in as ${userEmail}. Choose an organization to connect.`
-              : 'Enter your 20x Cloud credentials to connect.'}
+              : 'Sign in or create an account to connect.'}
           </DialogDescription>
         </DialogHeader>
         <DialogBody>
@@ -218,6 +224,22 @@ export function EnterpriseLoginModal({ open, onClose }: EnterpriseLoginModalProp
 
               {/* Browser signup/login */}
               <div className="flex flex-col gap-2 pt-2">
+                <label className="flex items-start gap-3 rounded-md border border-border bg-background p-3 cursor-pointer">
+                  <Checkbox
+                    checked={includeAiSubscription}
+                    onCheckedChange={(checked) => setIncludeAiSubscription(checked === true)}
+                    className="mt-0.5"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+                      <CreditCard className="h-4 w-4 text-muted-foreground" />
+                      Include AI subscription
+                    </span>
+                    <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                      Roll model access into this new 20x Cloud account.
+                    </span>
+                  </span>
+                </label>
                 <Button
                   type="button"
                   variant="outline"

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -482,12 +482,12 @@ export const onWorkspaceCleanupProgress = (callback: (event: WorkspaceCleanupPro
 }
 
 export const enterpriseApi = {
-  signupInBrowser: (mode: 'register' | 'login' = 'register'): Promise<{
+  signupInBrowser: (mode: 'register' | 'login' = 'register', options?: { includeAiSubscription?: boolean }): Promise<{
     userId: string
     email: string
     companies: { id: string; name: string; isPrimary: boolean }[]
   }> => {
-    return window.electronAPI.enterprise.signupInBrowser(mode)
+    return window.electronAPI.enterprise.signupInBrowser(mode, options)
   },
 
   login: (email: string, password: string): Promise<{

--- a/src/renderer/src/stores/enterprise-store.test.ts
+++ b/src/renderer/src/stores/enterprise-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { enterpriseApi } from '@/lib/ipc-client'
 import { useEnterpriseStore, type EnterpriseSyncStats } from './enterprise-store'
 
 // Mock the ipc-client so the store can be imported without Electron
@@ -7,6 +8,7 @@ vi.mock('@/lib/ipc-client', () => ({
     apiRequest: vi.fn().mockResolvedValue({}),
     getSession: vi.fn().mockResolvedValue({ isAuthenticated: false }),
     login: vi.fn(),
+    signupInBrowser: vi.fn(),
     selectTenant: vi.fn(),
     logout: vi.fn(),
     refreshToken: vi.fn(),
@@ -16,6 +18,7 @@ vi.mock('@/lib/ipc-client', () => ({
 
 describe('useEnterpriseStore — sync stats', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     // Reset store to initial state
     useEnterpriseStore.setState({
       isAuthenticated: false,
@@ -111,5 +114,21 @@ describe('useEnterpriseStore — sync stats', () => {
     const state = useEnterpriseStore.getState()
     expect(state.lastSyncStats).toEqual(stats)
     expect(state.lastSyncMs).toBe(999)
+  })
+
+  it('passes the AI subscription preference to browser signup', async () => {
+    vi.mocked(enterpriseApi.signupInBrowser).mockResolvedValue({
+      userId: 'user-1',
+      email: 'new@example.com',
+      companies: []
+    })
+
+    await useEnterpriseStore.getState().signupInBrowser('register', {
+      includeAiSubscription: true
+    })
+
+    expect(enterpriseApi.signupInBrowser).toHaveBeenCalledWith('register', {
+      includeAiSubscription: true
+    })
   })
 })

--- a/src/renderer/src/stores/enterprise-store.ts
+++ b/src/renderer/src/stores/enterprise-store.ts
@@ -39,7 +39,7 @@ interface EnterpriseState {
 
   // Actions
   login: (email: string, password: string) => Promise<void>
-  signupInBrowser: (mode?: 'register' | 'login') => Promise<void>
+  signupInBrowser: (mode?: 'register' | 'login', options?: { includeAiSubscription?: boolean }) => Promise<void>
   selectTenant: (tenantId: string) => Promise<void>
   switchOrg: () => Promise<void>
   logout: () => Promise<void>
@@ -109,10 +109,10 @@ export const useEnterpriseStore = create<EnterpriseState>((set) => ({
     }
   },
 
-  signupInBrowser: async (mode: 'register' | 'login' = 'register') => {
+  signupInBrowser: async (mode: 'register' | 'login' = 'register', options?: { includeAiSubscription?: boolean }) => {
     set({ isLoading: true, error: null })
     try {
-      const result = await enterpriseApi.signupInBrowser(mode)
+      const result = await enterpriseApi.signupInBrowser(mode, options)
       set({
         isLoading: false,
         userEmail: result.email,

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -335,7 +335,7 @@ interface ElectronAPI {
     getInfo: () => Promise<{ url: string; port: number }>
   }
   enterprise: {
-    signupInBrowser: (mode: 'register' | 'login') => Promise<{
+    signupInBrowser: (mode: 'register' | 'login', options?: { includeAiSubscription?: boolean }) => Promise<{
       userId: string
       email: string
       companies: { id: string; name: string; isPrimary: boolean }[]


### PR DESCRIPTION
## Summary
- routes the dashboard cloud connect CTA through the existing 20x Cloud modal so signup can ask one more question before opening the browser
- adds a default-on "Include AI subscription" checkbox for browser registration and passes the choice through renderer, preload, and main IPC
- appends include_ai_subscription=true to workflow-builder /register URLs when selected

## Test plan
- pnpm test:run --project renderer src/renderer/src/components/settings/tabs/EnterpriseLoginModal.test.tsx src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx src/renderer/src/stores/enterprise-store.test.ts
- pnpm test:run --project renderer
- pnpm typecheck
- pnpm lint
- pnpm test:run (fails in main suites because better-sqlite3 native binding is missing after rebuild failure under local Node 26; renderer suites passed)