### PR TITLE
fix: prevent multi-tenant users from skipping OpenCode install

### DIFF
--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -295,6 +295,9 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
   // Initialize state on open
   useEffect(() => {
     if (!open) return
+    // Sync wasAuthenticated so the auth-watcher useEffect doesn't falsely
+    // detect a false→true transition from loadSession restoring a session.
+    setWasAuthenticated(useEnterpriseStore.getState().isAuthenticated)
     setError(null)
     setScreen(OnboardingScreen.MAIN)
 
@@ -473,16 +476,16 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
     }
   }, [createDefaultAgent, fetchPresetups, onOpenChange])
 
-  // When auth completes while login modal is open, auto-close it and run post-auth flow.
-  // This handles the browser signup flow where login/tenant-select happens in the background
-  // and isAuthenticated flips to true while the modal is still showing.
+  // When auth changes from false→true during onboarding, auto-run setup.
+  // Don't gate on loginModalOpen — handleSelectTenant may have already
+  // closed the modal before isAuthenticated flips (which was the bug).
   useEffect(() => {
-    if (isAuthenticated && !wasAuthenticated && loginModalOpen) {
+    if (isAuthenticated && !wasAuthenticated) {
       setLoginModalOpen(false)
       runPostAuthFlow()
     }
     setWasAuthenticated(isAuthenticated)
-  }, [isAuthenticated, wasAuthenticated, loginModalOpen, runPostAuthFlow])
+  }, [isAuthenticated, wasAuthenticated, runPostAuthFlow])
 
   const handleStart = async () => {
     if (!selectedAgent) return

--- a/src/renderer/src/components/settings/tabs/EnterpriseLoginModal.tsx
+++ b/src/renderer/src/components/settings/tabs/EnterpriseLoginModal.tsx
@@ -49,9 +49,11 @@ export function EnterpriseLoginModal({ open, onClose }: EnterpriseLoginModalProp
   }, [signupInBrowser])
 
   const handleSelectTenant = useCallback(async (tenantId: string) => {
-    // Close modal immediately — sync runs in the background via IPC
-    onClose()
+    // Must await selectTenant before closing — the onClose callback checks
+    // isAuthenticated, which is only set after selectTenant completes.
+    // The loading spinner keeps the UI responsive while we wait.
     await selectTenant(tenantId)
+    onClose()
   }, [selectTenant, onClose])
 
   const handleClose = useCallback(() => {


### PR DESCRIPTION
## Summary
- **Root cause**: `handleSelectTenant` in `EnterpriseLoginModal` called `onClose()` before `await selectTenant(tenantId)`, so the modal closed while `isAuthenticated` was still false. The auth-watcher useEffect in `OnboardingWizard` gated on `loginModalOpen` — which was already false — so `runPostAuthFlow` never fired.
- **Fix in EnterpriseLoginModal**: Swap order — `await selectTenant()` first, then `onClose()`. The loading spinner keeps the UI responsive while waiting.
- **Fix in OnboardingWizard**: Remove `loginModalOpen` from the auth-watcher guard so `runPostAuthFlow` fires on any `isAuthenticated` false→true transition during onboarding. Also sync `wasAuthenticated` on wizard open to prevent false triggers from `loadSession` restoring a prior session.

## Impact
All multi-tenant users (users with >1 organization) were affected — they could log in and select a tenant, but OpenCode installation was silently skipped. Single-tenant users were unaffected because `selectTenant` is called inline during `login()`.

## Test plan
- [ ] Log in with a multi-tenant account → verify OpenCode install toast appears after tenant selection
- [ ] Log in with a single-tenant account → verify install flow still works as before
- [ ] Close and reopen the app after auth → verify onboarding doesn't falsely re-trigger setup
- [ ] Cancel tenant selection mid-flow → verify partial state is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)