### PR TITLE
fix: align terminal selection in zoomed canvas

### DIFF
--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -469,6 +469,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
             taskLayout={taskLayout}
             browserSessionId={panel.browserSessionId}
             streamPort={panel.streamPort}
+            zoom={zoom}
           />
         </div>
       )}
@@ -567,9 +568,10 @@ interface PanelContentProps {
   taskLayout?: TaskWorkspaceLayout
   browserSessionId?: string
   streamPort?: number
+  zoom: number
 }
 
-const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, title, taskLayout, browserSessionId, streamPort }: PanelContentProps) {
+const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, title, taskLayout, browserSessionId, streamPort, zoom }: PanelContentProps) {
   if (type === 'task' && refId) {
     return <TaskPanelContent panelId={id} taskId={refId} panelLayout={taskLayout} />
   }
@@ -583,7 +585,7 @@ const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, 
     return <WebPagePanelContent panelId={id} url={url} title={title} />
   }
   if (type === 'terminal') {
-    return <TerminalPanelContent terminalId={id} cwd={url} />
+    return <TerminalPanelContent terminalId={id} cwd={url} canvasZoom={zoom} />
   }
   if (type === 'browser') {
     return <BrowserPanelContent panelId={id} url={url} sessionName={browserSessionId} streamPort={streamPort} />

--- a/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
@@ -14,8 +14,16 @@ vi.mock('@xterm/xterm', () => ({
     cols = 80
     rows = 24
     textarea = document.createElement('textarea')
+    element?: HTMLElement
     loadAddon() {}
-    open() {}
+    open(container: HTMLElement) {
+      this.element = document.createElement('div')
+      this.element.className = 'xterm'
+      const screen = document.createElement('div')
+      screen.className = 'xterm-screen'
+      this.element.appendChild(screen)
+      container.appendChild(this.element)
+    }
     focus() {}
     clear() {}
     write() {}
@@ -175,6 +183,55 @@ describe('TerminalPanelContent', () => {
     secondCwd.resolve({ cwd: '/tmp/two' })
     await waitFor(() => {
       expect(terminalKill).toHaveBeenCalledWith('panel-1', 222)
+    })
+  })
+
+  it('keeps terminal rendering unchanged and adjusts xterm mouse coordinates inside the zoomed canvas', async () => {
+    terminalCreate.mockResolvedValue({ pid: 333 })
+    terminalGetCwd.mockResolvedValue({ cwd: null })
+
+    const { container } = render(
+      <TerminalPanelContent terminalId="panel-1" cwd="/tmp" canvasZoom={0.5} />
+    )
+
+    const terminal = container.querySelector('.xterm-container') as HTMLElement
+    const xterm = container.querySelector('.xterm') as HTMLElement
+    const screen = container.querySelector('.xterm-screen') as HTMLElement
+
+    expect(terminal.style.width).toBe('')
+    expect(terminal.style.height).toBe('')
+    expect(terminal.style.transform).toBe('')
+
+    vi.spyOn(screen, 'getBoundingClientRect').mockReturnValue({
+      width: 320,
+      height: 240,
+      top: 20,
+      left: 10,
+      right: 330,
+      bottom: 260,
+      x: 10,
+      y: 20,
+      toJSON: () => ({}),
+    })
+    const mouseDownHandler = vi.fn((event: MouseEvent) => {
+      expect(event.clientX).toBe(70)
+      expect(event.clientY).toBe(120)
+    })
+    xterm.addEventListener('mousedown', mouseDownHandler)
+
+    screen.dispatchEvent(new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 40,
+      clientY: 70,
+      button: 0,
+      buttons: 1,
+    }))
+
+    expect(mouseDownHandler).toHaveBeenCalledTimes(1)
+
+    await waitFor(() => {
+      expect(terminalCreate).toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -10,6 +10,8 @@ interface TerminalPanelContentProps {
   terminalId: string
   /** Initial working directory — restored from persisted panel state */
   cwd?: string
+  /** Current canvas zoom. xterm pointer math must compensate for canvas transforms. */
+  canvasZoom?: number
 }
 
 /**
@@ -25,7 +27,7 @@ interface TerminalPanelContentProps {
  *      sees truly-zero values even during layout shifts.
  *   3. Every fit() call is wrapped in try-catch.
  */
-export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentProps) {
+export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: TerminalPanelContentProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
@@ -39,6 +41,8 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
 
   // Store cwd in a ref — only used at init time, never triggers re-init
   const cwdRef = useRef(cwd)
+  const adjustedMouseEventsRef = useRef<WeakSet<MouseEvent>>(new WeakSet())
+  const activeMouseAdjustmentRef = useRef<{ left: number; top: number; zoom: number } | null>(null)
 
   const initTerminal = useCallback(async () => {
     console.log(`[Terminal:${terminalId}] initTerminal called`, {
@@ -288,6 +292,96 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
     return () => clearInterval(interval)
   }, [isReady, terminalId])
 
+  const safeCanvasZoom = Number.isFinite(canvasZoom) && canvasZoom > 0 ? canvasZoom : 1
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || Math.abs(safeCanvasZoom - 1) < 0.001) return
+
+    const ownerDocument = container.ownerDocument
+
+    const getAnchor = () => {
+      const anchor =
+        container.querySelector<HTMLElement>('.xterm-screen') ??
+        xtermRef.current?.element ??
+        container
+      const rect = anchor.getBoundingClientRect()
+      return { left: rect.left, top: rect.top, zoom: safeCanvasZoom }
+    }
+
+    const cloneMouseEvent = (event: MouseEvent, anchor: { left: number; top: number; zoom: number }) => {
+      const clientX = anchor.left + (event.clientX - anchor.left) / anchor.zoom
+      const clientY = anchor.top + (event.clientY - anchor.top) / anchor.zoom
+      const cloned = new MouseEvent(event.type, {
+        bubbles: event.bubbles,
+        cancelable: event.cancelable,
+        composed: event.composed,
+        detail: event.detail,
+        screenX: event.screenX,
+        screenY: event.screenY,
+        clientX,
+        clientY,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+        button: event.button,
+        buttons: event.buttons,
+        relatedTarget: event.relatedTarget,
+      })
+      adjustedMouseEventsRef.current.add(cloned)
+      return cloned
+    }
+
+    const redispatchAdjustedEvent = (
+      event: MouseEvent,
+      target: EventTarget | null,
+      anchor: { left: number; top: number; zoom: number }
+    ) => {
+      if (!target) return
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      target.dispatchEvent(cloneMouseEvent(event, anchor))
+    }
+
+    const handleMouseDownCapture = (event: MouseEvent) => {
+      if (adjustedMouseEventsRef.current.has(event) || event.button !== 0) return
+      const anchor = getAnchor()
+      activeMouseAdjustmentRef.current = anchor
+      redispatchAdjustedEvent(event, event.target, anchor)
+    }
+
+    const handleDocumentMouseCapture = (event: MouseEvent) => {
+      if (adjustedMouseEventsRef.current.has(event)) return
+      const anchor = activeMouseAdjustmentRef.current
+      if (!anchor) return
+      redispatchAdjustedEvent(event, event.target, anchor)
+      if (event.type === 'mouseup') {
+        activeMouseAdjustmentRef.current = null
+      }
+    }
+
+    container.addEventListener('mousedown', handleMouseDownCapture, true)
+    ownerDocument.addEventListener('mousemove', handleDocumentMouseCapture, true)
+    ownerDocument.addEventListener('mouseup', handleDocumentMouseCapture, true)
+
+    return () => {
+      container.removeEventListener('mousedown', handleMouseDownCapture, true)
+      ownerDocument.removeEventListener('mousemove', handleDocumentMouseCapture, true)
+      ownerDocument.removeEventListener('mouseup', handleDocumentMouseCapture, true)
+      activeMouseAdjustmentRef.current = null
+    }
+  }, [safeCanvasZoom])
+
+  // Focus the terminal when the container is clicked
+  const handleClick = useCallback(() => {
+    console.log(`[Terminal:${terminalId}] container clicked, focusing. hasXterm:`, !!xtermRef.current, 'textarea:', !!xtermRef.current?.textarea)
+    xtermRef.current?.focus()
+    setTimeout(() => {
+      console.log(`[Terminal:${terminalId}] after click-focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
+    }, 50)
+  }, [terminalId])
+
   if (error) {
     return (
       <div className="flex items-center justify-center h-full text-red-400/60 text-xs">
@@ -298,15 +392,6 @@ export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentPr
       </div>
     )
   }
-
-  // Focus the terminal when the container is clicked
-  const handleClick = useCallback(() => {
-    console.log(`[Terminal:${terminalId}] container clicked, focusing. hasXterm:`, !!xtermRef.current, 'textarea:', !!xtermRef.current?.textarea)
-    xtermRef.current?.focus()
-    setTimeout(() => {
-      console.log(`[Terminal:${terminalId}] after click-focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
-    }, 50)
-  }, [terminalId])
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Fix xterm mouse selection being offset when terminal panels are inside the scaled canvas layer
- Keep terminal rendering exactly as before, including canvas zoom scaling of text
- Correct only the mouse coordinates xterm receives during selection by redispatching zoom-adjusted mouse events
- Add a renderer regression test proving the terminal has no zoom override styles and receives corrected mouse coordinates

## Test plan
- node node_modules/vitest/vitest.mjs run --project renderer src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
- node node_modules/eslint/bin/eslint.js src/renderer/src/components/canvas/CanvasPanel.tsx src/renderer/src/components/canvas/TerminalPanelContent.tsx src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
- node node_modules/typescript/bin/tsc --build --noEmit

Note: pnpm install failed to complete in this workspace because better-sqlite3 does not compile against the local Node 26 toolchain; linked JS dependencies were sufficient for the targeted checks above.