### PR TITLE
fix: require admin for windows installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
         }
       ],
       "icon": "resources/icon.ico",
-      "requestedExecutionLevel": "asInvoker"
+      "requestedExecutionLevel": "requireAdministrator"
     },
     "linux": {
       "target": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       lucide-react:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.4)
+      node-gyp-build:
+        specifier: ^4.8.4
+        version: 4.8.4
       png-to-ico:
         specifier: ^3.0.1
         version: 3.0.1
@@ -2107,6 +2110,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -3959,6 +3963,10 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
   node-gyp@11.5.0:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4161,6 +4169,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -6169,14 +6178,14 @@ snapshots:
       '@remotion/studio-shared': 4.0.434(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@rspack/core': 1.7.6
       '@rspack/plugin-react-refresh': 1.6.1(react-refresh@0.18.0)
-      css-loader: 5.2.7(webpack@5.105.0)
+      css-loader: 5.2.7(webpack@5.105.0(esbuild@0.25.0))
       esbuild: 0.25.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-refresh: 0.18.0
       remotion: 4.0.434(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       source-map: 0.7.3
-      style-loader: 4.0.0(webpack@5.105.0)
+      style-loader: 4.0.0(webpack@5.105.0(esbuild@0.25.0))
       webpack: 5.105.0(esbuild@0.25.0)
     transitivePeerDependencies:
       - '@swc/core'
@@ -7573,7 +7582,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@5.2.7(webpack@5.105.0):
+  css-loader@5.2.7(webpack@5.105.0(esbuild@0.25.0)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       loader-utils: 2.0.4
@@ -9231,6 +9240,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-gyp-build@4.8.4: {}
+
   node-gyp@11.5.0:
     dependencies:
       env-paths: 2.2.1
@@ -9969,7 +9980,7 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
-  style-loader@4.0.0(webpack@5.105.0):
+  style-loader@4.0.0(webpack@5.105.0(esbuild@0.25.0)):
     dependencies:
       webpack: 5.105.0(esbuild@0.25.0)
 

--- a/resources/installer.nsh
+++ b/resources/installer.nsh
@@ -1,4 +1,5 @@
 !include "WinMessages.nsh"
+RequestExecutionLevel admin
 
 !define PYTHON_VERSION "3.11.9"
 !define PYTHON_INSTALLER_URL "https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-amd64.exe"
@@ -33,7 +34,7 @@ Function InstallPythonIfMissing
 
   downloadSucceeded:
   DetailPrint "Installing Python ${PYTHON_VERSION}..."
-  ExecWait '"$0" /quiet InstallAllUsers=0 PrependPath=1 Include_launcher=1 Include_pip=1 Include_test=0 Shortcuts=0 SimpleInstall=1' $1
+  ExecWait '"$0" /quiet InstallAllUsers=1 PrependPath=1 Include_launcher=1 Include_pip=1 Include_test=0 Shortcuts=0 SimpleInstall=1' $1
   Delete "$0"
   StrCmp $1 0 pythonInstallSucceeded
 

--- a/scripts/installer-script.test.ts
+++ b/scripts/installer-script.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { describe, expect, it } from 'vitest'
+import packageJson from '../package.json'
 
 describe('installer script', () => {
   it('skips app data removal prompt during NSIS upgrades', () => {
@@ -24,7 +25,17 @@ describe('installer script', () => {
     expect(script).toContain('Invoke-WebRequest')
     expect(script).toContain('-ExecutionPolicy Bypass')
     expect(script).toContain('Section "-InstallPython"')
-    expect(script).toContain('/quiet InstallAllUsers=0 PrependPath=1 Include_launcher=1 Include_pip=1')
+    expect(script).toContain('RequestExecutionLevel admin')
+    expect(script).toContain('/quiet InstallAllUsers=1 PrependPath=1 Include_launcher=1 Include_pip=1')
     expect(script).toContain('Call BroadcastEnvironmentChange')
+  })
+
+  it('requests administrator privileges for Windows NSIS installs', () => {
+    expect(packageJson.build.win).toMatchObject({
+      requestedExecutionLevel: 'requireAdministrator'
+    })
+    expect(packageJson.build.nsis).toMatchObject({
+      allowElevation: true
+    })
   })
 })


### PR DESCRIPTION
Summary:\n- require administrator privileges for the Windows electron-builder target instead of running the app manifest as invoker\n- make the custom NSIS installer request admin and install the bootstrapped Python runtime for all users\n- extend the installer script test to assert the elevated Windows packaging config\n\nTest plan:\n- pnpm test:run scripts/installer-script.test.ts\n- pnpm typecheck\n- pnpm test:run (fails in existing main SQLite-backed suites because better-sqlite3 did not build under local Node 26, so the native binding is missing)