### PR TITLE
Fix Codex ACP overlapping stream chunks

### DIFF
--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -2837,6 +2837,167 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
       expect(finalParts).toHaveLength(0)
     })
 
+    it('should merge overlapping assistant chunks without repeating the shared boundary text', () => {
+      const sessionId = 'test-session'
+      const priv = adapterPrivate(adapter)
+      const session = createMockSession(sessionId)
+      priv.sessions.set(sessionId, session)
+
+      const seenPartIds = new Set<string>()
+      const partContentLengths = new Map<string, string>()
+
+      const chunk1 = {
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'The matching UI' }
+          }
+        }
+      }
+
+      const chunk2 = {
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'matching UI looks like the transcript' }
+          }
+        }
+      }
+
+      priv.convertAcpEventToMessageParts(chunk1, new Set(), seenPartIds, partContentLengths, session)
+      const parts2 = priv.convertAcpEventToMessageParts(chunk2, new Set(), seenPartIds, partContentLengths, session)
+
+      expect(parts2).toHaveLength(1)
+      expect(parts2[0].text).toBe('The matching UI looks like the transcript')
+      expect(parts2[0].text).not.toContain('matching UImatching UI')
+    })
+
+    it('should handle cumulative assistant chunks by keeping the latest full text', () => {
+      const sessionId = 'test-session'
+      const priv = adapterPrivate(adapter)
+      const session = createMockSession(sessionId)
+      priv.sessions.set(sessionId, session)
+
+      const seenPartIds = new Set<string>()
+      const partContentLengths = new Map<string, string>()
+
+      const chunk1 = {
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Error: streaming' }
+          }
+        }
+      }
+
+      const chunk2 = {
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'Error: streaming failed after timeout' }
+          }
+        }
+      }
+
+      priv.convertAcpEventToMessageParts(chunk1, new Set(), seenPartIds, partContentLengths, session)
+      const parts2 = priv.convertAcpEventToMessageParts(chunk2, new Set(), seenPartIds, partContentLengths, session)
+
+      expect(parts2).toHaveLength(1)
+      expect(parts2[0].text).toBe('Error: streaming failed after timeout')
+    })
+
+    it('should merge replayed assistant chunks that restart after the first character', () => {
+      const sessionId = 'test-session'
+      const priv = adapterPrivate(adapter)
+      const session = createMockSession(sessionId)
+      priv.sessions.set(sessionId, session)
+
+      const seenPartIds = new Set<string>()
+      const partContentLengths = new Map<string, string>()
+
+      const chunk1 = {
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: {
+              type: 'text',
+              text: "I'll use the pr-heartbeat-check workflow for this"
+            }
+          }
+        }
+      }
+
+      const chunk2 = {
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: {
+              type: 'text',
+              text: "'ll use the pr-heartbeat-check workflow for this, scoped to PR #380"
+            }
+          }
+        }
+      }
+
+      priv.convertAcpEventToMessageParts(chunk1, new Set(), seenPartIds, partContentLengths, session)
+      const parts2 = priv.convertAcpEventToMessageParts(chunk2, new Set(), seenPartIds, partContentLengths, session)
+
+      expect(parts2).toHaveLength(1)
+      expect(parts2[0].text).toBe("I'll use the pr-heartbeat-check workflow for this, scoped to PR #380")
+      expect(parts2[0].text).not.toContain("workflow for this'll use")
+    })
+
+    it('should consolidate permanent history with overlap-aware chunk merging', async () => {
+      const sessionId = 'test-session'
+      const priv = adapterPrivate(adapter)
+      const session = createMockSession(sessionId)
+      priv.sessions.set(sessionId, session)
+
+      priv.handleRpcMessage(session, {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'some errors are shown' }
+          }
+        }
+      })
+
+      priv.handleRpcMessage(session, {
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'errors are shown 3 times' }
+          }
+        }
+      })
+
+      expect(session.permanentMessages).toHaveLength(1)
+
+      const messages = await adapter.getAllMessages(sessionId, {} as never)
+      const text = messages.flatMap((message) => message.parts).map((part) => part.text).join('')
+
+      expect(text).toBe('some errors are shown 3 times')
+      expect(text).not.toContain('errors are shownerrors are shown')
+    })
+
     it('should update existing entry when agent_message has more complete text than chunks', () => {
       const sessionId = 'test-session'
       const priv = adapterPrivate(adapter)

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -1206,7 +1206,7 @@ export class AcpAdapter implements CodingAgentAdapter {
         const lastText = this.extractTextFromUpdateContent(lastUpdate.content)
         const nextText = this.extractTextFromUpdateContent(nextUpdate.content)
         if (typeof lastUpdate.content === 'object' && lastUpdate.content !== null) {
-          (lastUpdate.content as Record<string, unknown>).text = lastText + nextText
+          (lastUpdate.content as Record<string, unknown>).text = this.mergeStreamingText(lastText, nextText)
           consolidated = true
         }
       }
@@ -1497,6 +1497,38 @@ export class AcpAdapter implements CodingAgentAdapter {
     }
 
     return ''
+  }
+
+  private mergeStreamingText(currentText: string, incomingChunk: string): string {
+    if (!currentText) return incomingChunk
+    if (!incomingChunk) return currentText
+
+    if (incomingChunk.startsWith(currentText)) {
+      return incomingChunk
+    }
+
+    if (currentText.endsWith(incomingChunk)) {
+      return currentText
+    }
+
+    const MIN_OVERLAP_CHARS = 8
+
+    const maxSkippedPrefix = Math.min(32, currentText.length - MIN_OVERLAP_CHARS)
+    for (let skipped = 1; skipped <= maxSkippedPrefix; skipped++) {
+      const replayedText = currentText.slice(skipped)
+      if (incomingChunk.startsWith(replayedText)) {
+        return currentText.slice(0, skipped) + incomingChunk
+      }
+    }
+
+    const maxOverlap = Math.min(currentText.length, incomingChunk.length)
+    for (let length = maxOverlap; length > 0; length--) {
+      if (length >= MIN_OVERLAP_CHARS && currentText.endsWith(incomingChunk.slice(0, length))) {
+        return currentText + incomingChunk.slice(length)
+      }
+    }
+
+    return currentText + incomingChunk
   }
 
   private isUserUpdateType(sessionUpdate?: string | null): boolean {
@@ -1802,7 +1834,7 @@ export class AcpAdapter implements CodingAgentAdapter {
         if (chunk) {
           // Accumulate text across multiple chunks
           const currentText = partContentLengths.get(messageId) || ''
-          const newText = currentText + chunk
+          const newText = this.mergeStreamingText(currentText, chunk)
           partContentLengths.set(messageId, newText)
 
           // Return update part with accumulated text
@@ -1826,7 +1858,7 @@ export class AcpAdapter implements CodingAgentAdapter {
         if (chunk) {
           // Accumulate text across multiple chunks
           const currentText = partContentLengths.get(thinkingId) || ''
-          const newText = currentText + chunk
+          const newText = this.mergeStreamingText(currentText, chunk)
           partContentLengths.set(thinkingId, newText)
 
           // Return update part with accumulated text
@@ -1849,7 +1881,7 @@ export class AcpAdapter implements CodingAgentAdapter {
         if (chunk) {
           // Accumulate text across multiple chunks
           const currentText = partContentLengths.get(userId) || ''
-          const newText = currentText + chunk
+          const newText = this.mergeStreamingText(currentText, chunk)
           partContentLengths.set(userId, newText)
 
           // Return update part with accumulated text


### PR DESCRIPTION
## Summary
- normalize Codex ACP streaming chunks with overlap-aware text merging
- apply the same merge path to permanent transcript history used for resume/replay
- add regression coverage for overlapping chunks, cumulative chunks, and permanent history consolidation

## Verification
- git diff --check
- attempted pnpm run test:main src/main/adapters/acp-adapter.test.ts --runInBand, but the worktree had no node_modules/electron
- attempted pnpm install --offline; install failed rebuilding better-sqlite3 against Node 26 before Electron was linked