### PR TITLE
fix: improve transcript tool call presentation

### DIFF
--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -90,6 +90,7 @@ export interface MessagePart {
     name: string
     status?: string
     title?: string
+    description?: string
     input?: unknown
     output?: unknown
     error?: string
@@ -123,6 +124,7 @@ export interface MessagePayload {
     name: string
     status?: string
     title?: string
+    description?: string
     input?: unknown
     output?: unknown
     error?: string

--- a/src/mobile/components/MessageBubble.test.tsx
+++ b/src/mobile/components/MessageBubble.test.tsx
@@ -120,4 +120,92 @@ describe('MessageBubble message layout', () => {
     expect(getByText('Output')).toBeTruthy()
     expect(getByText('pass')).toBeTruthy()
   })
+
+  it('shows tool descriptions in compact rows and exact commands in expanded details', () => {
+    const command = `cd "/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/vebrwpyobv88637krcachtxa/workflow-builder" && git add packages/ui/app/business-context/graph/page.tsx && git commit -q -F - <<'MSG'
+fix(ui): move custom-property editor from Overview into the Properties tab
+
+The "add custom property" controls were on the Overview (main) tab, so users
+who went to Properties to add a field saw only the read-only cube params.
+MSG
+git push 2>&1 | tail -2`
+
+    const toolMessage: AgentMessage = {
+      id: 'tool-description',
+      role: 'assistant',
+      content: 'Bash',
+      timestamp: new Date('2026-03-10T00:00:00.000Z'),
+      partType: 'tool',
+      tool: {
+        name: 'Bash',
+        status: 'success',
+        input: JSON.stringify({
+          command,
+          description: 'Commit and push placement fix'
+        }, null, 2),
+        output: 'pass'
+      }
+    }
+
+    const { getByRole, queryByText, getByText } = render(<MessageBubble message={toolMessage} />)
+    const toolButton = getByRole('button', { name: /Bash Commit and push placement fix/i })
+    expect(queryByText(/workflow-builder/)).toBeNull()
+    expect(queryByText('Command')).toBeNull()
+
+    fireEvent.click(toolButton)
+
+    expect(getByText('Command')).toBeTruthy()
+    expect(getByText((_, element) => element?.tagName === 'PRE' && element.textContent === command)).toBeTruthy()
+  })
+
+  it('shows only filenames for file editing tool subtitles', () => {
+    const filePath = '/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/vebrwpyobv88637krcachtxa/workflow-builder/packages/ui/app/business-context/graph/page.tsx'
+
+    const toolMessage: AgentMessage = {
+      id: 'tool-edit',
+      role: 'assistant',
+      content: 'Edit',
+      timestamp: new Date('2026-03-10T00:00:00.000Z'),
+      partType: 'tool',
+      tool: {
+        name: 'Edit',
+        status: 'success',
+        input: JSON.stringify({
+          replace_all: false,
+          file_path: filePath,
+          old_string: '              {/* Properties Tab */}',
+          new_string: '              {/* Properties Tab */}'
+        }, null, 2),
+        output: 'updated'
+      }
+    }
+
+    const { getByRole, queryByRole } = render(<MessageBubble message={toolMessage} />)
+
+    expect(getByRole('button', { name: /Edit page\.tsx/i })).toBeTruthy()
+    expect(queryByRole('button', { name: /workflow-builder/i })).toBeNull()
+  })
+
+  it('shows only filenames for read tool subtitles', () => {
+    const filePath = '/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/vebrwpyobv88637krcachtxa/workflow-builder/packages/cubejs/lib/custom-dimensions.js'
+
+    const toolMessage: AgentMessage = {
+      id: 'tool-read',
+      role: 'assistant',
+      content: 'Read',
+      timestamp: new Date('2026-03-10T00:00:00.000Z'),
+      partType: 'tool',
+      tool: {
+        name: 'Read',
+        status: 'success',
+        input: JSON.stringify({ file_path: filePath }, null, 2),
+        output: 'const customDimensions = []'
+      }
+    }
+
+    const { getByRole, queryByRole } = render(<MessageBubble message={toolMessage} />)
+
+    expect(getByRole('button', { name: /Read custom-dimensions\.js/i })).toBeTruthy()
+    expect(queryByRole('button', { name: /workflow-builder/i })).toBeNull()
+  })
 })

--- a/src/mobile/components/MessageBubble.tsx
+++ b/src/mobile/components/MessageBubble.tsx
@@ -135,11 +135,69 @@ function PlanReviewMessage({ message }: { message: AgentMessage }) {
 
 function deriveToolSubtitle(tool?: AgentMessage['tool']): string {
   if (!tool) return ''
-  if (tool.title) return tool.title
+
+  const description = deriveToolDescription(tool)
+  if (description) return description
+
+  if (tool.title) {
+    return isFilePathTool(tool.name) ? basenameFromPath(tool.title) : tool.title
+  }
 
   if (tool.name === 'command' && typeof tool.input === 'string') {
     const firstLine = tool.input.split('\n').map((line) => line.trim()).find(Boolean)
     return firstLine ? firstLine.slice(0, 120) : ''
+  }
+
+  const input = parseToolInput(tool.input)
+  const filePath = input?.file_path || input?.path || input?.filename
+  if (isFilePathTool(tool.name) && typeof filePath === 'string') {
+    return basenameFromPath(filePath)
+  }
+
+  return ''
+}
+
+function parseToolInput(input: unknown): Record<string, unknown> | null {
+  if (!input) return null
+  if (typeof input === 'object') return input as Record<string, unknown>
+  if (typeof input !== 'string') return null
+
+  try {
+    const parsed = JSON.parse(input)
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : null
+  } catch {
+    return null
+  }
+}
+
+function basenameFromPath(value: string): string {
+  const normalized = value.replace(/\\/g, '/').replace(/\/+$/, '')
+  return normalized.split('/').filter(Boolean).pop() || value
+}
+
+function isFilePathTool(toolName: string): boolean {
+  return ['read', 'edit', 'multiedit', 'write', 'notebookedit'].includes(toolName.toLowerCase())
+}
+
+function deriveToolDescription(tool: AgentMessage['tool']): string {
+  if (!tool) return ''
+  if (tool.description) return tool.description
+
+  const input = parseToolInput(tool.input)
+  const description = input?.description
+  return typeof description === 'string' ? description : ''
+}
+
+function deriveToolCommand(tool: AgentMessage['tool']): string {
+  if (!tool) return ''
+
+  const input = parseToolInput(tool.input)
+  const command = input?.command
+  if (Array.isArray(command)) return command.map(String).join(' ')
+  if (typeof command === 'string') return command
+
+  if (tool.name.toLowerCase() === 'command' && typeof tool.input === 'string') {
+    return tool.input
   }
 
   return ''
@@ -187,7 +245,6 @@ function TaskProgressMessage({ message }: { message: AgentMessage }) {
   const tp = message.taskProgress!
   const isRunning = tp.status === 'started' || tp.status === 'running'
   const isError = tp.status === 'failed'
-  const isDone = tp.status === 'completed'
   const isStopped = tp.status === 'stopped'
 
   return (
@@ -266,6 +323,7 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
   const isRunning = !tool.status || tool.status === 'in_progress' || tool.status === 'running' || tool.status === 'pending'
   const isError = tool.status === 'error' || tool.status === 'failed'
   const subtitle = deriveToolSubtitle(tool)
+  const command = deriveToolCommand(tool)
 
   return (
     <div className="group/tool w-full min-w-0 overflow-hidden">
@@ -300,6 +358,12 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
       </button>
       {expanded && (
         <div className="ml-5 border-l border-border/40 pl-3 py-1.5 space-y-2 text-[11px] font-mono">
+          {command && (
+            <div>
+              <div className="text-muted-foreground mb-0.5">Command</div>
+              <pre className="overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words text-muted-foreground">{command}</pre>
+            </div>
+          )}
           {tool.input && (
             <div>
               <div className="text-muted-foreground mb-0.5">Input</div>

--- a/src/mobile/stores/agent-store.ts
+++ b/src/mobile/stores/agent-store.ts
@@ -29,6 +29,7 @@ export interface AgentMessage {
     name: string
     status: string
     title?: string
+    description?: string
     input?: string
     output?: string
     error?: string

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
@@ -191,4 +191,111 @@ describe('AgentTranscriptPanel message layout', () => {
     expect(screen.getByText('Output:')).toBeInTheDocument()
     expect(screen.getByText('pass')).toBeInTheDocument()
   })
+
+  it('shows tool descriptions in compact rows and exact commands in expanded details', () => {
+    const command = `cd "/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/vebrwpyobv88637krcachtxa/workflow-builder" && git add packages/ui/app/business-context/graph/page.tsx && git commit -q -F - <<'MSG'
+fix(ui): move custom-property editor from Overview into the Properties tab
+
+The "add custom property" controls were on the Overview (main) tab, so users
+who went to Properties to add a field saw only the read-only cube params.
+MSG
+git push 2>&1 | tail -2`
+
+    render(
+      <AgentTranscriptPanel
+        messages={[
+          {
+            id: 'tool-description',
+            role: 'assistant',
+            content: 'Bash',
+            timestamp: new Date(),
+            partType: 'tool',
+            tool: {
+              name: 'Bash',
+              status: 'success',
+              input: JSON.stringify({
+                command,
+                description: 'Commit and push placement fix'
+              }, null, 2),
+              output: 'pass'
+            }
+          }
+        ]}
+        status={SessionStatus.IDLE}
+        onStop={() => undefined}
+      />
+    )
+
+    const toolButton = screen.getByRole('button', { name: /Bash Commit and push placement fix/i })
+    expect(screen.queryByRole('button', { name: /workflow-builder/i })).toBeNull()
+    expect(screen.queryByText('Command:')).toBeNull()
+
+    fireEvent.click(toolButton)
+
+    expect(screen.getByText('Command:')).toBeInTheDocument()
+    expect(screen.getByText((_, element) => element?.tagName === 'PRE' && element.textContent === command)).toBeInTheDocument()
+  })
+
+  it('shows only filenames for file editing tool subtitles', () => {
+    const filePath = '/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/vebrwpyobv88637krcachtxa/workflow-builder/packages/ui/app/business-context/graph/page.tsx'
+
+    render(
+      <AgentTranscriptPanel
+        messages={[
+          {
+            id: 'tool-edit',
+            role: 'assistant',
+            content: 'Edit',
+            timestamp: new Date(),
+            partType: 'tool',
+            tool: {
+              name: 'Edit',
+              status: 'success',
+              input: JSON.stringify({
+                replace_all: false,
+                file_path: filePath,
+                old_string: '              {/* Properties Tab */}',
+                new_string: '              {/* Properties Tab */}'
+              }, null, 2),
+              output: 'updated'
+            }
+          }
+        ]}
+        status={SessionStatus.IDLE}
+        onStop={() => undefined}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /Edit page\.tsx/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /workflow-builder/i })).toBeNull()
+  })
+
+  it('shows only filenames for read tool subtitles', () => {
+    const filePath = '/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/vebrwpyobv88637krcachtxa/workflow-builder/packages/cubejs/lib/custom-dimensions.js'
+
+    render(
+      <AgentTranscriptPanel
+        messages={[
+          {
+            id: 'tool-read',
+            role: 'assistant',
+            content: 'Read',
+            timestamp: new Date(),
+            partType: 'tool',
+            tool: {
+              name: 'Read',
+              status: 'success',
+              input: JSON.stringify({ file_path: filePath }, null, 2),
+              output: 'const customDimensions = []'
+            }
+          }
+        ]}
+        status={SessionStatus.IDLE}
+        onStop={() => undefined}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: /Read custom-dimensions\.js/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /workflow-builder/i })).toBeNull()
+  })
 })

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -72,13 +72,72 @@ function sanitizeToolContent(content: unknown): string {
 
   return str.substring(0, MAX_DISPLAY_LENGTH) + `\n\n... (${str.length - MAX_DISPLAY_LENGTH} more characters)`
 }
+
+function parseToolInput(input: unknown): Record<string, unknown> | null {
+  if (!input) return null
+  if (typeof input === 'object') return input as Record<string, unknown>
+  if (typeof input !== 'string') return null
+
+  try {
+    const parsed = JSON.parse(input)
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : null
+  } catch {
+    return null
+  }
+}
+
+function basenameFromPath(value: string): string {
+  const normalized = value.replace(/\\/g, '/').replace(/\/+$/, '')
+  return normalized.split('/').filter(Boolean).pop() || value
+}
+
+function isFilePathTool(toolName: string): boolean {
+  return ['read', 'edit', 'multiedit', 'write', 'notebookedit'].includes(toolName.toLowerCase())
+}
+
+function deriveToolDescription(tool: AgentMessage['tool']): string {
+  if (!tool) return ''
+  if (tool.description) return tool.description
+
+  const input = parseToolInput(tool.input)
+  const description = input?.description
+  return typeof description === 'string' ? description : ''
+}
+
+function deriveToolCommand(tool: AgentMessage['tool']): string {
+  if (!tool) return ''
+
+  const input = parseToolInput(tool.input)
+  const command = input?.command
+  if (Array.isArray(command)) return command.map(String).join(' ')
+  if (typeof command === 'string') return command
+
+  if (tool.name.toLowerCase() === 'command' && typeof tool.input === 'string') {
+    return tool.input
+  }
+
+  return ''
+}
+
 function deriveToolSubtitle(tool?: AgentMessage['tool']): string {
   if (!tool) return ''
-  if (tool.title) return tool.title
+
+  const description = deriveToolDescription(tool)
+  if (description) return description
+
+  if (tool.title) {
+    return isFilePathTool(tool.name) ? basenameFromPath(tool.title) : tool.title
+  }
 
   if (tool.name === 'command' && typeof tool.input === 'string') {
     const firstLine = tool.input.split('\n').map((line) => line.trim()).find(Boolean)
     return firstLine ? firstLine.slice(0, 120) : ''
+  }
+
+  const input = parseToolInput(tool.input)
+  const filePath = input?.file_path || input?.path || input?.filename
+  if (isFilePathTool(tool.name) && typeof filePath === 'string') {
+    return basenameFromPath(filePath)
   }
 
   return ''
@@ -353,6 +412,7 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
   const isRunning = !tool.status || tool.status === 'in_progress' || tool.status === 'running' || tool.status === 'pending'
   const isError = tool.status === 'error' || tool.status === 'failed'
   const subtitle = deriveToolSubtitle(tool)
+  const command = deriveToolCommand(tool)
 
   return (
     <div className="group/tool w-full min-w-0 overflow-hidden">
@@ -373,6 +433,12 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
       </button>
       {expanded && (
         <div className="ml-5 border-l border-border/40 pl-3 py-1.5 text-[11px] font-mono space-y-2">
+          {command && (
+            <div>
+              <span className="text-muted-foreground">Command:</span>
+              <pre className="mt-0.5 text-muted-foreground whitespace-pre-wrap break-words max-h-40 overflow-y-auto">{command}</pre>
+            </div>
+          )}
           {tool.input && (
             <div>
               <span className="text-muted-foreground">Input:</span>

--- a/src/renderer/src/stores/agent-store.ts
+++ b/src/renderer/src/stores/agent-store.ts
@@ -30,6 +30,7 @@ export interface AgentMessage {
     name: string
     status: string
     title?: string
+    description?: string
     input?: string
     output?: string
     error?: string


### PR DESCRIPTION
## Summary
- Show tool descriptions in compact transcript tool-call rows when a description is present on the tool or in structured tool input.
- Show the exact command as its own expanded-detail field for command-style tool calls.
- Collapse edit/write-style tool file paths to just the filename in compact rows while preserving full input details when expanded.

## Test plan
- pnpm test:run src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx src/mobile/components/MessageBubble.test.tsx
- pnpm typecheck
- pnpm exec eslint src/renderer/src/components/agents/AgentTranscriptPanel.tsx src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx src/mobile/components/MessageBubble.tsx src/mobile/components/MessageBubble.test.tsx src/renderer/src/stores/agent-store.ts src/mobile/stores/agent-store.ts src/main/adapters/coding-agent-adapter.ts