### PR TITLE
fix: Codex ACP scrambled message beginnings — history consolidation mutated the live poll buffer

### DIFF
--- a/src/main/adapters/acp-adapter.test.ts
+++ b/src/main/adapters/acp-adapter.test.ts
@@ -3261,3 +3261,132 @@ describe('AcpAdapter - configureCodexAuthEnv (Codex auth precedence)', () => {
     expect(sendRpc).toHaveBeenCalledWith(session, 'authenticate', { methodId: 'openai-api-key' })
   })
 })
+
+// ─── Regression: live buffer / permanent history aliasing (scrambled message start) ───
+//
+// handleRpcMessage() pushes each notification object into BOTH session.messageBuffer
+// (live polling) and session.permanentMessages (resume history). addToPermanentMessages()
+// consolidates consecutive assistant chunks by MUTATING content.text on the last stored
+// event — which, without a defensive copy, is the SAME object still sitting un-polled in
+// messageBuffer. When several delta chunks arrive between polls (always the case at the
+// start of a response: the first token burst lands before the first poll cycle), the first
+// buffered chunk silently becomes the full accumulated text while the following buffered
+// chunks stay raw deltas. pollMessages() then re-appends those middle deltas after the
+// already-complete text, scrambling the beginning of the message
+// ("Hello world, how world, how" style).
+describe('AcpAdapter - live buffer vs permanent history aliasing', () => {
+  let adapter: AcpAdapter
+
+  beforeEach(() => {
+    adapter = new AcpAdapter('codex')
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function chunkNotification(sessionId: string, text: string): unknown {
+    return {
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {
+        sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text }
+        }
+      }
+    }
+  }
+
+  it('does not scramble the message start when several delta chunks arrive before the first poll', async () => {
+    const sessionId = 'burst-session'
+    const priv = adapterPrivate(adapter)
+    const session = createMockSession(sessionId)
+    priv.sessions.set(sessionId, session)
+
+    // A burst of small delta chunks arrives on stdout before the polling
+    // loop gets a chance to run (typical at the START of every response).
+    priv.handleRpcMessage(session, chunkNotification(sessionId, 'Hello'))
+    priv.handleRpcMessage(session, chunkNotification(sessionId, ' world'))
+    priv.handleRpcMessage(session, chunkNotification(sessionId, ', how are you?'))
+
+    const parts = await adapter.pollMessages(sessionId, new Set(), new Set(), new Map(), {} as never)
+
+    expect(parts.length).toBeGreaterThan(0)
+    const finalText = parts[parts.length - 1]?.text
+    expect(finalText).toBe('Hello world, how are you?')
+  })
+
+  it('does not scramble longer delta bursts with short middle chunks', async () => {
+    const sessionId = 'burst-session-2'
+    const priv = adapterPrivate(adapter)
+    const session = createMockSession(sessionId)
+    priv.sessions.set(sessionId, session)
+
+    const deltas = ['I', "'ll", ' check', ' the', ' logs', ' and', ' reproduce', ' the issue now.']
+    for (const delta of deltas) {
+      priv.handleRpcMessage(session, chunkNotification(sessionId, delta))
+    }
+
+    const parts = await adapter.pollMessages(sessionId, new Set(), new Set(), new Map(), {} as never)
+
+    const finalText = parts[parts.length - 1]?.text
+    expect(finalText).toBe("I'll check the logs and reproduce the issue now.")
+  })
+
+  it('keeps un-polled live chunks pristine when permanent history consolidates them', () => {
+    const sessionId = 'pristine-session'
+    const priv = adapterPrivate(adapter)
+    const session = createMockSession(sessionId)
+    priv.sessions.set(sessionId, session)
+
+    priv.handleRpcMessage(session, chunkNotification(sessionId, 'Hello'))
+    priv.handleRpcMessage(session, chunkNotification(sessionId, ' world'))
+
+    // Permanent history consolidates into one event…
+    expect(session.permanentMessages).toHaveLength(1)
+    const permText = (session.permanentMessages[0] as { params: { update: { content: { text: string } } } })
+      .params.update.content.text
+    expect(permText).toBe('Hello world')
+
+    // …but the live buffer must still hold the ORIGINAL raw deltas.
+    const bufferTexts = session.messageBuffer.map((e) =>
+      (e as { params: { update: { content: { text: string } } } }).params.update.content.text
+    )
+    expect(bufferTexts).toEqual(['Hello', ' world'])
+  })
+
+  it('does not truncate live tool output when capping permanent history', () => {
+    const sessionId = 'truncate-session'
+    const priv = adapterPrivate(adapter)
+    const session = createMockSession(sessionId)
+    priv.sessions.set(sessionId, session)
+
+    const bigOutput = 'x'.repeat(150_000)
+    priv.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {
+        sessionId,
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tool-big',
+          status: 'completed',
+          rawOutput: { stdout: bigOutput }
+        }
+      }
+    })
+
+    // Permanent history is capped at 100KB per tool output…
+    const permStdout = (session.permanentMessages[0] as { params: { update: { rawOutput: { stdout: string } } } })
+      .params.update.rawOutput.stdout
+    expect(permStdout.length).toBeLessThan(bigOutput.length)
+    expect(permStdout).toContain('truncated in history')
+
+    // …but the live buffer must still carry the FULL output to the UI.
+    const liveStdout = (session.messageBuffer[0] as { params: { update: { rawOutput: { stdout: string } } } })
+      .params.update.rawOutput.stdout
+    expect(liveStdout).toBe(bigOutput)
+  })
+})

--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -1247,6 +1247,20 @@ export class AcpAdapter implements CodingAgentAdapter {
   /**
    * Adds a notification or event to the permanent message history, with
    * consolidation and size-based pruning to prevent OOM.
+   *
+   * IMPORTANT: events are stored as deep clones. The incoming `event` object is
+   * the SAME object that handleRpcMessage() pushed into session.messageBuffer
+   * for live polling. This method mutates stored events in two ways:
+   *   1. chunk consolidation rewrites content.text on the last stored event
+   *   2. tool outputs are truncated to 100KB for history
+   * Without cloning, those mutations corrupted the un-polled live buffer:
+   * when several agent_message_chunk deltas arrived between polls (always the
+   * case at the START of a response — the first token burst lands before the
+   * first poll cycle), consolidation silently rewrote the FIRST buffered chunk
+   * into the full accumulated text while the later buffered chunks stayed raw
+   * deltas. pollMessages() then appended those deltas again after the already
+   * complete text, scrambling the beginning of the message
+   * ("Hello world, how are you? world, how are you?").
    */
   private addToPermanentMessages(session: AcpSession, event: unknown): void {
     const notification = event as JsonRpcNotification
@@ -1271,11 +1285,16 @@ export class AcpAdapter implements CodingAgentAdapter {
     }
 
     if (!consolidated) {
+      // Deep-clone before storing so history-only mutations (chunk
+      // consolidation above on later events, output truncation below) never
+      // leak into the identical object still queued in session.messageBuffer.
+      const stored = structuredClone(notification)
+
       // Capping tool output size in permanent messages (replayed on resume).
       // The full output is still delivered to the UI during the live session,
       // but truncated here to keep the history bounded.
-      if (notification.method === 'session/update') {
-        const update = (notification.params as { update?: SessionUpdate })?.update
+      if (stored.method === 'session/update') {
+        const update = (stored.params as { update?: SessionUpdate })?.update
         if (update?.rawOutput && typeof update.rawOutput === 'object') {
           const ro = update.rawOutput as Record<string, unknown>
           const MAX_HISTORY_OUTPUT_CHARS = 100_000 // 100KB per tool output in history
@@ -1289,8 +1308,8 @@ export class AcpAdapter implements CodingAgentAdapter {
       }
 
       // Stamp with arrival time so replays can preserve original timing
-      ;(notification as unknown as Record<string, unknown>)._receivedAt = Date.now()
-      session.permanentMessages.push(notification)
+      ;(stored as unknown as Record<string, unknown>)._receivedAt = Date.now()
+      session.permanentMessages.push(stored)
     }
 
     // Enforce absolute limit on permanent history to prevent OOM.


### PR DESCRIPTION
## Summary

Codex via ACP still showed **scrambled text at the beginning of assistant messages** after the mergeStreamingText heuristics from #380. Root cause found and fixed at the source.

### Root cause

\`handleRpcMessage()\` pushes each \`session/update\` notification **by reference** into BOTH:
- \`session.messageBuffer\` — consumed by live polling (\`pollMessages\`)
- \`session.permanentMessages\` — resume/replay history (via \`addToPermanentMessages\`)

\`addToPermanentMessages()\` consolidates consecutive assistant chunks by **mutating** \`content.text\` on the last stored event — but that object is the *same object* still queued, un-polled, in \`messageBuffer\`.

Whenever ≥3 chunks arrive between polls — which is **always the case at the start of a response**, since the first token burst lands before the first poll cycle — the first buffered chunk is silently rewritten into the full accumulated text while later buffered chunks stay raw deltas. \`pollMessages()\` then re-appends those deltas after the already-complete text:

```
deltas:   "Hello" + " world" + ", how are you?"
rendered: "Hello world, how are you? world, how are you?"
```

The #380 heuristics (suffix-overlap / skipped-prefix dedup) only masked the 2-chunk variant of this self-inflicted aliasing; bursts of 3+ chunks and short middle chunks (< 8-char overlap threshold) still scrambled — the "dedup not working" behaviour reported.

### Fix

Store a **deep clone** in \`permanentMessages\` so history-only mutations (chunk consolidation, 100KB tool-output truncation) never leak into the live buffer. Bonus: the live UI now actually receives full, untruncated tool output as the existing comment always claimed.

## Reproduction

New regression test drives the real ingestion path (\`handleRpcMessage\` → \`pollMessages\`) with a 3-chunk burst; on \`main\` it fails with exactly the reported scramble:

```
Expected: "Hello world, how are you?"
Received: "Hello world, how are you? world, how are you?"
```

## Test plan
- [x] 4 new regression tests (burst-before-first-poll scramble, short middle chunks, buffer pristineness, live tool-output truncation) — all fail on main, pass with fix
- [x] Full \`acp-adapter.test.ts\` suite: 91/91 pass
- [x] \`agent-manager.test.ts\` + all adapter suites: 231/231 pass
- [x] \`tsc --noEmit -p tsconfig.node.json\` clean; eslint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)