### PR TITLE
fix: OpenCode Windows install — replace scoop with direct download

### DIFF
--- a/src/main/agent-installer/detect.js
+++ b/src/main/agent-installer/detect.js
@@ -1,7 +1,35 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
+import { join } from 'path'
+import { homedir } from 'os'
+import { existsSync } from 'fs'
 
 const execFileAsync = promisify(execFile)
+
+/**
+ * Ensure well-known agent install directories are on the running process's
+ * PATH so detection works immediately after install without an app restart.
+ */
+function ensureAgentPaths() {
+  const home = homedir()
+  const sep = process.platform === 'win32' ? ';' : ':'
+  const pathEnv = process.env.PATH || ''
+  const segments = pathEnv.split(sep)
+
+  const knownDirs = [
+    join(home, '.opencode', 'bin'),  // OpenCode standalone installer
+    join(home, '.local', 'bin')       // Linux binary installs
+  ]
+
+  let modified = false
+  for (const dir of knownDirs) {
+    if (existsSync(dir) && !segments.includes(dir) && !segments.includes(`${dir}/`)) {
+      process.env.PATH = `${dir}${sep}${process.env.PATH}`
+      modified = true
+    }
+  }
+  return modified
+}
 
 /**
  * Detect which agents and tools are installed on this system.
@@ -9,6 +37,9 @@ const execFileAsync = promisify(execFile)
  */
 export async function detectInstalledAgents() {
   const isWin = process.platform === 'win32'
+
+  // Ensure well-known install dirs are on PATH before probing
+  ensureAgentPaths()
 
   /**
    * Run a command and extract a version string from stdout.

--- a/src/main/agent-installer/install.js
+++ b/src/main/agent-installer/install.js
@@ -699,9 +699,18 @@ export async function installAgent(agentName, onProgress) {
     return installStandaloneAgent(agentName, {
       curlUrl: 'https://opencode.ai/install',
       curlShell: 'bash',
-      winCmd: 'scoop',
-      winArgs: ['install', 'opencode'],
-      winFallback: 'Install OpenCode from https://opencode.ai/download or run: scoop install opencode',
+      winPowershell: [
+        '$installDir = "$env:USERPROFILE\\.opencode\\bin"',
+        'New-Item -ItemType Directory -Force -Path $installDir | Out-Null',
+        '$zip = "$env:TEMP\\opencode-windows-x64.zip"',
+        'Invoke-WebRequest -Uri "https://github.com/anomalyco/opencode/releases/latest/download/opencode-windows-x64.zip" -OutFile $zip',
+        'Expand-Archive -Force -Path $zip -DestinationPath $installDir',
+        'Remove-Item $zip -Force',
+        '$userPath = [Environment]::GetEnvironmentVariable("Path", "User")',
+        'if ($userPath -notlike "*$installDir*") { [Environment]::SetEnvironmentVariable("Path", "$installDir;$userPath", "User") }',
+        'Write-Host "OpenCode installed to $installDir"'
+      ].join('; '),
+      winFallback: 'Install OpenCode from https://opencode.ai/download',
       successMsg: 'OpenCode installed successfully!\n',
       detectKey: 'opencode'
     }, onProgress)
@@ -1137,6 +1146,11 @@ async function installStandaloneAgent(agentName, opts, onProgress) {
           resolve({ success: false, error: err.message, newStatus: await detectInstalledAgents() })
         })
         proc.on('close', async (code) => {
+          // Ensure well-known install dirs are on this process's PATH
+          // so detection works immediately without an app restart
+          const opencodeDir = join(homedir(), '.opencode', 'bin')
+          ensureOnPath(opencodeDir)
+
           const newStatus = await detectInstalledAgents()
           if (code === 0 || newStatus[opts.detectKey]?.installed) {
             onProgress({ stage: 'complete', output: opts.successMsg, percent: 100 })
@@ -1150,7 +1164,7 @@ async function installStandaloneAgent(agentName, opts, onProgress) {
     }
 
     if (opts.winCmd && opts.winArgs) {
-      // Use scoop/winget (OpenCode)
+      // Use scoop/winget as fallback
       onProgress({ stage: 'starting', output: `$ ${opts.winCmd} ${opts.winArgs.join(' ')}\n`, percent: 5 })
       try {
         return await spawnInstall(opts.winCmd, opts.winArgs, agentName, onProgress)


### PR DESCRIPTION
## Summary
- **Replace `scoop install opencode`** with a PowerShell script that downloads the binary directly from GitHub releases — scoop is not installed on most Windows machines, causing silent install failures during onboarding
- **Add `ensureAgentPaths()` to `detect.js`** — injects `~/.opencode/bin` into the Electron process PATH so the binary is detected immediately after install without an app restart
- **Add `ensureOnPath()` call** in the standalone installer close handler for the same reason

## What was broken
On Windows, onboarding would silently fail to install OpenCode because `scoop` is not a default tool. The error `'scoop' is not recognized as an internal or external command` was swallowed by the `runPostAuthFlow()` catch-all. The agent was created with OpenCode type but the binary was never there.

## How it works now
PowerShell downloads `opencode-windows-x64.zip` from `https://github.com/anomalyco/opencode/releases/latest/download/opencode-windows-x64.zip`, extracts to `%USERPROFILE%\.opencode\bin`, and adds it to the user PATH. Zero external dependencies — uses only built-in PowerShell cmdlets (`Invoke-WebRequest`, `Expand-Archive`).

## Test plan
- [x] 22/22 onboarding wizard tests pass
- [ ] Verify on Windows: fresh install detects OpenCode after onboarding completes
- [ ] Verify on macOS: curl-based install still works (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)