### PR TITLE
fix: don't reopen onboarding dialog after setup completes

### DIFF
--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -460,15 +460,9 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
       toasts.update(TOAST_ID, { message: 'Loading templates...', percent: 90 })
       await fetchPresetups()
 
-      // Done!
+      // Done! — don't reopen the dialog; let the user start working immediately.
+      // Templates are available from the Dashboard whenever they need them.
       toasts.finish(TOAST_ID, 'Agent ready — you can start working!')
-
-      // If templates exist, show them
-      const templates = useDashboardStore.getState().presetupTemplates
-      if (templates.length > 0) {
-        setScreen(OnboardingScreen.TEMPLATES)
-        onOpenChange(true)
-      }
     } catch (err) {
       console.error('[OnboardingWizard] Background setup failed:', err)
       toasts.fail(TOAST_ID, 'Setup failed — configure agent in Settings')

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -397,11 +397,9 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
   )
 
   /**
-   * Run post-auth setup in background: close dialog immediately,
-   * show progress via the general-purpose progress toast.
-   *
-   * Always installs the binary + starts the server, even if an agent
-   * record already exists (it may be stale from a previous version).
+   * Run post-auth setup: kick off install + config in the background (toast),
+   * then immediately advance the wizard to the templates screen so the user
+   * can continue onboarding while the agent installs.
    */
   const setupRunning = React.useRef(false)
   const runPostAuthFlow = useCallback(async () => {
@@ -412,11 +410,19 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
     const toasts = useProgressToastStore.getState()
     const TOAST_ID = 'agent-setup'
 
-    // Close dialog immediately — don't block the main UI
-    onOpenChange(false)
-
-    // Start background progress toast
+    // Show background progress toast
     toasts.show(TOAST_ID, 'Setting up agent', 'Detecting installed tools...')
+
+    // Move to templates screen immediately — don't wait for install
+    fetchPresetups().then(() => {
+      const templates = useDashboardStore.getState().presetupTemplates
+      if (templates.length > 0) {
+        setScreen(OnboardingScreen.TEMPLATES)
+      } else {
+        // No templates — close the dialog, toast is enough
+        onOpenChange(false)
+      }
+    })
 
     try {
       // Phase 1: Detect tools
@@ -456,12 +462,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
       await createDefaultAgent(CodingAgentType.OPENCODE)
       await useAgentStore.getState().fetchAgents()
 
-      // Phase 4: Fetch templates
-      toasts.update(TOAST_ID, { message: 'Loading templates...', percent: 90 })
-      await fetchPresetups()
-
-      // Done! — don't reopen the dialog; let the user start working immediately.
-      // Templates are available from the Dashboard whenever they need them.
+      // Done!
       toasts.finish(TOAST_ID, 'Agent ready — you can start working!')
     } catch (err) {
       console.error('[OnboardingWizard] Background setup failed:', err)


### PR DESCRIPTION
## Summary
- Onboarding wizard now shows the **templates screen in parallel** with the background install
- Flow: click "Get Started" → wizard transitions to templates screen → toast shows install/config progress in the corner → user browses templates while agent installs → toast shows "Agent ready" → user clicks "Done"
- No more closing and reopening the dialog — smooth single-flow wizard experience

## What changed
`runPostAuthFlow` now:
1. Kicks off `fetchPresetups()` immediately and transitions to the templates screen as soon as templates load
2. Runs install → server start → agent config in parallel via the background toast
3. If no templates exist, closes the dialog (toast is enough)

## Test plan
- [ ] Login → "Get Started" → wizard smoothly transitions to templates screen
- [ ] Background toast shows install progress while templates are visible
- [ ] Toast finishes with "Agent ready" — user can click "Done" whenever
- [ ] If no templates: dialog closes, toast runs alone
- [ ] Double-click "Get Started" doesn't trigger duplicate setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)