### PR TITLE
feat: add claude-fable-5 model support

### DIFF
--- a/src/renderer/src/types/index.test.ts
+++ b/src/renderer/src/types/index.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { CLAUDE_MODELS, ClaudeModel, CODEX_MODELS, CodexModel } from './index'
 
 describe('CLAUDE_MODELS', () => {
+  it('includes Claude Fable 5', () => {
+    expect(CLAUDE_MODELS).toContainEqual({
+      id: ClaudeModel.FABLE_5,
+      name: 'claude-fable-5'
+    })
+  })
+
   it('includes Claude Opus 4.8', () => {
     expect(CLAUDE_MODELS).toContainEqual({
       id: ClaudeModel.OPUS_4_8,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -43,6 +43,7 @@ export const CODING_AGENTS: { value: CodingAgentType; label: string }[] = [
 ]
 
 export enum ClaudeModel {
+  FABLE_5 = 'claude-fable-5',
   OPUS_4_8 = 'claude-opus-4-8',
   OPUS_4_7 = 'claude-opus-4-7',
   SONNET_4_6 = 'claude-sonnet-4-6',
@@ -55,6 +56,7 @@ export enum ClaudeModel {
 }
 
 export const CLAUDE_MODELS: { id: ClaudeModel; name: string }[] = [
+  { id: ClaudeModel.FABLE_5, name: 'claude-fable-5' },
   { id: ClaudeModel.OPUS_4_8, name: 'claude-opus-4-8' },
   { id: ClaudeModel.OPUS_4_7, name: 'Claude Opus 4.7' },
   { id: ClaudeModel.SONNET_4_6, name: 'Claude Sonnet 4.6' },


### PR DESCRIPTION
## Summary
- Added `claude-fable-5` to the `ClaudeModel` enum and `CLAUDE_MODELS` list in the types definition
- Added corresponding test case

## Test plan
- [x] All 7 tests pass in `src/renderer/src/types/index.test.ts`
- [ ] CI lint check passes

Generated with opencode