### PR TITLE
[FIX] Normalize free OpenCode model selection during onboarding

### DIFF
--- a/src/renderer/src/components/onboarding/OnboardingWizard.test.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { OnboardingWizard, shouldShowOnboarding, isForceOnboarding } from './OnboardingWizard'
+import {
+  OnboardingWizard,
+  shouldShowOnboarding,
+  isForceOnboarding,
+  pickFreeModel
+} from './OnboardingWizard'
 
 // Access mock electronAPI from test/setup-renderer.ts
 const mockAgentInstaller = window.electronAPI.agentInstaller as unknown as {
@@ -24,6 +29,21 @@ const mockSettings = window.electronAPI.settings as unknown as {
 const mockEnterprise = window.electronAPI.enterprise as unknown as {
   getSession: Mock
 }
+
+describe('pickFreeModel', () => {
+  it.each([
+    ['array model ID', [{ id: 'kimi-k2.5-free', name: 'Kimi K2.5' }], 'opencode/kimi-k2.5-free'],
+    ['object-map key', { 'kimi-k2.5-free': { name: 'Kimi K2.5' } }, 'opencode/kimi-k2.5-free'],
+    ['explicit object-map ID', { alias: { id: 'model-free' } }, 'opencode/model-free'],
+    ['display name', [{ id: 'model-1', name: 'Community Free Model' }], 'opencode/model-1']
+  ])('detects a free model from its %s', (_, models, expected) => {
+    expect(pickFreeModel('opencode', models)).toBe(expected)
+  })
+
+  it('returns null when no free model exists', () => {
+    expect(pickFreeModel('opencode', { 'paid-model': { name: 'Paid Model' } })).toBeNull()
+  })
+})
 
 describe('shouldShowOnboarding', () => {
   beforeEach(() => {

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -149,14 +149,30 @@ function pickFirstModel(
 }
 
 /** Pick first "free" model from a provider's model list. */
-function pickFreeModel(
+export function pickFreeModel(
   providerId: string,
   models: unknown
 ): string | null {
-  if (!Array.isArray(models)) return null
-  for (const m of models as { id?: string; name?: string }[]) {
-    if (m?.id && (m.name || '').toLowerCase().includes('free')) {
-      return `${providerId}/${m.id}`
+  const candidates = Array.isArray(models)
+    ? (models as { id?: string; name?: string }[]).map((model) => ({
+        id: model?.id,
+        name: model?.name
+      }))
+    : models && typeof models === 'object'
+      ? Object.entries(models as Record<string, { id?: string; name?: string }>).map(
+          ([key, model]) => ({
+            id: model?.id || key,
+            name: model?.name
+          })
+        )
+      : []
+
+  for (const model of candidates) {
+    if (
+      model.id &&
+      `${model.id} ${model.name || ''}`.toLowerCase().includes('free')
+    ) {
+      return `${providerId}/${model.id}`
     }
   }
   return null


### PR DESCRIPTION
## Summary


OpenCode providers may return models either as arrays or as object maps keyed by model ID. Previously, free-model selection only handled array responses and checked only model display names for the `free` marker.

As a result, onboarding could miss an available free model and fall back to the first model returned by the provider. This PR applies the same response-shape handling already established in `AgentForm.tsx`, while additionally checking both model IDs and display names to select a free default.


## Changes

- Support both array and object-map model responses when selecting a free OpenCode model.
- Detect the `free` marker in both model IDs and display names.
- Use explicit model IDs when present, falling back to object-map keys.
- Add regression tests for all supported response shapes and fallback behavior.

## Testing

- `pnpm typecheck` passes.
- `pnpm build` succeeds.
- Focused onboarding test suite passes: 27 tests.
- Ran the Windows-equivalent full test suite:

```powershell
$env:ELECTRON_RUN_AS_NODE='1'
.\node_modules\.bin\electron.cmd .\node_modules\vitest\vitest.mjs run
```


## Checklist

- [X] `pnpm typecheck` passes
- [X] `pnpm build` succeeds
- [ ] `pnpm test:run` passes
- [X] No hardcoded color classes (use CSS variable tokens)

## Notes

The full suite completed with unrelated existing failures:
```
Test Files  3 failed | 94 passed (97)
Tests       11 failed | 1438 passed (1449)
```
Failures remain in `agent-manager.test.ts`, `ipc-handlers.test.ts`, and `opencode-config.test.ts`.
Literal `pnpm test:run` is not Windows-compatible because it uses Unix-style environment-variable syntax.