### PR TITLE
Shell upgrades: command palette, status bar, floating workspace, collapsible sidebar

### DIFF
--- a/src/mobile/components/ChatInput.tsx
+++ b/src/mobile/components/ChatInput.tsx
@@ -98,7 +98,7 @@ export function ChatInput({
           placeholder={placeholder}
           disabled={disabled}
           rows={1}
-          className="flex-1 bg-muted/50 border border-border rounded-lg px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground resize-none overflow-hidden max-h-32 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/30 min-h-[32px] disabled:opacity-40"
+          className="flex-1 bg-input border border-border rounded-lg px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground resize-none overflow-hidden max-h-32 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/30 min-h-[32px] disabled:opacity-40"
         />
         {onOpenAttachmentPicker && (
           <button

--- a/src/mobile/styles/globals.css
+++ b/src/mobile/styles/globals.css
@@ -36,17 +36,17 @@
 
 /* Light theme (true-gray neutrals, azure brand) */
 :root {
-  --background: #fafafa;
+  --background: #f4f4f5;
   --foreground: #121212;
   --card: #ffffff;
   --card-foreground: #121212;
   --primary: #1e96eb;
   --primary-foreground: #ffffff;
-  --secondary: #f4f4f5;
+  --secondary: #eaeaec;
   --secondary-foreground: #232323;
-  --muted: #f4f4f5;
+  --muted: #eeeeef;
   --muted-foreground: #8e8d91;
-  --accent: #eeeeef;
+  --accent: #e6e6e8;
   --accent-foreground: #121212;
   --destructive: #eb4335;
   --destructive-foreground: #ffffff;

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -252,7 +252,7 @@ function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessa
                 onChange={(e) => handleTextChange(qi, e.target.value)}
                 disabled={isLocked}
                 placeholder="Type your answer..."
-                className="w-full bg-background border border-border/50 rounded px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/50"
+                className="w-full bg-input border border-border/50 rounded px-3 py-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-primary/50"
                 onKeyDown={(e) => { if (e.key === 'Enter' && allAnswered) handleSubmit() }}
               />
             )}
@@ -1097,7 +1097,7 @@ export function AgentTranscriptPanel({
                 ref={inputRef}
                 rows={1}
                 placeholder="Send a message... (Shift+Enter for new line)"
-                className="flex-1 bg-muted/50 border border-border rounded-lg px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/30 resize-none overflow-hidden max-h-32 min-h-[32px]"
+                className="flex-1 bg-input border border-border rounded-lg px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/30 resize-none overflow-hidden max-h-32 min-h-[32px]"
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && !e.shiftKey) {
                     e.preventDefault()

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -209,7 +209,7 @@ export function AppLayout() {
   return (
     <>
       {/* ── Top bar: drag region with logo (left) + nav switcher (center) + actions (right) ── */}
-      <div className="drag-region frost h-13 flex-shrink-0 flex items-center justify-center px-4 border-b border-border/70 windows-titlebar-pad">
+      <div className="drag-region bg-background h-13 flex-shrink-0 flex items-center justify-center px-4 windows-titlebar-pad">
         {/* Logo + wordmark + update indicator — pinned left. The white logo mark
             always sits on a brand-gradient tile, so it stays visible in both themes. */}
         <div className="no-drag absolute left-4 flex items-center gap-2.5 macos-titlebar-pad">
@@ -293,7 +293,7 @@ export function AppLayout() {
       {/* ── Content area: left rail + optional sidebar + workspace + orchestrator ── */}
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Primary navigation — slim vertical icon rail */}
-        <nav className="no-drag flex w-14 flex-shrink-0 flex-col items-center gap-1 border-r border-sidebar-border bg-sidebar py-3">
+        <nav className="no-drag flex w-14 flex-shrink-0 flex-col items-center gap-1 bg-background py-3">
           {NAV_ITEMS.map(({ key, label, icon: Icon }, i) => {
             const active = sidebarView === key && activeModal !== 'settings'
             return (

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -209,7 +209,7 @@ export function AppLayout() {
   return (
     <>
       {/* ── Top bar: drag region with logo (left) + nav switcher (center) + actions (right) ── */}
-      <div className="drag-region bg-background h-13 flex-shrink-0 flex items-center justify-center px-4 windows-titlebar-pad">
+      <div className="drag-region bg-background h-11 flex-shrink-0 flex items-center justify-center px-4 windows-titlebar-pad">
         {/* Logo + wordmark + update indicator — pinned left. The white logo mark
             always sits on a brand-gradient tile, so it stays visible in both themes. */}
         <div className="no-drag absolute left-4 flex items-center gap-2.5 macos-titlebar-pad">
@@ -293,7 +293,7 @@ export function AppLayout() {
       {/* ── Content area: left rail + optional sidebar + workspace + orchestrator ── */}
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Primary navigation — slim vertical icon rail */}
-        <nav className="no-drag flex w-14 flex-shrink-0 flex-col items-center gap-1 bg-background py-3">
+        <nav className="no-drag flex w-12 flex-shrink-0 flex-col items-center gap-1 bg-background py-2.5">
           {NAV_ITEMS.map(({ key, label, icon: Icon }, i) => {
             const active = sidebarView === key && activeModal !== 'settings'
             return (
@@ -304,16 +304,16 @@ export function AppLayout() {
                   setSidebarView(key)
                 }}
                 aria-label={label}
-                className={`group relative grid h-11 w-11 place-items-center rounded-xl transition-all duration-150 cursor-pointer ${
+                className={`group relative grid h-10 w-10 place-items-center rounded-xl transition-all duration-150 cursor-pointer ${
                   active
                     ? 'bg-primary/12 text-primary'
                     : 'text-muted-foreground hover:bg-accent hover:text-foreground'
                 }`}
               >
                 {active && (
-                  <span className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full bg-primary" />
+                  <span className="absolute left-0 top-1/2 h-4 w-[3px] -translate-y-1/2 rounded-r-full bg-primary" />
                 )}
-                <Icon className="h-[18px] w-[18px]" />
+                <Icon className="h-[17px] w-[17px]" />
                 {/* Hover flyout label + shortcut */}
                 <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 flex -translate-y-1/2 translate-x-[-4px] items-center gap-2 whitespace-nowrap rounded-lg border border-border bg-popover px-2 py-1 text-xs font-medium text-foreground opacity-0 shadow-pop transition-all duration-150 group-hover:translate-x-0 group-hover:opacity-100">
                   {label}

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -25,14 +25,25 @@ import { useTaskSourceStore } from '@/stores/task-source-store'
 import { isOverdue, isSnoozed } from '@/lib/utils'
 import { TaskStatus, PluginActionId } from '@/types'
 import type { FileAttachment } from '@/types'
-import { MessageSquare, ExternalLink, LayoutDashboard, CheckSquare, Zap, Settings, Layers } from 'lucide-react'
+import { MessageSquare, ExternalLink, LayoutDashboard, CheckSquare, Zap, Settings, Layers, PanelLeftClose, PanelLeftOpen, Search } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { ThemeToggle } from './ThemeToggle'
+import { StatusBar } from './StatusBar'
+import { CommandPalette } from './CommandPalette'
 import type { SidebarView } from '@/stores/ui-store'
 import logo20x from '@/assets/logos/20x.svg'
 
 const isWindows = navigator.platform.toLowerCase().startsWith('win') || navigator.userAgent.includes('Windows')
+const isMac = navigator.platform.toLowerCase().includes('mac')
+const modKey = isMac ? '⌘' : 'Ctrl'
 const WINDOWS_TITLEBAR_ACTION_RIGHT = 168
+
+const NAV_ITEMS: { key: SidebarView; label: string; icon: typeof LayoutDashboard }[] = [
+  { key: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { key: 'canvas', label: 'Canvas', icon: Layers },
+  { key: 'tasks', label: 'Tasks', icon: CheckSquare },
+  { key: 'skills', label: 'Skills', icon: Zap }
+]
 
 export function AppLayout() {
   const { tasks, allTasks, selectedTask, createTask, updateTask, deleteTask, selectTask } = useTasks()
@@ -62,6 +73,11 @@ export function AppLayout() {
   const toggleOrchestrator = useUIStore((s) => s.toggleOrchestrator)
   const createTaskPrefill = useUIStore((s) => s.createTaskPrefill)
   const clearCreateTaskPrefill = useUIStore((s) => s.clearCreateTaskPrefill)
+  const sidebarCollapsed = useUIStore((s) => s.sidebarCollapsed)
+  const toggleSidebarCollapsed = useUIStore((s) => s.toggleSidebarCollapsed)
+
+  // ── Command palette ──
+  const [cmdOpen, setCmdOpen] = useState(false)
 
   // ── Update indicator state ──
   const [updateAvailableVersion, setUpdateAvailableVersion] = useState<string | null>(null)
@@ -170,12 +186,25 @@ export function AppLayout() {
     return () => window.removeEventListener('resize', update)
   }, [])
 
-  const NAV_ITEMS: { key: SidebarView; label: string; icon: typeof LayoutDashboard }[] = [
-    { key: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { key: 'canvas', label: 'Canvas', icon: Layers },
-    { key: 'tasks', label: 'Tasks', icon: CheckSquare },
-    { key: 'skills', label: 'Skills', icon: Zap }
-  ]
+  // ── Global keyboard shortcuts: ⌘/Ctrl+K command palette, ⌘/Ctrl+1–4 view switch ──
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey) return
+      if (e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setCmdOpen((v) => !v)
+        return
+      }
+      const n = Number(e.key)
+      if (Number.isInteger(n) && n >= 1 && n <= NAV_ITEMS.length) {
+        e.preventDefault()
+        if (activeModal === 'settings') closeModal()
+        setSidebarView(NAV_ITEMS[n - 1].key)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [activeModal, closeModal, setSidebarView])
 
   return (
     <>
@@ -195,12 +224,45 @@ export function AppLayout() {
             )}
           </div>
           <span className="text-[15px] font-semibold tracking-tight text-foreground">20x</span>
+
+          {/* Sidebar collapse toggle — only for views that have a contextual sidebar */}
+          {(sidebarView === 'tasks' || sidebarView === 'skills') && activeModal !== 'settings' && (
+            <button
+              onClick={toggleSidebarCollapsed}
+              title={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+              className="ml-0.5 grid h-7 w-7 place-items-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground transition-colors cursor-pointer"
+            >
+              {sidebarCollapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
+            </button>
+          )}
+
+          {/* Breadcrumb — current section */}
+          {(() => {
+            const item = activeModal === 'settings'
+              ? { label: 'Settings', icon: Settings }
+              : NAV_ITEMS.find((n) => n.key === sidebarView)
+            if (!item) return null
+            const Icon = item.icon
+            return (
+              <div className="flex items-center gap-1.5">
+                <span className="text-border/80 text-sm">/</span>
+                <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-[13px] font-medium text-foreground/90">{item.label}</span>
+              </div>
+            )
+          })()}
         </div>
 
-        {/* Current section — centered label (primary nav now lives in the left rail) */}
-        <div className="no-drag text-[13px] font-medium text-muted-foreground/90 pointer-events-none select-none">
-          {activeModal === 'settings' ? 'Settings' : NAV_ITEMS.find((n) => n.key === sidebarView)?.label ?? ''}
-        </div>
+        {/* Centered command/search launcher (⌘K) */}
+        <button
+          onClick={() => setCmdOpen(true)}
+          title="Search or run a command"
+          className="no-drag flex h-8 w-[240px] max-w-[34vw] items-center gap-2 rounded-lg border border-border/60 bg-muted/40 px-3 text-xs text-muted-foreground shadow-xs transition-colors hover:bg-accent hover:text-foreground cursor-pointer"
+        >
+          <Search className="h-3.5 w-3.5 shrink-0" />
+          <span className="flex-1 truncate text-left">Search or run a command…</span>
+          <kbd className="shrink-0 rounded border border-border bg-background/60 px-1.5 py-0.5 text-[10px]">{modKey}K</kbd>
+        </button>
 
         {/* Global actions — pinned right; offset on Windows to avoid native window controls. */}
         <div
@@ -232,7 +294,7 @@ export function AppLayout() {
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Primary navigation — slim vertical icon rail */}
         <nav className="no-drag flex w-14 flex-shrink-0 flex-col items-center gap-1 border-r border-sidebar-border bg-sidebar py-3">
-          {NAV_ITEMS.map(({ key, label, icon: Icon }) => {
+          {NAV_ITEMS.map(({ key, label, icon: Icon }, i) => {
             const active = sidebarView === key && activeModal !== 'settings'
             return (
               <button
@@ -241,9 +303,8 @@ export function AppLayout() {
                   if (activeModal === 'settings') closeModal()
                   setSidebarView(key)
                 }}
-                title={label}
                 aria-label={label}
-                className={`relative grid h-11 w-11 place-items-center rounded-xl transition-all duration-150 cursor-pointer ${
+                className={`group relative grid h-11 w-11 place-items-center rounded-xl transition-all duration-150 cursor-pointer ${
                   active
                     ? 'bg-primary/12 text-primary'
                     : 'text-muted-foreground hover:bg-accent hover:text-foreground'
@@ -253,13 +314,18 @@ export function AppLayout() {
                   <span className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-r-full bg-primary" />
                 )}
                 <Icon className="h-[18px] w-[18px]" />
+                {/* Hover flyout label + shortcut */}
+                <span className="pointer-events-none absolute left-full top-1/2 z-50 ml-2 flex -translate-y-1/2 translate-x-[-4px] items-center gap-2 whitespace-nowrap rounded-lg border border-border bg-popover px-2 py-1 text-xs font-medium text-foreground opacity-0 shadow-pop transition-all duration-150 group-hover:translate-x-0 group-hover:opacity-100">
+                  {label}
+                  <kbd className="rounded border border-border bg-muted px-1 text-[10px] text-muted-foreground">{modKey}{i + 1}</kbd>
+                </span>
               </button>
             )
           })}
         </nav>
 
-        {/* Sidebar — only for tasks and skills views */}
-        {sidebarView !== 'dashboard' && sidebarView !== 'canvas' && (
+        {/* Sidebar — only for tasks and skills views, and when not collapsed */}
+        {sidebarView !== 'dashboard' && sidebarView !== 'canvas' && !sidebarCollapsed && (
           <Sidebar
             tasks={tasks}
             selectedTaskId={selectedTask?.id || null}
@@ -269,8 +335,8 @@ export function AppLayout() {
           />
         )}
 
-        {/* Workspace — shrinks when orchestrator is open */}
-        <main className="flex flex-col flex-1 min-w-0 overflow-hidden bg-background transition-all duration-200">
+        {/* Workspace — floats as a rounded card, shrinks when orchestrator is open */}
+        <main className="flex flex-col flex-1 min-w-0 overflow-hidden rounded-2xl border border-border bg-card shadow-card m-2 transition-all duration-200">
           <div className="flex-1 h-0 overflow-hidden relative">
             {/* Canvas — always mounted so iframes/terminals survive navigation */}
             <div
@@ -362,6 +428,9 @@ export function AppLayout() {
           </div>
         </div>
       </div>
+
+      {/* Bottom status bar — live agent/task counts + version */}
+      <StatusBar />
 
       {/* Create Task Dialog — dismiss on outside click */}
       <Dialog open={activeModal === 'create'} onOpenChange={(open) => { if (!open) { closeModal(); clearCreateTaskPrefill() } }}>
@@ -549,6 +618,9 @@ export function AppLayout() {
           {toast.message}
         </div>
       )}
+
+      {/* Command palette (⌘K / Ctrl+K) */}
+      <CommandPalette open={cmdOpen} onOpenChange={setCmdOpen} />
 
       {/* Background progress toasts (setup, task progress, etc.) */}
       <ProgressToastStack />

--- a/src/renderer/src/components/layout/CommandPalette.tsx
+++ b/src/renderer/src/components/layout/CommandPalette.tsx
@@ -2,11 +2,13 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import {
   Search, LayoutDashboard, Layers, CheckSquare, Zap, Settings, MessageSquare,
-  Plus, Sun, Moon, CornerDownLeft, type LucideIcon
+  Plus, Sun, Moon, CornerDownLeft, LayoutGrid, type LucideIcon
 } from 'lucide-react'
 import { useUIStore } from '@/stores/ui-store'
 import { useThemeStore } from '@/stores/theme-store'
 import { useTaskStore } from '@/stores/task-store'
+import { useSkillStore } from '@/stores/skill-store'
+import { useDashboardStore } from '@/stores/dashboard-store'
 import { cn } from '@/lib/utils'
 
 interface CommandItem {
@@ -36,10 +38,20 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
   const themeResolved = useThemeStore((s) => s.resolved)
   const tasks = useTaskStore((s) => s.tasks)
   const selectTask = useTaskStore((s) => s.selectTask)
+  const skills = useSkillStore((s) => s.skills)
+  const selectSkill = useSkillStore((s) => s.selectSkill)
+  const applications = useDashboardStore((s) => s.applications)
+  const openApplication = useDashboardStore((s) => s.openApplication)
 
-  // Reset query + highlight whenever the palette opens.
+  // Reset query + highlight whenever the palette opens, and make sure skills +
+  // applications are loaded so they're searchable even before those views are visited.
   useEffect(() => {
-    if (open) { setQuery(''); setActive(0) }
+    if (open) {
+      setQuery('')
+      setActive(0)
+      useSkillStore.getState().fetchSkills()
+      useDashboardStore.getState().fetchAllIfNeeded()
+    }
   }, [open])
 
   const close = () => onOpenChange(false)
@@ -62,7 +74,33 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
       ? base.filter((c) => (c.label + ' ' + (c.keywords ?? '')).toLowerCase().includes(q))
       : base
 
-    // Task search — only when the user has typed something.
+    // Content search — only when the user has typed something.
+    const appItems: CommandItem[] = q
+      ? applications
+          .filter((a) => a.name.toLowerCase().includes(q))
+          .slice(0, 6)
+          .map((a) => ({
+            id: `app-${a.workflowId}`,
+            group: 'Applications',
+            label: a.name,
+            icon: LayoutGrid,
+            run: () => { closeModal(); setSidebarView('dashboard'); void openApplication(a.workflowId); close() },
+          }))
+      : []
+
+    const skillItems: CommandItem[] = q
+      ? skills
+          .filter((s) => s.name.toLowerCase().includes(q) || (s.description ?? '').toLowerCase().includes(q))
+          .slice(0, 6)
+          .map((s) => ({
+            id: `skill-${s.id}`,
+            group: 'Skills',
+            label: s.name,
+            icon: Zap,
+            run: () => { closeModal(); selectSkill(s.id); setSidebarView('skills'); close() },
+          }))
+      : []
+
     const taskItems: CommandItem[] = q
       ? tasks
           .filter((t) => !t.parent_task_id && t.title.toLowerCase().includes(q))
@@ -76,8 +114,8 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
           }))
       : []
 
-    return [...filteredBase, ...taskItems]
-  }, [query, tasks, themeResolved, closeModal, setSidebarView, openCreateModal, toggleOrchestrator, openSettings, toggleTheme, selectTask])
+    return [...filteredBase, ...appItems, ...skillItems, ...taskItems]
+  }, [query, tasks, skills, applications, themeResolved, closeModal, setSidebarView, openCreateModal, toggleOrchestrator, openSettings, toggleTheme, selectTask, selectSkill, openApplication])
 
   // Keep highlight within bounds when the list shrinks.
   useEffect(() => { setActive((a) => Math.min(a, Math.max(0, items.length - 1))) }, [items.length])
@@ -111,7 +149,7 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
               autoFocus
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search or run a command…"
+              placeholder="Search tasks, skills, apps — or run a command…"
               className="h-12 w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
             />
             <kbd className="hidden shrink-0 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground sm:block">esc</kbd>

--- a/src/renderer/src/components/layout/CommandPalette.tsx
+++ b/src/renderer/src/components/layout/CommandPalette.tsx
@@ -114,7 +114,7 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
           }))
       : []
 
-    return [...filteredBase, ...appItems, ...skillItems, ...taskItems]
+    return [...filteredBase, ...appItems, ...taskItems, ...skillItems]
   }, [query, tasks, skills, applications, themeResolved, closeModal, setSidebarView, openCreateModal, toggleOrchestrator, openSettings, toggleTheme, selectTask, selectSkill, openApplication])
 
   // Keep highlight within bounds when the list shrinks.

--- a/src/renderer/src/components/layout/CommandPalette.tsx
+++ b/src/renderer/src/components/layout/CommandPalette.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import {
+  Search, LayoutDashboard, Layers, CheckSquare, Zap, Settings, MessageSquare,
+  Plus, Sun, Moon, CornerDownLeft, type LucideIcon
+} from 'lucide-react'
+import { useUIStore } from '@/stores/ui-store'
+import { useThemeStore } from '@/stores/theme-store'
+import { useTaskStore } from '@/stores/task-store'
+import { cn } from '@/lib/utils'
+
+interface CommandItem {
+  id: string
+  group: string
+  label: string
+  icon: LucideIcon
+  keywords?: string
+  shortcut?: string
+  run: () => void
+}
+
+const isMac = navigator.platform.toLowerCase().includes('mac')
+const mod = isMac ? '⌘' : 'Ctrl'
+
+export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenChange: (v: boolean) => void }) {
+  const [query, setQuery] = useState('')
+  const [active, setActive] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const setSidebarView = useUIStore((s) => s.setSidebarView)
+  const openSettings = useUIStore((s) => s.openSettings)
+  const closeModal = useUIStore((s) => s.closeModal)
+  const openCreateModal = useUIStore((s) => s.openCreateModal)
+  const toggleOrchestrator = useUIStore((s) => s.toggleOrchestrator)
+  const toggleTheme = useThemeStore((s) => s.toggle)
+  const themeResolved = useThemeStore((s) => s.resolved)
+  const tasks = useTaskStore((s) => s.tasks)
+  const selectTask = useTaskStore((s) => s.selectTask)
+
+  // Reset query + highlight whenever the palette opens.
+  useEffect(() => {
+    if (open) { setQuery(''); setActive(0) }
+  }, [open])
+
+  const close = () => onOpenChange(false)
+
+  const items = useMemo<CommandItem[]>(() => {
+    const goto = (view: 'dashboard' | 'canvas' | 'tasks' | 'skills') => () => { closeModal(); setSidebarView(view); close() }
+    const base: CommandItem[] = [
+      { id: 'nav-dashboard', group: 'Navigation', label: 'Go to Dashboard', icon: LayoutDashboard, keywords: 'home overview', shortcut: `${mod}1`, run: goto('dashboard') },
+      { id: 'nav-canvas', group: 'Navigation', label: 'Go to Canvas', icon: Layers, keywords: 'board panels', shortcut: `${mod}2`, run: goto('canvas') },
+      { id: 'nav-tasks', group: 'Navigation', label: 'Go to Tasks', icon: CheckSquare, keywords: 'todo list', shortcut: `${mod}3`, run: goto('tasks') },
+      { id: 'nav-skills', group: 'Navigation', label: 'Go to Skills', icon: Zap, keywords: 'abilities', shortcut: `${mod}4`, run: goto('skills') },
+      { id: 'act-new-task', group: 'Actions', label: 'New Task', icon: Plus, keywords: 'create add', run: () => { openCreateModal(); close() } },
+      { id: 'act-mastermind', group: 'Actions', label: 'Toggle Mastermind', icon: MessageSquare, keywords: 'orchestrator chat', run: () => { toggleOrchestrator(); close() } },
+      { id: 'act-settings', group: 'Actions', label: 'Open Settings', icon: Settings, keywords: 'preferences config', run: () => { openSettings(); close() } },
+      { id: 'act-theme', group: 'Actions', label: themeResolved === 'dark' ? 'Switch to Light mode' : 'Switch to Dark mode', icon: themeResolved === 'dark' ? Sun : Moon, keywords: 'theme dark light appearance', run: () => { toggleTheme(); close() } },
+    ]
+
+    const q = query.trim().toLowerCase()
+    const filteredBase = q
+      ? base.filter((c) => (c.label + ' ' + (c.keywords ?? '')).toLowerCase().includes(q))
+      : base
+
+    // Task search — only when the user has typed something.
+    const taskItems: CommandItem[] = q
+      ? tasks
+          .filter((t) => !t.parent_task_id && t.title.toLowerCase().includes(q))
+          .slice(0, 8)
+          .map((t) => ({
+            id: `task-${t.id}`,
+            group: 'Tasks',
+            label: t.title,
+            icon: CheckSquare,
+            run: () => { closeModal(); selectTask(t.id); setSidebarView('tasks'); close() },
+          }))
+      : []
+
+    return [...filteredBase, ...taskItems]
+  }, [query, tasks, themeResolved, closeModal, setSidebarView, openCreateModal, toggleOrchestrator, openSettings, toggleTheme, selectTask])
+
+  // Keep highlight within bounds when the list shrinks.
+  useEffect(() => { setActive((a) => Math.min(a, Math.max(0, items.length - 1))) }, [items.length])
+
+  // Scroll highlighted item into view.
+  useEffect(() => {
+    listRef.current?.querySelector<HTMLElement>('[data-active="true"]')?.scrollIntoView({ block: 'nearest' })
+  }, [active])
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActive((a) => Math.min(a + 1, items.length - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActive((a) => Math.max(a - 1, 0)) }
+    else if (e.key === 'Enter') { e.preventDefault(); items[active]?.run() }
+  }
+
+  let lastGroup = ''
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[100] bg-[var(--overlay)] backdrop-blur-[2px] data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          onKeyDown={onKeyDown}
+          aria-label="Command palette"
+          className="fixed left-1/2 top-[14%] z-[101] w-full max-w-[560px] -translate-x-1/2 overflow-hidden rounded-2xl border border-border bg-popover shadow-float data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+        >
+          <DialogPrimitive.Title className="sr-only">Command palette</DialogPrimitive.Title>
+          <div className="flex items-center gap-2.5 border-b border-border px-4">
+            <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <input
+              autoFocus
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search or run a command…"
+              className="h-12 w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+            />
+            <kbd className="hidden shrink-0 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground sm:block">esc</kbd>
+          </div>
+
+          <div ref={listRef} className="max-h-[54vh] overflow-y-auto p-1.5">
+            {items.length === 0 && (
+              <div className="px-3 py-8 text-center text-sm text-muted-foreground">No results</div>
+            )}
+            {items.map((item, i) => {
+              const showGroup = item.group !== lastGroup
+              lastGroup = item.group
+              const isActive = i === active
+              const Icon = item.icon
+              return (
+                <div key={item.id}>
+                  {showGroup && (
+                    <div className="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                      {item.group}
+                    </div>
+                  )}
+                  <button
+                    data-active={isActive}
+                    onMouseMove={() => setActive(i)}
+                    onClick={() => item.run()}
+                    className={cn(
+                      'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm transition-colors',
+                      isActive ? 'bg-accent text-foreground' : 'text-muted-foreground'
+                    )}
+                  >
+                    <Icon className="h-4 w-4 shrink-0" />
+                    <span className="flex-1 truncate text-foreground">{item.label}</span>
+                    {item.shortcut && (
+                      <kbd className="shrink-0 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{item.shortcut}</kbd>
+                    )}
+                    {isActive && !item.shortcut && <CornerDownLeft className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />}
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -155,7 +155,7 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
 
   return (
     <aside
-      className="relative flex flex-col h-full shrink-0 border-r border-sidebar-border bg-sidebar text-sidebar-foreground overflow-hidden"
+      className="relative flex flex-col h-full shrink-0 bg-background text-sidebar-foreground overflow-hidden"
       style={{ width: sidebarWidth }}
     >
       {sidebarView === 'tasks' ? (

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -50,6 +50,8 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
   const setSearchQuery = useUIStore((s) => s.setSearchQuery)
   const skillSearchQuery = useUIStore((s) => s.skillSearchQuery)
   const setSkillSearchQuery = useUIStore((s) => s.setSkillSearchQuery)
+  const sidebarWidth = useUIStore((s) => s.sidebarWidth)
+  const setSidebarWidth = useUIStore((s) => s.setSidebarWidth)
 
   const sources = useTaskSourceStore((s) => s.sources)
   const syncingIds = useTaskSourceStore((s) => s.syncingIds)
@@ -133,8 +135,29 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
     onSelectTask(id)
   }, [activeModal, closeModal, onSelectTask])
 
+  // Drag-to-resize the sidebar (width persisted in the UI store).
+  const startResize = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    const startX = e.clientX
+    const startWidth = sidebarWidth
+    const onMove = (ev: MouseEvent) => setSidebarWidth(startWidth + (ev.clientX - startX))
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+      document.body.style.userSelect = ''
+      document.body.style.cursor = ''
+    }
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = 'col-resize'
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+  }, [sidebarWidth, setSidebarWidth])
+
   return (
-    <aside className="flex flex-col h-full w-[264px] shrink-0 border-r border-sidebar-border bg-sidebar text-sidebar-foreground overflow-hidden">
+    <aside
+      className="relative flex flex-col h-full shrink-0 border-r border-sidebar-border bg-sidebar text-sidebar-foreground overflow-hidden"
+      style={{ width: sidebarWidth }}
+    >
       {sidebarView === 'tasks' ? (
         <>
           <div className="no-drag flex items-center justify-between px-4 pt-4 pb-3">
@@ -327,6 +350,13 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
           </div>
         </>
       )}
+
+      {/* Drag-to-resize handle on the right edge */}
+      <div
+        onMouseDown={startResize}
+        title="Drag to resize"
+        className="no-drag absolute right-0 top-0 z-10 h-full w-1.5 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
+      />
     </aside>
   )
 }

--- a/src/renderer/src/components/layout/StatusBar.tsx
+++ b/src/renderer/src/components/layout/StatusBar.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ListChecks } from 'lucide-react'
+import { useTaskStore } from '@/stores/task-store'
+import { useAgentStore, SessionStatus } from '@/stores/agent-store'
+import { TaskStatus } from '@/types'
+import { isSnoozed } from '@/lib/utils'
+
+/**
+ * Slim always-visible strip at the bottom of the shell: live agent + task
+ * counts on the left, app version on the right. Read-only.
+ */
+export function StatusBar() {
+  const tasks = useTaskStore((s) => s.tasks)
+  const sessions = useAgentStore((s) => s.sessions)
+  const [version, setVersion] = useState('')
+
+  useEffect(() => {
+    window.electronAPI?.app?.getVersion().then((v) => v && setVersion(v))
+  }, [])
+
+  const runningAgents = useMemo(() => {
+    let n = 0
+    for (const s of sessions.values()) if (s.status !== SessionStatus.IDLE) n++
+    return n
+  }, [sessions])
+
+  const { active, total } = useMemo(() => {
+    let a = 0
+    let t = 0
+    for (const task of tasks) {
+      if (task.parent_task_id) continue
+      t++
+      if (task.status !== TaskStatus.Completed && !isSnoozed(task.snoozed_until)) a++
+    }
+    return { active: a, total: t }
+  }, [tasks])
+
+  return (
+    <div className="frost flex-shrink-0 flex items-center gap-4 h-6 px-3 border-t border-border/70 text-[11px] text-muted-foreground select-none tabular-nums">
+      <span className="flex items-center gap-1.5" title={`${runningAgents} agent session${runningAgents !== 1 ? 's' : ''} running`}>
+        <span
+          className={`h-1.5 w-1.5 rounded-full ${runningAgents > 0 ? 'bg-primary animate-pulse' : 'bg-muted-foreground/40'}`}
+        />
+        {runningAgents} running
+      </span>
+      <span className="flex items-center gap-1.5" title="Active · total top-level tasks">
+        <ListChecks className="h-3 w-3" />
+        {active} active · {total} total
+      </span>
+      <div className="flex-1" />
+      {version && <span className="opacity-70">v{version}</span>}
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/StatusBar.tsx
+++ b/src/renderer/src/components/layout/StatusBar.tsx
@@ -36,7 +36,7 @@ export function StatusBar() {
   }, [tasks])
 
   return (
-    <div className="frost flex-shrink-0 flex items-center gap-4 h-6 px-3 border-t border-border/70 text-[11px] text-muted-foreground select-none tabular-nums">
+    <div className="bg-background flex-shrink-0 flex items-center gap-4 h-6 px-3 text-[11px] text-muted-foreground select-none tabular-nums">
       <span className="flex items-center gap-1.5" title={`${runningAgents} agent session${runningAgents !== 1 ? 's' : ''} running`}>
         <span
           className={`h-1.5 w-1.5 rounded-full ${runningAgents > 0 ? 'bg-primary animate-pulse' : 'bg-muted-foreground/40'}`}

--- a/src/renderer/src/stores/ui-store.ts
+++ b/src/renderer/src/stores/ui-store.ts
@@ -7,6 +7,29 @@ export type SortDirection = 'asc' | 'desc'
 export type ActiveModal = 'create' | 'edit' | 'delete' | 'settings' | 'repo-selector' | 'gh-setup' | null
 export type SidebarView = 'tasks' | 'skills' | 'dashboard' | 'canvas'
 
+// ── Persisted sidebar layout (localStorage) ──
+const SIDEBAR_WIDTH_KEY = 'ui-sidebar-width'
+const SIDEBAR_COLLAPSED_KEY = 'ui-sidebar-collapsed'
+const SIDEBAR_MIN_WIDTH = 220
+const SIDEBAR_MAX_WIDTH = 440
+const SIDEBAR_DEFAULT_WIDTH = 264
+
+function readStoredWidth(): number {
+  try {
+    const v = Number(localStorage.getItem(SIDEBAR_WIDTH_KEY))
+    return v >= SIDEBAR_MIN_WIDTH && v <= SIDEBAR_MAX_WIDTH ? v : SIDEBAR_DEFAULT_WIDTH
+  } catch {
+    return SIDEBAR_DEFAULT_WIDTH
+  }
+}
+function readStoredCollapsed(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
 interface UIState {
   sidebarView: SidebarView
   statusFilter: TaskStatus | 'all'
@@ -29,6 +52,10 @@ interface UIState {
   createTaskPrefill: { title: string; description: string } | null
   /** Whether the Mastermind drawer is open (global) */
   showOrchestrator: boolean
+  /** Whether the contextual (tasks/skills) sidebar is collapsed (persisted) */
+  sidebarCollapsed: boolean
+  /** Contextual sidebar width in px (persisted) */
+  sidebarWidth: number
 
   setSidebarView: (view: SidebarView) => void
   setStatusFilter: (filter: TaskStatus | 'all') => void
@@ -61,6 +88,11 @@ interface UIState {
   /** Toggle the Mastermind orchestrator drawer */
   setShowOrchestrator: (show: boolean) => void
   toggleOrchestrator: () => void
+  /** Collapse/expand the contextual sidebar (persisted) */
+  toggleSidebarCollapsed: () => void
+  setSidebarCollapsed: (collapsed: boolean) => void
+  /** Set the contextual sidebar width (clamped + persisted) */
+  setSidebarWidth: (width: number) => void
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -81,6 +113,8 @@ export const useUIStore = create<UIState>((set) => ({
   canvasPendingApp: null,
   createTaskPrefill: null,
   showOrchestrator: false,
+  sidebarCollapsed: readStoredCollapsed(),
+  sidebarWidth: readStoredWidth(),
 
   setSidebarView: (sidebarView) => set({ sidebarView }),
   setStatusFilter: (statusFilter) => set({ statusFilter }),
@@ -137,5 +171,19 @@ export const useUIStore = create<UIState>((set) => ({
   },
   clearCreateTaskPrefill: () => set({ createTaskPrefill: null }),
   setShowOrchestrator: (showOrchestrator) => set({ showOrchestrator }),
-  toggleOrchestrator: () => set((s) => ({ showOrchestrator: !s.showOrchestrator }))
+  toggleOrchestrator: () => set((s) => ({ showOrchestrator: !s.showOrchestrator })),
+  toggleSidebarCollapsed: () => set((s) => {
+    const sidebarCollapsed = !s.sidebarCollapsed
+    try { localStorage.setItem(SIDEBAR_COLLAPSED_KEY, sidebarCollapsed ? '1' : '0') } catch { /* ignore */ }
+    return { sidebarCollapsed }
+  }),
+  setSidebarCollapsed: (sidebarCollapsed) => {
+    try { localStorage.setItem(SIDEBAR_COLLAPSED_KEY, sidebarCollapsed ? '1' : '0') } catch { /* ignore */ }
+    set({ sidebarCollapsed })
+  },
+  setSidebarWidth: (width) => {
+    const clamped = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, Math.round(width)))
+    try { localStorage.setItem(SIDEBAR_WIDTH_KEY, String(clamped)) } catch { /* ignore */ }
+    set({ sidebarWidth: clamped })
+  }
 }))

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -56,7 +56,7 @@
 
 /* ── Light theme (default) — true-gray neutrals, azure brand ──────────────── */
 :root {
-  --background: #fafafa;
+  --background: #f4f4f5;
   --foreground: #121212;
   --card: #ffffff;
   --card-foreground: #121212;
@@ -64,11 +64,11 @@
   --popover-foreground: #121212;
   --primary: #1e96eb;
   --primary-foreground: #ffffff;
-  --secondary: #f4f4f5;
+  --secondary: #eaeaec;
   --secondary-foreground: #232323;
-  --muted: #f4f4f5;
+  --muted: #eeeeef;
   --muted-foreground: #8e8d91;
-  --accent: #eeeeef;
+  --accent: #e6e6e8;
   --accent-foreground: #121212;
   --destructive: #eb4335;
   --destructive-foreground: #ffffff;
@@ -87,8 +87,8 @@
   --sidebar-muted: #eeeeef;
 
   /* Frosted chrome surfaces (top bar / sidebar translucency) */
-  --chrome: rgba(250, 250, 250, 0.72);
-  --chrome-solid: #fafafa;
+  --chrome: rgba(244, 244, 245, 0.72);
+  --chrome-solid: #f4f4f5;
   --overlay: rgba(0, 0, 0, 0.30);
 
   /* Infinite-canvas surfaces */


### PR DESCRIPTION
Builds on the Aperture design system (#399) with six shell/layout features.

## Features

- **⌘K Command palette** — new `CommandPalette` component. Fuzzy navigation, actions (New Task, toggle Mastermind, open Settings, toggle theme) and live **task search**, with full keyboard nav (↑/↓/Enter/Esc). A centered `⌘K` launcher sits in the top bar.
- **Floating workspace** — the main content is now a rounded card inset from the window edges (`bg-card` + border + soft shadow + gutter), revealing the app background behind it for depth.
- **Bottom status bar** — slim frosted strip: running-agent count, active/total task counts, and app version.
- **Collapsible + resizable sidebar** — collapse state and width persist to `localStorage`; drag handle on the sidebar edge, toggle button in the top bar.
- **Rail polish** — hover flyout labels with `⌘1–4` shortcut hints; global `⌘1–4` switches views.
- **Breadcrumb** — the bare centered label became a section breadcrumb (icon + name) in the top-bar left cluster.

## Files
- New: `components/layout/CommandPalette.tsx`, `components/layout/StatusBar.tsx`
- `ui-store.ts` gains `sidebarCollapsed` + `sidebarWidth` (both persisted)
- `AppLayout.tsx`, `Sidebar.tsx` wiring

## Keyboard
- `⌘K` / `Ctrl+K` — command palette
- `⌘1–4` / `Ctrl+1–4` — Dashboard / Canvas / Tasks / Skills

## Validation
- `pnpm typecheck` — clean
- `pnpm build` (electron-vite renderer) — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)