### PR TITLE
fix: refresh MCP OAuth tokens before Codex connect

### DIFF
--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -451,7 +451,7 @@ export class AgentManager extends EventEmitter {
         // Inject OAuth Bearer token if the server has one
         let finalHeaders = { ...mcpServer.headers }
         if (this.oauthManager && mcpServer.oauth_metadata && 'resource_url' in mcpServer.oauth_metadata) {
-          const token = await this.oauthManager.getValidMcpServerToken(mcpServer.id)
+          const token = await this.oauthManager.getValidMcpServerToken(mcpServer.id, { forceRefresh: true })
           if (token) {
             finalHeaders = { ...finalHeaders, Authorization: `Bearer ${token}` }
           }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -748,7 +748,7 @@ export function registerIpcHandlers(
     }
 
     if (!oauthManager) return { connected: false }
-    return oauthManager.getMcpServerOAuthStatus(mcpServerId)
+    return await oauthManager.validateMcpServerOAuthStatus(mcpServerId)
   })
 
   ipcMain.handle('mcp:revokeOAuthToken', async (_, mcpServerId: string) => {

--- a/src/main/oauth/oauth-manager-refresh.test.ts
+++ b/src/main/oauth/oauth-manager-refresh.test.ts
@@ -84,7 +84,16 @@ function makeMockDb(tokenRecord = makeTokenRecord()) {
       if (id === tokenRecord.mcp_server_id) storedToken = null
     }),
     deleteOAuthToken: vi.fn(),
-    updateOAuthToken: vi.fn(),
+    updateOAuthToken: vi.fn((id: string, accessToken: string, refreshToken: string, expiresIn: number) => {
+      if (!storedToken || storedToken.id !== id) return
+      storedToken = {
+        ...storedToken,
+        access_token: accessToken,
+        refresh_token: refreshToken,
+        expires_at: new Date(Date.now() + expiresIn * 1000).toISOString(),
+        updated_at: new Date().toISOString()
+      }
+    }),
     // Stub out methods called by constructor/init that we don't care about
     _storedToken: () => storedToken
   }
@@ -195,5 +204,40 @@ describe('OAuthManager — refresh failure cleanup', () => {
 
     expect(result).toBe('still-valid-token')
     expect(mockNotificationConstructor).not.toHaveBeenCalled()
+  })
+
+  it('force refreshes a non-expired token before handing it to agent sessions', async () => {
+    const freshDb = makeMockDb(makeTokenRecord({
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      access_token: 'still-valid-token'
+    }))
+    const freshManager = new OAuthManager(freshDb as never)
+    const mcpProvider = (freshManager as any).providers.get('mcp-server')
+    mcpProvider.refreshToken = vi.fn().mockResolvedValue({
+      access_token: 'fresh-access-token',
+      refresh_token: 'fresh-refresh-token',
+      expires_in: 3600
+    })
+
+    const result = await freshManager.getValidMcpServerToken('srv-notion', { forceRefresh: true })
+
+    expect(result).toBe('fresh-access-token')
+    expect(freshDb.updateOAuthToken).toHaveBeenCalled()
+  })
+
+  it('validateMcpServerOAuthStatus marks server disconnected when forced refresh fails', async () => {
+    const freshDb = makeMockDb(makeTokenRecord({
+      expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString()
+    }))
+    const freshManager = new OAuthManager(freshDb as never)
+    const mcpProvider = (freshManager as any).providers.get('mcp-server')
+    mcpProvider.refreshToken = vi.fn().mockRejectedValue(
+      new Error('MCP OAuth token refresh failed: 400 {"error":"invalid_grant"}')
+    )
+
+    const status = await freshManager.validateMcpServerOAuthStatus('srv-notion')
+
+    expect(status).toEqual({ connected: false })
+    expect(freshDb.deleteOAuthTokenByMcpServer).toHaveBeenCalledWith('srv-notion')
   })
 })

--- a/src/main/oauth/oauth-manager.ts
+++ b/src/main/oauth/oauth-manager.ts
@@ -455,14 +455,18 @@ export class OAuthManager {
   /**
    * Get a valid access token for an MCP server, refreshing if needed.
    */
-  async getValidMcpServerToken(mcpServerId: string): Promise<string | null> {
+  async getValidMcpServerToken(
+    mcpServerId: string,
+    opts?: { forceRefresh?: boolean }
+  ): Promise<string | null> {
     const tokenRecord = this.db.getOAuthTokenByMcpServer(mcpServerId)
     if (!tokenRecord) return null
 
     const expiresAt = new Date(tokenRecord.expires_at).getTime()
     const nowPlus5Min = Date.now() + 5 * 60 * 1000
+    const shouldRefresh = tokenRecord.refresh_token && (opts?.forceRefresh || expiresAt < nowPlus5Min)
 
-    if (expiresAt < nowPlus5Min) {
+    if (shouldRefresh) {
       try {
         await this.refreshMcpServerToken(tokenRecord)
         const refreshed = this.db.getOAuthTokenByMcpServer(mcpServerId)
@@ -495,6 +499,22 @@ export class OAuthManager {
     }
 
     return tokenRecord.access_token
+  }
+
+  /**
+   * Validate OAuth status for an MCP server using the same token path used by
+   * agent sessions. This prevents the UI from reporting "connected" when the
+   * stored access token has been revoked upstream but still exists locally.
+   */
+  async validateMcpServerOAuthStatus(mcpServerId: string): Promise<{ connected: boolean; expiresAt?: string }> {
+    const tokenRecord = this.db.getOAuthTokenByMcpServer(mcpServerId)
+    if (!tokenRecord) return { connected: false }
+
+    const token = await this.getValidMcpServerToken(mcpServerId, { forceRefresh: true })
+    if (!token) return { connected: false }
+
+    const refreshed = this.db.getOAuthTokenByMcpServer(mcpServerId)
+    return refreshed ? { connected: true, expiresAt: refreshed.expires_at } : { connected: false }
   }
 
   /**


### PR DESCRIPTION
## Summary
- refresh MCP OAuth tokens before building agent-session MCP headers
- validate MCP OAuth status through the same token path used by agent sessions
- add focused coverage for forced refresh and disconnected-status handling

## Verification
- Source review of the Codex/agent session path and settings status path
- Focused test command could not run in this checkout because node_modules is missing