### PR TITLE
feat: add Codex App Server adapter

### DIFF
--- a/scripts/probe-codex-app-server.mjs
+++ b/scripts/probe-codex-app-server.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+/**
+ * Non-model Codex App Server probe.
+ *
+ * This validates the local app-server protocol path without sending a turn or
+ * prompt. It exercises:
+ * - process startup over stdio
+ * - initialize / initialized
+ * - thread/start without a model turn, followed by thread/delete cleanup
+ * - thread/read
+ * - thread/items/list with thread/turns/list fallback
+ *
+ * Usage:
+ *   node scripts/probe-codex-app-server.mjs [--cwd <dir>] [--timeout-ms <ms>]
+ */
+
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const args = process.argv.slice(2)
+
+function argValue(name, fallback) {
+  const index = args.indexOf(name)
+  if (index === -1) return fallback
+  return args[index + 1] ?? fallback
+}
+
+const cwd = resolve(argValue('--cwd', process.cwd()))
+const timeoutMs = Number(argValue('--timeout-ms', '20000'))
+
+if (!existsSync(cwd)) {
+  throw new Error(`cwd does not exist: ${cwd}`)
+}
+
+const env = { ...process.env }
+delete env.OPENAI_API_KEY
+delete env.CODEX_API_KEY
+
+const child = spawn('codex', ['app-server', '--stdio'], {
+  cwd,
+  stdio: ['pipe', 'pipe', 'pipe'],
+  // Keep this probe on the user's existing Codex login path. Do not inject API
+  // keys here; the probe should match subscription/CLI-login app behavior.
+  env
+})
+
+let nextId = 1
+let stdoutBuffer = ''
+const pending = new Map()
+const notifications = []
+const serverRequests = []
+
+const timeout = setTimeout(() => {
+  child.kill('SIGTERM')
+  throw new Error(`Probe timed out after ${timeoutMs}ms`)
+}, timeoutMs)
+
+function write(message) {
+  child.stdin.write(`${JSON.stringify(message)}\n`)
+}
+
+function request(method, params) {
+  const id = nextId++
+  write({ jsonrpc: '2.0', id, method, params })
+  return new Promise((resolvePromise, rejectPromise) => {
+    pending.set(id, { resolve: resolvePromise, reject: rejectPromise, method })
+  })
+}
+
+function notify(method, params = {}) {
+  write({ jsonrpc: '2.0', method, params })
+}
+
+function respond(id, result) {
+  write({ jsonrpc: '2.0', id, result })
+}
+
+function handleMessage(message) {
+  if ('id' in message && 'method' in message) {
+    serverRequests.push(message.method)
+    if (message.method === 'currentTime/read') {
+      respond(message.id, { nowMs: Date.now(), timezone: Intl.DateTimeFormat().resolvedOptions().timeZone })
+      return
+    }
+    respond(message.id, {})
+    return
+  }
+
+  if ('id' in message) {
+    const entry = pending.get(message.id)
+    if (!entry) return
+    pending.delete(message.id)
+    if (message.error) {
+      entry.reject(new Error(`${entry.method}: ${message.error.message}`))
+    } else {
+      entry.resolve(message.result)
+    }
+    return
+  }
+
+  if (message.method) {
+    notifications.push(message.method)
+  }
+}
+
+child.stdout.on('data', (chunk) => {
+  stdoutBuffer += chunk.toString()
+  let newlineIndex
+  while ((newlineIndex = stdoutBuffer.indexOf('\n')) !== -1) {
+    const line = stdoutBuffer.slice(0, newlineIndex).trim()
+    stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1)
+    if (!line) continue
+    handleMessage(JSON.parse(line))
+  }
+})
+
+child.stderr.on('data', (chunk) => {
+  process.stderr.write(`[codex app-server stderr] ${chunk}`)
+})
+
+child.on('exit', (code, signal) => {
+  for (const entry of pending.values()) {
+    entry.reject(new Error(`codex app-server exited: code=${code} signal=${signal}`))
+  }
+  pending.clear()
+})
+
+try {
+  const init = await request('initialize', {
+    clientInfo: { name: '20x-app-server-probe', version: '0.0.1', title: '20x App Server Probe' },
+    capabilities: { experimentalApi: true, mcpServerOpenaiFormElicitation: true }
+  })
+  notify('initialized')
+
+  const started = await request('thread/start', {
+    cwd,
+    ephemeral: false,
+    approvalPolicy: 'on-request',
+    approvalsReviewer: 'user',
+    sandbox: 'workspace-write',
+    runtimeWorkspaceRoots: [cwd],
+    threadSource: '20x-probe'
+  })
+
+  const threadId = started?.thread?.id || started?.threadId || started?.id
+  if (!threadId) {
+    throw new Error(`thread/start did not return a thread id: ${JSON.stringify(started)}`)
+  }
+
+  const read = await request('thread/read', { threadId })
+  let historyMethod = 'thread/items/list'
+  let history
+  let historyUnavailableReason = null
+  try {
+    history = await request('thread/items/list', { threadId, limit: 20, sortDirection: 'asc' })
+  } catch (error) {
+    if (!String(error?.message || error).includes('not supported')) throw error
+    historyMethod = 'thread/turns/list'
+    try {
+      history = await request('thread/turns/list', { threadId, limit: 20, sortDirection: 'asc', itemsView: 'full' })
+    } catch (turnsError) {
+      const message = String(turnsError?.message || turnsError)
+      if (!message.includes('not materialized yet') && !message.includes('before first user message')) {
+        throw turnsError
+      }
+      historyUnavailableReason = message
+      history = { data: [] }
+    }
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    codexHome: init?.codexHome,
+    userAgent: init?.userAgent,
+    threadId,
+    model: started?.model,
+    modelProvider: started?.modelProvider,
+    readHasThread: Boolean(read?.thread || read?.id || read?.threadId),
+    historyMethod,
+    historyCount: Array.isArray(history?.data) ? history.data.length : null,
+    historyUnavailableReason,
+    notifications: [...new Set(notifications)].sort(),
+    serverRequests: [...new Set(serverRequests)].sort()
+  }, null, 2))
+
+  await request('thread/delete', { threadId })
+} finally {
+  clearTimeout(timeout)
+  child.kill('SIGTERM')
+}

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -34,7 +34,9 @@ interface AppServerAdapterPrivate {
     summary: string
   }
   buildConfigOverrides(config: {
+    workspaceDir: string
     reasoningEffort?: string
+    sandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access'
     mcpServers?: Record<string, {
       type: 'stdio' | 'http' | 'sse'
       command?: string
@@ -348,7 +350,9 @@ describe('CodexAppServerAdapter', () => {
     const adapter = adapterPrivate(new CodexAppServerAdapter())
 
     const config = adapter.buildConfigOverrides({
+      workspaceDir: '/tmp/workspace',
       reasoningEffort: 'high',
+      sandboxMode: 'workspace-write',
       mcpServers: {
         local: {
           type: 'stdio',
@@ -366,6 +370,10 @@ describe('CodexAppServerAdapter', () => {
 
     expect(config).toEqual({
       model_reasoning_effort: 'high',
+      sandbox_workspace_write: {
+        network_access: true,
+        writable_roots: ['/tmp/workspace']
+      },
       mcp_servers: {
         local: {
           command: 'node',

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -346,6 +346,114 @@ describe('CodexAppServerAdapter', () => {
     expect(parts[0].tool?.output as string).toContain('truncated for display')
   })
 
+  it('uses server and tool names for app-server MCP tool calls', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const parts = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        item: {
+          type: 'mcpToolCall',
+          id: 'call-1',
+          server: 'Carousell_MCP',
+          tool: 'workflow_get_node_parameter',
+          status: 'completed',
+          arguments: { workflowId: 'wf-1' },
+          result: { content: [{ type: 'text', text: 'ok' }] }
+        },
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(parts[0]).toMatchObject({
+      id: 'tool-call-1',
+      type: MessagePartType.TOOL,
+      tool: {
+        name: 'Carousell_MCP.workflow_get_node_parameter',
+        title: 'Carousell_MCP.workflow_get_node_parameter',
+        status: 'completed'
+      }
+    })
+  })
+
+  it('uses changed file names for app-server file change tool titles', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const parts = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        item: {
+          type: 'fileChange',
+          id: 'call-2',
+          changes: [{
+            path: '/tmp/workspace/src/renderer/src/components/agents/AgentTranscriptPanel.tsx',
+            kind: { type: 'modify' }
+          }],
+          status: 'completed'
+        },
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(parts[0]).toMatchObject({
+      id: 'tool-call-2',
+      type: MessagePartType.TOOL,
+      tool: {
+        name: 'fileChange',
+        title: 'AgentTranscriptPanel.tsx',
+        status: 'completed'
+      }
+    })
+  })
+
+  it('uses command text for app-server command execution tool titles', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const parts = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        item: {
+          type: 'commandExecution',
+          id: 'call-3',
+          command: '/bin/zsh -lc "rg fallback"',
+          commandActions: [{
+            type: 'search',
+            command: 'rg -n "mcpToolCall" src/main/adapters',
+            query: 'mcpToolCall',
+            path: 'adapters'
+          }],
+          status: 'completed'
+        },
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(parts[0]).toMatchObject({
+      id: 'tool-call-3',
+      type: MessagePartType.TOOL,
+      tool: {
+        name: 'commandExecution',
+        title: 'rg -n "mcpToolCall" src/main/adapters',
+        status: 'completed'
+      }
+    })
+  })
+
   it('converts 20x MCP configs to codex app-server config shape', () => {
     const adapter = adapterPrivate(new CodexAppServerAdapter())
 

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -55,7 +55,7 @@ interface AppServerSessionForTest {
   pendingApproval: unknown | null
   nextRequestId: number
   lastError: string | null
-  config: { permissionMode?: 'ask' | 'allow' }
+  config: { permissionMode?: 'ask' | 'allow'; sandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access' }
   streamedTextByItemId: Map<string, string>
   runningTools: Map<string, {
     partId: string
@@ -233,6 +233,47 @@ describe('CodexAppServerAdapter', () => {
         { optionId: 'cancel', name: 'Deny and Stop', kind: 'reject' }
       ]
     })
+  })
+
+  it('auto-approves MCP elicitation requests with app-server action shape', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    session.config.permissionMode = 'allow'
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      id: 9,
+      method: 'mcpServer/elicitation/request',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        message: 'Need input'
+      }
+    })
+
+    expect(session.process.stdin.write).toHaveBeenCalledWith(
+      `${JSON.stringify({ jsonrpc: '2.0', id: 9, result: { action: 'accept', content: {} } })}\n`
+    )
+  })
+
+  it('passes configured sandbox mode to app-server turn start', async () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    adapter.sessions.set('thread-1', session)
+    const sendRpcRequest = vi.fn().mockResolvedValue({ turnId: 'turn-1' })
+    adapter.sendRpcRequest = sendRpcRequest
+
+    await adapterInstance.sendPrompt('thread-1', [{ type: MessagePartType.TEXT, text: 'hello' }], {
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      workspaceDir: '/tmp/workspace',
+      sandboxMode: 'danger-full-access'
+    })
+
+    expect(sendRpcRequest).toHaveBeenCalledWith(session, 'turn/start', expect.objectContaining({
+      sandbox: 'danger-full-access'
+    }))
   })
 
   it('converts command output deltas into updating tool parts', () => {

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -33,6 +33,17 @@ interface AppServerAdapterPrivate {
     usesApiKey: boolean
     summary: string
   }
+  buildConfigOverrides(config: {
+    reasoningEffort?: string
+    mcpServers?: Record<string, {
+      type: 'stdio' | 'http' | 'sse'
+      command?: string
+      args?: string[]
+      env?: Record<string, string>
+      url?: string
+      headers?: Record<string, string>
+    }>
+  }): Record<string, unknown>
   bufferAllThreadItems(session: AppServerSessionForTest, threadId: string): Promise<void>
   sendRpcRequest(session: AppServerSessionForTest, method: string, params?: unknown): Promise<unknown>
 }
@@ -331,6 +342,42 @@ describe('CodexAppServerAdapter', () => {
     expect(parts[0].tool?.output).toEqual(expect.any(String))
     expect((parts[0].tool?.output as string).length).toBeLessThan(101_000)
     expect(parts[0].tool?.output as string).toContain('truncated for display')
+  })
+
+  it('converts 20x MCP configs to codex app-server config shape', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+
+    const config = adapter.buildConfigOverrides({
+      reasoningEffort: 'high',
+      mcpServers: {
+        local: {
+          type: 'stdio',
+          command: 'node',
+          args: ['server.js'],
+          env: { TOKEN: 'secret' }
+        },
+        remote: {
+          type: 'http',
+          url: 'https://example.com/mcp',
+          headers: { Authorization: 'Bearer token' }
+        }
+      }
+    })
+
+    expect(config).toEqual({
+      model_reasoning_effort: 'high',
+      mcp_servers: {
+        local: {
+          command: 'node',
+          args: ['server.js'],
+          env: { TOKEN: 'secret' }
+        },
+        remote: {
+          url: 'https://example.com/mcp',
+          http_headers: { Authorization: 'Bearer token' }
+        }
+      }
+    })
   })
 
   it('clears stale live buffer before sending a new prompt', async () => {

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi } from 'vitest'
+import { CodexAppServerAdapter } from './codex-app-server-adapter'
+import { MessagePartType, MessageRole, SessionStatusType } from './coding-agent-adapter'
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  execFile: vi.fn((_cmd, _args, callback) => callback(null, '/usr/local/bin/codex\n', ''))
+}))
+
+interface AppServerAdapterPrivate {
+  sessions: Map<string, AppServerSessionForTest>
+  handleRpcMessage(session: AppServerSessionForTest, message: unknown): void
+  convertEventToMessageParts(
+    event: unknown,
+    seenMessageIds: Set<string>,
+    seenPartIds: Set<string>,
+    partContentLengths: Map<string, string>,
+    session: AppServerSessionForTest
+  ): Array<{
+    id?: string
+    type: MessagePartType
+    text?: string
+    role?: string
+    update?: boolean
+    tool?: { name: string; status?: string; input?: unknown; output?: unknown }
+  }>
+  buildEnvironment(config: {
+    authMethod?: 'subscription' | 'api_key'
+    apiKeys?: { openai?: string }
+    secretEnvVars?: Record<string, string>
+  }): {
+    env: NodeJS.ProcessEnv
+    usesApiKey: boolean
+    summary: string
+  }
+  bufferAllThreadItems(session: AppServerSessionForTest, threadId: string): Promise<void>
+  sendRpcRequest(session: AppServerSessionForTest, method: string, params?: unknown): Promise<unknown>
+}
+
+interface AppServerSessionForTest {
+  sessionId: string
+  threadId: string | null
+  activeTurnId: string | null
+  process: {
+    stdin: { write: ReturnType<typeof vi.fn> }
+  }
+  stdoutBuffer: string
+  status: SessionStatusType
+  messageBuffer: unknown[]
+  permanentMessages: unknown[]
+  pendingRequests: Map<string | number, {
+    resolve: (value: unknown) => void
+    reject: (error: Error) => void
+  }>
+  pendingApproval: unknown | null
+  nextRequestId: number
+  lastError: string | null
+  config: { permissionMode?: 'ask' | 'allow' }
+  streamedTextByItemId: Map<string, string>
+  runningTools: Map<string, {
+    partId: string
+    toolName: string
+    startTime?: number
+    input?: Record<string, unknown>
+  }>
+  codexUseApiKey: boolean
+  codexAuthSummary: string
+}
+
+function adapterPrivate(adapter: CodexAppServerAdapter): AppServerAdapterPrivate {
+  return adapter as unknown as AppServerAdapterPrivate
+}
+
+function createSession(): AppServerSessionForTest {
+  return {
+    sessionId: 'task-1',
+    threadId: 'thread-1',
+    activeTurnId: null,
+    process: { stdin: { write: vi.fn() } },
+    stdoutBuffer: '',
+    status: SessionStatusType.IDLE,
+    messageBuffer: [],
+    permanentMessages: [],
+    pendingRequests: new Map(),
+    pendingApproval: null,
+    nextRequestId: 1,
+    lastError: null,
+    config: { permissionMode: 'ask' },
+    streamedTextByItemId: new Map(),
+    runningTools: new Map(),
+    codexUseApiKey: false,
+    codexAuthSummary: ''
+  }
+}
+
+describe('CodexAppServerAdapter', () => {
+  it('accumulates agent message deltas into an updating text part', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const first = adapter.convertEventToMessageParts({
+      method: 'item/agentMessage/delta',
+      params: { itemId: 'item-1', delta: 'hel', threadId: 'thread-1', turnId: 'turn-1' }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    const second = adapter.convertEventToMessageParts({
+      method: 'item/agentMessage/delta',
+      params: { itemId: 'item-1', delta: 'lo', threadId: 'thread-1', turnId: 'turn-1' }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(first[0]).toMatchObject({
+      id: 'agent-item-1',
+      type: MessagePartType.TEXT,
+      text: 'hel',
+      role: MessageRole.ASSISTANT,
+      update: false
+    })
+    expect(second[0]).toMatchObject({
+      id: 'agent-item-1',
+      type: MessagePartType.TEXT,
+      text: 'hello',
+      role: MessageRole.ASSISTANT,
+      update: true
+    })
+  })
+
+  it('tracks running tool items and clears them on completion', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const started = adapter.convertEventToMessageParts({
+      method: 'item/started',
+      params: {
+        startedAtMs: 123,
+        item: { id: 'tool-1', type: 'commandExecution', command: 'pnpm test' },
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(started[0]).toMatchObject({
+      id: 'tool-tool-1',
+      type: MessagePartType.TOOL,
+      tool: { name: 'commandExecution', status: 'running' }
+    })
+    expect(session.runningTools.get('tool-tool-1')).toMatchObject({
+      partId: 'tool-tool-1',
+      toolName: 'commandExecution',
+      startTime: 123
+    })
+
+    const completed = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        item: { id: 'tool-1', type: 'commandExecution', output: 'ok' },
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(completed[0]).toMatchObject({
+      id: 'tool-tool-1',
+      type: MessagePartType.TOOL,
+      update: true,
+      tool: { name: 'commandExecution', status: 'completed' }
+    })
+    expect(session.runningTools.has('tool-tool-1')).toBe(false)
+  })
+
+  it('stores command approval requests and responds with app-server decision shape', async () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    adapter.sessions.set('thread-1', session)
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      id: 7,
+      method: 'item/commandExecution/requestApproval',
+      params: {
+        itemId: 'cmd-1',
+        command: 'git status',
+        reason: 'needs shell access',
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        startedAtMs: 1
+      }
+    })
+
+    expect(session.status).toBe(SessionStatusType.WAITING_APPROVAL)
+    expect(session.pendingApproval).toMatchObject({
+      requestId: 7,
+      toolCallId: 'cmd-1',
+      responseKind: 'commandExecution'
+    })
+
+    await adapterInstance.respondToApproval('thread-1', true)
+
+    expect(session.process.stdin.write).toHaveBeenCalledWith(
+      `${JSON.stringify({ jsonrpc: '2.0', id: 7, result: { decision: 'accept' } })}\n`
+    )
+    expect(session.pendingApproval).toBeNull()
+  })
+
+  it('preserves app-server approval decisions when provided', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      id: 8,
+      method: 'item/commandExecution/requestApproval',
+      params: {
+        itemId: 'cmd-2',
+        command: 'curl https://example.com',
+        availableDecisions: ['acceptForSession', 'decline', 'cancel'],
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        startedAtMs: 1
+      }
+    })
+
+    expect(session.pendingApproval).toMatchObject({
+      options: [
+        { optionId: 'acceptForSession', name: 'Allow for Session', kind: 'allow' },
+        { optionId: 'decline', name: 'Deny', kind: 'reject' },
+        { optionId: 'cancel', name: 'Deny and Stop', kind: 'reject' }
+      ]
+    })
+  })
+
+  it('converts command output deltas into updating tool parts', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const first = adapter.convertEventToMessageParts({
+      method: 'item/commandExecution/outputDelta',
+      params: { itemId: 'cmd-1', delta: 'line 1\n' }
+    }, seenMessageIds, seenPartIds, lengths, session)
+    const second = adapter.convertEventToMessageParts({
+      method: 'item/commandExecution/outputDelta',
+      params: { itemId: 'cmd-1', delta: 'line 2\n' }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(first[0]).toMatchObject({
+      id: 'tool-cmd-1',
+      type: MessagePartType.TOOL,
+      update: false,
+      tool: { name: 'command', status: 'running', output: 'line 1\n' }
+    })
+    expect(second[0]).toMatchObject({
+      id: 'tool-cmd-1',
+      type: MessagePartType.TOOL,
+      update: true,
+      tool: { name: 'command', status: 'running', output: 'line 1\nline 2\n' }
+    })
+  })
+
+  it('clears stale live buffer before sending a new prompt', async () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    adapter.sessions.set('thread-1', session)
+    session.messageBuffer.push({ method: 'item/agentMessage/delta', params: { itemId: 'stale', delta: 'stale' } })
+    session.pendingRequests.set(1, { resolve: vi.fn(), reject: vi.fn() })
+
+    const sendPromise = adapterInstance.sendPrompt('thread-1', [{ type: MessagePartType.TEXT, text: 'hello' }], {
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      workspaceDir: '/tmp/workspace'
+    })
+    const pending = session.pendingRequests.get(1)
+    expect(pending).toBeTruthy()
+    pending?.resolve({ turnId: 'turn-1' })
+    await sendPromise
+
+    expect(session.messageBuffer).toHaveLength(1)
+    expect(session.messageBuffer[0]).toMatchObject({
+      method: 'item/completed',
+      params: { item: { type: 'user_message', text: 'hello' } }
+    })
+  })
+
+  it('strips ambient OpenAI keys for subscription auth and preserves explicit API-key mode', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const originalOpenAI = process.env.OPENAI_API_KEY
+    const originalCodex = process.env.CODEX_API_KEY
+    process.env.OPENAI_API_KEY = 'ambient-openai'
+    process.env.CODEX_API_KEY = 'ambient-codex'
+
+    try {
+      const subscriptionEnv = adapter.buildEnvironment({
+        authMethod: 'subscription',
+        secretEnvVars: { OPENAI_API_KEY: 'secret-openai' }
+      })
+      expect(subscriptionEnv.usesApiKey).toBe(false)
+      expect(subscriptionEnv.env.OPENAI_API_KEY).toBeUndefined()
+      expect(subscriptionEnv.env.CODEX_API_KEY).toBeUndefined()
+
+      const apiKeyEnv = adapter.buildEnvironment({
+        authMethod: 'api_key',
+        apiKeys: { openai: 'explicit-key' },
+        secretEnvVars: { CUSTOM_SECRET: 'secret' }
+      })
+      expect(apiKeyEnv.usesApiKey).toBe(true)
+      expect(apiKeyEnv.env.OPENAI_API_KEY).toBe('explicit-key')
+      expect(apiKeyEnv.env.CODEX_API_KEY).toBe('explicit-key')
+      expect(apiKeyEnv.env.CUSTOM_SECRET).toBe('secret')
+      expect(apiKeyEnv.env.NO_BROWSER).toBe('1')
+      expect(apiKeyEnv.env.CODEX_HOME).toContain('codex-app-server-session-')
+    } finally {
+      if (originalOpenAI === undefined) delete process.env.OPENAI_API_KEY
+      else process.env.OPENAI_API_KEY = originalOpenAI
+      if (originalCodex === undefined) delete process.env.CODEX_API_KEY
+      else process.env.CODEX_API_KEY = originalCodex
+    }
+  })
+})

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -356,7 +356,7 @@ describe('CodexAppServerAdapter', () => {
           args: ['server.js'],
           env: { TOKEN: 'secret' }
         },
-        remote: {
+        'Carousell MCP': {
           type: 'http',
           url: 'https://example.com/mcp',
           headers: { Authorization: 'Bearer token' }
@@ -372,7 +372,7 @@ describe('CodexAppServerAdapter', () => {
           args: ['server.js'],
           env: { TOKEN: 'secret' }
         },
-        remote: {
+        Carousell_MCP: {
           url: 'https://example.com/mcp',
           http_headers: { Authorization: 'Bearer token' }
         }

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -306,6 +306,33 @@ describe('CodexAppServerAdapter', () => {
     })
   })
 
+  it('serializes and caps command tool payloads before IPC delivery', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const parts = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        item: {
+          id: 'cmd-large',
+          type: 'commandExecution',
+          command: 'yes',
+          output: 'x'.repeat(120_000)
+        },
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(parts[0].tool?.input).toEqual(expect.any(String))
+    expect(parts[0].tool?.output).toEqual(expect.any(String))
+    expect((parts[0].tool?.output as string).length).toBeLessThan(101_000)
+    expect(parts[0].tool?.output as string).toContain('truncated for display')
+  })
+
   it('clears stale live buffer before sending a new prompt', async () => {
     const adapterInstance = new CodexAppServerAdapter()
     const adapter = adapterPrivate(adapterInstance)

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -162,6 +162,11 @@ function stringifyForIpc(value: unknown, maxChars: number): string | undefined {
   }
 }
 
+function normalizeCodexMcpServerName(name: string): string {
+  const normalized = name.replace(/[^a-zA-Z0-9_-]+/g, '_').replace(/^_+|_+$/g, '')
+  return normalized || 'mcp_server'
+}
+
 function summarizeApproval(params: Record<string, unknown>, fallback: string): string {
   const command = asString(params.command)
   const reason = asString(params.reason)
@@ -630,8 +635,9 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
   private convertMcpServers(servers: Record<string, McpServerConfig>): Record<string, unknown> {
     const result: Record<string, unknown> = {}
     for (const [name, server] of Object.entries(servers)) {
+      const codexName = normalizeCodexMcpServerName(name)
       if (server.type === 'stdio') {
-        result[name] = {
+        result[codexName] = {
           command: server.command,
           args: server.args || [],
           env: server.env || {}
@@ -641,7 +647,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
         if (server.headers && Object.keys(server.headers).length > 0) {
           remoteConfig.http_headers = server.headers
         }
-        result[name] = remoteConfig
+        result[codexName] = remoteConfig
       }
     }
     return result

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -234,6 +234,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     session.threadId = threadId
     this.sessions.delete(config.taskId)
     this.sessions.set(threadId, session)
+    void this.logMcpServerInventory(session, threadId, 'thread/start')
     return threadId
   }
 
@@ -255,6 +256,8 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       initialTurnsPage: { limit: 50 },
       config: this.buildConfigOverrides(config)
     })
+
+    void this.logMcpServerInventory(session, sessionId, 'thread/resume')
 
     try {
       await this.bufferAllThreadItems(session, sessionId)
@@ -642,6 +645,39 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       }
     }
     return result
+  }
+
+  private async logMcpServerInventory(session: AppServerSession, threadId: string, context: string): Promise<void> {
+    try {
+      const result = await this.sendRpcRequest(session, 'mcpServerStatus/list', {
+        threadId,
+        detail: 'toolsAndAuthOnly',
+        limit: 100
+      })
+      if (!isObject(result) || !Array.isArray(result.data)) return
+
+      const servers = result.data
+        .filter(isObject)
+        .map((server) => {
+          const tools = server.tools
+          const toolNames = Array.isArray(tools)
+            ? tools.map((tool) => isObject(tool) ? asString(tool.name) : undefined).filter(Boolean)
+            : isObject(tools)
+              ? Object.keys(tools)
+              : []
+
+          return {
+            name: asString(server.name) || 'unknown',
+            authStatus: asString(server.authStatus) || null,
+            toolCount: toolNames.length,
+            toolNames: toolNames.slice(0, 50)
+          }
+        })
+
+      console.log('[CodexAppServerAdapter] MCP inventory', { context, threadId, servers })
+    } catch (error) {
+      console.warn('[CodexAppServerAdapter] Failed to list MCP inventory:', error)
+    }
   }
 
   private setupStdoutParser(process: ChildProcess, session: AppServerSession): void {

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -9,7 +9,7 @@
 import { spawn, type ChildProcess } from 'child_process'
 import { mkdtempSync } from 'fs'
 import { homedir, tmpdir } from 'os'
-import { join } from 'path'
+import { basename, join } from 'path'
 import { promisify } from 'util'
 import type {
   CodingAgentAdapter,
@@ -129,6 +129,12 @@ function extractText(value: unknown): string {
 }
 
 function extractToolName(item: Record<string, unknown>): string {
+  const server = asString(item.server)
+  const tool = asString(item.tool)
+  if ((item.type === 'mcpToolCall' || server || tool) && (server || tool)) {
+    return [server, tool].filter(Boolean).join('.')
+  }
+
   return (
     asString(item.toolName) ||
     asString(item.tool_name) ||
@@ -136,6 +142,34 @@ function extractToolName(item: Record<string, unknown>): string {
     asString(item.type) ||
     'tool'
   )
+}
+
+function extractToolTitle(item: Record<string, unknown>, toolName: string): string {
+  if (item.type === 'commandExecution') {
+    const actionCommand = Array.isArray(item.commandActions)
+      ? item.commandActions
+        .filter(isObject)
+        .map((action) => asString(action.command))
+        .find(Boolean)
+      : undefined
+    const command = actionCommand || asString(item.command)
+    if (command) return command
+  }
+
+  if (item.type === 'fileChange') {
+    const paths = Array.isArray(item.changes)
+      ? item.changes
+        .filter(isObject)
+        .map((change) => asString(change.path))
+        .filter((path): path is string => !!path)
+      : []
+    const directPath = asString(item.path)
+    if (paths.length === 1) return basename(paths[0])
+    if (paths.length > 1) return `${basename(paths[0])} +${paths.length - 1}`
+    if (directPath) return basename(directPath)
+  }
+
+  return toolName
 }
 
 function truncateForIpc(value: string, maxChars: number): string {
@@ -1118,6 +1152,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     }
 
     const toolName = extractToolName(item)
+    const toolTitle = extractToolTitle(item, toolName)
     const partId = `tool-${itemId}`
     const isCompleted = method === 'item/completed'
     if (!isCompleted && seenPartIds.has(partId)) return []
@@ -1130,7 +1165,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       tool: {
         name: toolName,
         status: isCompleted ? 'completed' : 'running',
-        title: toolName,
+        title: toolTitle,
         input: stringifyForIpc(item, MAX_IPC_TOOL_INPUT_CHARS),
         output: isCompleted ? stringifyForIpc(extractText(item) || item, MAX_IPC_TOOL_OUTPUT_CHARS) : undefined
       },

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -6,7 +6,7 @@
  * 20x's CodingAgentAdapter contract.
  */
 
-import { spawn, execFile, type ChildProcess } from 'child_process'
+import { spawn, type ChildProcess } from 'child_process'
 import { mkdtempSync } from 'fs'
 import { homedir, tmpdir } from 'os'
 import { join } from 'path'
@@ -21,7 +21,6 @@ import type {
 } from './coding-agent-adapter'
 import { MessagePartType, MessageRole, SessionStatusType } from './coding-agent-adapter'
 
-const execFileAsync = promisify(execFile)
 const DEFAULT_CODEX_APP_SERVER_MODEL = 'gpt-5.5'
 
 interface JsonRpcRequest {
@@ -415,7 +414,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
   async checkHealth(): Promise<{ available: boolean; reason?: string }> {
     try {
       const executable = await this.findCodexExecutable()
-      await execFileAsync(executable, ['app-server', '--help'], { timeout: 5000 })
+      await this.execFileAsync(executable, ['app-server', '--help'], { timeout: 5000 })
       return { available: true }
     } catch (error) {
       return {
@@ -524,9 +523,19 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     const isWin = process.platform === 'win32'
     const finder = isWin ? 'where' : 'which'
     const binary = isWin ? 'codex.cmd' : 'codex'
-    const { stdout } = await execFileAsync(finder, [binary])
+    const { stdout } = await this.execFileAsync(finder, [binary])
     this.codexExecutablePath = stdout.trim().split(/\r?\n/)[0]
     return this.codexExecutablePath
+  }
+
+  private async execFileAsync(
+    command: string,
+    args: string[],
+    options?: { timeout?: number }
+  ): Promise<{ stdout: string }> {
+    const { execFile } = await import('child_process')
+    const execFileAsync = promisify(execFile)
+    return await execFileAsync(command, args, options) as { stdout: string }
   }
 
   private buildEnvironment(config: SessionConfig): {

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -194,7 +194,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       model: config.model || DEFAULT_CODEX_APP_SERVER_MODEL,
       approvalPolicy: config.permissionMode === 'allow' ? 'never' : 'on-request',
       approvalsReviewer: 'user',
-      sandbox: 'workspace-write',
+      sandbox: this.resolveSandboxMode(config),
       developerInstructions: config.systemPrompt || null,
       runtimeWorkspaceRoots: [config.workspaceDir],
       config: this.buildConfigOverrides(config)
@@ -224,6 +224,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       model: config.model || DEFAULT_CODEX_APP_SERVER_MODEL,
       approvalPolicy: config.permissionMode === 'allow' ? 'never' : 'on-request',
       approvalsReviewer: 'user',
+      sandbox: this.resolveSandboxMode(config),
       runtimeWorkspaceRoots: [config.workspaceDir],
       initialTurnsPage: { limit: 50 },
       config: this.buildConfigOverrides(config)
@@ -281,7 +282,8 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       model: config.model || DEFAULT_CODEX_APP_SERVER_MODEL,
       effort: config.reasoningEffort && config.reasoningEffort !== 'max' ? config.reasoningEffort : null,
       approvalPolicy: config.permissionMode === 'allow' ? 'never' : 'on-request',
-      approvalsReviewer: 'user'
+      approvalsReviewer: 'user',
+      sandbox: this.resolveSandboxMode(config)
     })
 
     if (isObject(result)) {
@@ -714,10 +716,9 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     params: Record<string, unknown>
   ): void {
     if (session.config.permissionMode === 'allow') {
-      const response = request.method === 'execCommandApproval'
-        ? { decision: 'approved' }
-        : { decision: 'accept' }
-      this.sendRpcResponse(session, request.id, response)
+      const responseKind = this.getApprovalResponseKind(request.method)
+      const selected = responseKind === 'execCommand' ? 'approved' : 'accept'
+      this.sendRpcResponse(session, request.id, this.buildApprovalResponse(responseKind, selected, true))
       return
     }
 
@@ -784,6 +785,17 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     if (method === 'mcpServer/elicitation/request') return 'elicitation'
     if (method === 'item/tool/requestUserInput') return 'userInput'
     return 'generic'
+  }
+
+  private resolveSandboxMode(config: SessionConfig): 'read-only' | 'workspace-write' | 'danger-full-access' {
+    switch (config.sandboxMode) {
+      case 'read-only':
+      case 'workspace-write':
+      case 'danger-full-access':
+        return config.sandboxMode
+      default:
+        return 'workspace-write'
+    }
   }
 
   private addEvent(session: AppServerSession, event: unknown): void {

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -626,6 +626,12 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     if (config.reasoningEffort && config.reasoningEffort !== 'max') {
       overrides.model_reasoning_effort = config.reasoningEffort
     }
+    if (this.resolveSandboxMode(config) === 'workspace-write') {
+      overrides.sandbox_workspace_write = {
+        network_access: true,
+        writable_roots: [config.workspaceDir]
+      }
+    }
     if (config.mcpServers && Object.keys(config.mcpServers).length > 0) {
       overrides.mcp_servers = this.convertMcpServers(config.mcpServers)
     }

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -1,0 +1,1092 @@
+/**
+ * Codex App Server adapter.
+ *
+ * Experimental replacement path for Codex ACP. This talks to `codex app-server`
+ * over JSON-RPC stdio and maps the app-server thread/turn/item protocol onto
+ * 20x's CodingAgentAdapter contract.
+ */
+
+import { spawn, execFile, type ChildProcess } from 'child_process'
+import { mkdtempSync } from 'fs'
+import { homedir, tmpdir } from 'os'
+import { join } from 'path'
+import { promisify } from 'util'
+import type {
+  CodingAgentAdapter,
+  SessionConfig,
+  SessionStatus,
+  SessionMessage,
+  MessagePart,
+  McpServerConfig
+} from './coding-agent-adapter'
+import { MessagePartType, MessageRole, SessionStatusType } from './coding-agent-adapter'
+
+const execFileAsync = promisify(execFile)
+const DEFAULT_CODEX_APP_SERVER_MODEL = 'gpt-5.5'
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id: string | number
+  method: string
+  params?: unknown
+}
+
+interface JsonRpcNotification {
+  jsonrpc: '2.0'
+  method: string
+  params?: unknown
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id: string | number
+  result?: unknown
+  error?: {
+    code: number
+    message: string
+    data?: unknown
+  }
+}
+
+type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse
+
+interface PendingApproval {
+  requestId: string | number
+  toolCallId: string
+  question: string
+  options: Array<{
+    optionId: string
+    name: string
+    kind: string
+  }>
+  responseKind: 'execCommand' | 'commandExecution' | 'fileChange' | 'permissions' | 'elicitation' | 'userInput' | 'generic'
+}
+
+interface AppServerSession {
+  sessionId: string
+  threadId: string | null
+  activeTurnId: string | null
+  process: ChildProcess
+  stdoutBuffer: string
+  status: SessionStatusType
+  messageBuffer: unknown[]
+  permanentMessages: unknown[]
+  pendingRequests: Map<string | number, {
+    resolve: (value: unknown) => void
+    reject: (error: Error) => void
+  }>
+  pendingApproval: PendingApproval | null
+  nextRequestId: number
+  lastError: string | null
+  config: SessionConfig
+  streamedTextByItemId: Map<string, string>
+  runningTools: Map<string, {
+    partId: string
+    toolName: string
+    startTime?: number
+    input?: Record<string, unknown>
+  }>
+  codexUseApiKey: boolean
+  codexAuthSummary: string
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function extractThreadId(value: unknown): string | null {
+  if (!isObject(value)) return null
+  const direct = asString(value.threadId) || asString(value.thread_id) || asString(value.id)
+  if (direct) return direct
+  if (isObject(value.thread)) {
+    return asString(value.thread.id) || asString(value.thread.threadId) || asString(value.thread.thread_id) || null
+  }
+  return null
+}
+
+function extractItemId(params: Record<string, unknown>): string {
+  const item = isObject(params.item) ? params.item : undefined
+  return asString(params.itemId) || asString(item?.id) || `item-${Date.now()}`
+}
+
+function extractText(value: unknown): string {
+  if (!value) return ''
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) return value.map(extractText).filter(Boolean).join('\n')
+  if (!isObject(value)) return ''
+
+  for (const key of ['text', 'content', 'delta', 'message', 'output']) {
+    const text = extractText(value[key])
+    if (text) return text
+  }
+
+  return ''
+}
+
+function extractToolName(item: Record<string, unknown>): string {
+  return (
+    asString(item.toolName) ||
+    asString(item.tool_name) ||
+    asString(item.name) ||
+    asString(item.type) ||
+    'tool'
+  )
+}
+
+function summarizeApproval(params: Record<string, unknown>, fallback: string): string {
+  const command = asString(params.command)
+  const reason = asString(params.reason)
+  const itemId = asString(params.itemId) || asString(params.callId)
+  return [command || fallback, reason, itemId ? `id: ${itemId}` : ''].filter(Boolean).join('\n')
+}
+
+function normalizeDecisionName(decision: unknown): string {
+  if (typeof decision === 'string') return decision
+  if (isObject(decision)) {
+    return Object.keys(decision)[0] || 'accept'
+  }
+  return 'accept'
+}
+
+function decisionLabel(decision: string): string {
+  switch (decision) {
+    case 'accept':
+    case 'approved':
+      return 'Allow'
+    case 'acceptForSession':
+    case 'approved_for_session':
+      return 'Allow for Session'
+    case 'decline':
+    case 'denied':
+      return 'Deny'
+    case 'cancel':
+    case 'abort':
+      return 'Deny and Stop'
+    default:
+      return decision
+  }
+}
+
+export class CodexAppServerAdapter implements CodingAgentAdapter {
+  private sessions = new Map<string, AppServerSession>()
+  private codexExecutablePath: string | null = null
+
+  onDataAvailable?: (sessionId: string) => void
+
+  async initialize(): Promise<void> {
+    const health = await this.checkHealth()
+    if (!health.available) {
+      throw new Error(health.reason || 'Codex app-server not available')
+    }
+  }
+
+  async createSession(config: SessionConfig): Promise<string> {
+    const session = await this.startAppServerProcess(config, config.taskId)
+    this.sessions.set(config.taskId, session)
+
+    await this.initializeAppServer(session)
+
+    const result = await this.sendRpcRequest(session, 'thread/start', {
+      cwd: config.workspaceDir,
+      model: config.model || DEFAULT_CODEX_APP_SERVER_MODEL,
+      approvalPolicy: config.permissionMode === 'allow' ? 'never' : 'on-request',
+      approvalsReviewer: 'user',
+      sandbox: 'workspace-write',
+      developerInstructions: config.systemPrompt || null,
+      runtimeWorkspaceRoots: [config.workspaceDir],
+      config: this.buildConfigOverrides(config)
+    })
+
+    const threadId = extractThreadId(result)
+    if (!threadId) {
+      throw new Error('Codex app-server did not return a thread id')
+    }
+
+    session.threadId = threadId
+    this.sessions.delete(config.taskId)
+    this.sessions.set(threadId, session)
+    return threadId
+  }
+
+  async resumeSession(sessionId: string, config: SessionConfig): Promise<SessionMessage[]> {
+    const session = await this.startAppServerProcess(config, sessionId)
+    session.threadId = sessionId
+    this.sessions.set(sessionId, session)
+
+    await this.initializeAppServer(session)
+
+    await this.sendRpcRequest(session, 'thread/resume', {
+      threadId: sessionId,
+      cwd: config.workspaceDir,
+      model: config.model || DEFAULT_CODEX_APP_SERVER_MODEL,
+      approvalPolicy: config.permissionMode === 'allow' ? 'never' : 'on-request',
+      approvalsReviewer: 'user',
+      runtimeWorkspaceRoots: [config.workspaceDir],
+      initialTurnsPage: { limit: 50 },
+      config: this.buildConfigOverrides(config)
+    })
+
+    try {
+      await this.bufferAllThreadItems(session, sessionId)
+    } catch (error) {
+      console.warn('[CodexAppServerAdapter] Failed to list thread items after resume:', error)
+    }
+
+    const messages = await this.getAllMessages(sessionId, config)
+    session.messageBuffer = []
+    return messages
+  }
+
+  async sendPrompt(sessionId: string, parts: MessagePart[], config: SessionConfig): Promise<void> {
+    const session = this.requireSession(sessionId)
+    if (!session.threadId) {
+      throw new Error(`Codex app-server session has no thread id: ${sessionId}`)
+    }
+
+    const promptText = parts
+      .filter((part) => part.type === MessagePartType.TEXT && part.text)
+      .map((part) => part.text)
+      .join('\n')
+
+    if (!promptText) {
+      throw new Error('No text content in message parts')
+    }
+
+    session.messageBuffer = []
+
+    const userItem = {
+      method: 'item/completed',
+      params: {
+        threadId: session.threadId,
+        turnId: session.activeTurnId || `local-${Date.now()}`,
+        item: {
+          id: `user-${Date.now()}`,
+          type: 'user_message',
+          text: promptText
+        }
+      }
+    }
+    this.addEvent(session, userItem)
+
+    session.status = SessionStatusType.BUSY
+    session.lastError = null
+
+    const result = await this.sendRpcRequest(session, 'turn/start', {
+      threadId: session.threadId,
+      input: [{ type: 'text', text: promptText }],
+      cwd: config.workspaceDir,
+      model: config.model || DEFAULT_CODEX_APP_SERVER_MODEL,
+      effort: config.reasoningEffort && config.reasoningEffort !== 'max' ? config.reasoningEffort : null,
+      approvalPolicy: config.permissionMode === 'allow' ? 'never' : 'on-request',
+      approvalsReviewer: 'user'
+    })
+
+    if (isObject(result)) {
+      session.activeTurnId = asString(result.turnId) || asString(result.turn_id) || session.activeTurnId
+    }
+  }
+
+  async getStatus(sessionId: string, _config: SessionConfig): Promise<SessionStatus> {
+    const session = this.sessions.get(sessionId)
+    if (!session) {
+      return { type: SessionStatusType.ERROR, message: 'Session not found' }
+    }
+    return {
+      type: session.status,
+      message: session.status === SessionStatusType.ERROR ? (session.lastError || 'Process error') : undefined
+    }
+  }
+
+  async pollMessages(
+    sessionId: string,
+    seenMessageIds: Set<string>,
+    seenPartIds: Set<string>,
+    partContentLengths: Map<string, string>,
+    _config: SessionConfig
+  ): Promise<MessagePart[]> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return []
+
+    const parts = session.messageBuffer.flatMap((event) =>
+      this.convertEventToMessageParts(event, seenMessageIds, seenPartIds, partContentLengths, session)
+    )
+    session.messageBuffer = []
+    return parts
+  }
+
+  async getAllMessages(sessionId: string, _config: SessionConfig): Promise<SessionMessage[]> {
+    const session = this.requireSession(sessionId)
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+    const partsByIdAndRole = new Map<string, MessagePart>()
+
+    for (const event of session.permanentMessages) {
+      const parts = this.convertEventToMessageParts(event, seenMessageIds, seenPartIds, partContentLengths, session)
+      for (const part of parts) {
+        const key = `${part.id || `part-${partsByIdAndRole.size}`}-${part.role || MessageRole.ASSISTANT}`
+        if (!partsByIdAndRole.has(key) || part.update) {
+          partsByIdAndRole.set(key, part)
+        }
+      }
+    }
+
+    const messages: SessionMessage[] = []
+    let currentMessage: SessionMessage | null = null
+    let previousPart: MessagePart | null = null
+    let messageCounter = 0
+
+    for (const part of partsByIdAndRole.values()) {
+      const role = part.role === MessageRole.USER
+        ? MessageRole.USER
+        : part.role === MessageRole.SYSTEM
+          ? MessageRole.SYSTEM
+          : MessageRole.ASSISTANT
+      const startsNewMessage = !currentMessage
+        || currentMessage.role !== role
+        || !previousPart
+        || part.id !== previousPart.id
+
+      if (startsNewMessage) {
+        if (currentMessage) messages.push(currentMessage)
+        currentMessage = {
+          id: `msg-${messageCounter++}`,
+          role,
+          parts: []
+        }
+      }
+
+      currentMessage!.parts.push(part)
+      previousPart = part
+    }
+
+    if (currentMessage) messages.push(currentMessage)
+    return messages
+  }
+
+  async abortPrompt(sessionId: string, _config: SessionConfig): Promise<void> {
+    const session = this.requireSession(sessionId)
+    if (!session.threadId || !session.activeTurnId) return
+    await this.sendRpcRequest(session, 'turn/interrupt', {
+      threadId: session.threadId,
+      turnId: session.activeTurnId
+    })
+    session.status = SessionStatusType.IDLE
+  }
+
+  async destroySession(sessionId: string, _config: SessionConfig): Promise<void> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return
+    session.process.kill('SIGTERM')
+    setTimeout(() => {
+      if (!session.process.killed) {
+        session.process.kill('SIGKILL')
+      }
+    }, 1000)
+    session.messageBuffer.length = 0
+    session.permanentMessages.length = 0
+    session.pendingRequests.clear()
+    session.streamedTextByItemId.clear()
+    session.runningTools.clear()
+    this.sessions.delete(sessionId)
+  }
+
+  async registerMcpServer(
+    _serverName: string,
+    _mcpConfig: {
+      type: 'local' | 'remote'
+      command?: string[]
+      args?: string[]
+      url?: string
+      headers?: Record<string, string>
+      environment?: Record<string, string>
+    },
+    _workspaceDir?: string
+  ): Promise<void> {
+    // App Server reads MCP configuration from Codex config. Per-session MCP
+    // injection will be added after the thread config shape is verified in app.
+    console.log('[CodexAppServerAdapter] MCP server registration deferred to Codex app-server config')
+  }
+
+  async checkHealth(): Promise<{ available: boolean; reason?: string }> {
+    try {
+      const executable = await this.findCodexExecutable()
+      await execFileAsync(executable, ['app-server', '--help'], { timeout: 5000 })
+      return { available: true }
+    } catch (error) {
+      return {
+        available: false,
+        reason: error instanceof Error ? error.message : String(error)
+      }
+    }
+  }
+
+  getPendingApproval(sessionId: string): PendingApproval | null {
+    return this.sessions.get(sessionId)?.pendingApproval || null
+  }
+
+  async respondToApproval(sessionId: string, approved: boolean, optionId?: string): Promise<void> {
+    const session = this.requireSession(sessionId)
+    const approval = session.pendingApproval
+    if (!approval) return
+
+    const selected = optionId || approval.options.find((option) =>
+      approved
+        ? ['acceptForSession', 'accept', 'approved_for_session', 'approved'].includes(option.optionId)
+        : ['cancel', 'abort', 'decline', 'denied'].includes(option.optionId)
+    )?.optionId || (approved ? 'accept' : 'cancel')
+    const response = this.buildApprovalResponse(approval.responseKind, selected, approved)
+
+    this.sendRpcResponse(session, approval.requestId, response)
+    session.pendingApproval = null
+    if (!approved) {
+      session.status = SessionStatusType.IDLE
+    }
+  }
+
+  async getRunningTools(sessionId: string, _config: SessionConfig): Promise<Array<{
+    partId: string
+    toolName: string
+    startTime?: number
+    input?: Record<string, unknown>
+  }>> {
+    return Array.from(this.sessions.get(sessionId)?.runningTools.values() || [])
+  }
+
+  private async startAppServerProcess(config: SessionConfig, sessionId: string): Promise<AppServerSession> {
+    const executable = await this.findCodexExecutable()
+    const authEnv = this.buildEnvironment(config)
+    const env = authEnv.env
+    const needsShell = process.platform === 'win32' && /\.(cmd|bat)$/i.test(executable)
+    const child = spawn(executable, ['app-server', '--stdio'], {
+      cwd: config.workspaceDir,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(needsShell ? { shell: true } : {})
+    })
+
+    const session: AppServerSession = {
+      sessionId,
+      threadId: null,
+      activeTurnId: null,
+      process: child,
+      stdoutBuffer: '',
+      status: SessionStatusType.IDLE,
+      messageBuffer: [],
+      permanentMessages: [],
+      pendingRequests: new Map(),
+      pendingApproval: null,
+      nextRequestId: 1,
+      lastError: null,
+      config,
+      streamedTextByItemId: new Map(),
+      runningTools: new Map(),
+      codexUseApiKey: authEnv.usesApiKey,
+      codexAuthSummary: authEnv.summary
+    }
+
+    this.setupStdoutParser(child, session)
+    child.stderr?.on('data', (chunk: Buffer) => {
+      console.log('[CodexAppServerAdapter] stderr:', chunk.toString())
+    })
+    child.on('exit', (code, signal) => {
+      console.log(`[CodexAppServerAdapter] process exited: code=${code}, signal=${signal}`)
+      if (code !== 0 && code !== null) {
+        session.status = SessionStatusType.ERROR
+        session.lastError = `Codex app-server exited with code ${code}`
+      }
+    })
+
+    return session
+  }
+
+  private async initializeAppServer(session: AppServerSession): Promise<void> {
+    await this.sendRpcRequest(session, 'initialize', {
+      clientInfo: {
+        name: '20x',
+        title: '20x',
+        version: '0.0.1'
+      },
+      capabilities: {
+        experimentalApi: true,
+        mcpServerOpenaiFormElicitation: true
+      }
+    })
+    this.sendRpcNotification(session, 'initialized', {})
+  }
+
+  private async findCodexExecutable(): Promise<string> {
+    if (this.codexExecutablePath) return this.codexExecutablePath
+    const isWin = process.platform === 'win32'
+    const finder = isWin ? 'where' : 'which'
+    const binary = isWin ? 'codex.cmd' : 'codex'
+    const { stdout } = await execFileAsync(finder, [binary])
+    this.codexExecutablePath = stdout.trim().split(/\r?\n/)[0]
+    return this.codexExecutablePath
+  }
+
+  private buildEnvironment(config: SessionConfig): {
+    env: NodeJS.ProcessEnv
+    usesApiKey: boolean
+    summary: string
+  } {
+    const env: NodeJS.ProcessEnv = { ...process.env }
+
+    for (const [key, value] of Object.entries(config.secretEnvVars || {})) {
+      env[key] = value
+    }
+
+    const explicitApiKey = config.apiKeys?.openai
+    const useApiKey =
+      config.authMethod === 'api_key' ? true
+      : config.authMethod === 'subscription' ? false
+      : !!explicitApiKey
+
+    if (useApiKey) {
+      const key = explicitApiKey || env.OPENAI_API_KEY || env.CODEX_API_KEY
+      if (key) {
+        env.OPENAI_API_KEY = key
+        env.CODEX_API_KEY = key
+      }
+      env.NO_BROWSER = '1'
+      env.CODEX_HOME = mkdtempSync(join(tmpdir(), 'codex-app-server-session-'))
+      return {
+        env,
+        usesApiKey: true,
+        summary: `API key (authMethod=${config.authMethod ?? 'legacy'}, isolated CODEX_HOME)`
+      }
+    }
+
+    if (!useApiKey) {
+      delete env.OPENAI_API_KEY
+      delete env.CODEX_API_KEY
+      if (!env.CODEX_HOME) {
+        env.CODEX_HOME = join(homedir(), '.codex')
+      }
+    }
+
+    return {
+      env,
+      usesApiKey: false,
+      summary: `subscription (authMethod=${config.authMethod ?? 'legacy'}, CODEX_HOME=${env.CODEX_HOME ?? 'default'})`
+    }
+  }
+
+  private buildConfigOverrides(config: SessionConfig): Record<string, unknown> {
+    const overrides: Record<string, unknown> = {}
+    if (config.reasoningEffort && config.reasoningEffort !== 'max') {
+      overrides.model_reasoning_effort = config.reasoningEffort
+    }
+    if (config.mcpServers && Object.keys(config.mcpServers).length > 0) {
+      overrides.mcp_servers = this.convertMcpServers(config.mcpServers)
+    }
+    return overrides
+  }
+
+  private convertMcpServers(servers: Record<string, McpServerConfig>): Record<string, unknown> {
+    const result: Record<string, unknown> = {}
+    for (const [name, server] of Object.entries(servers)) {
+      if (server.type === 'stdio') {
+        result[name] = {
+          command: server.command,
+          args: server.args || [],
+          env: server.env || {}
+        }
+      } else {
+        result[name] = {
+          type: server.type,
+          url: server.url,
+          headers: server.headers || {}
+        }
+      }
+    }
+    return result
+  }
+
+  private setupStdoutParser(process: ChildProcess, session: AppServerSession): void {
+    process.stdout?.on('data', (chunk: Buffer) => {
+      session.stdoutBuffer += chunk.toString()
+      let newlineIndex: number
+      while ((newlineIndex = session.stdoutBuffer.indexOf('\n')) !== -1) {
+        const line = session.stdoutBuffer.slice(0, newlineIndex).trim()
+        session.stdoutBuffer = session.stdoutBuffer.slice(newlineIndex + 1)
+        if (!line) continue
+        try {
+          this.handleRpcMessage(session, JSON.parse(line) as JsonRpcMessage)
+        } catch (error) {
+          console.error('[CodexAppServerAdapter] Failed to parse JSON-RPC:', line, error)
+        }
+      }
+    })
+  }
+
+  private handleRpcMessage(session: AppServerSession, message: JsonRpcMessage): void {
+    if ('id' in message && 'method' in message) {
+      this.handleServerRequest(session, message as JsonRpcRequest)
+      return
+    }
+
+    if ('id' in message) {
+      const pending = session.pendingRequests.get(message.id)
+      if (!pending) return
+      session.pendingRequests.delete(message.id)
+      const response = message as JsonRpcResponse
+      if (response.error) {
+        pending.reject(new Error(response.error.message))
+      } else {
+        pending.resolve(response.result)
+      }
+      return
+    }
+
+    if ('method' in message) {
+      this.handleNotification(session, message as JsonRpcNotification)
+    }
+  }
+
+  private handleServerRequest(session: AppServerSession, request: JsonRpcRequest): void {
+    const params = isObject(request.params) ? request.params : {}
+    if (request.method.includes('Approval') || request.method.includes('requestApproval')) {
+      this.handleApprovalRequest(session, request, params)
+      return
+    }
+
+    if (request.method === 'mcpServer/elicitation/request' || request.method === 'item/tool/requestUserInput') {
+      this.handleApprovalRequest(session, request, params)
+      return
+    }
+
+    this.sendRpcResponse(session, request.id, {})
+  }
+
+  private handleNotification(session: AppServerSession, notification: JsonRpcNotification): void {
+    const params = isObject(notification.params) ? notification.params : {}
+
+    if (notification.method === 'thread/status/changed') {
+      const status = asString(params.status)
+      session.status = status === 'running' || status === 'busy' ? SessionStatusType.BUSY : SessionStatusType.IDLE
+    }
+
+    if (notification.method === 'turn/started') {
+      session.status = SessionStatusType.BUSY
+      session.activeTurnId = asString(params.turnId) || session.activeTurnId
+    }
+
+    if (notification.method === 'turn/completed') {
+      session.status = SessionStatusType.IDLE
+      session.activeTurnId = null
+    }
+
+    if (notification.method === 'error') {
+      session.status = SessionStatusType.ERROR
+      session.lastError = extractText(params) || 'Codex app-server error'
+    }
+
+    if (notification.method === 'serverRequest/resolved') {
+      const requestId = params.requestId
+      if (session.pendingApproval && String(session.pendingApproval.requestId) === String(requestId)) {
+        session.pendingApproval = null
+        if (session.status === SessionStatusType.WAITING_APPROVAL) {
+          session.status = SessionStatusType.BUSY
+        }
+      }
+    }
+
+    this.addEvent(session, notification)
+  }
+
+  private handleApprovalRequest(
+    session: AppServerSession,
+    request: JsonRpcRequest,
+    params: Record<string, unknown>
+  ): void {
+    if (session.config.permissionMode === 'allow') {
+      const response = request.method === 'execCommandApproval'
+        ? { decision: 'approved' }
+        : { decision: 'accept' }
+      this.sendRpcResponse(session, request.id, response)
+      return
+    }
+
+    const toolCallId = asString(params.approvalId) || asString(params.itemId) || asString(params.callId) || String(request.id)
+    const responseKind = this.getApprovalResponseKind(request.method)
+
+    const rawDecisions = Array.isArray(params.availableDecisions) ? params.availableDecisions : []
+    const approvalOptions = rawDecisions.length > 0
+      ? rawDecisions.map((decision) => {
+          const optionId = normalizeDecisionName(decision)
+          return {
+            optionId,
+            name: decisionLabel(optionId),
+            kind: optionId.includes('accept') || optionId === 'approved' ? 'allow' : 'reject'
+          }
+        })
+      : [
+          { optionId: 'accept', name: 'Allow', kind: 'allow' },
+          { optionId: 'cancel', name: 'Deny', kind: 'reject' }
+        ]
+
+    session.pendingApproval = {
+      requestId: request.id,
+      toolCallId,
+      question: summarizeApproval(params, request.method),
+      options: approvalOptions,
+      responseKind
+    }
+    session.status = SessionStatusType.WAITING_APPROVAL
+    this.onDataAvailable?.(session.threadId || session.sessionId)
+  }
+
+  private buildApprovalResponse(
+    responseKind: PendingApproval['responseKind'],
+    selected: string,
+    approved: boolean
+  ): unknown {
+    switch (responseKind) {
+      case 'execCommand':
+        return { decision: approved ? (selected === 'approved_for_session' ? 'approved_for_session' : 'approved') : (selected === 'denied' ? 'denied' : 'abort') }
+      case 'commandExecution':
+        return { decision: selected }
+      case 'fileChange':
+      case 'permissions':
+        return { decision: selected }
+      case 'elicitation':
+        return approved
+          ? { action: 'accept', content: {} }
+          : { action: 'decline' }
+      case 'userInput':
+        return approved
+          ? { response: selected }
+          : { response: null }
+      default:
+        return { decision: approved ? selected : 'cancel' }
+    }
+  }
+
+  private getApprovalResponseKind(method: string): PendingApproval['responseKind'] {
+    if (method === 'execCommandApproval') return 'execCommand'
+    if (method.includes('commandExecution')) return 'commandExecution'
+    if (method.includes('fileChange')) return 'fileChange'
+    if (method.includes('permissions')) return 'permissions'
+    if (method === 'mcpServer/elicitation/request') return 'elicitation'
+    if (method === 'item/tool/requestUserInput') return 'userInput'
+    return 'generic'
+  }
+
+  private addEvent(session: AppServerSession, event: unknown): void {
+    session.messageBuffer.push(event)
+    session.permanentMessages.push(event)
+    if (session.permanentMessages.length > 1000) {
+      session.permanentMessages.splice(0, 250)
+    }
+    this.onDataAvailable?.(session.threadId || session.sessionId)
+  }
+
+  private bufferThreadItems(session: AppServerSession, result: unknown): void {
+    const items = isObject(result) && Array.isArray(result.data) ? result.data : []
+    for (const item of items) {
+      this.addEvent(session, {
+        method: 'item/completed',
+        params: {
+          threadId: session.threadId,
+          turnId: isObject(item) ? asString(item.turnId) : undefined,
+          item
+        }
+      })
+    }
+  }
+
+  private async bufferAllThreadItems(session: AppServerSession, threadId: string): Promise<void> {
+    try {
+      let cursor: string | null = null
+      for (let page = 0; page < 20; page++) {
+        const result = await this.sendRpcRequest(session, 'thread/items/list', {
+          threadId,
+          cursor,
+          limit: 200,
+          sortDirection: 'asc'
+        })
+        this.bufferThreadItems(session, result)
+        cursor = isObject(result) ? (asString(result.nextCursor) || null) : null
+        if (!cursor) return
+      }
+      console.warn('[CodexAppServerAdapter] Stopped thread/items pagination after 20 pages')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (!message.includes('not supported')) throw error
+      await this.bufferAllThreadTurns(session, threadId)
+    }
+  }
+
+  private async bufferAllThreadTurns(session: AppServerSession, threadId: string): Promise<void> {
+    let cursor: string | null = null
+    for (let page = 0; page < 20; page++) {
+      let result: unknown
+      try {
+        result = await this.sendRpcRequest(session, 'thread/turns/list', {
+          threadId,
+          cursor,
+          limit: 100,
+          sortDirection: 'asc',
+          itemsView: 'full'
+        })
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        if (message.includes('not materialized yet') || message.includes('before first user message')) {
+          return
+        }
+        throw error
+      }
+      const turns = isObject(result) && Array.isArray(result.data) ? result.data : []
+      for (const turn of turns) {
+        if (!isObject(turn) || !Array.isArray(turn.items)) continue
+        for (const item of turn.items) {
+          this.addEvent(session, {
+            method: 'item/completed',
+            params: {
+              threadId: session.threadId,
+              turnId: asString(turn.id),
+              item
+            }
+          })
+        }
+      }
+      cursor = isObject(result) ? (asString(result.nextCursor) || null) : null
+      if (!cursor) return
+    }
+    console.warn('[CodexAppServerAdapter] Stopped thread/turns pagination after 20 pages')
+  }
+
+  private convertEventToMessageParts(
+    event: unknown,
+    seenMessageIds: Set<string>,
+    seenPartIds: Set<string>,
+    partContentLengths: Map<string, string>,
+    session: AppServerSession
+  ): MessagePart[] {
+    if (!isObject(event) || !asString(event.method)) return []
+    const method = event.method
+    const params = isObject(event.params) ? event.params : {}
+    const item = isObject(params.item) ? params.item : undefined
+
+    if (method === 'item/agentMessage/delta') {
+      const itemId = asString(params.itemId) || `agent-${Date.now()}`
+      const partId = `agent-${itemId}`
+      const delta = asString(params.delta) || ''
+      const previous = session.streamedTextByItemId.get(itemId) || ''
+      const next = previous + delta
+      const update = seenPartIds.has(partId)
+      seenPartIds.add(partId)
+      session.streamedTextByItemId.set(itemId, next)
+      partContentLengths.set(partId, String(next.length))
+      return [{
+        id: partId,
+        type: MessagePartType.TEXT,
+        text: next,
+        role: MessageRole.ASSISTANT,
+        update
+      }]
+    }
+
+    if (method === 'item/reasoning/textDelta' || method === 'item/reasoning/summaryTextDelta') {
+      const itemId = asString(params.itemId) || `reasoning-${Date.now()}`
+      const partId = `reasoning-${itemId}`
+      const text = asString(params.delta) || ''
+      if (!text && seenPartIds.has(partId)) return []
+      seenPartIds.add(partId)
+      partContentLengths.set(partId, String(text.length))
+      return [{
+        id: partId,
+        type: MessagePartType.REASONING,
+        text,
+        role: MessageRole.ASSISTANT
+      }]
+    }
+
+    if (
+      method === 'item/commandExecution/outputDelta' ||
+      method === 'command/exec/outputDelta' ||
+      method === 'process/outputDelta'
+    ) {
+      return this.convertOutputDeltaEvent('command', params, seenPartIds, partContentLengths, session)
+    }
+
+    if (
+      method === 'item/fileChange/outputDelta' ||
+      method === 'item/fileChange/patchUpdated'
+    ) {
+      return this.convertOutputDeltaEvent('file_change', params, seenPartIds, partContentLengths, session)
+    }
+
+    if (
+      method === 'item/plan/delta' ||
+      method === 'turn/plan/updated'
+    ) {
+      return this.convertOutputDeltaEvent('plan', params, seenPartIds, partContentLengths, session)
+    }
+
+    if (method === 'item/mcpToolCall/progress') {
+      return this.convertOutputDeltaEvent('mcp_tool', params, seenPartIds, partContentLengths, session)
+    }
+
+    if ((method === 'item/started' || method === 'item/completed') && item) {
+      return this.convertThreadItem(method, item, params, seenMessageIds, seenPartIds, partContentLengths, session)
+    }
+
+    if (method === 'error') {
+      const partId = `error-${Date.now()}`
+      return [{
+        id: partId,
+        type: MessagePartType.ERROR,
+        text: extractText(params) || 'Codex app-server error',
+        role: MessageRole.ASSISTANT
+      }]
+    }
+
+    return []
+  }
+
+  private convertOutputDeltaEvent(
+    toolName: string,
+    params: Record<string, unknown>,
+    seenPartIds: Set<string>,
+    partContentLengths: Map<string, string>,
+    session: AppServerSession
+  ): MessagePart[] {
+    const itemId = asString(params.itemId) || asString(params.processId) || asString(params.turnId) || `${toolName}-${Date.now()}`
+    const partId = `tool-${itemId}`
+    const previous = session.streamedTextByItemId.get(partId) || ''
+    const next = previous + extractText(params)
+    const update = seenPartIds.has(partId)
+    seenPartIds.add(partId)
+    session.streamedTextByItemId.set(partId, next)
+    partContentLengths.set(partId, `${next.length}:${toolName}`)
+
+    return [{
+      id: partId,
+      type: MessagePartType.TOOL,
+      role: MessageRole.ASSISTANT,
+      tool: {
+        name: toolName,
+        status: 'running',
+        title: toolName,
+        input: params,
+        output: next
+      },
+      update
+    }]
+  }
+
+  private convertThreadItem(
+    method: string,
+    item: Record<string, unknown>,
+    params: Record<string, unknown>,
+    _seenMessageIds: Set<string>,
+    seenPartIds: Set<string>,
+    partContentLengths: Map<string, string>,
+    session: AppServerSession
+  ): MessagePart[] {
+    const itemId = extractItemId(params)
+    const type = asString(item.type) || ''
+    const text = extractText(item)
+
+    if (type.includes('user') || type === 'user_message') {
+      const partId = `user-${itemId}`
+      if (seenPartIds.has(partId)) return []
+      seenPartIds.add(partId)
+      partContentLengths.set(partId, String(text.length))
+      return [{
+        id: partId,
+        type: MessagePartType.TEXT,
+        text,
+        role: MessageRole.USER
+      }]
+    }
+
+    if (type.includes('agent') || type.includes('assistant') || (!type && text)) {
+      const partId = `agent-${itemId}`
+      if (seenPartIds.has(partId) && method !== 'item/completed') return []
+      seenPartIds.add(partId)
+      const finalText = text || session.streamedTextByItemId.get(itemId) || ''
+      partContentLengths.set(partId, String(finalText.length))
+      return [{
+        id: partId,
+        type: MessagePartType.TEXT,
+        text: finalText,
+        role: MessageRole.ASSISTANT,
+        update: method === 'item/completed' && session.streamedTextByItemId.has(itemId)
+      }]
+    }
+
+    const toolName = extractToolName(item)
+    const partId = `tool-${itemId}`
+    const isCompleted = method === 'item/completed'
+    if (!isCompleted && seenPartIds.has(partId)) return []
+    seenPartIds.add(partId)
+
+    const part: MessagePart = {
+      id: partId,
+      type: MessagePartType.TOOL,
+      role: MessageRole.ASSISTANT,
+      tool: {
+        name: toolName,
+        status: isCompleted ? 'completed' : 'running',
+        title: toolName,
+        input: item,
+        output: isCompleted ? item : undefined
+      },
+      update: isCompleted
+    }
+
+    if (isCompleted) {
+      session.runningTools.delete(partId)
+    } else {
+      session.runningTools.set(partId, {
+        partId,
+        toolName,
+        startTime: typeof params.startedAtMs === 'number' ? params.startedAtMs : Date.now(),
+        input: item
+      })
+    }
+
+    partContentLengths.set(partId, `${part.tool?.status}:${toolName}`)
+    return [part]
+  }
+
+  private sendRpcRequest(session: AppServerSession, method: string, params?: unknown): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = session.nextRequestId++
+      session.pendingRequests.set(id, { resolve, reject })
+      this.writeJson(session, { jsonrpc: '2.0', id, method, params })
+      setTimeout(() => {
+        if (!session.pendingRequests.has(id)) return
+        session.pendingRequests.delete(id)
+        reject(new Error(`Codex app-server RPC timed out: ${method}`))
+      }, 30000)
+    })
+  }
+
+  private sendRpcResponse(session: AppServerSession, id: string | number, result: unknown): void {
+    this.writeJson(session, { jsonrpc: '2.0', id, result })
+  }
+
+  private sendRpcNotification(session: AppServerSession, method: string, params?: unknown): void {
+    this.writeJson(session, { jsonrpc: '2.0', method, params })
+  }
+
+  private writeJson(session: AppServerSession, payload: unknown): void {
+    session.process.stdin?.write(`${JSON.stringify(payload)}\n`)
+  }
+
+  private requireSession(sessionId: string): AppServerSession {
+    const session = this.sessions.get(sessionId)
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`)
+    }
+    return session
+  }
+}

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -22,6 +22,8 @@ import type {
 import { MessagePartType, MessageRole, SessionStatusType } from './coding-agent-adapter'
 
 const DEFAULT_CODEX_APP_SERVER_MODEL = 'gpt-5.5'
+const MAX_IPC_TOOL_INPUT_CHARS = 20_000
+const MAX_IPC_TOOL_OUTPUT_CHARS = 100_000
 
 interface JsonRpcRequest {
   jsonrpc: '2.0'
@@ -134,6 +136,30 @@ function extractToolName(item: Record<string, unknown>): string {
     asString(item.type) ||
     'tool'
   )
+}
+
+function truncateForIpc(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value
+  return `${value.slice(0, maxChars)}\n... (truncated for display)`
+}
+
+function stringifyForIpc(value: unknown, maxChars: number): string | undefined {
+  if (value == null) return undefined
+  if (typeof value === 'string') return truncateForIpc(value, maxChars)
+  try {
+    const seen = new WeakSet<object>()
+    return truncateForIpc(JSON.stringify(value, (_key, nested) => {
+      if (typeof nested === 'bigint') return nested.toString()
+      if (typeof nested === 'function' || typeof nested === 'symbol') return undefined
+      if (nested && typeof nested === 'object') {
+        if (seen.has(nested)) return '[Circular]'
+        seen.add(nested)
+      }
+      return nested
+    }, 2), maxChars)
+  } catch {
+    return truncateForIpc(String(value), maxChars)
+  }
 }
 
 function summarizeApproval(params: Record<string, unknown>, fallback: string): string {
@@ -981,7 +1007,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     const itemId = asString(params.itemId) || asString(params.processId) || asString(params.turnId) || `${toolName}-${Date.now()}`
     const partId = `tool-${itemId}`
     const previous = session.streamedTextByItemId.get(partId) || ''
-    const next = previous + extractText(params)
+    const next = truncateForIpc(previous + extractText(params), MAX_IPC_TOOL_OUTPUT_CHARS)
     const update = seenPartIds.has(partId)
     seenPartIds.add(partId)
     session.streamedTextByItemId.set(partId, next)
@@ -995,7 +1021,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
         name: toolName,
         status: 'running',
         title: toolName,
-        input: params,
+        input: stringifyForIpc(params, MAX_IPC_TOOL_INPUT_CHARS),
         output: next
       },
       update
@@ -1057,8 +1083,8 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
         name: toolName,
         status: isCompleted ? 'completed' : 'running',
         title: toolName,
-        input: item,
-        output: isCompleted ? item : undefined
+        input: stringifyForIpc(item, MAX_IPC_TOOL_INPUT_CHARS),
+        output: isCompleted ? stringifyForIpc(extractText(item) || item, MAX_IPC_TOOL_OUTPUT_CHARS) : undefined
       },
       update: isCompleted
     }

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -634,11 +634,11 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
           env: server.env || {}
         }
       } else {
-        result[name] = {
-          type: server.type,
-          url: server.url,
-          headers: server.headers || {}
+        const remoteConfig: Record<string, unknown> = { url: server.url }
+        if (server.headers && Object.keys(server.headers).length > 0) {
+          remoteConfig.http_headers = server.headers
         }
+        result[name] = remoteConfig
       }
     }
     return result

--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -52,6 +52,7 @@ export interface SessionConfig {
   /** Claude Code auth method: 'subscription' (OAuth/Pro/Max) or 'api_key' (pay-per-use). Defaults to 'subscription'. */
   authMethod?: 'subscription' | 'api_key'
   permissionMode?: 'ask' | 'allow'
+  sandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access'
   apiKeys?: {
     openai?: string
     anthropic?: string

--- a/src/main/adapters/index.ts
+++ b/src/main/adapters/index.ts
@@ -16,6 +16,7 @@ export type {
 export { ClaudeCodeAdapter } from './claude-code-adapter'
 export { CodexAdapter } from './codex-adapter'
 export { AcpAdapter, type AcpAgentType } from './acp-adapter'
+export { CodexAppServerAdapter } from './codex-app-server-adapter'
 
 // TODO: Extract OpencodeAdapter from AgentManager once ready
 // export { OpencodeAdapter } from './opencode-adapter'

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -44,6 +44,7 @@ vi.mock('electron', () => {
 vi.mock('./adapters/opencode-adapter', () => ({ OpencodeAdapter: vi.fn() }))
 vi.mock('./adapters/claude-code-adapter', () => ({ ClaudeCodeAdapter: vi.fn() }))
 vi.mock('./adapters/acp-adapter', () => ({ AcpAdapter: vi.fn() }))
+vi.mock('./adapters/codex-app-server-adapter', () => ({ CodexAppServerAdapter: vi.fn() }))
 vi.mock('./task-api-server', () => ({ getTaskApiPort: vi.fn(), waitForTaskApiServer: vi.fn() }))
 vi.mock('./secret-broker', () => ({
   registerSecretSession: vi.fn(),
@@ -54,6 +55,8 @@ vi.mock('./secret-broker', () => ({
 
 import { mkdir as mkdirAsync, writeFile as writeFileAsync } from 'fs/promises'
 import { existsSync, copyFileSync, mkdirSync, readFileSync } from 'fs'
+import { AcpAdapter } from './adapters/acp-adapter'
+import { CodexAppServerAdapter } from './adapters/codex-app-server-adapter'
 
 const mockedMkdirAsync = vi.mocked(mkdirAsync)
 const mockedWriteFileAsync = vi.mocked(writeFileAsync)
@@ -121,6 +124,32 @@ let manager: AgentManager
 describe('AgentManager skill file paths', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    delete process.env.CODEX_APP_SERVER
+  })
+
+  describe('getAdapter', () => {
+    it('uses Codex app-server by default for Codex agents', () => {
+      const mockDb = createMockDb({ coding_agent: 'codex' })
+      manager = new AgentManager(mockDb)
+
+      const adapter = (manager as any).getAdapter('agent-1')
+
+      expect(adapter).toBeInstanceOf(CodexAppServerAdapter)
+      expect(CodexAppServerAdapter).toHaveBeenCalledOnce()
+      expect(AcpAdapter).not.toHaveBeenCalled()
+    })
+
+    it('keeps an explicit ACP fallback for Codex agents', () => {
+      process.env.CODEX_APP_SERVER = '0'
+      const mockDb = createMockDb({ coding_agent: 'codex' })
+      manager = new AgentManager(mockDb)
+
+      const adapter = (manager as any).getAdapter('agent-1')
+
+      expect(adapter).toBeInstanceOf(AcpAdapter)
+      expect(AcpAdapter).toHaveBeenCalledWith('codex')
+      expect(CodexAppServerAdapter).not.toHaveBeenCalled()
+    })
   })
 
   describe('shouldEnableTillDone', () => {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -580,6 +580,7 @@ export class AgentManager extends EventEmitter {
       mcpServers,
       authMethod: agent.config?.auth_method,
       permissionMode: agent.config?.permission_mode,
+      sandboxMode: agent.config?.sandbox_mode,
       apiKeys: agent.config?.api_keys,
       tillDone: this.shouldEnableTillDone(taskId, task)
     }
@@ -1217,6 +1218,7 @@ export class AgentManager extends EventEmitter {
       mcpServers,
       authMethod: agent.config?.auth_method,
       permissionMode: agent.config?.permission_mode,
+      sandboxMode: agent.config?.sandbox_mode,
       apiKeys: agent.config?.api_keys,
       tillDone: this.shouldEnableTillDone(taskId, task)
     }
@@ -2280,6 +2282,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       mcpServers,
       authMethod: agent.config?.auth_method,
       permissionMode: agent.config?.permission_mode,
+      sandboxMode: agent.config?.sandbox_mode,
       apiKeys: agent.config?.api_keys,
       tillDone: this.shouldEnableTillDone(taskId, task)
     }

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -415,12 +415,12 @@ export class AgentManager extends EventEmitter {
         adapter = new ClaudeCodeAdapter()
         break
       case CodingAgentType.CODEX:
-        if (process.env.CODEX_APP_SERVER === '1') {
-          console.log('[AgentManager] Creating new CodexAppServerAdapter for Codex')
-          adapter = new CodexAppServerAdapter()
-        } else {
+        if (process.env.CODEX_APP_SERVER === '0') {
           console.log('[AgentManager] Creating new AcpAdapter for Codex')
           adapter = new AcpAdapter('codex')
+        } else {
+          console.log('[AgentManager] Creating new CodexAppServerAdapter for Codex')
+          adapter = new CodexAppServerAdapter()
         }
         break
       default:

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -13,6 +13,7 @@ import type { GitLabManager } from './gitlab-manager'
 import { OpencodeAdapter } from './adapters/opencode-adapter'
 import { ClaudeCodeAdapter } from './adapters/claude-code-adapter'
 import { AcpAdapter } from './adapters/acp-adapter'
+import { CodexAppServerAdapter } from './adapters/codex-app-server-adapter'
 import type { CodingAgentAdapter, SessionConfig, MessagePart, SessionMessage, McpServerConfig } from './adapters/coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './adapters/coding-agent-adapter'
 import { getTaskApiPort, waitForTaskApiServer } from './task-api-server'
@@ -414,8 +415,13 @@ export class AgentManager extends EventEmitter {
         adapter = new ClaudeCodeAdapter()
         break
       case CodingAgentType.CODEX:
-        console.log('[AgentManager] Creating new AcpAdapter for Codex')
-        adapter = new AcpAdapter('codex')
+        if (process.env.CODEX_APP_SERVER === '1') {
+          console.log('[AgentManager] Creating new CodexAppServerAdapter for Codex')
+          adapter = new CodexAppServerAdapter()
+        } else {
+          console.log('[AgentManager] Creating new AcpAdapter for Codex')
+          adapter = new AcpAdapter('codex')
+        }
         break
       default:
         console.warn(`[AgentManager] Unknown coding agent type: ${backendType}`)

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -38,6 +38,7 @@ export interface AgentConfigRecord {
   reasoning_effort?: ReasoningEffort
   auth_method?: 'subscription' | 'api_key'
   permission_mode?: 'ask' | 'allow'
+  sandbox_mode?: 'read-only' | 'workspace-write' | 'danger-full-access'
   system_prompt?: string
   mcp_servers?: Array<string | AgentMcpServerEntry>
   skill_ids?: string[]

--- a/src/renderer/src/components/agents/AgentForm.tsx
+++ b/src/renderer/src/components/agents/AgentForm.tsx
@@ -12,7 +12,7 @@ import { useSkillStore } from '@/stores/skill-store'
 import { SkillSelectorDialog } from '@/components/skills/SkillSelectorDialog'
 import { SecretSelector } from '@/components/secrets/SecretSelector'
 import { CLAUDE_REASONING_EFFORT_VALUES, CODEX_REASONING_EFFORT_VALUES } from '@shared/reasoning-effort'
-import type { Agent, CreateAgentDTO, UpdateAgentDTO, AgentMcpServerEntry, ClaudeAuthMethod, AgentPermissionMode } from '@/types'
+import type { Agent, CreateAgentDTO, UpdateAgentDTO, AgentMcpServerEntry, ClaudeAuthMethod, AgentPermissionMode, AgentSandboxMode } from '@/types'
 import type { ReasoningEffort } from '@/types'
 import { CodingAgentType, CODING_AGENTS, CLAUDE_MODELS, CODEX_MODELS } from '@/types'
 
@@ -63,6 +63,9 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
   )
   const [permissionMode, setPermissionMode] = useState<AgentPermissionMode>(
     agent?.config.permission_mode ?? 'ask'
+  )
+  const [sandboxMode, setSandboxMode] = useState<AgentSandboxMode>(
+    agent?.config.sandbox_mode ?? 'workspace-write'
   )
 
   // API keys state
@@ -229,6 +232,7 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
           ? authMethod
           : undefined,
         permission_mode: permissionMode,
+        sandbox_mode: codingAgent === CodingAgentType.CODEX ? sandboxMode : undefined,
         system_prompt: systemPrompt.trim() || undefined,
         max_parallel_sessions: maxParallelSessions,
         mcp_servers: mcpServersConfig.length > 0 ? mcpServersConfig : undefined,
@@ -369,10 +373,25 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
             </select>
             <p className="text-xs text-muted-foreground">
               {codingAgent === CodingAgentType.CODEX
-                ? 'Allow automatically auto-approves Codex ACP permission requests for this agent.'
+                ? 'Allow automatically auto-approves Codex permission requests for this agent.'
                 : 'Controls how this agent handles tool and command approval prompts.'}
             </p>
           </div>
+          {codingAgent === CodingAgentType.CODEX && (
+            <div className="space-y-1.5">
+              <Label htmlFor="agent-sandbox-mode">Sandbox</Label>
+              <select
+                id="agent-sandbox-mode"
+                value={sandboxMode}
+                onChange={(e) => setSandboxMode(e.target.value as AgentSandboxMode)}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm cursor-pointer"
+              >
+                <option value="read-only">Read only</option>
+                <option value="workspace-write">Workspace write</option>
+                <option value="danger-full-access">Full access</option>
+              </select>
+            </div>
+          )}
           <div className="space-y-1.5">
             <Label htmlFor="agent-model">Model</Label>
           <div className="relative">

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -126,6 +126,7 @@ function deriveToolSubtitle(tool?: AgentMessage['tool']): string {
   if (description) return description
 
   if (tool.title) {
+    if (tool.title === tool.name) return ''
     return isFilePathTool(tool.name) ? basenameFromPath(tool.title) : tool.title
   }
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -33,6 +33,7 @@ export enum CodingAgentType {
 }
 
 export type AgentPermissionMode = 'ask' | 'allow'
+export type AgentSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access'
 
 export type ClaudeAuthMethod = 'subscription' | 'api_key'
 
@@ -169,6 +170,7 @@ export interface AgentConfig {
   reasoning_effort?: ReasoningEffort
   auth_method?: ClaudeAuthMethod
   permission_mode?: AgentPermissionMode
+  sandbox_mode?: AgentSandboxMode
   system_prompt?: string
   mcp_servers?: Array<string | AgentMcpServerEntry>
   skill_ids?: string[]


### PR DESCRIPTION
## Summary
- add an experimental `CodexAppServerAdapter` for Codex via `codex app-server --stdio`
- keep ACP as the default and opt into App Server with `CODEX_APP_SERVER=1`
- map thread/turn lifecycle, streaming text, tool output deltas, approvals, auth precedence, cleanup, and replay fallback behavior into the existing `CodingAgentAdapter` contract
- add a non-model probe script for real local app-server startup/thread/read/history behavior

## Test plan
- [x] `pnpm test:run src/main/adapters/codex-app-server-adapter.test.ts`
- [x] `pnpm typecheck`
- [x] `node scripts/probe-codex-app-server.mjs --cwd . --timeout-ms 30000`

## Notes
- The probe does not send a prompt or start a model turn.
- Real app-server behavior observed: `thread/items/list` returns `not supported yet`; adapter falls back to `thread/turns/list`.
- `thread/turns/list` is unavailable before the first user message; adapter handles that as empty replay.