### PR TITLE
feat: AI generation links knowledge bases

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -2284,3 +2284,331 @@ describe('AgentManager tillDone nudge on idle', () => {
     expect(sendSpy).not.toHaveBeenCalled()
   })
 })
+
+// ── Entity-KB Linkage Awareness Tests ──────────────────────────────
+
+describe('Entity-KB Linkage Awareness', () => {
+  function createMockDbWithMcpTools(tools: Array<{ name: string; description: string }>, agentConfig: Record<string, unknown> = {}) {
+    return {
+      getTask: vi.fn(() => ({
+        id: 'task-1',
+        title: 'Test Task',
+        repos: ['org/repo'],
+        skill_ids: ['skill-1'],
+        labels: [],
+      })),
+      getTasks: vi.fn(() => []),
+      getSubtasks: vi.fn(() => []),
+      getAgent: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'Test Agent',
+        config: {
+          mcp_servers: ['mcp-server-1'],
+          ...agentConfig,
+        },
+      })),
+      getAgents: vi.fn(() => ([{
+        id: 'agent-1',
+        name: 'Test Agent',
+        is_default: true,
+        config: { mcp_servers: ['mcp-server-1'], ...agentConfig },
+      }])),
+      getSkills: vi.fn(() => [makeSkillRecord()]),
+      getSkillsByIds: vi.fn(() => [makeSkillRecord()]),
+      getSkillByName: vi.fn(() => null),
+      getMcpServer: vi.fn(() => ({
+        id: 'mcp-server-1',
+        name: 'Workflo MCP Dev Server',
+        type: 'remote',
+        url: 'https://example.com/api/mcp/dev/mcp',
+        tools,
+        headers: {},
+        environment: {},
+        source: 'enterprise',
+      })),
+      getMcpServers: vi.fn(() => []),
+      getSecretsByIds: vi.fn(() => []),
+      getSecretsWithValues: vi.fn(() => []),
+      getSetting: vi.fn(() => null),
+      getWorkspaceDir: vi.fn(() => '/tmp/test-workspace'),
+      updateTask: vi.fn(),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+  }
+
+  describe('getBusinessContextToolAccess', () => {
+    it('returns hasGraphTools=true when agent has graph_* tools', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_resolve', description: 'Resolve entity' },
+      ])
+      const mgr = new AgentManager(db)
+      const access = (mgr as any).getBusinessContextToolAccess('agent-1')
+
+      expect(access.hasGraphTools).toBe(true)
+      expect(access.hasDatastoreTools).toBe(false)
+      expect(access.hasLinkTool).toBe(false)
+      expect(access.graphToolNames).toEqual(['graph_entities', 'graph_resolve'])
+    })
+
+    it('returns hasDatastoreTools=true when agent has datastore_* tools', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'datastore_list', description: 'List datastores' },
+        { name: 'datastore_query', description: 'Query datastore' },
+      ])
+      const mgr = new AgentManager(db)
+      const access = (mgr as any).getBusinessContextToolAccess('agent-1')
+
+      expect(access.hasGraphTools).toBe(false)
+      expect(access.hasDatastoreTools).toBe(true)
+      expect(access.datastoreToolNames).toEqual(['datastore_list', 'datastore_query'])
+    })
+
+    it('detects graph_link_datastore tool specifically', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_link_datastore', description: 'Link entity to datastore' },
+        { name: 'datastore_list', description: 'List datastores' },
+      ])
+      const mgr = new AgentManager(db)
+      const access = (mgr as any).getBusinessContextToolAccess('agent-1')
+
+      expect(access.hasGraphTools).toBe(true)
+      expect(access.hasDatastoreTools).toBe(true)
+      expect(access.hasLinkTool).toBe(true)
+    })
+
+    it('returns false for all when agent has no graph/datastore tools', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'workflow_list', description: 'List workflows' },
+        { name: 'task_list', description: 'List tasks' },
+      ])
+      const mgr = new AgentManager(db)
+      const access = (mgr as any).getBusinessContextToolAccess('agent-1')
+
+      expect(access.hasGraphTools).toBe(false)
+      expect(access.hasDatastoreTools).toBe(false)
+      expect(access.hasLinkTool).toBe(false)
+    })
+
+    it('respects enabledTools filter on MCP server entries', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_link_datastore', description: 'Link entity to datastore' },
+        { name: 'datastore_list', description: 'List datastores' },
+        { name: 'datastore_query', description: 'Query datastore' },
+      ])
+      // Override getAgent to use enabledTools filter
+      ;(db.getAgent as any).mockReturnValue({
+        id: 'agent-1',
+        name: 'Test Agent',
+        config: {
+          mcp_servers: [{ serverId: 'mcp-server-1', enabledTools: ['graph_entities', 'datastore_list'] }],
+        },
+      })
+      const mgr = new AgentManager(db)
+      const access = (mgr as any).getBusinessContextToolAccess('agent-1')
+
+      expect(access.hasGraphTools).toBe(true)
+      expect(access.hasDatastoreTools).toBe(true)
+      expect(access.hasLinkTool).toBe(false) // graph_link_datastore filtered out
+      expect(access.graphToolNames).toEqual(['graph_entities'])
+      expect(access.datastoreToolNames).toEqual(['datastore_list'])
+    })
+  })
+
+  describe('buildEntityKbLinkageSection', () => {
+    it('returns empty string when agent lacks graph tools', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'datastore_list', description: 'List datastores' },
+      ])
+      const mgr = new AgentManager(db)
+      const section = (mgr as any).buildEntityKbLinkageSection('agent-1')
+
+      expect(section).toBe('')
+    })
+
+    it('returns empty string when agent lacks datastore tools', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+      ])
+      const mgr = new AgentManager(db)
+      const section = (mgr as any).buildEntityKbLinkageSection('agent-1')
+
+      expect(section).toBe('')
+    })
+
+    it('returns documentation section when agent has both graph and datastore tools', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_link_datastore', description: 'Link entity to datastore' },
+        { name: 'datastore_list', description: 'List datastores' },
+        { name: 'datastore_query', description: 'Query datastore' },
+      ])
+      const mgr = new AgentManager(db)
+      const section = (mgr as any).buildEntityKbLinkageSection('agent-1')
+
+      expect(section).toContain('Business Context: Entity–Datastore Linkage')
+      expect(section).toContain('Entity generation workflow')
+      expect(section).toContain('Discover')
+      expect(section).toContain('Query')
+      expect(section).toContain('Generate')
+      expect(section).toContain('Link')
+      expect(section).toContain('graph_link_datastore')
+      expect(section).toContain('Never invent IDs')
+      expect(section).toContain('Tenant isolation is automatic')
+    })
+
+    it('omits link step when graph_link_datastore tool is not available', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_resolve', description: 'Resolve entity' },
+        { name: 'datastore_list', description: 'List datastores' },
+      ])
+      const mgr = new AgentManager(db)
+      const section = (mgr as any).buildEntityKbLinkageSection('agent-1')
+
+      expect(section).toContain('Business Context: Entity–Datastore Linkage')
+      expect(section).toContain('Discover')
+      expect(section).toContain('Query')
+      expect(section).toContain('Generate')
+      expect(section).not.toContain('graph_link_datastore')
+      expect(section).not.toContain('link_role')
+    })
+  })
+
+  describe('buildEntityKbLinkageInstructions', () => {
+    it('returns empty string when agent lacks Business Context tools', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'workflow_list', description: 'List workflows' },
+      ])
+      const mgr = new AgentManager(db)
+      const task = {
+        id: 'task-1',
+        title: 'Generate entity types for AP',
+        description: 'Create entity types from knowledge base',
+        labels: ['entity-graph'],
+      }
+      const instructions = (mgr as any).buildEntityKbLinkageInstructions(task, 'agent-1')
+
+      expect(instructions).toBe('')
+    })
+
+    it('returns empty string when task is not entity-related', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_link_datastore', description: 'Link entity to datastore' },
+        { name: 'datastore_list', description: 'List datastores' },
+        { name: 'datastore_query', description: 'Query datastore' },
+      ])
+      const mgr = new AgentManager(db)
+      const task = {
+        id: 'task-1',
+        title: 'Fix login bug',
+        description: 'The login page shows an error',
+        labels: ['bugfix'],
+      }
+      const instructions = (mgr as any).buildEntityKbLinkageInstructions(task, 'agent-1')
+
+      expect(instructions).toBe('')
+    })
+
+    it('returns instructions when task title mentions entities', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_link_datastore', description: 'Link entity to datastore' },
+        { name: 'datastore_list', description: 'List datastores' },
+        { name: 'datastore_query', description: 'Query datastore' },
+      ])
+      const mgr = new AgentManager(db)
+      const task = {
+        id: 'task-1',
+        title: 'Generate entity types for AP workflow',
+        description: 'Create new entity types based on AP processes',
+        labels: [],
+      }
+      const instructions = (mgr as any).buildEntityKbLinkageInstructions(task, 'agent-1')
+
+      expect(instructions).toContain('Entity–Datastore Linkage Protocol')
+      expect(instructions).toContain('Before generating')
+      expect(instructions).toContain('After generating')
+      expect(instructions).toContain('graph_link_datastore')
+      expect(instructions).toContain('Never fabricate')
+    })
+
+    it('detects entity-related tasks by labels', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_link_datastore', description: 'Link entity to datastore' },
+        { name: 'datastore_list', description: 'List datastores' },
+      ])
+      const mgr = new AgentManager(db)
+      const task = {
+        id: 'task-1',
+        title: 'Update AP configuration',
+        description: 'Modify the AP setup',
+        labels: ['entity-graph', 'ap'],
+      }
+      const instructions = (mgr as any).buildEntityKbLinkageInstructions(task, 'agent-1')
+
+      expect(instructions).toContain('Entity–Datastore Linkage Protocol')
+    })
+
+    it('detects entity-related tasks by description keywords', () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_link_datastore', description: 'Link entity to datastore' },
+        { name: 'datastore_list', description: 'List datastores' },
+      ])
+      const mgr = new AgentManager(db)
+      const task = {
+        id: 'task-1',
+        title: 'Build financial framework',
+        description: 'Query the knowledge base and create business context entries',
+        labels: [],
+      }
+      const instructions = (mgr as any).buildEntityKbLinkageInstructions(task, 'agent-1')
+
+      expect(instructions).toContain('Entity–Datastore Linkage Protocol')
+    })
+  })
+
+  describe('CLAUDE.md and AGENTS.md include Entity-KB section', () => {
+    it('includes Entity-KB linkage section in CLAUDE.md when tools are available', async () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_link_datastore', description: 'Link entity to datastore' },
+        { name: 'datastore_list', description: 'List datastores' },
+        { name: 'datastore_query', description: 'Query datastore' },
+      ], { coding_agent: 'claude-code' })
+      const mgr = new AgentManager(db)
+      const md = (mgr as any).generateClaudeMd([makeSkillRecord()], ['org/repo'], '/tmp/workspace', 'agent-1')
+
+      expect(md).toContain('Business Context: Entity–Datastore Linkage')
+      expect(md).toContain('Entity generation workflow')
+    })
+
+    it('excludes Entity-KB linkage section in CLAUDE.md when tools are not available', async () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'workflow_list', description: 'List workflows' },
+      ], { coding_agent: 'claude-code' })
+      const mgr = new AgentManager(db)
+      const md = (mgr as any).generateClaudeMd([makeSkillRecord()], ['org/repo'], '/tmp/workspace', 'agent-1')
+
+      expect(md).not.toContain('Business Context: Entity–Datastore Linkage')
+    })
+
+    it('includes Entity-KB linkage section in AGENTS.md when tools are available', async () => {
+      const db = createMockDbWithMcpTools([
+        { name: 'graph_entities', description: 'List entities' },
+        { name: 'graph_link_datastore', description: 'Link entity to datastore' },
+        { name: 'datastore_list', description: 'List datastores' },
+        { name: 'datastore_query', description: 'Query datastore' },
+      ], { coding_agent: 'opencode' })
+      const mgr = new AgentManager(db)
+      const md = (mgr as any).generateAgentsMd([makeSkillRecord()], ['org/repo'], '/tmp/workspace', 'agent-1')
+
+      expect(md).toContain('Business Context: Entity–Datastore Linkage')
+      expect(md).toContain('Entity generation workflow')
+    })
+  })
+})

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -953,6 +953,11 @@ export class AgentManager extends EventEmitter {
       }
     }
 
+    // Add Entity-KB Linkage section (only when agent has both graph_* and datastore_* tools)
+    if (agentId) {
+      md += this.buildEntityKbLinkageSection(agentId)
+    }
+
     // Add secrets section — name and description only, never the value
     if (agentId) {
       const agent2 = this.db.getAgent(agentId)
@@ -1062,6 +1067,11 @@ export class AgentManager extends EventEmitter {
 
         md += `---\n\n`
       }
+    }
+
+    // Add Entity-KB Linkage section (only when agent has both graph_* and datastore_* tools)
+    if (agentId) {
+      md += this.buildEntityKbLinkageSection(agentId)
     }
 
     // Add secrets section — name and description only, never the value
@@ -1384,6 +1394,12 @@ export class AgentManager extends EventEmitter {
         // Append output field instructions
         if (currentTask?.output_fields && Array.isArray(currentTask.output_fields) && currentTask.output_fields.length > 0) {
           promptText += this.buildOutputFieldInstructions(currentTask.output_fields)
+        }
+
+        // Append entity-KB linkage instructions when the task involves entities
+        // and the agent has access to both graph_* and datastore_* tools
+        if (currentTask) {
+          promptText += this.buildEntityKbLinkageInstructions(currentTask, agentId)
         }
 
         // Copy attachments and build references
@@ -3908,6 +3924,137 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     return lines.join('\n')
   }
 
+  // ── Entity-KB Linkage Awareness ──────────────────────────────
+
+  /**
+   * Checks whether an agent has access to Business Context tools (graph_* and
+   * datastore_*) via any of its MCP servers. Returns an object describing which
+   * tool families are available so callers can generate targeted documentation.
+   */
+  private getBusinessContextToolAccess(agentId: string): {
+    hasGraphTools: boolean
+    hasDatastoreTools: boolean
+    hasLinkTool: boolean
+    graphToolNames: string[]
+    datastoreToolNames: string[]
+  } {
+    const agent = this.db.getAgent(agentId)
+    const mcpEntries = agent?.config?.mcp_servers || []
+
+    const graphToolNames: string[] = []
+    const datastoreToolNames: string[] = []
+
+    for (const entry of mcpEntries) {
+      const serverId = typeof entry === 'string' ? entry : (entry as AgentMcpServerEntry).serverId
+      const enabledTools = typeof entry === 'string' ? undefined : (entry as AgentMcpServerEntry).enabledTools
+      const mcpServer = this.db.getMcpServer(serverId)
+      if (!mcpServer?.tools) continue
+
+      const tools = enabledTools
+        ? mcpServer.tools.filter(t => enabledTools.includes(t.name))
+        : mcpServer.tools
+
+      for (const tool of tools) {
+        if (tool.name.startsWith('graph_')) graphToolNames.push(tool.name)
+        if (tool.name.startsWith('datastore_')) datastoreToolNames.push(tool.name)
+      }
+    }
+
+    return {
+      hasGraphTools: graphToolNames.length > 0,
+      hasDatastoreTools: datastoreToolNames.length > 0,
+      hasLinkTool: graphToolNames.includes('graph_link_datastore'),
+      graphToolNames: [...new Set(graphToolNames)],
+      datastoreToolNames: [...new Set(datastoreToolNames)]
+    }
+  }
+
+  /**
+   * Generates a documentation section about the Entity-KB linkage workflow
+   * for inclusion in CLAUDE.md or AGENTS.md. Only returns content when the
+   * agent actually has access to both graph_* and datastore_* tools.
+   */
+  private buildEntityKbLinkageSection(agentId: string): string {
+    const access = this.getBusinessContextToolAccess(agentId)
+    if (!access.hasGraphTools || !access.hasDatastoreTools) return ''
+
+    let section = `## Business Context: Entity–Datastore Linkage\n\n`
+    section += `This agent has access to **Graph** tools (\`graph_*\`) and **Datastore** tools (\`datastore_*\`) `
+    section += `that work together to provide context-aware entity generation.\n\n`
+
+    section += `### How it works\n\n`
+    section += `- **Datastores** hold knowledge base content (documents, chunks) that provide domain context.\n`
+    section += `- **Graph** tools manage entities, relationships, and their metadata.\n`
+
+    if (access.hasLinkTool) {
+      section += `- **\`graph_link_datastore\`** creates links between graph objects (entities, relationships, entity types) and datastore assets (datastores, files, chunks).\n`
+      section += `- Links record which datastore sources informed a generated entity (provenance).\n`
+    }
+
+    section += `\n### Entity generation workflow\n\n`
+    section += `When generating or enriching entities, follow this protocol:\n\n`
+    section += `1. **Discover** — Use \`datastore_list\` to find relevant datastores in the workspace.\n`
+    section += `2. **Query** — Use \`datastore_query\` with semantic search to find content relevant to the entity being generated. Note the datastore ID, file ID, and chunk ID from the results.\n`
+    section += `3. **Generate** — Create or update the entity using the retrieved context.\n`
+
+    if (access.hasLinkTool) {
+      section += `4. **Link** — Call \`graph_link_datastore\` to connect the generated entity to each datastore source that informed it:\n`
+      section += `   - \`subject_type\`: "entity" | "relationship" | "entity_type"\n`
+      section += `   - \`subject_id\`: the ID of the generated graph object\n`
+      section += `   - \`asset_type\`: "datastore" | "file" | "chunk" (use the most specific level available)\n`
+      section += `   - \`asset_id\`: the datastore/file/chunk ID from step 2\n`
+      section += `   - \`link_role\`: "source" (generation source), "evidence" (relationship support), or "reference" (general)\n`
+      section += `   - \`confidence\`: 0.0–1.0 reflecting retrieval relevance\n`
+      section += `   - \`reason\`: brief human-readable explanation of why this source is linked\n`
+    }
+
+    section += `\n### Important rules\n\n`
+    section += `- **Never invent IDs.** Datastore, file, and chunk IDs must come from tool results (\`datastore_list\`, \`datastore_query\`, \`datastore_get_files\`, \`datastore_get_chunks\`). Do not fabricate or guess them.\n`
+    section += `- **Tenant isolation is automatic.** The server enforces tenant scoping — do not pass tenant/company IDs in tool arguments.\n`
+    section += `- **Link roles matter.** Use "source" when the datastore content directly informed entity generation. Use "evidence" when it supports a relationship claim. Use "reference" only for general background material.\n`
+    section += `- **Be specific.** Prefer linking to a chunk or file over linking to an entire datastore when the source is a specific document section.\n`
+
+    section += `\n---\n\n`
+
+    return section
+  }
+
+  /**
+   * Returns entity-KB linkage instructions to append to the initial prompt
+   * when the task involves entity generation and the agent has access to
+   * Business Context tools. Returns empty string if not applicable.
+   */
+  private buildEntityKbLinkageInstructions(task: TaskRecord, agentId: string): string {
+    const access = this.getBusinessContextToolAccess(agentId)
+
+    // Only inject instructions when the agent has both graph and datastore tools
+    if (!access.hasGraphTools || !access.hasDatastoreTools) return ''
+
+    // Detect whether this task involves entities/graph/knowledge base work
+    const entityKeywords = [
+      'entity', 'entities', 'graph', 'knowledge base', 'datastore',
+      'business context', 'relationship', 'entity type', 'knowledge graph',
+      'entity graph', 'linked datastore', 'kb linkage'
+    ]
+    const taskText = `${task.title} ${task.description || ''} ${(task.labels || []).join(' ')}`.toLowerCase()
+    const isEntityRelated = entityKeywords.some(kw => taskText.includes(kw))
+
+    if (!isEntityRelated) return ''
+
+    let instructions = `\n\n## Entity–Datastore Linkage Protocol\n\n`
+    instructions += `This task involves graph entities. When you create or modify entities/relationships, follow the Business Context linkage protocol:\n\n`
+    instructions += `1. **Before generating**: Query relevant datastores using \`datastore_list\` and \`datastore_query\` to gather context. Record the IDs (datastore, file, chunk) of every source you use.\n`
+    instructions += `2. **After generating**: For each entity or relationship you create/modify, call \`graph_link_datastore\` to link it to the datastore sources that informed the generation.\n`
+    instructions += `   - Use \`link_role: "source"\` for content that directly informed the entity.\n`
+    instructions += `   - Use \`link_role: "evidence"\` for content that supports a relationship.\n`
+    instructions += `   - Include a brief \`reason\` explaining the link (e.g., "AP aging analysis from financial health framework").\n`
+    instructions += `   - Set \`confidence\` based on how relevant the source was (0.0–1.0).\n`
+    instructions += `3. **Return linked results**: When reporting generated entities, include their linked datastores for transparency.\n\n`
+    instructions += `**Important**: Only use real IDs returned by datastore tools. Never fabricate datastore, file, or chunk IDs.\n`
+
+    return instructions
+  }
+
   private resolveDefaultAgentId(): string | null {
     const agents = this.db.getAgents()
     const defaultAgent = agents.find((agent) => agent.is_default)
@@ -3968,7 +4115,8 @@ Important:
 - If the task already has output_fields defined (from an external source), preserve them and only add additional fields if needed. Do not remove existing output fields.
 - When creating subtasks, the parent task's agent will coordinate — subtask agents handle individual pieces.
 - Subtask agents can see the parent task, all sibling subtasks' status/resolution/outputs, and sibling transcripts for coordination.
-- NEVER use external integration MCP tools (like pf-workflo-integrations) for local task updates — always use task-management tools.`
+- NEVER use external integration MCP tools (like pf-workflo-integrations) for local task updates — always use task-management tools.
+- If the task involves creating, generating, or enriching entities, relationships, entity types, or knowledge graphs, add the label "entity-graph" so the executing agent receives entity–datastore linkage instructions automatically.`
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds entity-KB linkage awareness to the AI agent system so that entity generation can access datastores and automatically link generated entities to their knowledge base sources
- Detects when agents have access to `graph_*` and `datastore_*` MCP tools, then injects Business Context documentation and task-specific linkage instructions
- Teaches agents the discover → query → generate → link protocol for entity-KB provenance

## Changes

### `src/main/agent-manager.ts` (+150 lines)
- **`getBusinessContextToolAccess(agentId)`** — Scans agent's MCP server entries for `graph_*` and `datastore_*` tools, respecting `enabledTools` filters. Returns which tool families are available including specific detection of `graph_link_datastore`
- **`buildEntityKbLinkageSection(agentId)`** — Generates a documentation section for CLAUDE.md/AGENTS.md explaining the entity-KB linkage workflow. Only emitted when agent has both graph and datastore tools. Includes the 4-step protocol (Discover → Query → Generate → Link), safety rules (never invent IDs, tenant isolation is automatic), and link role semantics (source/evidence/reference)
- **`buildEntityKbLinkageInstructions(task, agentId)`** — Returns task-specific entity-KB instructions for the initial prompt. Detects entity-related tasks by scanning title, description, and labels for keywords (`entity`, `graph`, `knowledge base`, `datastore`, `business context`, etc.). Only activates when the agent has both tool families
- **CLAUDE.md/AGENTS.md enhancement** — Entity-KB linkage section inserted between MCP tools listing and secrets section
- **Initial prompt enhancement** — Entity-KB protocol injected after output field instructions for entity-related tasks
- **Triage prompt enhancement** — Instructs triage agent to add `entity-graph` label when tasks involve entity generation, so execution agents receive linkage instructions automatically

### `src/main/agent-manager.test.ts` (+328 lines, 17 tests)
- `getBusinessContextToolAccess`: graph-only, datastore-only, both, neither, enabledTools filter
- `buildEntityKbLinkageSection`: empty when missing tools, full section with link tool, partial without link tool
- `buildEntityKbLinkageInstructions`: empty without tools, empty for non-entity tasks, detects by title/labels/description
- CLAUDE.md/AGENTS.md integration: section present/absent based on tool availability

## How it works

When an agent has access to the Workflo MCP Dev Server with both `graph_*` and `datastore_*` tools:
1. **CLAUDE.md/AGENTS.md** gets a "Business Context: Entity–Datastore Linkage" section documenting the protocol
2. **Entity-related tasks** (detected by keywords in title/description/labels) get an "Entity–Datastore Linkage Protocol" appended to their initial prompt
3. The protocol instructs agents to query datastores for context before entity generation, then call `graph_link_datastore` to create provenance links

This depends on the workflow-builder backend from PR peakflo/workflow-builder#1315 (Entity-KB linkage + MCP Dev Server).

## Test plan
- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] All 97 test files pass (1470 tests, +17 new)
- [x] Entity-KB section only appears in CLAUDE.md when agent has both graph_* and datastore_* tools
- [x] Entity-KB instructions only inject into initial prompt for entity-related tasks
- [x] Triage prompt includes entity-graph labeling guidance
- [ ] Integration test: agent with MCP Dev Server access generates entities and creates datastore links

🤖 Generated with [Claude Code](https://claude.com/claude-code)