### PR TITLE
fix: dedupe repeated agent errors

### DIFF
--- a/src/main/adapters/claude-code-adapter.test.ts
+++ b/src/main/adapters/claude-code-adapter.test.ts
@@ -75,6 +75,7 @@ describe('ClaudeCodeAdapter error result handling', () => {
 
       const errorPart = parts.find((p: any) => p.text?.includes('Rate limit'))
       expect(errorPart).toBeDefined()
+      expect(errorPart!.type).toBe(MessagePartType.ERROR)
       expect(errorPart!.text).toBe('Rate limit exceeded')
     })
 
@@ -93,6 +94,7 @@ describe('ClaudeCodeAdapter error result handling', () => {
 
       const errorPart = parts.find((p: any) => p.text?.includes('Connection timeout'))
       expect(errorPart).toBeDefined()
+      expect(errorPart!.type).toBe(MessagePartType.ERROR)
       expect(errorPart!.text).toBe('Connection timeout; Retry failed')
     })
 
@@ -111,7 +113,34 @@ describe('ClaudeCodeAdapter error result handling', () => {
 
       const errorPart = parts.find((p: any) => p.text?.includes('RATE_LIMIT'))
       expect(errorPart).toBeDefined()
+      expect(errorPart!.type).toBe(MessagePartType.ERROR)
       expect(errorPart!.text).toContain('Too many requests')
+    })
+
+    it('surfaces Claude API error assistant messages as error parts', async () => {
+      const errorMsg = {
+        type: 'assistant',
+        isApiErrorMessage: true,
+        message: {
+          id: 'api-error-msg',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Prompt is too long' }],
+        },
+        uuid: 'api-error-1',
+      }
+      const { adapter } = createAdapterWithSession('s1', [errorMsg])
+
+      const seenPartIds = new Set<string>()
+      const partContentLengths = new Map<string, string>()
+      const parts = await adapter.pollMessages('s1', new Set(), seenPartIds, partContentLengths, {} as any)
+
+      expect(parts).toEqual([
+        expect.objectContaining({
+          id: 'api-error-msg-text-0',
+          type: MessagePartType.ERROR,
+          text: 'Prompt is too long',
+        })
+      ])
     })
 
     it('surfaces fallback error text when no details available', async () => {

--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -1056,6 +1056,23 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
           session.lastError = errorText
         }
 
+        if (msg.type === 'assistant' && (msg as Record<string, unknown>).isApiErrorMessage === true) {
+          const raw = msg as Record<string, unknown>
+          const messageField = raw.message as { content?: unknown[] } | undefined
+          const contentField = Array.isArray(messageField?.content)
+            ? messageField.content
+            : Array.isArray(raw.content) ? raw.content as unknown[] : []
+          const text = contentField
+            .map((part) => {
+              const partRecord = part as { type?: string; text?: string }
+              return partRecord.type === 'text' ? partRecord.text || '' : ''
+            })
+            .filter(Boolean)
+            .join('\n')
+          session.status = 'error'
+          session.lastError = text || 'Claude Code API error'
+        }
+
         // Buffer message (only if we didn't throw above)
         session.messageBuffer.push(message)
 
@@ -1210,6 +1227,7 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
       usage?: { total_tokens: number; tool_uses: number; duration_ms: number }
       task_type?: string
       prompt?: string
+      isApiErrorMessage?: boolean
     }
 
     // ── Skip messages from inside a subtask ──
@@ -1227,6 +1245,7 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
     if (msgWithProps.type === 'assistant' || msgWithProps.type === 'assistant_message') {
       // Content is nested inside message.content for Claude Code SDK format
       const content = msgWithProps.message?.content || (Array.isArray(msgWithProps.content) ? msgWithProps.content : [])
+      const partType = msgWithProps.isApiErrorMessage ? MessagePartType.ERROR : MessagePartType.TEXT
 
       // Use the stable API message ID (e.g. msg_01FG7...) for dedup, not the streaming UUID.
       // Claude Code sends multiple streaming chunks with different UUIDs but the same API message ID
@@ -1252,7 +1271,7 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
               partContentLengths.set(partId, String(text.length))
               parts.push({
                 id: partId,
-                type: MessagePartType.TEXT,
+                type: partType,
                 text,
                 update: true,
               })
@@ -1263,7 +1282,7 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
           partContentLengths.set(partId, String(text.length))
           parts.push({
             id: partId,
-            type: MessagePartType.TEXT,
+            type: partType,
             text,
           })
         } else if (blockWithProps.type === 'thinking') {
@@ -1539,7 +1558,7 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
           partContentLengths.set(partId, String(errorText.length))
           parts.push({
             id: partId,
-            type: MessagePartType.TEXT,
+            type: MessagePartType.ERROR,
             text: errorText,
             role: 'system',
           })

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1819,6 +1819,61 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
     expect(entry.hasSeenWork).toBe(true)
   })
 
+  it('pollSingleSession does not inject a duplicate status error when the poll already emitted the same error text', async () => {
+    const mgr = buildManager()
+    const errorMessage = 'API Error: Server is temporarily limiting requests (not your usage limit) - Rate limited'
+    const adapter = {
+      pollMessages: vi.fn(async () => [
+        {
+          id: 'provider-error',
+          role: 'assistant',
+          type: MessagePartType.ERROR,
+          content: errorMessage,
+          receivedAt: Date.now(),
+        }
+      ] as any[]),
+      getStatus: vi.fn(async () => ({ type: SessionStatusType.ERROR, message: errorMessage })),
+    }
+
+    const session = {
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      status: 'working',
+      createdAt: new Date(),
+      seenMessageIds: new Set<string>(),
+      seenPartIds: new Set<string>(),
+      partContentLengths: new Map<string, string>(),
+      adapter,
+      pollingStarted: true,
+    }
+    ;(mgr as any).sessions.set('session-1', session)
+
+    ;(mgr as any).startAdapterPolling(
+      'session-1',
+      adapter,
+      { agentId: 'agent-1', taskId: 'task-1', workspaceDir: '/tmp/ws' },
+      undefined,
+      session
+    )
+
+    const entry = (mgr as any).pollingEntries.get('session-1')
+    await (mgr as any).pollSingleSession(entry)
+
+    const sendSpy = vi.mocked((mgr as any).sendToRenderer)
+    const outputBatchCalls = sendSpy.mock.calls.filter(([channel]) => channel === 'agent:output-batch')
+    const outputCalls = sendSpy.mock.calls.filter(([channel]) => channel === 'agent:output')
+    const statusCalls = sendSpy.mock.calls.filter(([channel]) => channel === 'agent:status')
+
+    expect(outputBatchCalls).toHaveLength(1)
+    expect((outputBatchCalls[0][1] as any).messages).toEqual([
+      expect.objectContaining({ id: 'provider-error', content: errorMessage })
+    ])
+    expect(outputCalls).toHaveLength(0)
+    expect(statusCalls).toEqual([
+      ['agent:status', expect.objectContaining({ status: 'error' })]
+    ])
+  })
+
   it('pollSingleSession transitions to idle after BUSY then IDLE (work completed)', async () => {
     const mgr = buildManager()
     const adapter = buildAdapter()

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -190,6 +190,7 @@ export class AgentManager extends EventEmitter {
   private static readonly MAX_SESSION_REDIRECTS = 200
   /** Maximum number of tillDone idle nudges per session before giving up. */
   private static readonly MAX_TILLDONE_NUDGES = 5
+  private static readonly ERROR_TEXT_DEDUPE_WINDOW_MS = 5_000
 
   /** Maximum time (ms) a session can stay BUSY with no new data before we abort it.
    *  Prevents sessions from being stuck indefinitely when a tool call hangs inside
@@ -226,6 +227,28 @@ export class AgentManager extends EventEmitter {
   constructor(db: DatabaseManager) {
     super()
     this.db = db
+  }
+
+  private normalizeErrorText(value?: string): string {
+    return (value || '').replace(/\s+/g, ' ').trim().toLowerCase()
+  }
+
+  private hasMatchingErrorMessage(
+    messages: Array<{ content: string; partType?: string; receivedAt?: number }>,
+    errorMessage?: string
+  ): boolean {
+    const normalizedError = this.normalizeErrorText(errorMessage)
+    if (!normalizedError) return false
+
+    const now = Date.now()
+    return messages.some((message) => {
+      if (message.partType !== 'error' && message.partType !== 'retry') return false
+      if (message.receivedAt && now - message.receivedAt > AgentManager.ERROR_TEXT_DEDUPE_WINDOW_MS) {
+        return false
+      }
+      const normalizedContent = this.normalizeErrorText(message.content)
+      return normalizedContent === normalizedError
+    })
   }
 
   /**
@@ -1790,7 +1813,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       // Collect all parts into a batch instead of sending individually.
       // This avoids flooding the renderer with N separate IPC messages
       // that each trigger a Zustand state update + React re-render.
-      const batchMessages: Array<{ id: string; role: string; content: string; partType?: string; tool?: unknown; update?: boolean; taskProgress?: unknown }> = []
+      const batchMessages: Array<{ id: string; role: string; content: string; partType?: string; tool?: unknown; update?: boolean; taskProgress?: unknown; receivedAt?: number }> = []
       for (const part of newParts) {
         // Skip ALL user/human messages from polling — we already show them in the UI
         // via sendToRenderer in startAdapterSession (initial) and doSendAdapterMessage (follow-ups).
@@ -1805,7 +1828,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           partType: part.type,
           tool: part.tool,
           update: part.update,
-          taskProgress: part.taskProgress
+          taskProgress: part.taskProgress,
+          receivedAt: part.receivedAt
         })
       }
 
@@ -1899,18 +1923,21 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           return
         }
 
-        // Regular error (e.g., rate limit)
-        this.sendToRenderer('agent:output', {
-          sessionId,
-          taskId: config.taskId,
-          type: 'message',
-          data: {
-            id: `error-${Date.now()}`,
-            role: 'system',
-            content: status.message || 'An unexpected error occurred. Check logs for details.',
-            partType: 'error'
-          }
-        })
+        // Regular error (e.g., rate limit). If the same poll already delivered
+        // the provider error as a transcript part, do not inject a second copy.
+        if (!this.hasMatchingErrorMessage(batchMessages, status.message)) {
+          this.sendToRenderer('agent:output', {
+            sessionId,
+            taskId: config.taskId,
+            type: 'message',
+            data: {
+              id: `error-${Date.now()}`,
+              role: 'system',
+              content: status.message || 'An unexpected error occurred. Check logs for details.',
+              partType: 'error'
+            }
+          })
+        }
 
         if (session) {
           session.status = 'error'

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
@@ -4,9 +4,14 @@ import { AgentTranscriptPanel } from './AgentTranscriptPanel'
 import { SessionStatus } from '@/stores/agent-store'
 
 vi.mock('@tanstack/react-virtual', () => ({
-  useVirtualizer: () => ({
-    getTotalSize: () => 0,
-    getVirtualItems: () => [],
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 120,
+    getVirtualItems: () => Array.from({ length: count }, (_, index) => ({
+      index,
+      key: index,
+      start: index * 120,
+      size: 120
+    })),
     scrollToIndex: vi.fn(),
     measureElement: vi.fn()
   })
@@ -79,5 +84,32 @@ describe('AgentTranscriptPanel drag and drop attachments', () => {
         }
       ]
     })
+  })
+})
+
+describe('AgentTranscriptPanel error display', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('does not render a separate banner for an error already shown as the final message', () => {
+    render(
+      <AgentTranscriptPanel
+        messages={[
+          {
+            id: 'error-1',
+            role: 'system',
+            content: 'API Error: Server is temporarily limiting requests',
+            timestamp: new Date(),
+            partType: 'error'
+          }
+        ]}
+        status={SessionStatus.IDLE}
+        onStop={() => undefined}
+      />
+    )
+
+    expect(screen.getAllByText('API Error: Server is temporarily limiting requests')).toHaveLength(1)
   })
 })

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -654,6 +654,7 @@ export function AgentTranscriptPanel({
     if (last.partType === 'error' || last.partType === 'retry') return last
     return null
   }, [messages, status])
+  const showErrorBanner = !!lastErrorMessage && lastErrorMessage.partType !== 'error'
 
   const atBottomRef = useRef(true)
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
@@ -826,7 +827,7 @@ export function AgentTranscriptPanel({
       </div>
 
       {/* Error banner */}
-      {lastErrorMessage && (
+      {showErrorBanner && lastErrorMessage && (
         <div className="flex items-center gap-2 px-4 py-2.5 bg-red-500/10 border-b border-red-500/20 shrink-0">
           <AlertTriangle className="h-3.5 w-3.5 text-red-400 shrink-0" />
           <span className="text-xs text-red-300 truncate">{lastErrorMessage.content}</span>

--- a/src/renderer/src/stores/agent-store.test.ts
+++ b/src/renderer/src/stores/agent-store.test.ts
@@ -249,6 +249,46 @@ describe('useAgentStore', () => {
       expect(msgs[0].content).toBe('Hello')
     })
 
+    it('deduplicates identical explicit error messages across roles', async () => {
+      useAgentStore.getState().initSession('task-1', 'sess-1', 'agent-1')
+
+      const content = 'API Error: Server is temporarily limiting requests (not your usage limit) - Rate limited'
+      batchCallback!({
+        sessionId: 'sess-1',
+        taskId: 'task-1',
+        messages: [
+          { id: 'assistant-error-text', role: 'assistant', content, partType: 'error' },
+          { id: 'system-error-text', role: 'system', content, partType: 'error' }
+        ]
+      })
+      await flushBatches()
+
+      const msgs = useAgentStore.getState().sessions.get('task-1')!.messages
+      expect(msgs).toHaveLength(1)
+      expect(msgs[0].content).toBe(content)
+      expect(msgs[0].partType).toBe('error')
+    })
+
+    it('does not infer errors from plain text content', async () => {
+      useAgentStore.getState().initSession('task-1', 'sess-1', 'agent-1')
+
+      const content = 'API Error: Server is temporarily limiting requests (not your usage limit) - Rate limited'
+      batchCallback!({
+        sessionId: 'sess-1',
+        taskId: 'task-1',
+        messages: [
+          { id: 'assistant-text', role: 'assistant', content, partType: 'text' },
+          { id: 'system-text', role: 'system', content, partType: 'text' }
+        ]
+      })
+      await flushBatches()
+
+      const msgs = useAgentStore.getState().sessions.get('task-1')!.messages
+      expect(msgs).toHaveLength(2)
+      expect(msgs[0].partType).toBe('text')
+      expect(msgs[1].partType).toBe('text')
+    })
+
     it('handles update messages (tool completion)', async () => {
       useAgentStore.getState().initSession('task-1', 'sess-1', 'agent-1')
 

--- a/src/renderer/src/stores/agent-store.ts
+++ b/src/renderer/src/stores/agent-store.ts
@@ -75,6 +75,7 @@ const stepStartTimes = new Map<string, number>()
 
 // Maximum dedup IDs per task before eviction (prevents memory leak during long sessions)
 const MAX_SEEN_IDS_PER_TASK = 10_000
+const ERROR_CONTENT_DEDUPE_WINDOW_MS = 5_000
 
 function getSeen(taskId: string): Set<string> {
   if (!seenIds.has(taskId)) seenIds.set(taskId, new Set())
@@ -95,6 +96,30 @@ function findBySessionId(sessions: Map<string, TaskSession>, sid: string): TaskS
     if (s.sessionId === sid) return s
   }
   return undefined
+}
+
+function normalizeMessageContent(content: string): string {
+  return content.replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
+function isErrorPart(partType: string | undefined): boolean {
+  return partType === 'error' || partType === 'retry'
+}
+
+function hasRecentDuplicateError(
+  messages: AgentMessage[],
+  partType: string | undefined,
+  content: string,
+  now: number
+): boolean {
+  if (!content || !isErrorPart(partType)) return false
+
+  const normalized = normalizeMessageContent(content)
+  return messages.some((message) => {
+    if (now - message.timestamp.getTime() > ERROR_CONTENT_DEDUPE_WINDOW_MS) return false
+    if (!isErrorPart(message.partType)) return false
+    return normalizeMessageContent(message.content) === normalized
+  })
 }
 
 // ── Store ─────────────────────────────────────────────────────
@@ -288,6 +313,16 @@ export const useAgentStore = create<AgentState>((set, get) => {
 
     // Ignore empty placeholder parts without poisoning dedup for the real content.
     if (!content && !data.tool && !data.questions && !data.todos && !data.taskProgress) return
+    const partType = data.partType as string | undefined
+    if (hasRecentDuplicateError(
+      resolvedSession.messages,
+      partType,
+      content,
+      Date.now()
+    )) {
+      seen.add(msgId)
+      return
+    }
     seen.add(msgId)
 
     set({
@@ -295,7 +330,7 @@ export const useAgentStore = create<AgentState>((set, get) => {
         ...resolvedSession,
         messages: [
           ...resolvedSession.messages,
-          { id: msgId, role, content, timestamp: new Date(), partType: data.partType as string, tool: data.tool as AgentMessage['tool'], taskProgress: data.taskProgress as AgentMessage['taskProgress'] }
+          { id: msgId, role, content, timestamp: new Date(), partType, tool: data.tool as AgentMessage['tool'], taskProgress: data.taskProgress as AgentMessage['taskProgress'] }
         ]
       })
     })
@@ -403,6 +438,12 @@ export const useAgentStore = create<AgentState>((set, get) => {
 
         // Allow empty content for tool/question/task_progress messages
         if (!content && !msg.tool && !(msg as Record<string, unknown>).taskProgress) continue
+        const now = Date.now()
+        const partType = msg.partType
+        if (hasRecentDuplicateError(messages, partType, content, now)) {
+          seen.add(msgId)
+          continue
+        }
         seen.add(msgId)
 
         messages.push({
@@ -411,8 +452,8 @@ export const useAgentStore = create<AgentState>((set, get) => {
           content,
           timestamp: (msg as Record<string, unknown>).receivedAt
             ? new Date((msg as Record<string, unknown>).receivedAt as number)
-            : new Date(),
-          partType: msg.partType,
+            : new Date(now),
+          partType,
           tool: msg.tool as AgentMessage['tool'],
           taskProgress: (msg as Record<string, unknown>).taskProgress as AgentMessage['taskProgress']
         })


### PR DESCRIPTION
## Summary
- Prevent the agent manager from injecting a duplicate status error when the same poll already emitted the provider error as a transcript part.
- Deduplicate recent identical provider error content in the renderer store across assistant/system/error variants, and promote obvious provider errors to error styling.
- Avoid rendering a separate transcript error banner when the final error message is already visible in the transcript.

## Test plan
- pnpm test:run src/main/agent-manager.test.ts src/renderer/src/stores/agent-store.test.ts src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
- pnpm run typecheck
- pnpm run lint (0 errors; existing warnings remain)