### PR TITLE
fix: prevent repeated app server auto-abort messages

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1848,6 +1848,78 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
     expect(entry.hasSeenWork).toBe(true)
   })
 
+  it('does not spam auto-abort messages when a stuck running tool remains visible after polling restarts', async () => {
+    const mgr = buildManager()
+    const startedAt = Date.now() - 240_000
+    const abortPrompt = vi.fn(async () => undefined)
+    const adapter = {
+      pollMessages: vi.fn(async () => [] as any[]),
+      getStatus: vi.fn(async () => ({ type: SessionStatusType.BUSY })),
+      getRunningTools: vi.fn(async () => [{
+        partId: 'tool-call-1',
+        toolName: 'commandExecution',
+        startTime: startedAt,
+        input: {}
+      }]),
+      abortPrompt,
+    }
+
+    const session = {
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      status: 'working',
+      createdAt: new Date(),
+      seenMessageIds: new Set<string>(),
+      seenPartIds: new Set<string>(),
+      partContentLengths: new Map<string, string>(),
+      adapter,
+      pollingStarted: true,
+    }
+    ;(mgr as any).sessions.set('session-1', session)
+
+    ;(mgr as any).startAdapterPolling(
+      'session-1',
+      adapter,
+      { agentId: 'agent-1', taskId: 'task-1', workspaceDir: '/tmp/ws' },
+      undefined,
+      session
+    )
+
+    const firstEntry = (mgr as any).pollingEntries.get('session-1')
+    await (mgr as any).pollSingleSession(firstEntry)
+
+    expect(abortPrompt).toHaveBeenCalledOnce()
+
+    // Reproduce the reported spam path: polling starts again while the same
+    // App Server running tool is still visible. The new PollingEntry has a
+    // fresh watchdogFired=false, so the session-level one-shot guard must
+    // suppress another chat error and abort attempt.
+    ;(mgr as any).startAdapterPolling(
+      'session-1',
+      adapter,
+      { agentId: 'agent-1', taskId: 'task-1', workspaceDir: '/tmp/ws' },
+      undefined,
+      session
+    )
+
+    const secondEntry = (mgr as any).pollingEntries.get('session-1')
+    await (mgr as any).pollSingleSession(secondEntry)
+
+    const sendSpy = vi.mocked((mgr as any).sendToRenderer)
+    const autoAbortMessages = sendSpy.mock.calls.filter(([channel, payload]) => (
+      channel === 'agent:output' &&
+      String((payload as any).data?.content || '').startsWith('Session auto-aborted:')
+    ))
+
+    expect(autoAbortMessages).toHaveLength(1)
+    expect(autoAbortMessages[0][1]).toMatchObject({
+      data: {
+        content: expect.stringContaining('Tool "commandExecution" has been running')
+      }
+    })
+    expect(abortPrompt).toHaveBeenCalledOnce()
+  })
+
   it('pollSingleSession does not inject a duplicate status error when the poll already emitted the same error text', async () => {
     const mgr = buildManager()
     const errorMessage = 'API Error: Server is temporarily limiting requests (not your usage limit) - Rate limited'

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -55,6 +55,9 @@ interface AgentSession {
   adapter?: CodingAgentAdapter
   secretSessionToken?: string
   pollingStarted?: boolean
+  /** True after an auto-abort notice has been shown for the current prompt.
+   *  Reset when the user sends a new prompt or the adapter emits fresh output. */
+  autoAbortNotified?: boolean
 }
 
 function normalizeUrlPath(pathname: string): string {
@@ -1585,6 +1588,29 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     }
   }
 
+  private sendAutoAbortMessageOnce(
+    sessionId: string,
+    session: AgentSession,
+    taskId: string,
+    idPrefix: string,
+    content: string
+  ): boolean {
+    if (session.autoAbortNotified) return false
+    session.autoAbortNotified = true
+    this.sendToRenderer('agent:output', {
+      sessionId,
+      taskId,
+      type: 'message',
+      data: {
+        id: `${idPrefix}-${Date.now()}`,
+        role: 'system',
+        content,
+        partType: 'error'
+      }
+    })
+    return true
+  }
+
   /**
    * Ensures the single polling coordinator timer is running.
    */
@@ -1766,6 +1792,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         // Reset watchdog flag — new data means the session is alive again.
         // If a follow-up message also gets stuck, the watchdog can re-fire.
         entry.watchdogFired = false
+        activeSession.autoAbortNotified = false
       }
 
       // ── Garbled output detection ──
@@ -1791,17 +1818,13 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
             console.warn(
               `[AgentManager] Session ${sessionId}: garbled model output detected (${entry.garbledOutputCount} cycles). Aborting to prevent token waste.`
             )
-            this.sendToRenderer('agent:output', {
+            this.sendAutoAbortMessageOnce(
               sessionId,
-              taskId: config.taskId,
-              type: 'message',
-              data: {
-                id: `garbled-abort-${Date.now()}`,
-                role: 'system',
-                content: 'Session aborted: model is producing garbled output (hallucinated tool-call markup). You can send a new message to continue.',
-                partType: 'error'
-              }
-            })
+              activeSession,
+              config.taskId,
+              'garbled-abort',
+              'Session aborted: model is producing garbled output (hallucinated tool-call markup). You can send a new message to continue.'
+            )
             try {
               await adapter.abortPrompt(sessionId, config)
             } catch (abortErr) {
@@ -2021,19 +2044,15 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
                   }
 
                   peBusy.watchdogFired = true
-                  console.warn(`[AgentManager] Session ${sessionId}: ${reason}. Aborting.`)
-
-                  this.sendToRenderer('agent:output', {
+                  const shouldAbort = this.sendAutoAbortMessageOnce(
                     sessionId,
-                    taskId: config.taskId,
-                    type: 'message',
-                    data: {
-                      id: `stuck-tool-${Date.now()}`,
-                      role: 'system',
-                      content: `Session auto-aborted: ${reason}. You can send a new message to continue.`,
-                      partType: 'error'
-                    }
-                  })
+                    session,
+                    config.taskId,
+                    'stuck-tool',
+                    `Session auto-aborted: ${reason}. You can send a new message to continue.`
+                  )
+                  if (!shouldAbort) return
+                  console.warn(`[AgentManager] Session ${sessionId}: ${reason}. Aborting.`)
                   try {
                     await adapter.abortPrompt(sessionId, config)
                   } catch (abortErr) {
@@ -2102,21 +2121,18 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
               // This prevents the abort notification from spamming every poll
               // tick while the backend transitions from BUSY → IDLE.
               peBusy.watchdogFired = true
+              // Notify the user that the session was auto-aborted
+              const shouldAbort = this.sendAutoAbortMessageOnce(
+                sessionId,
+                session,
+                config.taskId,
+                'stuck-abort',
+                `Session auto-aborted: no activity for ${Math.round(silentDuration / 1000)}s. A tool call may have hung. You can send a new message to continue.`
+              )
+              if (!shouldAbort) return
               console.warn(
                 `[AgentManager] Session ${sessionId} stuck: BUSY for ${Math.round(silentDuration / 1000)}s with no new data. Aborting prompt.`
               )
-              // Notify the user that the session was auto-aborted
-              this.sendToRenderer('agent:output', {
-                sessionId,
-                taskId: config.taskId,
-                type: 'message',
-                data: {
-                  id: `stuck-abort-${Date.now()}`,
-                  role: 'system',
-                  content: `Session auto-aborted: no activity for ${Math.round(silentDuration / 1000)}s. A tool call may have hung. You can send a new message to continue.`,
-                  partType: 'error'
-                }
-              })
               // Abort the prompt — this will cause executePromptWithRetry to exit,
               // and the next poll cycle will detect IDLE status.
               try {
@@ -3298,6 +3314,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     message: string,
     attachments?: MessageAttachmentRef[]
   ): Promise<void> {
+    session.autoAbortNotified = false
+
     if (session.status === 'error') {
       // Check if this is an incompatible session error (non-recoverable)
       if (session.adapter) {


### PR DESCRIPTION
## Summary
- add a session-level one-shot guard for auto-abort transcript messages
- reset the guard when the user sends a new prompt or fresh adapter output arrives
- cover the App Server stuck commandExecution case where polling restarts while the same running tool remains visible

## Test plan
- pnpm test:run src/main/agent-manager.test.ts
- pnpm typecheck