### PR TITLE
fix(tilldone): allow skill tool through before todo list creation

### DIFF
--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -57,6 +57,10 @@ describe('OpencodeAdapter', () => {
         ].join('\n'))
         expect(tillDoneCode).toContain('INITIAL_TODO_PROMPT')
 
+        // The skill tool is allowed through because skills contain planning instructions
+        // that the agent needs to read BEFORE creating the todo list
+        expect(tillDoneCode).toContain('input.tool === "skill"')
+
         // Idle nudging is handled by the agent-manager (universal for all agents),
         // not by the plugin. The plugin only handles tool blocking + todo state tracking.
         expect(tillDoneCode).not.toContain('session.idle')

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -1774,7 +1774,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       'export var TillDone = async function({ client }) {',
       '  return {',
       '    "tool.execute.before": async function(input) {',
-      '      if (input.tool === "todowrite") return;',
+      '      if (input.tool === "todowrite" || input.tool === "skill") return;',
       '      var sessionId = input.sessionID;',
       '      if (!sessionId) return;',
       '      if (!isTillDoneEnabled(sessionId)) return;',


### PR DESCRIPTION
## Summary
- The tillDone plugin's `tool.execute.before` hook now allows the `skill` tool through alongside `todowrite`
- Skills contain planning instructions that agents need to read before creating a meaningful todo list
- Without this fix, the tillDone plugin blocked the native skill tool, creating a chicken-and-egg problem: agents couldn't load skill planning guidance needed to form their task list

## Changes
- `opencode-adapter.ts`: Added `skill` exemption to the tillDone plugin's tool blocking logic
- `opencode-adapter.test.ts`: Added assertion verifying the skill tool exemption
- Updated tilldone-workflow-enforcement skill documentation

## Test plan
- [x] All 32 opencode-adapter tests pass
- [x] ESLint clean on changed files
- [x] No regressions to existing tillDone behavior (todowrite still required, other tools still blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)