### PR TITLE
feat: add GPT-5.6 Codex models

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Most AI tools make you copy-paste context between tabs. 20x flips it: **your tas
 ### 🤖 Multi-Agent Support
 - **Claude Code** — Anthropic's official agent SDK (Claude Sonnet 4.6)
 - **OpenCode** — Open-source coding agent
-- **Codex** — OpenAI's agent framework (GPT-5.5)
+- **Codex** — OpenAI's agent framework (GPT-5.6 Sol)
 - **Live transcripts** — Watch agents think and work in real time with message counts
 - **Human-in-the-loop** — Approve risky actions before execution
 - **Task progress tracking** — Real-time progress events during agent execution
@@ -259,7 +259,7 @@ We welcome contributions! Here's how:
 - ✅ Skills 2-way sync with Workflo
 - ✅ Heartbeat monitoring with CI failure detection
 - ✅ Presetup wizard and dashboard templates
-- ✅ Claude Sonnet 4.6 and GPT-5.5 model support
+- ✅ Claude Sonnet 4.6 and GPT-5.6 model family support
 - ✅ Multi-agent support (OpenCode, Claude Code, Codex)
 - ✅ Skills system with auto-learning
 - ✅ Recurring tasks

--- a/src/main/adapters/codex-adapter.test.ts
+++ b/src/main/adapters/codex-adapter.test.ts
@@ -6,8 +6,8 @@ type CodexAdapterWithArgs = {
 }
 
 describe('DEFAULT_CODEX_MODEL', () => {
-  it('defaults Codex sessions to GPT-5.5', () => {
-    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.5')
+  it('defaults Codex sessions to GPT-5.6 Sol', () => {
+    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.6-sol')
   })
 })
 
@@ -44,9 +44,9 @@ describe('CodexAdapter findCodexExecutable fallback paths', () => {
     const adapter = new CodexAdapter()
     const buildCodexArgs = (adapter as unknown as CodexAdapterWithArgs).buildCodexArgs.bind(adapter)
 
-    expect(buildCodexArgs({ model: 'gpt-5.5', reasoningEffort: 'high' })).toEqual([
+    expect(buildCodexArgs({ model: 'gpt-5.6-sol', reasoningEffort: 'high' })).toEqual([
       '--model',
-      'gpt-5.5',
+      'gpt-5.6-sol',
       '-c',
       'model_reasoning_effort="high"',
       '--json-rpc',
@@ -57,9 +57,9 @@ describe('CodexAdapter findCodexExecutable fallback paths', () => {
     const adapter = new CodexAdapter()
     const buildCodexArgs = (adapter as unknown as CodexAdapterWithArgs).buildCodexArgs.bind(adapter)
 
-    expect(buildCodexArgs({ model: 'gpt-5.5', reasoningEffort: 'max' })).toEqual([
+    expect(buildCodexArgs({ model: 'gpt-5.6-sol', reasoningEffort: 'max' })).toEqual([
       '--model',
-      'gpt-5.5',
+      'gpt-5.6-sol',
       '--json-rpc',
     ])
   })

--- a/src/main/adapters/codex-adapter.ts
+++ b/src/main/adapters/codex-adapter.ts
@@ -20,7 +20,7 @@ import type {
 } from './coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './coding-agent-adapter'
 
-export const DEFAULT_CODEX_MODEL = 'gpt-5.5'
+export const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol'
 
 interface JsonRpcRequest {
   jsonrpc: '2.0'

--- a/src/renderer/src/types/index.test.ts
+++ b/src/renderer/src/types/index.test.ts
@@ -25,25 +25,23 @@ describe('CLAUDE_MODELS', () => {
 })
 
 describe('CODEX_MODELS', () => {
-  it('lists GPT-5.5 first as the recommended model', () => {
+  it('lists GPT-5.6 Sol first as the recommended model', () => {
     expect(CODEX_MODELS[0]).toEqual({
-      id: CodexModel.GPT_5_5,
-      name: 'GPT-5.5 (Recommended)'
+      id: CodexModel.GPT_5_6_SOL,
+      name: 'GPT-5.6 Sol (Recommended)'
     })
   })
 
-  it('still includes GPT-5.4 as a selectable fallback model', () => {
-    expect(CODEX_MODELS).toContainEqual({
-      id: CodexModel.GPT_5_4,
-      name: 'GPT-5.4'
-    })
-  })
-
-  it('still includes the prior GPT-5.3 Codex model', () => {
-    expect(CODEX_MODELS).toContainEqual({
-      id: CodexModel.GPT_5_3_CODEX,
-      name: 'GPT-5.3 Codex'
-    })
+  it('lists the supported Codex models in preferred order', () => {
+    expect(CODEX_MODELS).toEqual([
+      { id: CodexModel.GPT_5_6_SOL, name: 'GPT-5.6 Sol (Recommended)' },
+      { id: CodexModel.GPT_5_6_TERRA, name: 'GPT-5.6 Terra' },
+      { id: CodexModel.GPT_5_6_LUNA, name: 'GPT-5.6 Luna' },
+      { id: CodexModel.GPT_5_5, name: 'GPT-5.5' },
+      { id: CodexModel.GPT_5_4, name: 'GPT-5.4' },
+      { id: CodexModel.GPT_5_4_MINI, name: 'GPT-5.4 Mini' },
+      { id: CodexModel.GPT_5_3_CODEX_SPARK, name: 'GPT-5.3 Codex Spark' }
+    ])
   })
 
   it('does not include unsupported GPT-5.4 Codex model', () => {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -69,29 +69,23 @@ export const CLAUDE_MODELS: { id: ClaudeModel; name: string }[] = [
 ]
 
 export enum CodexModel {
+  GPT_5_6_SOL = 'gpt-5.6-sol',
+  GPT_5_6_TERRA = 'gpt-5.6-terra',
+  GPT_5_6_LUNA = 'gpt-5.6-luna',
   GPT_5_5 = 'gpt-5.5',
-  GPT_5_3_CODEX = 'gpt-5.3-codex',
-  GPT_5_2_CODEX = 'gpt-5.2-codex',
-  GPT_5_1_CODEX_MAX = 'gpt-5.1-codex-max',
-  GPT_5_1_CODEX = 'gpt-5.1-codex',
-  GPT_5_1_CODEX_MINI = 'gpt-5.1-codex-mini',
-  GPT_5_CODEX = 'gpt-5-codex',
   GPT_5_4 = 'gpt-5.4',
-  GPT_5 = 'gpt-5',
-  GPT_5_MINI = 'gpt-5-mini'
+  GPT_5_4_MINI = 'gpt-5.4-mini',
+  GPT_5_3_CODEX_SPARK = 'gpt-5.3-codex-spark'
 }
 
 export const CODEX_MODELS: { id: CodexModel; name: string }[] = [
-  { id: CodexModel.GPT_5_5, name: 'GPT-5.5 (Recommended)' },
+  { id: CodexModel.GPT_5_6_SOL, name: 'GPT-5.6 Sol (Recommended)' },
+  { id: CodexModel.GPT_5_6_TERRA, name: 'GPT-5.6 Terra' },
+  { id: CodexModel.GPT_5_6_LUNA, name: 'GPT-5.6 Luna' },
+  { id: CodexModel.GPT_5_5, name: 'GPT-5.5' },
   { id: CodexModel.GPT_5_4, name: 'GPT-5.4' },
-  { id: CodexModel.GPT_5_3_CODEX, name: 'GPT-5.3 Codex' },
-  { id: CodexModel.GPT_5_2_CODEX, name: 'GPT-5.2 Codex' },
-  { id: CodexModel.GPT_5_1_CODEX_MAX, name: 'GPT-5.1 Codex Max' },
-  { id: CodexModel.GPT_5_1_CODEX, name: 'GPT-5.1 Codex' },
-  { id: CodexModel.GPT_5_1_CODEX_MINI, name: 'GPT-5.1 Codex Mini' },
-  { id: CodexModel.GPT_5_CODEX, name: 'GPT-5 Codex' },
-  { id: CodexModel.GPT_5, name: 'GPT-5' },
-  { id: CodexModel.GPT_5_MINI, name: 'GPT-5 Mini (Fastest)' }
+  { id: CodexModel.GPT_5_4_MINI, name: 'GPT-5.4 Mini' },
+  { id: CodexModel.GPT_5_3_CODEX_SPARK, name: 'GPT-5.3 Codex Spark' }
 ]
 
 export interface McpServerConfig {


### PR DESCRIPTION
## Summary
- Add the GPT-5.6 Codex model family in the requested order: Sol, Terra, Luna, then GPT-5.5, GPT-5.4, GPT-5.4 Mini, and GPT-5.3 Codex Spark.
- Set the Codex adapter default model to gpt-5.6-sol.
- Update README Codex model references for GPT-5.6 Sol/model-family support.

## Test plan
- pnpm test:run src/main/adapters/codex-adapter.test.ts src/renderer/src/types/index.test.ts
- pnpm exec eslint src/main/adapters/codex-adapter.ts src/main/adapters/codex-adapter.test.ts src/renderer/src/types/index.ts src/renderer/src/types/index.test.ts
- pnpm typecheck

Generated with Codex