### PR TITLE
fix: bearer token auth for task-api-server + JSON resilience in database + documentation updation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
-# AGENTS.md — Multi-Agent Architecture (Phase 3)
+# AGENTS.md — Multi-Agent Architecture
 
-This document describes the planned multi-agent system for 20x. It is not yet implemented — this serves as the architectural specification for Phase 3 development.
+This document describes the multi-agent system for 20x. The core architecture described here is fully implemented in `src/main/agent-manager.ts`.
 
 ## Overview
 
-20x will support running multiple AI coding agents in parallel, each working on assigned tasks within specific codebases. Agents are managed through the OpenCode SDK and interact with users via streaming terminal transcripts with human-in-the-loop (HITL) approval flows.
+20x supports running multiple AI coding agents in parallel, each working on assigned tasks within specific codebases. Three coding agent backends are supported: **Claude Code** (Anthropic), **OpenCode** (open-source), and **Codex** (OpenAI). Agents are managed through the `AgentManager` class and interact with users via streaming terminal transcripts with human-in-the-loop (HITL) approval flows.
 
 ## Agent Model
 

--- a/docs/mobile-api-spec.md
+++ b/docs/mobile-api-spec.md
@@ -260,18 +260,32 @@ List all configured skills (available to agents).
   {
     "id": "skill_abc123",
     "name": "Code Review",
-    "description": "Reviews pull requests",
-    "agent_id": "agent_abc123"
+    "description": "Reviews pull requests for correctness and style",
+    "content": "# Code Review\nReview the diff for...",
+    "version": 3,
+    "confidence": 0.85,
+    "uses": 12,
+    "last_used": "2026-05-10T09:00:00.000Z",
+    "tags": ["review", "quality"],
+    "created_at": "2026-01-15T10:00:00.000Z",
+    "updated_at": "2026-05-10T09:00:00.000Z"
   }
 ]
 ```
 
-| Field       | Type            | Description |
-|-------------|-----------------|-------------|
-| `id`        | `string`        | Skill ID |
-| `name`      | `string`        | Display name |
-| `description`| `string`       | What the skill does |
-| `agent_id`  | `string \| null`| Agent this skill belongs to (null = available to all) |
+| Field         | Type       | Description |
+|---------------|------------|-------------|
+| `id`          | `string`   | Skill ID |
+| `name`        | `string`   | Display name |
+| `description` | `string`   | What the skill does |
+| `content`     | `string`   | Full skill instructions (Markdown) |
+| `version`     | `number`   | Incremented on each update |
+| `confidence`  | `number`   | 0.0–1.0 score reflecting how reliably this skill performs |
+| `uses`        | `number`   | Total number of times this skill has been used |
+| `last_used`   | `string \| null` | ISO 8601 timestamp of last use |
+| `tags`        | `string[]` | Categorisation tags |
+| `created_at`  | `string`   | ISO 8601 |
+| `updated_at`  | `string`   | ISO 8601 |
 
 ---
 
@@ -327,6 +341,143 @@ Fetch repositories for a GitHub organization.
 ```
 
 **Error:** `400` — `org` is required. `500` — GitHub not configured.
+
+---
+
+#### `GET /api/github/orgs`
+
+List all available organizations and personal accounts across all authenticated git providers (GitHub and/or GitLab).
+
+**Response:** `200 OK`
+
+```json
+[
+  { "value": "rumaisa", "label": "rumaisa (GitHub personal)", "provider": "github" },
+  { "value": "peakflo", "label": "peakflo (GitHub)", "provider": "github" },
+  { "value": "my-gitlab-group", "label": "my-gitlab-group (GitLab)", "provider": "gitlab" }
+]
+```
+
+| Field      | Type     | Description |
+|------------|----------|-------------|
+| `value`    | `string` | Org/username to pass to `POST /api/github/repos` |
+| `label`    | `string` | Human-readable display name with provider suffix |
+| `provider` | `string` | `"github"` or `"gitlab"` |
+
+**Error:** `500` — No git provider authenticated.
+
+---
+
+### Task Sources
+
+#### `GET /api/task-sources`
+
+List all configured task sources (Linear, HubSpot, GitHub Issues, etc.).
+
+**Response:** `200 OK` — Array of task source objects.
+
+---
+
+#### `POST /api/task-sources`
+
+Create a new task source.
+
+**Request Body:**
+
+```json
+{
+  "name": "My Linear Workspace",
+  "plugin_id": "linear",
+  "config": { "team_id": "TEAM_123" },
+  "mcp_server_id": null
+}
+```
+
+| Field           | Type                   | Required | Description |
+|-----------------|------------------------|----------|-------------|
+| `name`          | `string`               | Yes      | Display name |
+| `plugin_id`     | `string`               | Yes      | Plugin identifier (e.g. `linear`, `hubspot`, `github-issues`) |
+| `config`        | `object`               | No       | Plugin-specific configuration |
+| `mcp_server_id` | `string \| null`       | No       | Associated MCP server ID |
+
+**Response:** `200 OK` — Created task source object.
+
+---
+
+#### `POST /api/task-sources/sync-all`
+
+Trigger a sync of all enabled task sources.
+
+**Response:** `200 OK` — Array of sync results, one per source.
+
+---
+
+#### `POST /api/task-sources/:id/sync`
+
+Sync a single task source by ID.
+
+**Response:** `200 OK`
+
+```json
+{ "source_id": "src_abc123", "imported": 5, "updated": 2, "errors": [] }
+```
+
+---
+
+### Tasks (additional endpoints)
+
+#### `POST /api/tasks`
+
+Create a new task.
+
+**Request Body:**
+
+```json
+{
+  "title": "Fix login bug",
+  "description": "Users cannot log in with SSO",
+  "type": "coding",
+  "priority": "high",
+  "labels": ["bug", "auth"],
+  "repos": ["peakflo/20x"]
+}
+```
+
+| Field         | Type       | Required | Description |
+|---------------|------------|----------|-------------|
+| `title`       | `string`   | Yes      | Task title |
+| `description` | `string`   | No       | Markdown description |
+| `type`        | `TaskType` | No       | Default: `general` |
+| `priority`    | `TaskPriority` | No   | Default: `medium` |
+| `labels`      | `string[]` | No       | Labels array |
+| `repos`       | `string[]` | No       | GitHub/GitLab repo full names |
+| `agent_id`    | `string`   | No       | Pre-assign an agent |
+
+**Response:** `200 OK` — Created task object.
+
+**Error:** `400` — `title` is required.
+
+---
+
+#### `POST /api/tasks/reorder-subtasks`
+
+Reorder subtasks under a parent task.
+
+**Request Body:**
+
+```json
+{
+  "parentId": "task_abc123",
+  "orderedIds": ["task_child3", "task_child1", "task_child2"]
+}
+```
+
+| Field        | Type       | Required | Description |
+|--------------|------------|----------|-------------|
+| `parentId`   | `string`   | Yes      | Parent task ID |
+| `orderedIds` | `string[]` | Yes      | Subtask IDs in desired order |
+
+**Response:** `200 OK` — `{ "success": true }`
 
 ---
 

--- a/docs/task-lifecycle.md
+++ b/docs/task-lifecycle.md
@@ -163,13 +163,16 @@ The task-management MCP server provides these tools used during triage:
 
 ### `find_similar_tasks` Algorithm
 
-Uses SQL `LIKE` substring matching — not semantic search:
+Uses **SQLite FTS5 full-text search** with BM25 ranking — not semantic search and not simple LIKE matching:
 
-- `title_keywords` → `WHERE title LIKE '%keyword%'`
-- `description_keywords` → `WHERE description LIKE '%keyword%'`
-- `type` → exact match
-- `labels` → JSON substring match
-- `completed_only` → filters to completed tasks only (default: true)
+- Keywords are tokenised into individual words and matched using FTS5 `MATCH` expressions
+- `title_keywords` → `title:<word>*` (prefix match, higher BM25 weight)
+- `description_keywords` → `description:<word>*` (prefix match, lower BM25 weight)
+- `type` → exact column filter
+- `labels` → `labels:<word>` per label token
+- Results are ranked by `bm25(tasks_fts, 10.0, 5.0, 2.0, 1.0)` — title matches weighted 10×, description 5×
+- `completed_only` → filters to completed tasks first; falls back to all statuses if no results found
+- Falls back to recent tasks ordered by `created_at DESC` if no keywords are provided
 
 ## Key Files
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -15,7 +15,7 @@ import { ClaudeCodeAdapter } from './adapters/claude-code-adapter'
 import { AcpAdapter } from './adapters/acp-adapter'
 import type { CodingAgentAdapter, SessionConfig, MessagePart, SessionMessage, McpServerConfig } from './adapters/coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './adapters/coding-agent-adapter'
-import { getTaskApiPort, waitForTaskApiServer } from './task-api-server'
+import { getTaskApiPort, getTaskApiToken, waitForTaskApiServer } from './task-api-server'
 import { randomUUID } from 'crypto'
 import { registerSecretSession, unregisterSecretSession, getSecretBrokerPort, writeSecretShellWrapper } from './secret-broker'
 import { registerMcpProxyTarget, getMcpAuthProxyPort } from './mcp-auth-proxy'
@@ -430,10 +430,14 @@ export class AgentManager extends EventEmitter {
         let env = { ...mcpServer.environment }
         if (mcpServer.name === 'task-management') {
           const apiPort = getTaskApiPort()
+          const apiToken = getTaskApiToken()
           if (apiPort) {
             env = { ...env, TASK_API_URL: `http://127.0.0.1:${apiPort}` }
           } else {
             console.warn(`[AgentManager] buildMcpServersForAdapter - task API port is null for task-management server`)
+          }
+          if (apiToken) {
+            env = { ...env, TASK_API_TOKEN: apiToken }
           }
           // Inject task scope for subtask agents (restricts access to parent + siblings only)
           if (opts?.taskScope) {
@@ -497,10 +501,15 @@ export class AgentManager extends EventEmitter {
       const tmServer = allServers.find(s => s.name === 'task-management')
       if (tmServer && tmServer.type === 'local') {
         const apiPort = getTaskApiPort()
+        const apiToken = getTaskApiToken()
         if (!apiPort) {
           console.warn('[AgentManager] buildMcpServersForAdapter - task API port is null! MCP server may fail to start')
         }
-        const env: Record<string, string> = { ...tmServer.environment, ...(apiPort ? { TASK_API_URL: `http://127.0.0.1:${apiPort}` } : {}) }
+        const env: Record<string, string> = {
+          ...tmServer.environment,
+          ...(apiPort ? { TASK_API_URL: `http://127.0.0.1:${apiPort}` } : {}),
+          ...(apiToken ? { TASK_API_TOKEN: apiToken } : {})
+        }
         if (opts?.taskScope) {
           env.TASK_SCOPE_PARENT_ID = opts.taskScope.parentTaskId
           env.TASK_SCOPE_TASK_ID = opts.taskScope.taskId
@@ -3602,11 +3611,13 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         finish({ status: 'failed', error: 'Connection timeout (30s)' })
       }, 30000)
 
-      // Inject TASK_API_URL for the built-in task-management server
+      // Inject TASK_API_URL and TASK_API_TOKEN for the built-in task-management server
       const extraEnv: Record<string, string> = {}
       if (serverData.name === 'task-management') {
         const apiPort = getTaskApiPort()
+        const apiToken = getTaskApiToken()
         if (apiPort) extraEnv.TASK_API_URL = `http://127.0.0.1:${apiPort}`
+        if (apiToken) extraEnv.TASK_API_TOKEN = apiToken
       }
 
       // Spawn directly with args array (no shell quoting) to avoid Windows single-quote issues.

--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -477,3 +477,48 @@ describe('Closed database behavior', () => {
     expect(db.getMcpServer('any-id')).toBeUndefined()
   })
 })
+
+describe('JSON resilience — malformed columns', () => {
+  let rawDb: import('better-sqlite3').Database
+
+  beforeEach(() => {
+    rawDb = (db as unknown as { db: import('better-sqlite3').Database }).db
+  })
+
+  it('returns [] for labels when column contains malformed JSON', () => {
+    const task = db.createTask(makeTask({ title: 'Corrupt Labels Task' }))!
+    rawDb.prepare('UPDATE tasks SET labels = ? WHERE id = ?').run('not valid json{', task.id)
+
+    const result = db.getTask(task.id)
+    expect(result).not.toBeNull()
+    expect(result?.title).toBe('Corrupt Labels Task')
+    expect(result?.labels).toEqual([])
+  })
+
+  it('returns [] for attachments when column contains malformed JSON', () => {
+    const task = db.createTask(makeTask({ title: 'Corrupt Attachments Task' }))!
+    rawDb.prepare('UPDATE tasks SET attachments = ? WHERE id = ?').run('{broken', task.id)
+
+    const result = db.getTask(task.id)
+    expect(result?.attachments).toEqual([])
+  })
+
+  it('returns [] for repos when column contains malformed JSON', () => {
+    const task = db.createTask(makeTask({ title: 'Corrupt Repos Task' }))!
+    rawDb.prepare('UPDATE tasks SET repos = ? WHERE id = ?').run('[[invalid', task.id)
+
+    const result = db.getTask(task.id)
+    expect(result?.repos).toEqual([])
+  })
+
+  it('does not crash getTasks when one task has malformed JSON', () => {
+    const task1 = db.createTask(makeTask({ title: 'Good Task' }))!
+    const task2 = db.createTask(makeTask({ title: 'Bad Task' }))!
+    rawDb.prepare('UPDATE tasks SET labels = ? WHERE id = ?').run('%%%broken%%%', task2.id)
+
+    const tasks = db.getTasks()
+    expect(tasks.length).toBe(2)
+    expect(tasks.find(t => t.id === task2.id)?.labels).toEqual([])
+    expect(tasks.find(t => t.id === task1.id)?.title).toBe('Good Task')
+  })
+})

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -451,8 +451,12 @@ function ensureArray<T = string>(value: unknown): T[] {
 
 /** Safely parse a JSON column that should be an array */
 function parseJsonArray<T = string>(raw: string | null | undefined, fallback = '[]'): T[] {
-  const parsed = JSON.parse(raw || fallback)
-  return ensureArray<T>(parsed)
+  try {
+    const parsed = JSON.parse(raw || fallback)
+    return ensureArray<T>(parsed)
+  } catch {
+    return []
+  }
 }
 
 function deserializeTask(row: TaskRow): TaskRecord {

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -5,6 +5,7 @@
  * endpoints via fetch, avoiding the native module version mismatch.
  */
 import { createServer, type Server as HttpServer } from 'http'
+import { randomUUID, timingSafeEqual } from 'crypto'
 import { CronExpressionParser } from 'cron-parser'
 import type { DatabaseManager } from './database'
 import { TaskStatus } from '../shared/constants'
@@ -16,6 +17,14 @@ let startupPromise: Promise<number> | null = null
 let notifyRenderer: ((channel: string, data: unknown) => void) | null = null
 let transcriptProvider: ((taskId: string) => Promise<Array<{ role: string; text: string }>>) | null = null
 let agentController: Pick<AgentManager, 'startTask'> | null = null
+
+/** Bearer token required by all callers of the task API (e.g. task-management MCP). */
+let taskApiToken: string | null = null
+
+/** Returns the bearer token to be passed to MCP child processes via TASK_API_TOKEN env var. */
+export function getTaskApiToken(): string | null {
+  return taskApiToken
+}
 
 export function getTaskApiPort(): number | null {
   return port
@@ -55,10 +64,28 @@ export function startTaskApiServer(db: DatabaseManager): Promise<number> {
   if (server && port) return Promise.resolve(port)
   if (startupPromise) return startupPromise
 
+  // Generate a fresh token each time the server starts
+  taskApiToken = randomUUID()
+
   startupPromise = new Promise((resolve, reject) => {
     server = createServer((req, res) => {
       // CORS not needed — local only
       res.setHeader('Content-Type', 'application/json')
+
+      // Auth check — reject requests without the correct bearer token
+      const authHeader = req.headers.authorization
+      const provided = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null
+      const expected = taskApiToken!
+      const tokenValid =
+        provided !== null &&
+        provided.length === expected.length &&
+        timingSafeEqual(Buffer.from(provided), Buffer.from(expected))
+
+      if (!tokenValid) {
+        res.writeHead(401)
+        res.end(JSON.stringify({ error: 'Unauthorized' }))
+        return
+      }
 
       let body = ''
       req.on('data', (chunk) => { body += chunk })

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { createTestDb } from './helpers/db-test-helper'
+import { makeTask } from './helpers/task-fixtures'
+
+describe('database resilience', () => {
+  it('returns task with empty arrays when JSON columns are malformed', () => {
+    const { db, rawDb } = createTestDb()
+
+    // First create a normal task
+    const task = db.createTask(makeTask({ title: 'Corrupt Task' }))
+
+    // Then directly corrupt its labels column with invalid JSON
+    rawDb.prepare(
+      `UPDATE tasks SET labels = ? WHERE id = ?`
+    ).run('not valid json{', task!.id)
+
+    // getTask should NOT throw — should return task with labels as []
+    const result = db.getTask(task!.id)
+
+    expect(result).not.toBeNull()
+    expect(result?.labels).toEqual([])
+    expect(result?.title).toBe('Corrupt Task')
+  })
+})


### PR DESCRIPTION

## Summary
Adds authentication to the local task API server and improves database resilience against malformed JSON data.

## Related Issue
Fixes #309 (item 2) — Local task API has no authentication

## Changes

**Security**
- `src/main/task-api-server.ts` — Added bearer token auth using `randomUUID()` + `timingSafeEqual` (prevents timing attacks)
- `src/main/agent-manager.ts` — Pass `TASK_API_TOKEN` env var to all three agent child process launch points

**Resilience**
- `src/main/database.ts` — Wrapped `parseJsonArray` in try-catch so one corrupt JSON column can't crash all task reads
- `src/main/database.test.ts` — 4 new tests (53 total, all passing)

**Documentation**
- `AGENTS.md` — Removed "not yet implemented" — architecture is fully built
- `docs/task-lifecycle.md` — Fixed `find_similar_tasks` description (FTS5 + BM25, not SQL LIKE)
- `docs/mobile-api-spec.md` — Fixed skills schema + added 7 undocumented endpoints