### PR TITLE
fix(tilldone): exempt task-management MCP tools from tillDone blocking

### DIFF
--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -61,6 +61,10 @@ describe('OpencodeAdapter', () => {
         // that the agent needs to read BEFORE creating the todo list
         expect(tillDoneCode).toContain('input.tool === "skill"')
 
+        // Task-management MCP tools are allowed through so agents can read task context
+        // (description, subtasks, skills) before creating the todo list
+        expect(tillDoneCode).toContain('input.tool.startsWith("mcp__task-management__")')
+
         // Idle nudging is handled by the agent-manager (universal for all agents),
         // not by the plugin. The plugin only handles tool blocking + todo state tracking.
         expect(tillDoneCode).not.toContain('session.idle')

--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -61,9 +61,9 @@ describe('OpencodeAdapter', () => {
         // that the agent needs to read BEFORE creating the todo list
         expect(tillDoneCode).toContain('input.tool === "skill"')
 
-        // Task-management MCP tools are allowed through so agents can read task context
-        // (description, subtasks, skills) before creating the todo list
-        expect(tillDoneCode).toContain('input.tool.startsWith("mcp__task-management__")')
+        // The task tool (subagent delegation) is allowed through so agents can
+        // delegate work to subagents before creating the todo list
+        expect(tillDoneCode).toContain('input.tool === "task"')
 
         // Idle nudging is handled by the agent-manager (universal for all agents),
         // not by the plugin. The plugin only handles tool blocking + todo state tracking.

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -1774,7 +1774,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       'export var TillDone = async function({ client }) {',
       '  return {',
       '    "tool.execute.before": async function(input) {',
-      '      if (input.tool === "todowrite" || input.tool === "skill") return;',
+      '      if (input.tool === "todowrite" || input.tool === "skill" || input.tool.startsWith("mcp__task-management__")) return;',
       '      var sessionId = input.sessionID;',
       '      if (!sessionId) return;',
       '      if (!isTillDoneEnabled(sessionId)) return;',

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -1774,7 +1774,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
       'export var TillDone = async function({ client }) {',
       '  return {',
       '    "tool.execute.before": async function(input) {',
-      '      if (input.tool === "todowrite" || input.tool === "skill" || input.tool.startsWith("mcp__task-management__")) return;',
+      '      if (input.tool === "todowrite" || input.tool === "skill" || input.tool === "task") return;',
       '      var sessionId = input.sessionID;',
       '      if (!sessionId) return;',
       '      if (!isTillDoneEnabled(sessionId)) return;',


### PR DESCRIPTION
## Summary
- The tillDone plugin's `tool.execute.before` hook blocks all tools until a todo list is created, except `todowrite` and `skill`
- The native OpenCode `task` tool (used for subagent delegation) was being blocked, preventing agents from delegating work before creating their todo list
- Added `input.tool === "task"` to the exemption list alongside `todowrite` and `skill`

## Test plan
- [x] All 32 opencode-adapter tests pass (including new assertion for `task` tool exemption)
- [x] TypeScript typecheck passes with no errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)