### PR TITLE
fix(enterprise): prevent premature logout, robust selectTenant, org selection

### DIFF
--- a/src/main/enterprise-auth.test.ts
+++ b/src/main/enterprise-auth.test.ts
@@ -522,7 +522,49 @@ describe('EnterpriseAuth — transient vs. definitive refresh failures', () => {
     expect(db.getSetting('enterprise_supabase_refresh_token')).not.toBeNull()
     expect(wasCleared(warnSpy)).toBe(false)
     expect(
-      warnSpy.mock.calls.some((c) => String(c[0]).includes('auth_api_401_retry_transient'))
+      warnSpy.mock.calls.some((c) => String(c[0]).includes('auth_api_401_retry_no_clear'))
+    ).toBe(true)
+  })
+
+  it('does NOT clear the session when a resource endpoint keeps returning 401 after a valid refresh', async () => {
+    // Reproduces the PRIMARY root cause: an optional post-auth resource fetch
+    // (e.g. AI-gateway virtual key) 401s, the token refreshes successfully, but
+    // the resource STILL 401s. That must surface a resource error, never wipe
+    // the freshly-established enterprise session.
+    db.setSetting('enterprise_jwt', enc('jwt-token'))
+    db.setSetting('enterprise_jwt_expires_at', String(Date.now() + 10 * 60_000))
+    db.setSetting('enterprise_supabase_access_token', enc('access-token'))
+    db.setSetting('enterprise_supabase_refresh_token', enc('refresh-token'))
+    db.setSetting('enterprise_tenant_id', 'tenant-1')
+    db.setSetting('enterprise_tenant_name', 'Peakflo')
+
+    // Refresh succeeds → session is proven valid
+    authMock.refreshSession.mockResolvedValue({
+      data: { session: { access_token: 'fresh-access', refresh_token: 'rotated-refresh' } },
+      error: null
+    })
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      // The pf-workflo JWT refresh endpoint succeeds
+      if (url.includes('/api/20x/auth/refresh')) {
+        return { ok: true, status: 200, json: async () => ({ token: 'new-jwt', expiresIn: 3600 }) }
+      }
+      // The resource endpoint always 401s (e.g. AI gateway not provisioned)
+      return { ok: false, status: 401, json: async () => ({ message: 'Virtual key not provisioned' }) }
+    }))
+
+    const auth = new EnterpriseAuth(db as never)
+
+    await expect(auth.apiRequest('GET', '/api/20x/ai-gateway/virtual-key')).rejects.toThrow(
+      'Virtual key not provisioned'
+    )
+
+    // The session survives the resource-level 401
+    expect(db.getSetting('enterprise_supabase_refresh_token')).not.toBeNull()
+    expect(db.getSetting('enterprise_tenant_id')).toBe('tenant-1')
+    expect(wasCleared(warnSpy)).toBe(false)
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes('auth_api_401_retry_resource_error'))
     ).toBe(true)
   })
 })

--- a/src/main/enterprise-auth.test.ts
+++ b/src/main/enterprise-auth.test.ts
@@ -6,10 +6,14 @@ const authMock = {
   signOut: vi.fn(async () => ({})),
   refreshSession: vi.fn(async (): Promise<{
     data: { session: { access_token: string; refresh_token: string } | null }
-    error: { message: string; status?: number } | null
+    error: { message: string; status?: number; code?: string; name?: string } | null
   }> => ({ data: { session: null }, error: null })),
   signInWithPassword: vi.fn(async () => ({ data: null, error: null }))
 }
+
+// Store an encrypted-at-rest value the way the mocked safeStorage (base64 utf8)
+// expects it, so getStored*/decryptValue round-trips in tests.
+const enc = (value: string): string => Buffer.from(value, 'utf8').toString('base64')
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(() => ({
@@ -403,5 +407,241 @@ describe('EnterpriseAuth logging', () => {
     expect(errCall![0]).toContain('500')
 
     errorSpy.mockRestore()
+  })
+})
+
+// ── Regression: premature logout on transient refresh failures ──────
+// Problem 1 from parent task u92mprhpqojofy42nmicvfa7: the user was signed out
+// after a successful enterprise login because ANY refresh failure (including
+// flaky network / 5xx) wiped stored credentials. These tests lock in the rule
+// that only DEFINITIVE auth errors clear the session.
+describe('EnterpriseAuth — transient vs. definitive refresh failures', () => {
+  let db: MockDb
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  const seedSession = (d: MockDb): void => {
+    d.setSetting('enterprise_supabase_access_token', enc('access-token'))
+    d.setSetting('enterprise_supabase_refresh_token', enc('refresh-token'))
+    d.setSetting('enterprise_tenant_id', 'tenant-1')
+    d.setSetting('enterprise_tenant_name', 'Peakflo')
+    d.setSetting('enterprise_user_id', 'user-1')
+    d.setSetting('enterprise_user_email', 'user@peakflo.co')
+  }
+
+  const wasCleared = (spy: ReturnType<typeof vi.spyOn>): boolean =>
+    spy.mock.calls.some((c) => String(c[0]).includes('auth_state_cleared'))
+
+  beforeEach(() => {
+    db = new MockDb()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })))
+    authMock.signOut.mockResolvedValue({})
+    authMock.refreshSession.mockResolvedValue({ data: { session: null }, error: null })
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('does NOT clear credentials on a transient 5xx refresh failure', async () => {
+    seedSession(db)
+    authMock.refreshSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Service Unavailable', status: 503 }
+    })
+
+    const auth = new EnterpriseAuth(db as never)
+
+    await expect(auth.refreshToken()).rejects.toThrow(/Unable to reach 20x Cloud/)
+
+    // Session must be preserved so a later retry can succeed
+    expect(db.getSetting('enterprise_supabase_refresh_token')).not.toBeNull()
+    expect(db.getSetting('enterprise_supabase_access_token')).not.toBeNull()
+    expect(db.getSetting('enterprise_tenant_id')).toBe('tenant-1')
+    expect(wasCleared(warnSpy)).toBe(false)
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes('auth_refresh_transient_skip_clear'))
+    ).toBe(true)
+  })
+
+  it('does NOT clear credentials when refreshSession throws a network error', async () => {
+    seedSession(db)
+    authMock.refreshSession.mockRejectedValue(new Error('fetch failed'))
+
+    const auth = new EnterpriseAuth(db as never)
+
+    await expect(auth.refreshToken()).rejects.toThrow(/Unable to reach 20x Cloud/)
+
+    expect(db.getSetting('enterprise_supabase_refresh_token')).not.toBeNull()
+    expect(wasCleared(warnSpy)).toBe(false)
+  })
+
+  it('DOES clear credentials when the refresh token is definitively invalid (invalid_grant)', async () => {
+    seedSession(db)
+    authMock.refreshSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Invalid Refresh Token', status: 400, code: 'invalid_grant' }
+    })
+
+    const auth = new EnterpriseAuth(db as never)
+
+    await expect(auth.refreshToken()).rejects.toThrow('Session expired')
+
+    expect(db.getSetting('enterprise_supabase_refresh_token')).toBeNull()
+    expect(db.getSetting('enterprise_supabase_access_token')).toBeNull()
+    expect(wasCleared(warnSpy)).toBe(true)
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes('auth_clear_supabase_refresh_failed'))
+    ).toBe(true)
+  })
+
+  it('apiRequest 401 → transient refresh failure keeps the session (no clear)', async () => {
+    db.setSetting('enterprise_jwt', enc('jwt-token'))
+    db.setSetting('enterprise_jwt_expires_at', String(Date.now() + 10 * 60_000))
+    db.setSetting('enterprise_supabase_refresh_token', enc('refresh-token'))
+    db.setSetting('enterprise_tenant_id', 'tenant-1')
+
+    authMock.refreshSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Bad Gateway', status: 502 }
+    })
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({ message: 'Unauthorized' })
+    })))
+
+    const auth = new EnterpriseAuth(db as never)
+
+    await expect(auth.apiRequest('GET', '/api/test')).rejects.toThrow(/Unable to reach 20x Cloud/)
+
+    // JWT + refresh token preserved; not signed out on a transient failure
+    expect(db.getSetting('enterprise_jwt')).not.toBeNull()
+    expect(db.getSetting('enterprise_supabase_refresh_token')).not.toBeNull()
+    expect(wasCleared(warnSpy)).toBe(false)
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes('auth_api_401_retry_transient'))
+    ).toBe(true)
+  })
+})
+
+// ── Regression: selectTenant session restoration ────────────────────
+// Problem 2 from parent task: selectTenant threw "Not authenticated — please
+// sign in first" even though the user still had a valid refresh token.
+describe('EnterpriseAuth — selectTenant session restoration', () => {
+  let db: MockDb
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    db = new MockDb()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    authMock.signOut.mockResolvedValue({})
+    authMock.refreshSession.mockResolvedValue({ data: { session: null }, error: null })
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('restores the access token from the refresh token when none is stored', async () => {
+    // No access token stored, but we DO hold a valid refresh token
+    db.setSetting('enterprise_supabase_refresh_token', enc('refresh-token'))
+    authMock.refreshSession.mockResolvedValue({
+      data: { session: { access_token: 'restored-access', refresh_token: 'rotated-refresh' } },
+      error: null
+    })
+
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/20x/auth/select-tenant')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            token: 'jwt-token',
+            expiresIn: 3600,
+            tenant: { id: 'tenant-1', name: 'Peakflo' }
+          })
+        }
+      }
+      if (url.includes('/api/20x/ai-gateway/virtual-key')) {
+        throw new Error('AI gateway unavailable')
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchFn)
+
+    const auth = new EnterpriseAuth(db as never)
+    const result = await auth.selectTenant('tenant-1')
+
+    expect(result.tenant).toEqual({ id: 'tenant-1', name: 'Peakflo' })
+    // select-tenant must have been called with the RESTORED access token
+    const selectCall = (fetchFn.mock.calls as Array<[RequestInfo | URL, RequestInit?]>).find(
+      ([input]) => String(input).includes('/api/20x/auth/select-tenant')
+    )
+    expect((selectCall?.[1]?.headers as Record<string, string>)?.Authorization).toBe(
+      'Bearer restored-access'
+    )
+    expect(authMock.refreshSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes the Supabase session and retries once when select-tenant returns 401', async () => {
+    db.setSetting('enterprise_supabase_access_token', enc('stale-access'))
+    db.setSetting('enterprise_supabase_refresh_token', enc('refresh-token'))
+    authMock.refreshSession.mockResolvedValue({
+      data: { session: { access_token: 'fresh-access', refresh_token: 'rotated-refresh' } },
+      error: null
+    })
+
+    let selectCalls = 0
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/20x/auth/select-tenant')) {
+        selectCalls++
+        if (selectCalls === 1) {
+          return { ok: false, status: 401, json: async () => ({ message: 'Token expired' }) }
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            token: 'jwt-token',
+            expiresIn: 3600,
+            tenant: { id: 'tenant-1', name: 'Peakflo' }
+          })
+        }
+      }
+      if (url.includes('/api/20x/ai-gateway/virtual-key')) {
+        throw new Error('AI gateway unavailable')
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchFn)
+
+    const auth = new EnterpriseAuth(db as never)
+    const result = await auth.selectTenant('tenant-1')
+
+    expect(result.tenant).toEqual({ id: 'tenant-1', name: 'Peakflo' })
+    expect(selectCalls).toBe(2)
+    const secondSelect = (fetchFn.mock.calls as Array<[RequestInfo | URL, RequestInit?]>).filter(
+      ([input]) => String(input).includes('/api/20x/auth/select-tenant')
+    )[1]
+    expect((secondSelect?.[1]?.headers as Record<string, string>)?.Authorization).toBe(
+      'Bearer fresh-access'
+    )
+  })
+
+  it('throws "Not authenticated" only when no tokens exist at all', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })))
+    const auth = new EnterpriseAuth(db as never)
+
+    await expect(auth.selectTenant('tenant-1')).rejects.toThrow('Not authenticated — please sign in first')
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes('auth_select_tenant_not_authenticated'))
+    ).toBe(true)
   })
 })

--- a/src/main/enterprise-auth.ts
+++ b/src/main/enterprise-auth.ts
@@ -618,27 +618,28 @@ export class EnterpriseAuth {
         headers['Authorization'] = `Bearer ${retryJwt}`
         const retryResponse = await fetch(url, { ...fetchOptions, headers })
 
-        // A fresh token that is STILL rejected means the session is genuinely
-        // invalid → clear and require re-login.
-        if (retryResponse.status === 401) {
-          this.logAuthEvent('auth_clear_after_api_401_retry_failed', {
+        if (!retryResponse.ok) {
+          // We just proved the session is valid by refreshing it successfully.
+          // A non-ok here (even another 401) is therefore a RESOURCE-level
+          // rejection specific to this endpoint (e.g. an AI-gateway virtual key
+          // that isn't provisioned) — NOT an invalid session. Surface the
+          // resource error WITHOUT clearing credentials, otherwise an optional
+          // post-auth call (like the AI-gateway key fetch inside selectTenant)
+          // would wipe the freshly-established session.
+          const retryBody = await retryResponse.json().catch(() => ({}))
+          this.logAuthEvent('auth_api_401_retry_resource_error', {
             method: normalizedMethod,
             path,
-            reason: 'retry_still_401'
+            status: retryResponse.status
           })
-          this.clearStoredData()
-          throw new EnterpriseAuthInvalidError('Session expired — please sign in again')
-        }
-
-        if (!retryResponse.ok) {
-          const retryBody = await retryResponse.json().catch(() => ({}))
           throw new Error(retryBody.message || `API request failed (${retryResponse.status})`)
         }
 
         return retryResponse.json().catch(() => null)
       } catch (error) {
-        // Only clear credentials when the failure is a DEFINITIVE auth error.
-        // Transient network/5xx failures must not sign the user out.
+        // Only clear credentials when the refresh itself proved the session is
+        // DEFINITIVELY invalid. Transient network/5xx failures and
+        // resource-level rejections must NOT sign the user out.
         if (error instanceof EnterpriseAuthInvalidError) {
           this.logAuthEvent('auth_clear_after_api_401_retry_failed', {
             method: normalizedMethod,
@@ -648,7 +649,7 @@ export class EnterpriseAuth {
           this.clearStoredData()
           throw new Error('Session expired — please sign in again')
         }
-        this.logAuthEvent('auth_api_401_retry_transient', {
+        this.logAuthEvent('auth_api_401_retry_no_clear', {
           method: normalizedMethod,
           path,
           error: this.describeError(error)

--- a/src/main/enterprise-auth.ts
+++ b/src/main/enterprise-auth.ts
@@ -85,6 +85,24 @@ export interface EnterpriseSession {
   currentTenant: { id: string; name: string } | null
 }
 
+/**
+ * Thrown when the enterprise session is *definitively* invalid and the user
+ * must sign in again (e.g. the Supabase refresh token was rejected with
+ * invalid_grant / refresh_token_not_found). Distinct from transient
+ * network/5xx failures, which must NOT invalidate the stored session.
+ *
+ * When this error is thrown, stored credentials have already been cleared.
+ */
+export class EnterpriseAuthInvalidError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'EnterpriseAuthInvalidError'
+  }
+}
+
+/** Minimal shape of a Supabase refresh error we inspect for classification. */
+type RefreshErrorLike = { message?: string; status?: number; code?: string; name?: string } | null
+
 interface EnterpriseAiGatewayVirtualKeyResponse {
   apiKey: string
   baseUrl: string
@@ -250,22 +268,51 @@ export class EnterpriseAuth {
       throw new Error('Tenant ID is required')
     }
 
-    const accessToken = this.getStoredSupabaseAccessToken()
+    this.logAuthEvent('auth_select_tenant_start', { tenantId })
+
+    // Prefer the stored Supabase access token. If it's missing (e.g. it was
+    // rotated/expired since login), attempt to restore it from the refresh
+    // token before giving up — this prevents the spurious
+    // "Not authenticated — please sign in first" error when the user actually
+    // still holds a valid refresh token.
+    let accessToken = this.getStoredSupabaseAccessToken()
     if (!accessToken) {
+      accessToken = await this.tryRefreshSupabaseAccessToken()
+    }
+    if (!accessToken) {
+      this.logAuthEvent('auth_select_tenant_not_authenticated')
       throw new Error('Not authenticated — please sign in first')
     }
 
-    const response = await fetch(`${this.apiUrl}/api/20x/auth/select-tenant`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${accessToken}`
-      },
-      body: JSON.stringify({ tenantId })
-    })
+    const doSelect = (token: string): Promise<Response> =>
+      fetch(`${this.apiUrl}/api/20x/auth/select-tenant`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ tenantId })
+      })
+
+    let response = await doSelect(accessToken)
+
+    // The stored access token may have expired between login and selection.
+    // Refresh the Supabase session once and retry before surfacing an error.
+    if (response.status === 401) {
+      this.logAuthEvent('auth_select_tenant_access_token_expired')
+      const refreshed = await this.tryRefreshSupabaseAccessToken()
+      if (refreshed) {
+        accessToken = refreshed
+        response = await doSelect(accessToken)
+      }
+    }
 
     if (!response.ok) {
       const body = await response.json().catch(() => ({}))
+      this.logAuthEvent('auth_select_tenant_failed', {
+        status: response.status,
+        message: body.message ?? null
+      })
       throw new Error(body.message || `Failed to select tenant (${response.status})`)
     }
 
@@ -275,6 +322,10 @@ export class EnterpriseAuth {
     this.storeJwt(result.token, result.expiresIn)
     this.db.setSetting(KEYS.TENANT_ID, result.tenant.id)
     this.db.setSetting(KEYS.TENANT_NAME, result.tenant.name)
+    this.logAuthEvent('auth_select_tenant_success', {
+      tenantId: result.tenant.id,
+      tenantName: result.tenant.name
+    })
     const warnings: string[] = []
     try {
       this.logAuthEvent('ai_gateway_virtual_key_fetch_start')
@@ -369,31 +420,10 @@ export class EnterpriseAuth {
   }
 
   private async executeRefresh(): Promise<{ token: string }> {
-    // First refresh the Supabase session
-    const refreshToken = this.getStoredSupabaseRefreshToken()
-    if (!refreshToken) {
-      this.logAuthEvent('auth_clear_missing_refresh_token')
-      this.clearStoredData()
-      this.notifySessionExpired('No refresh token — please sign in to 20x Cloud again.')
-      throw new Error('No refresh token available — please sign in again')
-    }
-
-    const { data, error } = await this.supabase.auth.refreshSession({
-      refresh_token: refreshToken
-    })
-
-    if (error || !data.session) {
-      this.logAuthEvent('auth_clear_supabase_refresh_failed', {
-        message: error?.message || 'No session returned',
-        status: (error as { status?: number } | null)?.status
-      })
-      this.clearStoredData()
-      this.notifySessionExpired('Session expired — please sign in to 20x Cloud again.')
-      throw new Error('Session expired — please sign in again')
-    }
-
-    // Store updated Supabase tokens
-    this.storeSupabaseSession(data.session)
+    // First refresh the Supabase session. This clears stored data ONLY when
+    // the refresh token is definitively invalid — transient network/5xx
+    // failures throw without wiping the session so the user stays signed in.
+    const accessToken = await this.refreshSupabaseSession()
 
     // Now refresh the pf-workflo JWT
     const tenantId = this.db.getSetting(KEYS.TENANT_ID)
@@ -405,7 +435,7 @@ export class EnterpriseAuth {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${data.session.access_token}`
+        'Authorization': `Bearer ${accessToken}`
       },
       body: JSON.stringify({ tenantId })
     })
@@ -419,6 +449,141 @@ export class EnterpriseAuth {
     this.storeJwt(result.token, result.expiresIn)
 
     return { token: result.token }
+  }
+
+  /**
+   * Refresh the underlying Supabase session using the stored refresh token and
+   * return the fresh access token.
+   *
+   * Credential-clearing policy:
+   * - Missing refresh token          → clear + throw EnterpriseAuthInvalidError
+   * - Refresh rejected (invalid_grant / 400/401 / refresh token not found)
+   *                                   → clear + throw EnterpriseAuthInvalidError
+   * - Transient failure (network / timeout / 5xx / 408 / 429 / unknown)
+   *                                   → KEEP session, throw plain Error
+   *
+   * This is the single choke-point that decides whether an involuntary
+   * sign-out happens, which is what prevented premature logouts on flaky
+   * networks.
+   */
+  private async refreshSupabaseSession(): Promise<string> {
+    const refreshToken = this.getStoredSupabaseRefreshToken()
+    if (!refreshToken) {
+      this.logAuthEvent('auth_clear_missing_refresh_token')
+      this.clearStoredData()
+      this.notifySessionExpired('No refresh token — please sign in to 20x Cloud again.')
+      throw new EnterpriseAuthInvalidError('No refresh token available — please sign in again')
+    }
+
+    let session: Session | null = null
+    let error: RefreshErrorLike = null
+    try {
+      const result = await this.supabase.auth.refreshSession({ refresh_token: refreshToken })
+      session = result.data.session
+      error = result.error as RefreshErrorLike
+    } catch (err) {
+      // A thrown error (rather than a returned { error }) is almost always a
+      // network/transport failure — treat as transient, do NOT clear.
+      this.logAuthEvent('auth_refresh_transient_skip_clear', {
+        reason: 'refresh_session_threw',
+        ...this.describeError(err)
+      })
+      throw new Error('Unable to reach 20x Cloud to refresh the session — please try again')
+    }
+
+    if (error || !session) {
+      const classification = this.classifyRefreshError(error)
+      if (classification === 'invalid') {
+        this.logAuthEvent('auth_clear_supabase_refresh_failed', {
+          message: error?.message || 'No session returned',
+          status: error?.status,
+          code: error?.code
+        })
+        this.clearStoredData()
+        this.notifySessionExpired('Session expired — please sign in to 20x Cloud again.')
+        throw new EnterpriseAuthInvalidError('Session expired — please sign in again')
+      }
+
+      // Transient: keep the stored session intact so a later retry can succeed.
+      this.logAuthEvent('auth_refresh_transient_skip_clear', {
+        message: error?.message || 'No session returned',
+        status: error?.status,
+        code: error?.code
+      })
+      throw new Error('Unable to reach 20x Cloud to refresh the session — please try again')
+    }
+
+    // Store updated Supabase tokens
+    this.storeSupabaseSession(session)
+    return session.access_token
+  }
+
+  /**
+   * Best-effort variant of refreshSupabaseSession used by selectTenant.
+   * Returns the fresh access token, or null if the session could not be
+   * restored (whether the failure was definitive or transient — the caller
+   * decides how to surface it). Definitive failures still clear credentials
+   * inside refreshSupabaseSession.
+   */
+  private async tryRefreshSupabaseAccessToken(): Promise<string | null> {
+    try {
+      return await this.refreshSupabaseSession()
+    } catch (err) {
+      this.logAuthEvent('auth_supabase_restore_failed', this.describeError(err))
+      return null
+    }
+  }
+
+  /**
+   * Classify a Supabase refresh error as a definitive auth failure ('invalid',
+   * requiring re-login) or a recoverable/transient one ('transient', keep the
+   * session). The default for ambiguous cases is 'transient' so we never sign a
+   * user out on an error we don't positively recognise as auth-invalid.
+   */
+  private classifyRefreshError(error: RefreshErrorLike): 'invalid' | 'transient' {
+    // No structured error but no session either — ambiguous; don't clear.
+    if (!error) return 'transient'
+
+    const status = typeof error.status === 'number' ? error.status : undefined
+    const code = (error.code || '').toLowerCase()
+    const message = (error.message || '').toLowerCase()
+    const name = (error.name || '').toLowerCase()
+
+    // Definitive auth-invalid signals: the refresh token itself is bad.
+    const invalidCodes = [
+      'invalid_grant',
+      'refresh_token_not_found',
+      'refresh_token_already_used',
+      'session_not_found',
+      'session_expired',
+      'bad_jwt'
+    ]
+    if (invalidCodes.includes(code)) return 'invalid'
+    if (
+      /invalid refresh token|refresh token not found|already used|invalid_grant|invalid token|session (?:not found|expired)|jwt expired/.test(
+        message
+      )
+    ) {
+      return 'invalid'
+    }
+
+    // Transient signals: network / server errors → keep the session.
+    if (name.includes('retryable') || name.includes('fetch')) return 'transient'
+    if (
+      /fetch failed|failed to fetch|network|timeout|timed out|econn|enotfound|eai_again|socket|temporar|unavailable|502|503|504/.test(
+        message
+      )
+    ) {
+      return 'transient'
+    }
+    if (status !== undefined) {
+      if (status >= 500 || status === 408 || status === 429 || status === 0) return 'transient'
+      // Explicit auth-rejection status codes from the refresh endpoint.
+      if (status === 400 || status === 401 || status === 403 || status === 422) return 'invalid'
+    }
+
+    // Unknown shape → be conservative and keep the session.
+    return 'transient'
   }
 
   // ── API Request Proxy ────────────────────────────────────────────
@@ -453,6 +618,18 @@ export class EnterpriseAuth {
         headers['Authorization'] = `Bearer ${retryJwt}`
         const retryResponse = await fetch(url, { ...fetchOptions, headers })
 
+        // A fresh token that is STILL rejected means the session is genuinely
+        // invalid → clear and require re-login.
+        if (retryResponse.status === 401) {
+          this.logAuthEvent('auth_clear_after_api_401_retry_failed', {
+            method: normalizedMethod,
+            path,
+            reason: 'retry_still_401'
+          })
+          this.clearStoredData()
+          throw new EnterpriseAuthInvalidError('Session expired — please sign in again')
+        }
+
         if (!retryResponse.ok) {
           const retryBody = await retryResponse.json().catch(() => ({}))
           throw new Error(retryBody.message || `API request failed (${retryResponse.status})`)
@@ -460,13 +637,23 @@ export class EnterpriseAuth {
 
         return retryResponse.json().catch(() => null)
       } catch (error) {
-        this.logAuthEvent('auth_clear_after_api_401_retry_failed', {
-          method: method.toUpperCase(),
+        // Only clear credentials when the failure is a DEFINITIVE auth error.
+        // Transient network/5xx failures must not sign the user out.
+        if (error instanceof EnterpriseAuthInvalidError) {
+          this.logAuthEvent('auth_clear_after_api_401_retry_failed', {
+            method: normalizedMethod,
+            path,
+            error: this.describeError(error)
+          })
+          this.clearStoredData()
+          throw new Error('Session expired — please sign in again')
+        }
+        this.logAuthEvent('auth_api_401_retry_transient', {
+          method: normalizedMethod,
           path,
           error: this.describeError(error)
         })
-        this.clearStoredData()
-        throw new Error('Session expired — please sign in again')
+        throw error instanceof Error ? error : new Error(String(error))
       }
     }
 
@@ -510,12 +697,21 @@ export class EnterpriseAuth {
         headers['Authorization'] = `Bearer ${retryJwt}`
         response = await fetch(url, { method: 'GET', headers })
       } catch (error) {
-        this.logAuthEvent('auth_clear_after_download_401_retry_failed', {
+        // Only clear credentials on a definitive auth failure — transient
+        // network/5xx errors must not sign the user out.
+        if (error instanceof EnterpriseAuthInvalidError) {
+          this.logAuthEvent('auth_clear_after_download_401_retry_failed', {
+            path,
+            error: this.describeError(error)
+          })
+          this.clearStoredData()
+          throw new Error('Session expired — please sign in again')
+        }
+        this.logAuthEvent('auth_download_401_retry_transient', {
           path,
           error: this.describeError(error)
         })
-        this.clearStoredData()
-        throw new Error('Session expired — please sign in again')
+        throw error instanceof Error ? error : new Error(String(error))
       }
     }
 

--- a/src/renderer/src/components/settings/tabs/EnterpriseLoginModal.tsx
+++ b/src/renderer/src/components/settings/tabs/EnterpriseLoginModal.tsx
@@ -53,7 +53,14 @@ export function EnterpriseLoginModal({ open, onClose }: EnterpriseLoginModalProp
     // isAuthenticated, which is only set after selectTenant completes.
     // The loading spinner keeps the UI responsive while we wait.
     await selectTenant(tenantId)
-    onClose()
+    // Only close on success. selectTenant() swallows failures into the store's
+    // `error` state (and leaves isAuthenticated false); closing unconditionally
+    // would hide that error and make it look like "nothing happened" after a
+    // click. Keep the modal open so the user sees what went wrong.
+    const { isAuthenticated: authed, error: selectError } = useEnterpriseStore.getState()
+    if (authed && !selectError) {
+      onClose()
+    }
   }, [selectTenant, onClose])
 
   const handleClose = useCallback(() => {

--- a/src/renderer/src/stores/enterprise-store.test.ts
+++ b/src/renderer/src/stores/enterprise-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useEnterpriseStore, type EnterpriseSyncStats } from './enterprise-store'
+import { enterpriseApi } from '@/lib/ipc-client'
 
 // Mock the ipc-client so the store can be imported without Electron
 vi.mock('@/lib/ipc-client', () => ({
@@ -111,5 +112,59 @@ describe('useEnterpriseStore — sync stats', () => {
     const state = useEnterpriseStore.getState()
     expect(state.lastSyncStats).toEqual(stats)
     expect(state.lastSyncMs).toBe(999)
+  })
+})
+
+// ── Regression: org selection (Problem 3) ───────────────────────────
+// Parent task u92mprhpqojofy42nmicvfa7: "sign in button shows org selection,
+// but nothing changes after I select it." On success the tenant must persist
+// and the picker state clear; on failure the error must surface and the picker
+// list must remain so the modal doesn't silently close.
+describe('useEnterpriseStore — selectTenant (org selection)', () => {
+  const selectTenantMock = enterpriseApi.selectTenant as unknown as ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useEnterpriseStore.setState({
+      isAuthenticated: false,
+      isLoading: false,
+      isSyncing: false,
+      error: null,
+      userEmail: 'user@peakflo.co',
+      userId: 'user-1',
+      currentTenant: null,
+      availableTenants: [
+        { id: 'tenant-1', name: 'Peakflo', isPrimary: true },
+        { id: 'tenant-2', name: 'Acme', isPrimary: false }
+      ],
+      lastSyncStats: null,
+      lastSyncMs: null
+    })
+  })
+
+  it('persists the tenant and clears the picker on success', async () => {
+    selectTenantMock.mockResolvedValue({ token: 'jwt', tenant: { id: 'tenant-2', name: 'Acme' } })
+
+    await useEnterpriseStore.getState().selectTenant('tenant-2')
+
+    const state = useEnterpriseStore.getState()
+    expect(state.isAuthenticated).toBe(true)
+    expect(state.currentTenant).toEqual({ id: 'tenant-2', name: 'Acme' })
+    expect(state.availableTenants).toBeNull()
+    expect(state.error).toBeNull()
+    expect(state.isSyncing).toBe(true)
+  })
+
+  it('surfaces the error and keeps the picker on failure', async () => {
+    selectTenantMock.mockRejectedValue(new Error('Not authenticated — please sign in first'))
+
+    await useEnterpriseStore.getState().selectTenant('tenant-1')
+
+    const state = useEnterpriseStore.getState()
+    expect(state.isAuthenticated).toBe(false)
+    expect(state.currentTenant).toBeNull()
+    // Picker list preserved so the modal stays open showing the error
+    expect(state.availableTenants).toHaveLength(2)
+    expect(state.error).toBe('Not authenticated — please sign in first')
   })
 })

--- a/src/renderer/src/stores/enterprise-store.ts
+++ b/src/renderer/src/stores/enterprise-store.ts
@@ -158,12 +158,16 @@ export const useEnterpriseStore = create<EnterpriseState>((set) => ({
     set({ isLoading: true, error: null })
     try {
       const result = await enterpriseApi.selectTenant(tenantId)
-      // Show "Connected" immediately — sync runs in background
+      // Show "Connected" immediately — sync runs in background.
+      // Clear availableTenants and error so the modal reflects the connected
+      // state (and doesn't re-render the org picker) on success.
       set({
         isLoading: false,
         isAuthenticated: true,
         isSyncing: true,
-        currentTenant: result.tenant
+        currentTenant: result.tenant,
+        availableTenants: null,
+        error: null
       })
       // Surface non-fatal warnings (e.g. AI gateway key fetch failure)
       if (result.warnings?.length) {


### PR DESCRIPTION
## Problem

Parent issue: users get logged out right after enterprise login, then see `Error invoking remote method 'enterprise:selectTenant': Error: Not authenticated — please sign in first`, and selecting an org does nothing.

### Root cause (from investigation subtask)
`EnterpriseAuth.selectTenant()` stores the JWT + tenant, then runs an **optional** post-auth AI-gateway virtual-key fetch via `apiRequest()`. If that endpoint returns 401 and the retry (after a token refresh) is still non-ok, the old `apiRequest()` catch called `clearStoredData()` — wiping the just-established session. `selectTenant()` swallowed the AI-gateway error and still returned "success", so the renderer thought auth worked while the DB was already wiped. The next `selectTenant` found no Supabase access token → "Not authenticated". More broadly, **any** transient refresh failure (network / 5xx) also wiped credentials.

## Fixes

### 1. Prevent premature logout (Problem 1)
- New `classifyRefreshError()` distinguishes **definitive** auth failures (`invalid_grant`, `refresh_token_not_found`, 400/401/403/422) from **transient** ones (network/timeout/5xx/408/429/unknown).
- New `refreshSupabaseSession()` is the single choke-point for involuntary sign-out: clears + throws `EnterpriseAuthInvalidError` only on definitive failures; transient failures throw a retryable error and **keep** the session.
- **Resource-level 401s no longer wipe the session:** once a refresh succeeds (session proven valid), a still-non-ok retry in `apiRequest`/`downloadFile` is surfaced as a resource error **without** clearing credentials. This directly fixes the nested AI-gateway-fetch clear inside `selectTenant` and the startup `refreshAiGatewayVirtualKey()` path.

### 2. Fix `enterprise:selectTenant` "Not authenticated" (Problem 2)
- `selectTenant` restores the Supabase access token from the refresh token when the stored access token is missing, and refreshes + retries once on a 401 from `select-tenant`.
- Only throws "Not authenticated — please sign in first" when there are genuinely no tokens.

### 3. Fix org selection UI (Problem 3)
- `store.selectTenant` clears the tenant picker + error and persists `currentTenant` on success.
- `EnterpriseLoginModal.handleSelectTenant` only closes on success, so a failure surfaces its error instead of the modal silently closing ("nothing changes").

### Structured logging
Added `auth_select_tenant_start/success/failed/not_authenticated/access_token_expired`, `auth_refresh_transient_skip_clear`, `auth_api_401_retry_no_clear`, `auth_api_401_retry_resource_error`, `auth_download_401_retry_transient`, `auth_supabase_restore_failed` (all include the API domain).

## Tests
28 tests passing across both files. New regression coverage:
- transient 5xx / thrown network refresh error → **no** clear
- `invalid_grant` → **does** clear
- resource endpoint keeps 401 after a valid refresh → session preserved (primary root cause)
- `apiRequest` 401 + transient refresh → session kept
- `selectTenant` restores access token from refresh token / retries on 401 / only fails with no tokens
- store: org selection persists tenant on success, keeps picker + error on failure

`pnpm vitest run` (enterprise-auth + enterprise-store) ✅ · `tsc --build --noEmit` ✅ · `eslint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)