### PR TITLE
fix: show friendly messages in install toast

### DIFF
--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -435,11 +435,12 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
 
         // Subscribe to install progress events for real-time updates
         const cleanup = window.electronAPI.agentInstaller.onProgress(
-          (data: { stage: string; percent: number; output: string }) => {
+          (data: { stage: string; percent: number }) => {
             if (data.stage === 'complete' || data.stage === 'error') return
             // Map install percent (0-100) to our range (10-50)
             const mapped = 10 + Math.round((data.percent || 0) * 0.4)
-            toasts.update(TOAST_ID, { percent: mapped, message: data.output?.trim()?.slice(-60) || 'Installing OpenCode...' })
+            const message = data.percent > 60 ? 'Almost there...' : 'Downloading & installing OpenCode...'
+            toasts.update(TOAST_ID, { percent: mapped, message })
           }
         )
 


### PR DESCRIPTION
## Summary
- The install progress toast was showing **raw PowerShell/bash script output** like `", "User") }; Write-Host "OpenCode installed to $i`
- Root cause: `data.output?.trim()?.slice(-60)` was taking the last 60 chars of shell script fragments and displaying them directly
- Now shows clean user-facing messages based on progress: "Downloading & installing OpenCode..." → "Almost there..."

## Test plan
- [ ] Windows install: toast shows "Downloading & installing OpenCode..." then "Almost there..." — no raw script fragments
- [ ] macOS install: same clean messages
- [ ] Progress bar still moves smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)