### PR TITLE
fix: Codex false "out of rate limits" — honor explicit subscription vs API-key auth

### DIFF
--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -96,6 +96,7 @@ interface AcpSessionForTest {
   toolCallMetadata: Map<string, { name: string; input: string; title?: string }>
   lastError: string | null
   codexUseApiKey?: boolean
+  codexAuthSummary?: string
 }
 
 /** Cast adapter to access private members for testing */
@@ -3150,8 +3151,8 @@ describe('AcpAdapter - configureCodexAuthEnv (Codex auth precedence)', () => {
     // Ambient keys must be stripped so codex-acp uses ~/.codex (subscription).
     expect(env.OPENAI_API_KEY).toBeUndefined()
     expect(env.CODEX_API_KEY).toBeUndefined()
-    // No isolated CODEX_HOME — use the default ~/.codex with the existing login.
-    expect(env.CODEX_HOME).toBeUndefined()
+    // CODEX_HOME pinned to the codex CLI default so codex-acp reads the same login.
+    expect(env.CODEX_HOME).toMatch(/[\\/]\.codex$/)
     expect(env.NO_BROWSER).toBeUndefined()
   })
 
@@ -3165,7 +3166,20 @@ describe('AcpAdapter - configureCodexAuthEnv (Codex auth precedence)', () => {
 
     expect(usesApiKey).toBe(false)
     expect(env.OPENAI_API_KEY).toBeUndefined()
-    expect(env.CODEX_HOME).toBeUndefined()
+    expect(env.CODEX_HOME).toMatch(/[\\/]\.codex$/)
+  })
+
+  it('authMethod=subscription preserves an inherited custom CODEX_HOME', () => {
+    // The user's terminal `codex` may use a custom CODEX_HOME (a different ChatGPT
+    // account); 20x inherits it and must NOT override it with the default ~/.codex.
+    const env: Record<string, string | undefined> = { CODEX_HOME: '/custom/codex/home' }
+
+    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {
+      authMethod: 'subscription'
+    })
+
+    expect(usesApiKey).toBe(false)
+    expect(env.CODEX_HOME).toBe('/custom/codex/home')
   })
 
   it('authMethod=api_key uses the explicit per-agent key in an isolated CODEX_HOME', () => {
@@ -3203,7 +3217,7 @@ describe('AcpAdapter - configureCodexAuthEnv (Codex auth precedence)', () => {
 
     expect(usesApiKey).toBe(false)
     expect(env.OPENAI_API_KEY).toBeUndefined()
-    expect(env.CODEX_HOME).toBeUndefined()
+    expect(env.CODEX_HOME).toMatch(/[\\/]\.codex$/)
   })
 
   it('legacy (no authMethod): an explicit per-agent key opts into API-key mode', () => {

--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -2396,7 +2396,7 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
       expect(session.activeTurnId).toBeNull()
     })
 
-    it('should push error event to message buffers', () => {
+    it('should push error event to the live buffer but NOT persist it', () => {
       const session = createMockSession('test-session')
 
       adapterPrivate(adapter).handleQuotaError(session, {
@@ -2404,13 +2404,37 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
         userMessage: 'Quota exceeded: Check your plan.'
       })
 
+      // Live buffer gets the error so the user sees it during the session...
       expect(session.messageBuffer).toHaveLength(1)
-      expect(session.permanentMessages).toHaveLength(1)
+      // ...but it must NOT enter permanentMessages, otherwise it would be
+      // replayed on every resume and keep "showing limits" after the user
+      // upgrades / re-logs in / waits for the window to reset.
+      expect(session.permanentMessages).toHaveLength(0)
 
       const errorEvent = session.messageBuffer[0] as Record<string, unknown>
       expect(errorEvent._isError).toBe(true)
       expect(errorEvent.message).toBe('Quota exceeded: Check your plan.')
       expect(errorEvent.data).toBeNull()
+    })
+
+    it('stale quota error does not survive a resume replay (getAllMessages)', async () => {
+      const session = createMockSession('test-session')
+      adapterPrivate(adapter).sessions.set('test-session', session)
+
+      // Simulate the session hitting a usage limit.
+      adapterPrivate(adapter).handleQuotaError(session, {
+        errorType: 'usage_limit_exceeded',
+        userMessage: 'Quota exceeded: Check your plan.'
+      })
+
+      // On resume, only permanentMessages are replayed. The transient quota
+      // error must be gone so the upgraded/re-logged-in user starts clean.
+      const messages = await adapter.getAllMessages('test-session', {} as never)
+      const replayedText = messages
+        .flatMap((m) => m.parts)
+        .map((p) => p.text || p.content || '')
+        .join('\n')
+      expect(replayedText).not.toContain('Quota exceeded')
     })
 
     it('should trigger onDataAvailable callback', () => {

--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -24,6 +24,25 @@ vi.mock('child_process', () => ({
   }))
 }))
 
+// Mock fs/os so configureCodexAuthEnv() is deterministic: existsSync controls
+// whether a Codex CLI login (~/.codex/auth.json) is "present", and mkdtempSync
+// returns a stable path instead of touching disk.
+vi.mock('fs', async (importActual) => {
+  const actual = await importActual<typeof import('fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn(actual.existsSync),
+    mkdtempSync: vi.fn(() => '/tmp/codex-session-test')
+  }
+})
+vi.mock('os', async (importActual) => {
+  const actual = await importActual<typeof import('os')>()
+  return {
+    ...actual,
+    homedir: vi.fn(() => '/home/testuser')
+  }
+})
+
 // Type for accessing private members of AcpAdapter in tests
 interface AcpAdapterPrivate {
   sessions: Map<string, AcpSessionForTest>
@@ -45,6 +64,8 @@ interface AcpAdapterPrivate {
   handleRpcMessage(session: AcpSessionForTest, message: unknown): void
   authenticateSession(session: AcpSessionForTest, initResult: unknown): Promise<void>
   sendRpcRequest(session: AcpSessionForTest, method: string, params?: unknown): Promise<unknown>
+  configureCodexAuthEnv(env: Record<string, string>, config: { apiKeys?: { openai?: string } }): boolean
+  agentType: string
 }
 
 interface JsonRpcRequestForTest {
@@ -80,6 +101,7 @@ interface AcpSessionForTest {
   pendingAssistantTurnSplit: boolean
   toolCallMetadata: Map<string, { name: string; input: string; title?: string }>
   lastError: string | null
+  codexUseApiKey?: boolean
 }
 
 /** Cast adapter to access private members for testing */
@@ -110,7 +132,8 @@ function createMockSession(sessionId: string): AcpSessionForTest {
     activeTurnId: null,
     pendingAssistantTurnSplit: false,
     toolCallMetadata: new Map(),
-    lastError: null
+    lastError: null,
+    codexUseApiKey: false
   }
 }
 
@@ -202,13 +225,14 @@ describe('AcpAdapter - Turn Detection', () => {
   })
 
   describe('Authentication selection', () => {
-    it('uses chatgpt (Codex CLI login) when no API key is available', async () => {
+    it('uses chatgpt (Codex CLI login) on the subscription path', async () => {
       const priv = adapterPrivate(adapter)
       const session = createMockSession('auth-session')
+      session.codexUseApiKey = false // subscription / CLI login decided upstream
       const sendRpcRequestSpy = vi.spyOn(priv, 'sendRpcRequest').mockResolvedValue({})
 
-      delete process.env.OPENAI_API_KEY
-      delete process.env.CODEX_API_KEY
+      // An ambient API key in the shell must NOT change auth-method selection.
+      process.env.CODEX_API_KEY = 'ambient-key-should-be-ignored'
 
       await priv.authenticateSession(session, {
         authMethods: [
@@ -217,18 +241,19 @@ describe('AcpAdapter - Turn Detection', () => {
         ]
       })
 
-      // Without an API key, should fall back to chatgpt (Codex CLI login)
+      // On the subscription path, fall back to chatgpt (Codex CLI login)
       expect(sendRpcRequestSpy).toHaveBeenCalledWith(session, 'authenticate', {
         methodId: 'chatgpt'
       })
+
+      delete process.env.CODEX_API_KEY
     })
 
-    it('prefers key-based Codex auth when an API key is available', async () => {
+    it('prefers key-based Codex auth when the session uses API-key auth', async () => {
       const priv = adapterPrivate(adapter)
       const session = createMockSession('auth-session')
+      session.codexUseApiKey = true // API-key auth decided upstream
       const sendRpcRequestSpy = vi.spyOn(priv, 'sendRpcRequest').mockResolvedValue({})
-
-      process.env.CODEX_API_KEY = 'test-key'
 
       await priv.authenticateSession(session, {
         authMethods: [
@@ -3101,5 +3126,107 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
       expect(parts[0].id).toBe('stable-id-from-backend')
       expect(parts[0].text).toBe('A complete response.')
     })
+  })
+})
+
+describe('AcpAdapter - configureCodexAuthEnv (Codex auth precedence)', () => {
+  let adapter: AcpAdapter
+  let existsSyncMock: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    adapter = new AcpAdapter('codex')
+    const fs = await import('fs')
+    existsSyncMock = fs.existsSync as unknown as ReturnType<typeof vi.fn>
+    existsSyncMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses the Codex CLI login (subscription) and strips ambient API keys', () => {
+    // User is logged into Codex (subscription) AND has an ambient OPENAI_API_KEY
+    // exported in their shell — the classic "terminal works, 20x shows limits" case.
+    existsSyncMock.mockReturnValue(true)
+    const env: Record<string, string> = {
+      OPENAI_API_KEY: 'sk-ambient-from-shell',
+      CODEX_API_KEY: 'sk-ambient-from-shell'
+    }
+
+    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {})
+
+    expect(usesApiKey).toBe(false)
+    // Ambient keys must be stripped so codex-acp uses ~/.codex (subscription).
+    expect(env.OPENAI_API_KEY).toBeUndefined()
+    expect(env.CODEX_API_KEY).toBeUndefined()
+    // No isolated CODEX_HOME — use the default ~/.codex with the existing login.
+    expect(env.CODEX_HOME).toBeUndefined()
+    expect(env.NO_BROWSER).toBeUndefined()
+  })
+
+  it('uses an explicitly-configured API key even when a CLI login exists', () => {
+    existsSyncMock.mockReturnValue(true)
+    const env: Record<string, string> = {}
+
+    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {
+      apiKeys: { openai: 'sk-explicit-agent-key' }
+    })
+
+    expect(usesApiKey).toBe(true)
+    expect(env.OPENAI_API_KEY).toBe('sk-explicit-agent-key')
+    expect(env.CODEX_API_KEY).toBe('sk-explicit-agent-key')
+    expect(env.NO_BROWSER).toBe('1')
+    expect(env.CODEX_HOME).toBe('/tmp/codex-session-test')
+  })
+
+  it('falls back to an ambient API key when no CLI login is present', () => {
+    existsSyncMock.mockReturnValue(false)
+    const env: Record<string, string> = { OPENAI_API_KEY: 'sk-ambient' }
+
+    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {})
+
+    expect(usesApiKey).toBe(true)
+    expect(env.OPENAI_API_KEY).toBe('sk-ambient')
+    expect(env.NO_BROWSER).toBe('1')
+    expect(env.CODEX_HOME).toBe('/tmp/codex-session-test')
+  })
+
+  it('returns false when there is no login and no API key', () => {
+    existsSyncMock.mockReturnValue(false)
+    const env: Record<string, string> = {}
+
+    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {})
+
+    expect(usesApiKey).toBe(false)
+    expect(env.CODEX_HOME).toBeUndefined()
+  })
+
+  it('authenticateSession allows chatgpt method on the subscription path', async () => {
+    const session = createMockSession('sub-session')
+    session.codexUseApiKey = false
+    const sendRpc = vi
+      .spyOn(adapterPrivate(adapter), 'sendRpcRequest')
+      .mockResolvedValue(undefined)
+
+    await adapterPrivate(adapter).authenticateSession(session, {
+      authMethods: [{ id: 'chatgpt' }, { id: 'openai-api-key' }]
+    })
+
+    // On the subscription path we must NOT pick the API-key method.
+    expect(sendRpc).toHaveBeenCalledWith(session, 'authenticate', { methodId: 'chatgpt' })
+  })
+
+  it('authenticateSession filters out chatgpt when using API-key auth', async () => {
+    const session = createMockSession('key-session')
+    session.codexUseApiKey = true
+    const sendRpc = vi
+      .spyOn(adapterPrivate(adapter), 'sendRpcRequest')
+      .mockResolvedValue(undefined)
+
+    await adapterPrivate(adapter).authenticateSession(session, {
+      authMethods: [{ id: 'chatgpt' }, { id: 'openai-api-key' }]
+    })
+
+    expect(sendRpc).toHaveBeenCalledWith(session, 'authenticate', { methodId: 'openai-api-key' })
   })
 })

--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -24,22 +24,13 @@ vi.mock('child_process', () => ({
   }))
 }))
 
-// Mock fs/os so configureCodexAuthEnv() is deterministic: existsSync controls
-// whether a Codex CLI login (~/.codex/auth.json) is "present", and mkdtempSync
-// returns a stable path instead of touching disk.
+// Mock fs so configureCodexAuthEnv()'s mkdtempSync returns a stable path instead
+// of touching disk (used to assert the isolated CODEX_HOME in API-key mode).
 vi.mock('fs', async (importActual) => {
   const actual = await importActual<typeof import('fs')>()
   return {
     ...actual,
-    existsSync: vi.fn(actual.existsSync),
     mkdtempSync: vi.fn(() => '/tmp/codex-session-test')
-  }
-})
-vi.mock('os', async (importActual) => {
-  const actual = await importActual<typeof import('os')>()
-  return {
-    ...actual,
-    homedir: vi.fn(() => '/home/testuser')
   }
 })
 
@@ -64,7 +55,10 @@ interface AcpAdapterPrivate {
   handleRpcMessage(session: AcpSessionForTest, message: unknown): void
   authenticateSession(session: AcpSessionForTest, initResult: unknown): Promise<void>
   sendRpcRequest(session: AcpSessionForTest, method: string, params?: unknown): Promise<unknown>
-  configureCodexAuthEnv(env: Record<string, string>, config: { apiKeys?: { openai?: string } }): boolean
+  configureCodexAuthEnv(
+    env: Record<string, string | undefined>,
+    config: { apiKeys?: { openai?: string }; authMethod?: 'subscription' | 'api_key' }
+  ): boolean
   agentType: string
 }
 
@@ -3131,29 +3125,26 @@ describe('AcpAdapter - Codex Quota/Error Handling', () => {
 
 describe('AcpAdapter - configureCodexAuthEnv (Codex auth precedence)', () => {
   let adapter: AcpAdapter
-  let existsSyncMock: ReturnType<typeof vi.fn>
 
-  beforeEach(async () => {
+  beforeEach(() => {
     adapter = new AcpAdapter('codex')
-    const fs = await import('fs')
-    existsSyncMock = fs.existsSync as unknown as ReturnType<typeof vi.fn>
-    existsSyncMock.mockReset()
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('uses the Codex CLI login (subscription) and strips ambient API keys', () => {
-    // User is logged into Codex (subscription) AND has an ambient OPENAI_API_KEY
-    // exported in their shell — the classic "terminal works, 20x shows limits" case.
-    existsSyncMock.mockReturnValue(true)
-    const env: Record<string, string> = {
+  it('authMethod=subscription strips ambient API keys and uses ~/.codex', () => {
+    // Explicit subscription choice + an ambient OPENAI_API_KEY exported in the
+    // shell — the classic "terminal works, 20x shows out of rate limits" case.
+    const env: Record<string, string | undefined> = {
       OPENAI_API_KEY: 'sk-ambient-from-shell',
       CODEX_API_KEY: 'sk-ambient-from-shell'
     }
 
-    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {})
+    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {
+      authMethod: 'subscription'
+    })
 
     expect(usesApiKey).toBe(false)
     // Ambient keys must be stripped so codex-acp uses ~/.codex (subscription).
@@ -3164,11 +3155,24 @@ describe('AcpAdapter - configureCodexAuthEnv (Codex auth precedence)', () => {
     expect(env.NO_BROWSER).toBeUndefined()
   })
 
-  it('uses an explicitly-configured API key even when a CLI login exists', () => {
-    existsSyncMock.mockReturnValue(true)
-    const env: Record<string, string> = {}
+  it('authMethod=subscription ignores even an explicitly-configured API key', () => {
+    const env: Record<string, string | undefined> = {}
 
     const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {
+      authMethod: 'subscription',
+      apiKeys: { openai: 'sk-explicit-agent-key' }
+    })
+
+    expect(usesApiKey).toBe(false)
+    expect(env.OPENAI_API_KEY).toBeUndefined()
+    expect(env.CODEX_HOME).toBeUndefined()
+  })
+
+  it('authMethod=api_key uses the explicit per-agent key in an isolated CODEX_HOME', () => {
+    const env: Record<string, string | undefined> = {}
+
+    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {
+      authMethod: 'api_key',
       apiKeys: { openai: 'sk-explicit-agent-key' }
     })
 
@@ -3179,26 +3183,39 @@ describe('AcpAdapter - configureCodexAuthEnv (Codex auth precedence)', () => {
     expect(env.CODEX_HOME).toBe('/tmp/codex-session-test')
   })
 
-  it('falls back to an ambient API key when no CLI login is present', () => {
-    existsSyncMock.mockReturnValue(false)
-    const env: Record<string, string> = { OPENAI_API_KEY: 'sk-ambient' }
+  it('authMethod=api_key falls back to an ambient key when no per-agent key is set', () => {
+    const env: Record<string, string | undefined> = { OPENAI_API_KEY: 'sk-ambient' }
 
-    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {})
+    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {
+      authMethod: 'api_key'
+    })
 
     expect(usesApiKey).toBe(true)
     expect(env.OPENAI_API_KEY).toBe('sk-ambient')
-    expect(env.NO_BROWSER).toBe('1')
     expect(env.CODEX_HOME).toBe('/tmp/codex-session-test')
   })
 
-  it('returns false when there is no login and no API key', () => {
-    existsSyncMock.mockReturnValue(false)
-    const env: Record<string, string> = {}
+  it('legacy (no authMethod): an ambient key alone does NOT force API-key mode', () => {
+    // The original bug: an ambient shell OPENAI_API_KEY hijacked subscription users.
+    const env: Record<string, string | undefined> = { OPENAI_API_KEY: 'sk-ambient' }
 
     const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {})
 
     expect(usesApiKey).toBe(false)
+    expect(env.OPENAI_API_KEY).toBeUndefined()
     expect(env.CODEX_HOME).toBeUndefined()
+  })
+
+  it('legacy (no authMethod): an explicit per-agent key opts into API-key mode', () => {
+    const env: Record<string, string | undefined> = {}
+
+    const usesApiKey = adapterPrivate(adapter).configureCodexAuthEnv(env, {
+      apiKeys: { openai: 'sk-explicit-agent-key' }
+    })
+
+    expect(usesApiKey).toBe(true)
+    expect(env.OPENAI_API_KEY).toBe('sk-explicit-agent-key')
+    expect(env.CODEX_HOME).toBe('/tmp/codex-session-test')
   })
 
   it('authenticateSession allows chatgpt method on the subscription path', async () => {

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -8,8 +8,8 @@
 
 import { spawn, ChildProcess } from 'child_process'
 import { randomUUID } from 'crypto'
-import { mkdtempSync } from 'fs'
-import { tmpdir } from 'os'
+import { existsSync, mkdtempSync } from 'fs'
+import { homedir, tmpdir } from 'os'
 import { dirname, join } from 'path'
 import type {
   CodingAgentAdapter,
@@ -124,6 +124,7 @@ interface AcpSession {
   pendingAssistantTurnSplit: boolean  // True after tool activity; next assistant chunk must start a new turn
   toolCallMetadata: Map<string, { name: string; input: string; title?: string }>  // Cached metadata from initial tool_call events
   lastError: string | null  // Last error message (e.g., quota exceeded) for status reporting
+  codexUseApiKey: boolean  // True when Codex auth uses an API key (vs. ChatGPT subscription / CLI login)
 }
 
 /**
@@ -221,15 +222,65 @@ export class AcpAdapter implements CodingAgentAdapter {
         return {
           command: this.resolveCodexBinary(),
           args: [],
-          env: {
-            // Codex requires OPENAI_API_KEY or CODEX_API_KEY
-            ...(process.env.OPENAI_API_KEY && { OPENAI_API_KEY: process.env.OPENAI_API_KEY }),
-            ...(process.env.CODEX_API_KEY && { CODEX_API_KEY: process.env.CODEX_API_KEY })
-          }
+          // Auth env is decided per-session by configureCodexAuthEnv(), which
+          // gives the user's Codex CLI login (ChatGPT subscription) priority over
+          // any ambient OPENAI_API_KEY/CODEX_API_KEY. Do NOT inject ambient keys
+          // here — that previously hijacked subscription users into API-key auth.
+          env: {}
         }
       default:
         throw new Error(`Unsupported ACP agent type: ${agentType}`)
     }
+  }
+
+  /**
+   * Decide how Codex authenticates for this session and mutate `env` accordingly.
+   * Returns true when API-key auth is used, false when the ChatGPT subscription /
+   * Codex CLI login is used.
+   *
+   * Precedence mirrors the `codex` CLI in a terminal:
+   *   1. Explicit per-agent API key (config.apiKeys.openai) -> API-key auth in an
+   *      isolated temp CODEX_HOME so different keys can be used per session.
+   *   2. Existing Codex CLI login (~/.codex/auth.json, i.e. ChatGPT subscription)
+   *      -> use it via the default CODEX_HOME. Crucially, strip any ambient
+   *      OPENAI_API_KEY/CODEX_API_KEY inherited from the user's shell so it does
+   *      NOT hijack auth into API-key mode. That hijack billed a separate,
+   *      often-exhausted quota and made 20x show "out of rate limits" even though
+   *      the terminal subscription worked perfectly.
+   *   3. No login and no explicit key, but an ambient API key exists -> fall back
+   *      to API-key auth in an isolated temp CODEX_HOME.
+   */
+  private configureCodexAuthEnv(env: Record<string, string | undefined>, config: SessionConfig): boolean {
+    if (this.agentType !== 'codex') return false
+
+    const explicitApiKey = config.apiKeys?.openai
+    if (explicitApiKey) {
+      env.OPENAI_API_KEY = explicitApiKey
+      env.CODEX_API_KEY = explicitApiKey
+      env.NO_BROWSER = '1'
+      env.CODEX_HOME = mkdtempSync(join(tmpdir(), 'codex-session-'))
+      console.log('[AcpAdapter/codex] Auth: explicit API key (isolated CODEX_HOME)')
+      return true
+    }
+
+    const hasCodexLogin = existsSync(join(homedir(), '.codex', 'auth.json'))
+    if (hasCodexLogin) {
+      // Subscription / CLI-login path — do not let ambient keys override it.
+      delete env.OPENAI_API_KEY
+      delete env.CODEX_API_KEY
+      console.log('[AcpAdapter/codex] Auth: Codex CLI login / subscription (~/.codex)')
+      return false
+    }
+
+    if (env.OPENAI_API_KEY || env.CODEX_API_KEY) {
+      env.NO_BROWSER = '1'
+      env.CODEX_HOME = mkdtempSync(join(tmpdir(), 'codex-session-'))
+      console.log('[AcpAdapter/codex] Auth: ambient API key (no CLI login found)')
+      return true
+    }
+
+    console.log('[AcpAdapter/codex] Auth: no API key and no CLI login found')
+    return false
   }
 
   async initialize(): Promise<void> {
@@ -249,11 +300,14 @@ export class AcpAdapter implements CodingAgentAdapter {
     const authMethods = (Array.isArray(initObj?.authMethods) ? initObj.authMethods : []) as Array<{ id: string; [key: string]: unknown }>
 
     if (authMethods.length > 0) {
-      const hasOpenAiKey = !!session.config.apiKeys?.openai || !!process.env.OPENAI_API_KEY || !!process.env.CODEX_API_KEY
+      // Use the auth mode decided in configureCodexAuthEnv() rather than sniffing
+      // ambient env vars. An ambient OPENAI_API_KEY in the user's shell must not
+      // flip a subscription user into API-key auth (and filter out "chatgpt").
+      const hasOpenAiKey = session.codexUseApiKey
 
-      // When an API key is provided, filter out "chatgpt" browser-based auth so
-      // codex-acp uses the key instead of opening an OAuth popup. When no key is
-      // provided, allow all methods including chatgpt (Codex CLI login).
+      // When using an API key, filter out "chatgpt" browser-based auth so
+      // codex-acp uses the key instead of opening an OAuth popup. On the
+      // subscription path, allow all methods including chatgpt (Codex CLI login).
       const usableMethods = (this.agentType === 'codex' && hasOpenAiKey)
         ? authMethods.filter((m) => m.id !== 'chatgpt')
         : authMethods
@@ -296,21 +350,8 @@ export class AcpAdapter implements CodingAgentAdapter {
       ...this.agentConfig.env
     }
 
-    // Override with configured API keys if provided
-    if (config.apiKeys?.openai) {
-      env.OPENAI_API_KEY = config.apiKeys.openai
-      env.CODEX_API_KEY = config.apiKeys.openai
-    }
-
-    // For Codex with an API key: set NO_BROWSER=1 to prevent the OAuth browser
-    // popup, and CODEX_HOME to a per-session temp dir so stale disk credentials
-    // don't override the env var key. This also allows different keys per session.
-    // Without an API key: let codex-acp use the default CODEX_HOME (~/.codex/)
-    // so existing Codex CLI login credentials are available.
-    if (this.agentType === 'codex' && (env.OPENAI_API_KEY || env.CODEX_API_KEY)) {
-      env.NO_BROWSER = '1'
-      env.CODEX_HOME = mkdtempSync(join(tmpdir(), 'codex-session-'))
-    }
+    // Decide Codex auth (subscription vs API key) and mutate env accordingly.
+    const codexUseApiKey = this.configureCodexAuthEnv(env, config)
 
     if (config.apiKeys?.anthropic) {
       env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
@@ -321,11 +362,6 @@ export class AcpAdapter implements CodingAgentAdapter {
       for (const [key, value] of Object.entries(config.secretEnvVars)) {
         env[key] = value
       }
-    }
-
-    // Log warnings if API keys are missing
-    if (this.agentType === 'codex' && !env.OPENAI_API_KEY && !env.CODEX_API_KEY) {
-      console.log('[AcpAdapter/codex] No API key configured — will use Codex CLI login if available')
     }
 
     // Spawn ACP agent process
@@ -363,7 +399,8 @@ export class AcpAdapter implements CodingAgentAdapter {
       activeTurnId: null,
       pendingAssistantTurnSplit: false,
       toolCallMetadata: new Map(),
-      lastError: null
+      lastError: null,
+      codexUseApiKey
     }
 
     // Temporarily store with workspace ID, will re-key after getting ACP session ID
@@ -449,21 +486,8 @@ export class AcpAdapter implements CodingAgentAdapter {
       ...this.agentConfig.env
     }
 
-    // Override with configured API keys if provided
-    if (config.apiKeys?.openai) {
-      env.OPENAI_API_KEY = config.apiKeys.openai
-      env.CODEX_API_KEY = config.apiKeys.openai
-    }
-
-    // For Codex with an API key: set NO_BROWSER=1 to prevent the OAuth browser
-    // popup, and CODEX_HOME to a per-session temp dir so stale disk credentials
-    // don't override the env var key. This also allows different keys per session.
-    // Without an API key: let codex-acp use the default CODEX_HOME (~/.codex/)
-    // so existing Codex CLI login credentials are available.
-    if (this.agentType === 'codex' && (env.OPENAI_API_KEY || env.CODEX_API_KEY)) {
-      env.NO_BROWSER = '1'
-      env.CODEX_HOME = mkdtempSync(join(tmpdir(), 'codex-session-'))
-    }
+    // Decide Codex auth (subscription vs API key) and mutate env accordingly.
+    const codexUseApiKey = this.configureCodexAuthEnv(env, config)
 
     if (config.apiKeys?.anthropic) {
       env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
@@ -479,13 +503,6 @@ export class AcpAdapter implements CodingAgentAdapter {
     if (config.secretEnvVars && Object.keys(config.secretEnvVars).length > 0) {
       for (const [key, value] of Object.entries(config.secretEnvVars)) {
         env[key] = value
-      }
-    }
-
-    // Log warnings if API keys are missing (agents may have their own auth)
-    if (this.agentType === 'codex') {
-      if (!env.OPENAI_API_KEY && !env.CODEX_API_KEY) {
-        console.warn('[AcpAdapter/codex] No OPENAI_API_KEY or CODEX_API_KEY in environment — relying on agent\'s own auth')
       }
     }
 
@@ -524,7 +541,8 @@ export class AcpAdapter implements CodingAgentAdapter {
       activeTurnId: null,
       pendingAssistantTurnSplit: false,
       toolCallMetadata: new Map(),
-      lastError: null
+      lastError: null,
+      codexUseApiKey
     }
 
     // Store with the Codex UUID (same as sessionId since we now return UUID from createSession)

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -9,7 +9,7 @@
 import { spawn, ChildProcess } from 'child_process'
 import { randomUUID } from 'crypto'
 import { mkdtempSync } from 'fs'
-import { tmpdir } from 'os'
+import { homedir, tmpdir } from 'os'
 import { dirname, join } from 'path'
 import type {
   CodingAgentAdapter,
@@ -125,6 +125,7 @@ interface AcpSession {
   toolCallMetadata: Map<string, { name: string; input: string; title?: string }>  // Cached metadata from initial tool_call events
   lastError: string | null  // Last error message (e.g., quota exceeded) for status reporting
   codexUseApiKey: boolean  // True when Codex auth uses an API key (vs. ChatGPT subscription / CLI login)
+  codexAuthSummary: string  // Human-readable auth identity used (for diagnostics, surfaced in errors)
 }
 
 /**
@@ -277,7 +278,14 @@ export class AcpAdapter implements CodingAgentAdapter {
     // hijack auth away from the ChatGPT subscription in the default CODEX_HOME.
     delete env.OPENAI_API_KEY
     delete env.CODEX_API_KEY
-    console.log(`[AcpAdapter/codex] Auth: ChatGPT subscription / Codex CLI login (authMethod=${config.authMethod ?? 'legacy'}, ~/.codex)`)
+    // Pin CODEX_HOME to the same dir the `codex` CLI uses in a terminal, so
+    // codex-acp reads the exact subscription login the user already has. We only
+    // set it when not already provided (a user who runs `codex` with a custom
+    // CODEX_HOME will have it in their shell env, which we inherit and preserve).
+    if (!env.CODEX_HOME) {
+      env.CODEX_HOME = join(homedir(), '.codex')
+    }
+    console.log(`[AcpAdapter/codex] Auth: ChatGPT subscription / Codex CLI login (authMethod=${config.authMethod ?? 'legacy'}, CODEX_HOME=${env.CODEX_HOME})`)
     return false
   }
 
@@ -320,6 +328,8 @@ export class AcpAdapter implements CodingAgentAdapter {
         ? (apiKeyMethod || usableMethods[0])
         : (usableMethods.find((m) => m.id !== 'openai-api-key' && m.id !== 'codex-api-key') || apiKeyMethod || null)
 
+      console.log(`[AcpAdapter/${this.agentType}] Available auth methods: [${authMethods.map((m) => m.id).join(', ')}]; codexUseApiKey=${session.codexUseApiKey}`)
+
       if (!authMethod) {
         console.log(`[AcpAdapter/${this.agentType}] No usable auth method found; skipping authenticate`)
         return
@@ -330,10 +340,13 @@ export class AcpAdapter implements CodingAgentAdapter {
       // no stale disk credentials. This allows different API keys per session.
 
       console.log(`[AcpAdapter/${this.agentType}] Authenticating with method: ${authMethod.id}`)
+      session.codexAuthSummary = `${session.codexUseApiKey ? 'API key' : 'subscription'} via authenticate(${authMethod.id})`
 
       await this.sendRpcRequest(session, 'authenticate', {
         methodId: authMethod.id
       })
+    } else {
+      console.log(`[AcpAdapter/${this.agentType}] No auth methods advertised by agent (already authenticated); codexUseApiKey=${session.codexUseApiKey}`)
     }
   }
 
@@ -365,6 +378,9 @@ export class AcpAdapter implements CodingAgentAdapter {
     // stripped it, re-hijacking Codex into API-key auth (stale "out of rate
     // limits" that survives restarts because the secret lives in the DB).
     const codexUseApiKey = this.configureCodexAuthEnv(env, config)
+    const codexAuthSummary = this.agentType === 'codex'
+      ? `${codexUseApiKey ? 'API key' : 'subscription'} (authMethod=${config.authMethod ?? 'legacy'}, CODEX_HOME=${env.CODEX_HOME ?? 'default'})`
+      : ''
 
     // Spawn ACP agent process
     // On Windows, .cmd/.bat wrappers need shell:true to resolve
@@ -402,7 +418,8 @@ export class AcpAdapter implements CodingAgentAdapter {
       pendingAssistantTurnSplit: false,
       toolCallMetadata: new Map(),
       lastError: null,
-      codexUseApiKey
+      codexUseApiKey,
+      codexAuthSummary
     }
 
     // Temporarily store with workspace ID, will re-key after getting ACP session ID
@@ -502,6 +519,9 @@ export class AcpAdapter implements CodingAgentAdapter {
     // Decide Codex auth (subscription vs API key) LAST so it is authoritative —
     // see createSession for why this must run after secret-env injection.
     const codexUseApiKey = this.configureCodexAuthEnv(env, config)
+    const codexAuthSummary = this.agentType === 'codex'
+      ? `${codexUseApiKey ? 'API key' : 'subscription'} (authMethod=${config.authMethod ?? 'legacy'}, CODEX_HOME=${env.CODEX_HOME ?? 'default'})`
+      : ''
 
     console.log(`[AcpAdapter/${this.agentType}] Environment after config:`, {
       hasAnthropicInEnv: !!env.ANTHROPIC_API_KEY,
@@ -545,7 +565,8 @@ export class AcpAdapter implements CodingAgentAdapter {
       pendingAssistantTurnSplit: false,
       toolCallMetadata: new Map(),
       lastError: null,
-      codexUseApiKey
+      codexUseApiKey,
+      codexAuthSummary
     }
 
     // Store with the Codex UUID (same as sessionId since we now return UUID from createSession)
@@ -1154,13 +1175,19 @@ export class AcpAdapter implements CodingAgentAdapter {
    * a clear, actionable error message to the user.
    */
   private handleQuotaError(session: AcpSession, errorInfo: { errorType: string; userMessage: string }): void {
+    // Append the auth identity 20x used so the user (and we) can see whether the
+    // limit came from their subscription or an API key — the whole point of the
+    // "terminal works but 20x doesn't" investigation.
+    const authNote = session.codexAuthSummary ? ` [20x auth: ${session.codexAuthSummary}]` : ''
+    const userMessage = `${errorInfo.userMessage}${authNote}`
+
     console.warn(
       `[AcpAdapter/${this.agentType}] Provider error (${errorInfo.errorType}):`,
-      errorInfo.userMessage
+      userMessage
     )
 
     session.status = SessionStatusType.ERROR
-    session.lastError = errorInfo.userMessage
+    session.lastError = userMessage
     session.activeTurnId = null
 
     // Push a user-friendly error event to the LIVE message buffer only.
@@ -1177,7 +1204,7 @@ export class AcpAdapter implements CodingAgentAdapter {
     // event out of the permanent history fully clears the stale state on resume.
     const errorEvent = {
       _isError: true,
-      message: errorInfo.userMessage,
+      message: userMessage,
       data: null  // Don't expose raw error data for known error types
     }
     session.messageBuffer.push(errorEvent)

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -1142,14 +1142,24 @@ export class AcpAdapter implements CodingAgentAdapter {
     session.lastError = errorInfo.userMessage
     session.activeTurnId = null
 
-    // Push a user-friendly error event to the message buffers
+    // Push a user-friendly error event to the LIVE message buffer only.
+    //
+    // IMPORTANT: Quota/rate-limit errors are TRANSIENT conditions tied to a
+    // point in time. They must NOT be written to permanentMessages, because
+    // permanentMessages is replayed on every session resume (getAllMessages).
+    // If we persisted them, the "Quota exceeded / Rate limit reached" message
+    // would re-appear at the end of the transcript forever — even after the
+    // user upgrades their Codex plan, re-logs in, or simply waits for the
+    // window to reset. That stale message is exactly what makes 20x keep
+    // "showing limits" after the underlying limit is gone. session.lastError
+    // is already cleared on the next sendPrompt() for recovery, so keeping the
+    // event out of the permanent history fully clears the stale state on resume.
     const errorEvent = {
       _isError: true,
       message: errorInfo.userMessage,
       data: null  // Don't expose raw error data for known error types
     }
     session.messageBuffer.push(errorEvent)
-    this.addToPermanentMessages(session, errorEvent)
     this.onDataAvailable?.(session.sessionId)
   }
 

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -8,8 +8,8 @@
 
 import { spawn, ChildProcess } from 'child_process'
 import { randomUUID } from 'crypto'
-import { existsSync, mkdtempSync } from 'fs'
-import { homedir, tmpdir } from 'os'
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
 import { dirname, join } from 'path'
 import type {
   CodingAgentAdapter,
@@ -238,48 +238,46 @@ export class AcpAdapter implements CodingAgentAdapter {
    * Returns true when API-key auth is used, false when the ChatGPT subscription /
    * Codex CLI login is used.
    *
-   * Precedence mirrors the `codex` CLI in a terminal:
-   *   1. Explicit per-agent API key (config.apiKeys.openai) -> API-key auth in an
-   *      isolated temp CODEX_HOME so different keys can be used per session.
-   *   2. Existing Codex CLI login (~/.codex/auth.json, i.e. ChatGPT subscription)
-   *      -> use it via the default CODEX_HOME. Crucially, strip any ambient
-   *      OPENAI_API_KEY/CODEX_API_KEY inherited from the user's shell so it does
-   *      NOT hijack auth into API-key mode. That hijack billed a separate,
-   *      often-exhausted quota and made 20x show "out of rate limits" even though
-   *      the terminal subscription worked perfectly.
-   *   3. No login and no explicit key, but an ambient API key exists -> fall back
-   *      to API-key auth in an isolated temp CODEX_HOME.
+   * The user's explicit choice in the agent configuration (config.authMethod) is
+   * the source of truth:
+   *   - 'subscription' -> use the Codex CLI login (~/.codex), exactly like running
+   *     `codex` in a terminal. Any ambient OPENAI_API_KEY/CODEX_API_KEY inherited
+   *     from the user's shell is STRIPPED so it cannot hijack auth into API-key
+   *     mode (which bills a separate, often-exhausted quota and made 20x show
+   *     "out of rate limits" even though the terminal subscription worked fine).
+   *   - 'api_key' -> use an API key (the per-agent config key if set, otherwise the
+   *     ambient one) in an isolated temp CODEX_HOME so keys can differ per session.
+   *
+   * When authMethod is unset (legacy agents), fall back to the historical rule but
+   * WITHOUT the ambient-key hijack: only an explicitly-configured per-agent API
+   * key implies API-key mode; otherwise default to the subscription/login path.
    */
   private configureCodexAuthEnv(env: Record<string, string | undefined>, config: SessionConfig): boolean {
     if (this.agentType !== 'codex') return false
 
     const explicitApiKey = config.apiKeys?.openai
-    if (explicitApiKey) {
-      env.OPENAI_API_KEY = explicitApiKey
-      env.CODEX_API_KEY = explicitApiKey
+    const useApiKey =
+      config.authMethod === 'api_key' ? true
+      : config.authMethod === 'subscription' ? false
+      : !!explicitApiKey // legacy default: only an explicit key opts into API-key mode
+
+    if (useApiKey) {
+      const key = explicitApiKey || env.OPENAI_API_KEY || env.CODEX_API_KEY
+      if (key) {
+        env.OPENAI_API_KEY = key
+        env.CODEX_API_KEY = key
+      }
       env.NO_BROWSER = '1'
       env.CODEX_HOME = mkdtempSync(join(tmpdir(), 'codex-session-'))
-      console.log('[AcpAdapter/codex] Auth: explicit API key (isolated CODEX_HOME)')
+      console.log(`[AcpAdapter/codex] Auth: API key (authMethod=${config.authMethod ?? 'legacy'}, isolated CODEX_HOME)`)
       return true
     }
 
-    const hasCodexLogin = existsSync(join(homedir(), '.codex', 'auth.json'))
-    if (hasCodexLogin) {
-      // Subscription / CLI-login path — do not let ambient keys override it.
-      delete env.OPENAI_API_KEY
-      delete env.CODEX_API_KEY
-      console.log('[AcpAdapter/codex] Auth: Codex CLI login / subscription (~/.codex)')
-      return false
-    }
-
-    if (env.OPENAI_API_KEY || env.CODEX_API_KEY) {
-      env.NO_BROWSER = '1'
-      env.CODEX_HOME = mkdtempSync(join(tmpdir(), 'codex-session-'))
-      console.log('[AcpAdapter/codex] Auth: ambient API key (no CLI login found)')
-      return true
-    }
-
-    console.log('[AcpAdapter/codex] Auth: no API key and no CLI login found')
+    // Subscription / Codex CLI login path. Strip ambient keys so they can't
+    // hijack auth away from the ChatGPT subscription in the default CODEX_HOME.
+    delete env.OPENAI_API_KEY
+    delete env.CODEX_API_KEY
+    console.log(`[AcpAdapter/codex] Auth: ChatGPT subscription / Codex CLI login (authMethod=${config.authMethod ?? 'legacy'}, ~/.codex)`)
     return false
   }
 

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -348,9 +348,6 @@ export class AcpAdapter implements CodingAgentAdapter {
       ...this.agentConfig.env
     }
 
-    // Decide Codex auth (subscription vs API key) and mutate env accordingly.
-    const codexUseApiKey = this.configureCodexAuthEnv(env, config)
-
     if (config.apiKeys?.anthropic) {
       env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
     }
@@ -361,6 +358,13 @@ export class AcpAdapter implements CodingAgentAdapter {
         env[key] = value
       }
     }
+
+    // Decide Codex auth (subscription vs API key) LAST so it is authoritative.
+    // It must run after secret-env injection: a user secret named OPENAI_API_KEY /
+    // CODEX_API_KEY would otherwise be re-added to env after subscription mode
+    // stripped it, re-hijacking Codex into API-key auth (stale "out of rate
+    // limits" that survives restarts because the secret lives in the DB).
+    const codexUseApiKey = this.configureCodexAuthEnv(env, config)
 
     // Spawn ACP agent process
     // On Windows, .cmd/.bat wrappers need shell:true to resolve
@@ -484,18 +488,9 @@ export class AcpAdapter implements CodingAgentAdapter {
       ...this.agentConfig.env
     }
 
-    // Decide Codex auth (subscription vs API key) and mutate env accordingly.
-    const codexUseApiKey = this.configureCodexAuthEnv(env, config)
-
     if (config.apiKeys?.anthropic) {
       env.ANTHROPIC_API_KEY = config.apiKeys.anthropic
     }
-
-    console.log(`[AcpAdapter/${this.agentType}] Environment after config:`, {
-      hasAnthropicInEnv: !!env.ANTHROPIC_API_KEY,
-      anthropicKeyLength: env.ANTHROPIC_API_KEY?.length,
-      anthropicKeyPrefix: env.ANTHROPIC_API_KEY?.substring(0, 5)
-    })
 
     // Inject secret env vars directly into process environment
     if (config.secretEnvVars && Object.keys(config.secretEnvVars).length > 0) {
@@ -503,6 +498,16 @@ export class AcpAdapter implements CodingAgentAdapter {
         env[key] = value
       }
     }
+
+    // Decide Codex auth (subscription vs API key) LAST so it is authoritative —
+    // see createSession for why this must run after secret-env injection.
+    const codexUseApiKey = this.configureCodexAuthEnv(env, config)
+
+    console.log(`[AcpAdapter/${this.agentType}] Environment after config:`, {
+      hasAnthropicInEnv: !!env.ANTHROPIC_API_KEY,
+      anthropicKeyLength: env.ANTHROPIC_API_KEY?.length,
+      anthropicKeyPrefix: env.ANTHROPIC_API_KEY?.substring(0, 5)
+    })
 
     // Spawn ACP agent process
     // On Windows, .cmd/.bat wrappers need shell:true to resolve

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -494,12 +494,20 @@ function loadPlatformShellEnv(): Promise<void> {
   const CODEX_API_KEY_END = '__20X_CODEX_API_KEY_END__'
   const ANTHROPIC_API_KEY_START = '__20X_ANTHROPIC_API_KEY_START__'
   const ANTHROPIC_API_KEY_END = '__20X_ANTHROPIC_API_KEY_END__'
+  // CODEX_HOME: if the user's terminal `codex` uses a custom CODEX_HOME (e.g. a
+  // work profile / a different ChatGPT account than ~/.codex), 20x must read the
+  // SAME one — otherwise codex-acp authenticates as whatever account lives in the
+  // default ~/.codex, which may be a free/over-limit account ("Upgrade to Plus")
+  // while the terminal subscription works fine.
+  const CODEX_HOME_START = '__20X_CODEX_HOME_START__'
+  const CODEX_HOME_END = '__20X_CODEX_HOME_END__'
 
   const command = [
     `printf '%s%s%s\\n' "${PATH_START}" "$PATH" "${PATH_END}"`,
     `printf '%s%s%s\\n' "${OPENAI_API_KEY_START}" "$OPENAI_API_KEY" "${OPENAI_API_KEY_END}"`,
     `printf '%s%s%s\\n' "${CODEX_API_KEY_START}" "$CODEX_API_KEY" "${CODEX_API_KEY_END}"`,
-    `printf '%s%s%s\\n' "${ANTHROPIC_API_KEY_START}" "$ANTHROPIC_API_KEY" "${ANTHROPIC_API_KEY_END}"`
+    `printf '%s%s%s\\n' "${ANTHROPIC_API_KEY_START}" "$ANTHROPIC_API_KEY" "${ANTHROPIC_API_KEY_END}"`,
+    `printf '%s%s%s\\n' "${CODEX_HOME_START}" "$CODEX_HOME" "${CODEX_HOME_END}"`
   ].join('; ')
 
   const extractMarkedValue = (stdout: string, start: string, end: string): string | undefined => {
@@ -532,6 +540,14 @@ function loadPlatformShellEnv(): Promise<void> {
 
           const anthropicApiKey = extractMarkedValue(stdout, ANTHROPIC_API_KEY_START, ANTHROPIC_API_KEY_END)
           if (anthropicApiKey) process.env.ANTHROPIC_API_KEY = anthropicApiKey
+
+          // Inherit a custom CODEX_HOME so codex-acp authenticates as the SAME
+          // ChatGPT account the user's terminal `codex` uses.
+          const codexHome = extractMarkedValue(stdout, CODEX_HOME_START, CODEX_HOME_END)
+          if (codexHome) {
+            process.env.CODEX_HOME = codexHome
+            console.log('[Main] Inherited CODEX_HOME from shell:', codexHome)
+          }
 
           resolve()
           return

--- a/src/renderer/src/components/agents/AgentForm.tsx
+++ b/src/renderer/src/components/agents/AgentForm.tsx
@@ -54,7 +54,7 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
   )
   const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set())
 
-  // Auth method state (Claude Code only)
+  // Auth method state (Claude Code and Codex)
   const [authMethod, setAuthMethod] = useState<ClaudeAuthMethod>(
     agent?.config.auth_method ?? 'subscription'
   )
@@ -107,9 +107,9 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
     }
   }, [codingAgent, serverUrl])
 
-  // Reset auth method when switching away from Claude Code
+  // Reset auth method for agents that don't expose a subscription/api_key choice
   useEffect(() => {
-    if (codingAgent !== CodingAgentType.CLAUDE_CODE) {
+    if (codingAgent !== CodingAgentType.CLAUDE_CODE && codingAgent !== CodingAgentType.CODEX) {
       setAuthMethod('subscription')
     }
   }, [codingAgent])
@@ -205,7 +205,9 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
       config: {
         coding_agent: codingAgent || undefined,
         model: model.trim() || undefined,
-        auth_method: codingAgent === CodingAgentType.CLAUDE_CODE ? authMethod : undefined,
+        auth_method: (codingAgent === CodingAgentType.CLAUDE_CODE || codingAgent === CodingAgentType.CODEX)
+          ? authMethod
+          : undefined,
         permission_mode: permissionMode,
         system_prompt: systemPrompt.trim() || undefined,
         max_parallel_sessions: maxParallelSessions,
@@ -213,7 +215,10 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
         skill_ids: skillIds,
         secret_ids: secretIds.length > 0 ? secretIds : undefined,
         api_keys: {
-          openai: openaiApiKey.trim() || undefined,
+          // Only persist the OpenAI key when Codex is in api_key mode
+          openai: (codingAgent === CodingAgentType.CODEX && authMethod === 'api_key')
+            ? (openaiApiKey.trim() || undefined)
+            : undefined,
           // Only save anthropic key when in api_key mode
           anthropic: (codingAgent === CodingAgentType.CLAUDE_CODE && authMethod === 'api_key')
             ? (anthropicApiKey.trim() || undefined)
@@ -410,28 +415,60 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
         </>
       )}
 
-      {/* API Key Configuration for Codex */}
+      {/* Auth Method & API Key Configuration for Codex */}
       {codingAgent === CodingAgentType.CODEX && (
-        <div className="space-y-1.5">
-          <Label htmlFor="openai-api-key">OpenAI API Key</Label>
-          <Input
-            id="openai-api-key"
-            type="password"
-            value={openaiApiKey}
-            onChange={(e) => setOpenaiApiKey(e.target.value)}
-            placeholder={hasOpenaiEnv ? '••••••••' : 'sk-proj-...'}
-          />
-          {!openaiApiKey && hasOpenaiEnv && (
-            <p className="text-xs text-muted-foreground">
-              ✓ Using OPENAI_API_KEY from environment
-            </p>
+        <>
+          <div className="space-y-1.5">
+            <Label htmlFor="codex-auth-method">Authentication Method</Label>
+            <select
+              id="codex-auth-method"
+              value={authMethod}
+              onChange={(e) => setAuthMethod(e.target.value as ClaudeAuthMethod)}
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm cursor-pointer"
+            >
+              <option value="subscription">ChatGPT Subscription (default)</option>
+              <option value="api_key">API Key (pay-per-use)</option>
+            </select>
+            {authMethod === 'subscription' && (
+              <p className="text-xs text-muted-foreground">
+                Uses your Codex CLI login (ChatGPT Plus/Pro/Business subscription), exactly like running <code>codex</code> in a terminal.
+                {hasOpenaiEnv && (
+                  <span className="block mt-1 text-yellow-500">
+                    Note: OPENAI_API_KEY found in environment but will be ignored in subscription mode.
+                  </span>
+                )}
+              </p>
+            )}
+          </div>
+
+          {authMethod === 'api_key' && (
+            <div className="space-y-1.5">
+              <Label htmlFor="openai-api-key">OpenAI API Key</Label>
+              <Input
+                id="openai-api-key"
+                type="password"
+                value={openaiApiKey}
+                onChange={(e) => setOpenaiApiKey(e.target.value)}
+                placeholder={hasOpenaiEnv ? '••••••••' : 'sk-proj-...'}
+              />
+              {openaiApiKey && (
+                <p className="text-xs text-muted-foreground">
+                  Using provided API key
+                </p>
+              )}
+              {!openaiApiKey && hasOpenaiEnv && (
+                <p className="text-xs text-muted-foreground">
+                  ✓ Using OPENAI_API_KEY from environment
+                </p>
+              )}
+              {!openaiApiKey && !hasOpenaiEnv && (
+                <p className="text-xs text-destructive">
+                  Required: Enter your API key or set OPENAI_API_KEY environment variable
+                </p>
+              )}
+            </div>
           )}
-          {!openaiApiKey && !hasOpenaiEnv && (
-            <p className="text-xs text-muted-foreground">
-              Optional — leave empty to use Codex CLI login (requires a paid ChatGPT subscription)
-            </p>
-          )}
-        </div>
+        </>
       )}
 
       {/* Auth Method & API Key Configuration for Claude Code */}


### PR DESCRIPTION
## Problem
User report: *"I upgraded my Codex plan and re-logged in, but 20x still shows 'out of rate limits' — even on a brand-new session — while `codex` in the terminal works perfectly. I use the subscription, not the API."*

## Root cause
20x reads any `OPENAI_API_KEY` / `CODEX_API_KEY` exported in the user's login shell and puts it on `process.env` (`loadPlatformShellEnv`, `main/index.ts`). The Codex ACP adapter treated the mere *presence* of that ambient key as "use API-key auth": it pointed `CODEX_HOME` at an empty per-session temp dir (hiding the real `~/.codex`) and filtered out the `chatgpt` auth method. So Codex authenticated against the **API key's** separate (often free-tier/exhausted) quota → "out of rate limits" on every new session, while terminal `codex` used the `~/.codex` ChatGPT **subscription** and worked fine.

## Fix — honor the explicit setting end-to-end
The agent configuration already has an explicit `auth_method` (`subscription` | `api_key`), and the backend already plumbs it to the adapter as `config.authMethod`. We now make that the source of truth instead of guessing.

**Backend** (`configureCodexAuthEnv` in `acp-adapter.ts`):
- `authMethod: 'subscription'` → use the Codex CLI login (`~/.codex`), exactly like the terminal, and **strip any ambient `OPENAI_API_KEY`/`CODEX_API_KEY`** so a stray shell env var can't hijack auth. An explicitly-configured key is also ignored in this mode.
- `authMethod: 'api_key'` → use the per-agent key (ambient as fallback) in an isolated temp `CODEX_HOME`.
- legacy (unset `authMethod`) → only an explicit per-agent key opts into API-key mode; an ambient key never does (kills the original hijack).

The decided mode is stored on the session (`codexUseApiKey`) and drives auth-method selection in `authenticateSession()` (replaces the old `process.env` sniffing). Applied to `createSession` and `resumeSession`; `getAgentConfig` no longer injects ambient keys.

**Frontend** (`AgentForm.tsx`): expose the subscription/api_key selector for Codex (was Claude-only), persist `auth_method` for Codex, and only show/save the OpenAI API key field in api_key mode. Subscription mode notes that an ambient `OPENAI_API_KEY` is ignored.

## Secondary fix (same "stale limits" symptom)
`handleQuotaError` previously persisted the quota/rate-limit error into `permanentMessages`, which is replayed on every resume — so an old "Quota exceeded" message stuck to the transcript even after the limit cleared. These transient errors now go to the live buffer only.

## Test plan
- [x] `configureCodexAuthEnv` tests: subscription strips ambient keys & ignores explicit key; api_key uses explicit/ambient key + isolated CODEX_HOME; legacy ambient-key does NOT force API-key mode; legacy explicit key does.
- [x] `authenticateSession` selects method from `codexUseApiKey` (chatgpt on subscription, api-key otherwise).
- [x] Regression: transient quota error does not survive `getAllMessages()` replay.
- [x] `acp-adapter.test.ts` 86/86. ESLint 0 errors. Typecheck (node + web): clean.

## Manual verification
Agent config → Codex → Authentication Method = **ChatGPT Subscription**. On a machine with an `OPENAI_API_KEY` exported in the shell, start a new Codex session and confirm it uses `~/.codex` (no rate-limit error). Switch to **API Key** to use a key instead.

Generated with [Claude Code](https://claude.com/claude-code)