### PR TITLE
feat(20x): auto-use Workflo MCP Dev Server for all agents after login

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -822,6 +822,15 @@ describe('AgentManager MCP server routing', () => {
         oauth_metadata: {},
         source: 'enterprise',
       })),
+      getMcpServers: vi.fn(() => [{
+        id: 'workflo-stage-server',
+        name: '[Workflo] MCP Dev Server',
+        type: 'remote',
+        url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
+        headers: {},
+        oauth_metadata: {},
+        source: 'enterprise',
+      }]),
     } as unknown as ConstructorParameters<typeof AgentManager>[0]
 
     const manager = new AgentManager(mockDb)
@@ -862,6 +871,15 @@ describe('AgentManager MCP server routing', () => {
         oauth_metadata: {},
         source: 'user',  // but it was added by the user, not by enterprise sync
       })),
+      getMcpServers: vi.fn(() => [{
+        id: 'tan-insurance-workflo',
+        name: '[Workflo] MCP Dev Server',
+        type: 'remote',
+        url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
+        headers: {},
+        oauth_metadata: {},
+        source: 'user',
+      }]),
     } as unknown as ConstructorParameters<typeof AgentManager>[0]
 
     const manager = new AgentManager(mockDb)
@@ -902,6 +920,15 @@ describe('AgentManager MCP server routing', () => {
         oauth_metadata: {},
         source: 'enterprise',
       })),
+      getMcpServers: vi.fn(() => [{
+        id: 'tan-insurance-workflo',
+        name: 'Tan Insurance MCP workflo',
+        type: 'remote',
+        url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
+        headers: { Authorization: 'Bearer pfwf_tenant_a_key' },
+        oauth_metadata: {},
+        source: 'enterprise',
+      }]),
     } as unknown as ConstructorParameters<typeof AgentManager>[0]
 
     const manager = new AgentManager(mockDb)
@@ -917,6 +944,75 @@ describe('AgentManager MCP server routing', () => {
       url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
       headers: { Authorization: 'Bearer pfwf_tenant_a_key' },
     })
+  })
+
+  it('auto-includes the enterprise MCP Dev Server for every agent even when it is NOT in the agent config', async () => {
+    // The core "by default" behaviour: an agent whose stored config.mcp_servers
+    // does NOT list the Workflo MCP Dev Server should still get it injected at
+    // session-build time, as long as the row exists in the DB (registered after
+    // login) and enterprise auth is active. This makes it available to ALL
+    // agents and is robust to enterprise sync overwriting per-agent mcp_servers.
+    const mockDb = {
+      getAgent: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'OPS L2',
+        config: {
+          mcp_servers: [], // agent has NO MCP servers configured
+        },
+      })),
+      getMcpServer: vi.fn(() => null),
+      getMcpServers: vi.fn(() => [{
+        id: 'workflo-dev',
+        name: '[Workflo] MCP Dev Server',
+        type: 'remote',
+        url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
+        headers: {},
+        oauth_metadata: {},
+        source: 'enterprise',
+      }]),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+
+    const manager = new AgentManager(mockDb)
+    manager.setEnterpriseAuth({
+      getApiUrl: vi.fn(() => 'https://api.peakflo.ai'),
+      getJwt: vi.fn(async () => 'fresh-prod-jwt'),
+    } as any)
+
+    const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
+
+    expect(mcpServers['[Workflo] MCP Dev Server']).toMatchObject({
+      type: 'http',
+      // URL canonicalised to the active enterprise origin
+      url: 'https://api.peakflo.ai/api/mcp/dev/mcp',
+      headers: { Authorization: 'Bearer fresh-prod-jwt' },
+    })
+  })
+
+  it('does NOT auto-include any MCP Dev Server when enterprise auth is not active', async () => {
+    const mockDb = {
+      getAgent: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'OPS L2',
+        config: { mcp_servers: [] },
+      })),
+      getMcpServer: vi.fn(() => null),
+      getMcpServers: vi.fn(() => [{
+        id: 'workflo-dev',
+        name: '[Workflo] MCP Dev Server',
+        type: 'remote',
+        url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
+        headers: {},
+        oauth_metadata: {},
+        source: 'enterprise',
+      }]),
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+
+    const manager = new AgentManager(mockDb)
+    // No setEnterpriseAuth — not logged into enterprise mode
+
+    const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
+
+    expect(mcpServers['[Workflo] MCP Dev Server']).toBeUndefined()
   })
 })
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -5,7 +5,7 @@ import { existsSync, copyFileSync, mkdirSync, readFileSync, readdirSync, statSyn
 import { mkdir, writeFile } from 'fs/promises'
 import { Notification } from 'electron'
 import type { BrowserWindow } from 'electron'
-import type { DatabaseManager, AgentMcpServerEntry, McpServerSource, OutputFieldRecord, SecretRecord, SkillRecord, TaskRecord } from './database'
+import type { DatabaseManager, AgentMcpServerEntry, McpServerRecord, McpServerSource, OutputFieldRecord, SecretRecord, SkillRecord, TaskRecord } from './database'
 import { TaskStatus, SessionStatus, PluginActionId } from '../shared/constants'
 import type { WorktreeManager } from './worktree-manager'
 import type { GitHubManager } from './github-manager'
@@ -471,46 +471,7 @@ export class AgentManager extends EventEmitter {
           env
         }
       } else if (mcpServer.type === 'remote') {
-        // Inject OAuth Bearer token if the server has one
-        let finalHeaders = { ...mcpServer.headers }
-        if (this.oauthManager && mcpServer.oauth_metadata && 'resource_url' in mcpServer.oauth_metadata) {
-          const token = await this.oauthManager.getValidMcpServerToken(mcpServer.id)
-          if (token) {
-            finalHeaders = { ...finalHeaders, Authorization: `Bearer ${token}` }
-          }
-        }
-
-        // Inject enterprise JWT for Workflo MCP Dev Server — route through auth proxy
-        let finalUrl = mcpServer.url
-        if (
-          this.enterpriseAuth &&
-          isEnterpriseMcpDevServer({ source: mcpServer.source, url: mcpServer.url, headers: finalHeaders })
-        ) {
-          finalUrl = resolveEnterpriseMcpDevUrl(mcpServer.url, this.enterpriseAuth.getApiUrl())
-          const proxyPort = getMcpAuthProxyPort()
-          const proxyUrl = proxyPort ? registerMcpProxyTarget(finalUrl, mcpServer.name) : null
-          if (proxyUrl) {
-            finalUrl = proxyUrl
-            // Don't send static Authorization — proxy injects fresh JWT per request
-            delete finalHeaders['Authorization']
-            console.log(`[AgentManager] MCP Dev Server routed through auth proxy: ${proxyUrl} -> ${resolveEnterpriseMcpDevUrl(mcpServer.url, this.enterpriseAuth.getApiUrl())}`)
-          } else {
-            // Fallback: static JWT (proxy not running)
-            try {
-              const jwt = await this.enterpriseAuth.getJwt()
-              finalHeaders = { ...finalHeaders, Authorization: `Bearer ${jwt}` }
-              console.log('[AgentManager] MCP Dev Server using static JWT (proxy not available)')
-            } catch (err) {
-              console.warn('[AgentManager] Failed to inject enterprise JWT for MCP Dev Server:', err)
-            }
-          }
-        }
-
-        result[mcpServer.name] = {
-          type: 'http',
-          url: finalUrl,
-          headers: finalHeaders
-        }
+        result[mcpServer.name] = await this.buildRemoteMcpServerConfig(mcpServer)
       }
     }
 
@@ -540,7 +501,76 @@ export class AgentManager extends EventEmitter {
       }
     }
 
+    // Always include the enterprise Workflo MCP Dev Server for every agent
+    // session once enterprise mode is active. It appears in the local DB after
+    // login (registered by the enterprise:selectTenant handler) and exposes
+    // workflows-as-tools, integrations, datastores and data tables. Auto-adding
+    // it here — rather than relying on each agent's stored config.mcp_servers —
+    // makes it available to ALL agents by default and is robust to enterprise
+    // sync overwriting per-agent mcp_servers. Mirrors the task-management
+    // force-include above.
+    if (this.enterpriseAuth) {
+      const devServer = this.db.getMcpServers().find(
+        (s) =>
+          s.type === 'remote' &&
+          isEnterpriseMcpDevServer({ source: s.source, url: s.url, headers: s.headers })
+      )
+      if (devServer && !result[devServer.name]) {
+        result[devServer.name] = await this.buildRemoteMcpServerConfig(devServer)
+      }
+    }
+
     return result
+  }
+
+  /**
+   * Builds the adapter config for a remote (HTTP) MCP server, applying:
+   *  - OAuth Bearer token injection for servers with an OAuth registration
+   *  - Enterprise JWT injection (via auth proxy, falling back to a static JWT)
+   *    for the Workflo MCP Dev Server, with URL canonicalisation to the active
+   *    enterprise API origin.
+   */
+  private async buildRemoteMcpServerConfig(mcpServer: McpServerRecord): Promise<McpServerConfig> {
+    // Inject OAuth Bearer token if the server has one
+    let finalHeaders = { ...mcpServer.headers }
+    if (this.oauthManager && mcpServer.oauth_metadata && 'resource_url' in mcpServer.oauth_metadata) {
+      const token = await this.oauthManager.getValidMcpServerToken(mcpServer.id)
+      if (token) {
+        finalHeaders = { ...finalHeaders, Authorization: `Bearer ${token}` }
+      }
+    }
+
+    // Inject enterprise JWT for Workflo MCP Dev Server — route through auth proxy
+    let finalUrl = mcpServer.url
+    if (
+      this.enterpriseAuth &&
+      isEnterpriseMcpDevServer({ source: mcpServer.source, url: mcpServer.url, headers: finalHeaders })
+    ) {
+      finalUrl = resolveEnterpriseMcpDevUrl(mcpServer.url, this.enterpriseAuth.getApiUrl())
+      const proxyPort = getMcpAuthProxyPort()
+      const proxyUrl = proxyPort ? registerMcpProxyTarget(finalUrl, mcpServer.name) : null
+      if (proxyUrl) {
+        finalUrl = proxyUrl
+        // Don't send static Authorization — proxy injects fresh JWT per request
+        delete finalHeaders['Authorization']
+        console.log(`[AgentManager] MCP Dev Server routed through auth proxy: ${proxyUrl} -> ${resolveEnterpriseMcpDevUrl(mcpServer.url, this.enterpriseAuth.getApiUrl())}`)
+      } else {
+        // Fallback: static JWT (proxy not running)
+        try {
+          const jwt = await this.enterpriseAuth.getJwt()
+          finalHeaders = { ...finalHeaders, Authorization: `Bearer ${jwt}` }
+          console.log('[AgentManager] MCP Dev Server using static JWT (proxy not available)')
+        } catch (err) {
+          console.warn('[AgentManager] Failed to inject enterprise JWT for MCP Dev Server:', err)
+        }
+      }
+    }
+
+    return {
+      type: 'http',
+      url: finalUrl,
+      headers: finalHeaders
+    }
   }
 
   private async buildSessionConfig(agentId: string, taskId: string, workspaceDir?: string): Promise<SessionConfig> {


### PR DESCRIPTION
## Problem

After enterprise login the app registers the **`[Workflo] MCP Dev Server`** in the local DB (via `enterprise:selectTenant` in `ipc-handlers.ts`) — it "appears after login". But it was only attached to the **default agent's** `config.mcp_servers`. Other agents — particularly those synced from Workflo org nodes — did **not** get it, so they couldn't use workflows-as-tools, integrations, datastores or data tables by default.

Persisting it per-agent is also fragile: enterprise sync **overwrites** each synced agent's `mcp_servers` on every sync (`enterprise-sync.ts:284`).

## Fix

Force-include the enterprise MCP Dev Server at **session-build time** for every agent, inside `buildMcpServersForAdapter()`, whenever enterprise auth is active. This mirrors the existing `ensureTaskManagement` force-include pattern.

```ts
if (this.enterpriseAuth) {
  const devServer = this.db.getMcpServers().find(
    (s) => s.type === 'remote' &&
           isEnterpriseMcpDevServer({ source: s.source, url: s.url, headers: s.headers })
  )
  if (devServer && !result[devServer.name]) {
    result[devServer.name] = await this.buildRemoteMcpServerConfig(devServer)
  }
}
```

The remote-server config building (OAuth + enterprise JWT/auth-proxy injection + URL canonicalisation) was extracted into a shared `buildRemoteMcpServerConfig()` so the per-agent loop and the force-include use one code path.

### Why this layer
- **Robust to sync clobbering** — doesn't depend on stored per-agent `mcp_servers`.
- **Applies to all agents** — default, synced, and user-created — only when enterprise auth is active.
- **Tenant-safe** — reuses the existing provenance-based `isEnterpriseMcpDevServer` check (source must be `'enterprise'`, no user-supplied auth header), so a user-added lookalike MCP is never hijacked or given another tenant's JWT.

## Tests

- 2 new tests in `agent-manager.test.ts`:
  - Auto-includes the dev server for an agent whose `config.mcp_servers` is empty (URL canonicalised + JWT injected).
  - Does **not** include it when enterprise auth is inactive.
- Existing MCP-routing test mocks updated with `getMcpServers`.
- `pnpm typecheck` ✅ · all 71 agent-manager tests ✅ · lint clean on changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)