### PR TITLE
fix: set source='enterprise' on MCP Dev Server for JWT auth

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -970,9 +970,12 @@ export function registerIpcHandlers(
           const existingMcpDev = localServers.find((s) => s.name === mcpDevServerName)
 
           if (existingMcpDev) {
-            // Update URL in case environment changed (e.g. local → stage → prod)
-            if (existingMcpDev.url !== mcpDevUrl) {
-              db.updateMcpServer(existingMcpDev.id, { url: mcpDevUrl })
+            // Update URL and ensure source is 'enterprise' (may be missing on
+            // servers created before this fix). Also handles env changes
+            // (e.g. local → stage → prod).
+            const needsUpdate = existingMcpDev.url !== mcpDevUrl || existingMcpDev.source !== 'enterprise'
+            if (needsUpdate) {
+              db.updateMcpServer(existingMcpDev.id, { url: mcpDevUrl, source: 'enterprise' })
               console.log('[enterprise] Updated MCP Dev Server URL:', mcpDevUrl)
             }
           } else {
@@ -981,6 +984,7 @@ export function registerIpcHandlers(
               type: 'remote',
               url: mcpDevUrl,
               headers: {},
+              source: 'enterprise',
               // The enterprise JWT is injected dynamically by the MCP transport
               // layer (via EnterpriseAuth.getJwt()), not stored statically here.
               // The MCP client retrieves a fresh JWT before each connection.


### PR DESCRIPTION
## Summary
- MCP Dev Server was created without `source: 'enterprise'` during tenant selection, defaulting to `source: 'user'`
- `isEnterpriseMcpDevServer()` in agent-manager checks `source === 'enterprise'` — so JWT injection and auth proxy routing were **silently skipped**
- This meant the MCP Dev Server couldn't authenticate with the enterprise backend

## What changed
- **Create path**: added `source: 'enterprise'` to `db.createMcpServer()` call
- **Update path**: existing servers from before this fix get patched to `source: 'enterprise'` on next login (self-healing)

## Test plan
- [ ] Fresh login: MCP Dev Server created with `source: 'enterprise'` — JWT injection works
- [ ] Existing user re-login: MCP Dev Server source updated from `'user'` → `'enterprise'`
- [ ] Workflo MCP tools (workflows, integrations, datastores) authenticate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)