### PR TITLE
Task Changes: git diff / changed-files view (multi-repo)

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -514,6 +514,10 @@ export function registerIpcHandlers(
     return await worktreeManager.setupWorkspaceForTask(taskId, repos, org, resolvedProvider)
   })
 
+  ipcMain.handle('worktree:changes', async (_, taskId: string, repos: { fullName: string }[]) => {
+    return await worktreeManager.getTaskChanges(taskId, repos)
+  })
+
   ipcMain.handle('worktree:cleanup', async (_, taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean) => {
     await worktreeManager.cleanupTaskWorkspace(taskId, repos, org, removeTaskDir ?? true)
   })

--- a/src/main/worktree-manager.ts
+++ b/src/main/worktree-manager.ts
@@ -267,8 +267,8 @@ export class WorktreeManager {
   async getTaskChanges(
     taskId: string,
     repos: { fullName: string }[]
-  ): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }>> {
-    const results: Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }> = []
+  ): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }>> {
+    const results: Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }> = []
     const gitOpts = { maxBuffer: 64 * 1024 * 1024 }
 
     for (const repo of repos) {
@@ -351,7 +351,49 @@ export class WorktreeManager {
           // Ignore untracked enumeration failures.
         }
 
-        results.push({ repo: repo.fullName, diff: tracked + untracked })
+        // Branch + PR metadata so the UI can group changes by branch / PR.
+        let branch: string | undefined
+        try {
+          const { stdout } = await execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: wtPath, ...gitOpts })
+          const b = stdout.trim()
+          branch = b && b !== 'HEAD' ? b : undefined
+        } catch { /* detached HEAD */ }
+
+        let pushed = false
+        if (branch) {
+          try {
+            await execFileAsync('git', ['rev-parse', '--verify', '--quiet', `origin/${branch}`], { cwd: wtPath, ...gitOpts })
+            pushed = true
+          } catch { /* branch not on remote yet */ }
+        }
+
+        // Best-effort PR/MR lookup (only when the branch is pushed).
+        let prNumber: number | undefined
+        let prUrl: string | undefined
+        let prState: string | undefined
+        if (branch && pushed) {
+          let provider: 'github' | 'gitlab' | 'other' = 'other'
+          try {
+            const { stdout } = await execFileAsync('git', ['remote', 'get-url', 'origin'], { cwd: wtPath, ...gitOpts })
+            const url = stdout.toLowerCase()
+            if (url.includes('gitlab')) provider = 'gitlab'
+            else if (url.includes('github')) provider = 'github'
+          } catch { /* ignore */ }
+
+          try {
+            if (provider === 'github') {
+              const { stdout } = await execFileAsync('gh', ['pr', 'view', branch, '--json', 'number,url,state'], { cwd: wtPath, timeout: 8000, ...gitOpts })
+              const j = JSON.parse(stdout) as { number?: number; url?: string; state?: string }
+              prNumber = j.number; prUrl = j.url; prState = j.state
+            } else if (provider === 'gitlab') {
+              const { stdout } = await execFileAsync('glab', ['mr', 'list', '--source-branch', branch, '--output', 'json'], { cwd: wtPath, timeout: 8000, ...gitOpts })
+              const arr = JSON.parse(stdout) as Array<{ iid?: number; web_url?: string; state?: string }>
+              if (Array.isArray(arr) && arr[0]) { prNumber = arr[0].iid; prUrl = arr[0].web_url; prState = arr[0].state }
+            }
+          } catch { /* no PR/MR, or CLI unavailable */ }
+        }
+
+        results.push({ repo: repo.fullName, diff: tracked + untracked, branch, pushed, prNumber, prUrl, prState })
       } catch (e) {
         results.push({ repo: repo.fullName, diff: '', error: (e as Error).message })
       }

--- a/src/main/worktree-manager.ts
+++ b/src/main/worktree-manager.ts
@@ -267,14 +267,18 @@ export class WorktreeManager {
   async getTaskChanges(
     taskId: string,
     repos: { fullName: string }[]
-  ): Promise<Array<{ repo: string; diff: string; error?: string }>> {
-    const results: Array<{ repo: string; diff: string; error?: string }> = []
+  ): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }>> {
+    const results: Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }> = []
     const gitOpts = { maxBuffer: 64 * 1024 * 1024 }
 
     for (const repo of repos) {
       const repoName = repo.fullName.split('/').pop() || repo.fullName
       const wtPath = this.worktreePath(taskId, repoName)
-      if (!existsSync(wtPath)) continue
+      if (!existsSync(wtPath)) {
+        console.log(`[WorktreeManager] getTaskChanges: no worktree for ${repo.fullName} at ${wtPath}`)
+        results.push({ repo: repo.fullName, diff: '', noWorktree: true, path: wtPath })
+        continue
+      }
 
       try {
         // Agents auto-commit, so "uncommitted only" (git diff HEAD) is usually

--- a/src/main/worktree-manager.ts
+++ b/src/main/worktree-manager.ts
@@ -256,4 +256,77 @@ export class WorktreeManager {
       }
     }
   }
+
+  /**
+   * Collect the working-tree diff for each of a task's repo worktrees.
+   * Returns one raw unified diff per repo — tracked changes vs HEAD plus
+   * untracked files rendered via `git diff --no-index` (read-only; never
+   * mutates the index). Repos without a worktree yet are skipped; per-repo
+   * failures are reported rather than thrown so one bad repo can't hide the rest.
+   */
+  async getTaskChanges(
+    taskId: string,
+    repos: { fullName: string }[]
+  ): Promise<Array<{ repo: string; diff: string; error?: string }>> {
+    const results: Array<{ repo: string; diff: string; error?: string }> = []
+    const gitOpts = { maxBuffer: 64 * 1024 * 1024 }
+
+    for (const repo of repos) {
+      const repoName = repo.fullName.split('/').pop() || repo.fullName
+      const wtPath = this.worktreePath(taskId, repoName)
+      if (!existsSync(wtPath)) continue
+
+      try {
+        // Tracked changes vs HEAD (modifications + deletions, staged or not).
+        let tracked = ''
+        try {
+          const { stdout } = await execFileAsync(
+            'git', ['-c', 'core.quotepath=false', 'diff', '--no-color', 'HEAD'],
+            { cwd: wtPath, ...gitOpts }
+          )
+          tracked = stdout
+        } catch (e) {
+          const err = e as { stdout?: string }
+          tracked = err.stdout ?? ''
+          if (!tracked) {
+            // No HEAD yet (empty repo) — fall back to index/worktree diff.
+            const { stdout } = await execFileAsync(
+              'git', ['-c', 'core.quotepath=false', 'diff', '--no-color'],
+              { cwd: wtPath, ...gitOpts }
+            ).catch(() => ({ stdout: '' }))
+            tracked = stdout
+          }
+        }
+
+        // Untracked files → new-file patches (no index mutation).
+        let untracked = ''
+        try {
+          const { stdout } = await execFileAsync(
+            'git', ['ls-files', '--others', '--exclude-standard', '-z'],
+            { cwd: wtPath, ...gitOpts }
+          )
+          for (const file of stdout.split('\0').filter(Boolean)) {
+            try {
+              await execFileAsync(
+                'git', ['diff', '--no-color', '--no-index', '--', '/dev/null', file],
+                { cwd: wtPath, ...gitOpts }
+              )
+            } catch (e) {
+              // --no-index exits 1 when files differ; the patch is on stdout.
+              const err = e as { stdout?: string }
+              if (err.stdout) untracked += err.stdout
+            }
+          }
+        } catch {
+          // Ignore untracked enumeration failures.
+        }
+
+        results.push({ repo: repo.fullName, diff: tracked + untracked })
+      } catch (e) {
+        results.push({ repo: repo.fullName, diff: '', error: (e as Error).message })
+      }
+    }
+
+    return results
+  }
 }

--- a/src/main/worktree-manager.ts
+++ b/src/main/worktree-manager.ts
@@ -277,25 +277,51 @@ export class WorktreeManager {
       if (!existsSync(wtPath)) continue
 
       try {
-        // Tracked changes vs HEAD (modifications + deletions, staged or not).
+        // Agents auto-commit, so "uncommitted only" (git diff HEAD) is usually
+        // empty. We want the task's whole diff: base branch → current work
+        // (committed + uncommitted). Discover the base branch this worktree
+        // forked from, then diff against the merge-base.
+        let baseRef = ''
+        try {
+          const { stdout } = await execFileAsync(
+            'git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+            { cwd: wtPath, ...gitOpts }
+          )
+          baseRef = stdout.trim() // e.g. "origin/main"
+        } catch { /* origin/HEAD not set */ }
+        if (!baseRef) {
+          for (const cand of ['origin/main', 'origin/master', 'main', 'master']) {
+            try {
+              await execFileAsync('git', ['rev-parse', '--verify', '--quiet', cand], { cwd: wtPath, ...gitOpts })
+              baseRef = cand
+              break
+            } catch { /* not this candidate */ }
+          }
+        }
+
+        // Diff target: merge-base with the base branch (captures committed work);
+        // fall back to HEAD (uncommitted only) if no base can be resolved.
+        let against = 'HEAD'
+        if (baseRef) {
+          try {
+            const { stdout } = await execFileAsync('git', ['merge-base', 'HEAD', baseRef], { cwd: wtPath, ...gitOpts })
+            const mergeBase = stdout.trim()
+            if (mergeBase) against = mergeBase
+          } catch { /* keep HEAD */ }
+        }
+
+        // `git diff <against>` compares that commit to the WORKING TREE, so the
+        // patch includes both committed and uncommitted changes.
         let tracked = ''
         try {
           const { stdout } = await execFileAsync(
-            'git', ['-c', 'core.quotepath=false', 'diff', '--no-color', 'HEAD'],
+            'git', ['-c', 'core.quotepath=false', 'diff', '--no-color', against],
             { cwd: wtPath, ...gitOpts }
           )
           tracked = stdout
         } catch (e) {
           const err = e as { stdout?: string }
           tracked = err.stdout ?? ''
-          if (!tracked) {
-            // No HEAD yet (empty repo) — fall back to index/worktree diff.
-            const { stdout } = await execFileAsync(
-              'git', ['-c', 'core.quotepath=false', 'diff', '--no-color'],
-              { cwd: wtPath, ...gitOpts }
-            ).catch(() => ({ stdout: '' }))
-            tracked = stdout
-          }
         }
 
         // Untracked files → new-file patches (no index mutation).

--- a/src/main/worktree-manager.ts
+++ b/src/main/worktree-manager.ts
@@ -267,8 +267,8 @@ export class WorktreeManager {
   async getTaskChanges(
     taskId: string,
     repos: { fullName: string }[]
-  ): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }>> {
-    const results: Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }> = []
+  ): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string; prTitle?: string; ciStatus?: 'passing' | 'failing' | 'pending' | 'none' }>> {
+    const results: Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string; prTitle?: string; ciStatus?: 'passing' | 'failing' | 'pending' | 'none' }> = []
     const gitOpts = { maxBuffer: 64 * 1024 * 1024 }
 
     for (const repo of repos) {
@@ -371,6 +371,8 @@ export class WorktreeManager {
         let prNumber: number | undefined
         let prUrl: string | undefined
         let prState: string | undefined
+        let prTitle: string | undefined
+        let ciStatus: 'passing' | 'failing' | 'pending' | 'none' | undefined
         if (branch && pushed) {
           let provider: 'github' | 'gitlab' | 'other' = 'other'
           try {
@@ -382,18 +384,39 @@ export class WorktreeManager {
 
           try {
             if (provider === 'github') {
-              const { stdout } = await execFileAsync('gh', ['pr', 'view', branch, '--json', 'number,url,state'], { cwd: wtPath, timeout: 8000, ...gitOpts })
-              const j = JSON.parse(stdout) as { number?: number; url?: string; state?: string }
-              prNumber = j.number; prUrl = j.url; prState = j.state
+              const { stdout } = await execFileAsync(
+                'gh', ['pr', 'view', branch, '--json', 'number,url,state,title,statusCheckRollup'],
+                { cwd: wtPath, timeout: 8000, ...gitOpts }
+              )
+              const j = JSON.parse(stdout) as {
+                number?: number; url?: string; state?: string; title?: string
+                statusCheckRollup?: Array<{ status?: string; conclusion?: string; state?: string }>
+              }
+              prNumber = j.number; prUrl = j.url; prState = j.state; prTitle = j.title
+              // Aggregate all check runs / status contexts into a single rollup.
+              const items = j.statusCheckRollup
+              if (!items || items.length === 0) {
+                ciStatus = 'none'
+              } else {
+                let pending = false
+                let failing = false
+                for (const it of items) {
+                  if (it.status && it.status !== 'COMPLETED') { pending = true; continue }
+                  const s = (it.conclusion || it.state || '').toUpperCase()
+                  if (['FAILURE', 'ERROR', 'CANCELLED', 'TIMED_OUT', 'ACTION_REQUIRED', 'STARTUP_FAILURE'].includes(s)) failing = true
+                  else if (['PENDING', 'EXPECTED', 'REQUESTED', 'WAITING', 'QUEUED', 'IN_PROGRESS'].includes(s)) pending = true
+                }
+                ciStatus = failing ? 'failing' : pending ? 'pending' : 'passing'
+              }
             } else if (provider === 'gitlab') {
               const { stdout } = await execFileAsync('glab', ['mr', 'list', '--source-branch', branch, '--output', 'json'], { cwd: wtPath, timeout: 8000, ...gitOpts })
-              const arr = JSON.parse(stdout) as Array<{ iid?: number; web_url?: string; state?: string }>
-              if (Array.isArray(arr) && arr[0]) { prNumber = arr[0].iid; prUrl = arr[0].web_url; prState = arr[0].state }
+              const arr = JSON.parse(stdout) as Array<{ iid?: number; web_url?: string; state?: string; title?: string }>
+              if (Array.isArray(arr) && arr[0]) { prNumber = arr[0].iid; prUrl = arr[0].web_url; prState = arr[0].state; prTitle = arr[0].title }
             }
           } catch { /* no PR/MR, or CLI unavailable */ }
         }
 
-        results.push({ repo: repo.fullName, diff: tracked + untracked, branch, pushed, prNumber, prUrl, prState })
+        results.push({ repo: repo.fullName, diff: tracked + untracked, branch, pushed, prNumber, prUrl, prState, prTitle, ciStatus })
       } catch (e) {
         results.push({ repo: repo.fullName, diff: '', error: (e as Error).message })
       }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -203,6 +203,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('worktree:setup', taskId, repos, org, provider),
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> =>
       ipcRenderer.invoke('worktree:cleanup', taskId, repos, org, removeTaskDir),
+    changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string }>> =>
+      ipcRenderer.invoke('worktree:changes', taskId, repos),
     runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> =>
       ipcRenderer.invoke('workspace:runCleanupNow')
   },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -203,7 +203,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('worktree:setup', taskId, repos, org, provider),
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> =>
       ipcRenderer.invoke('worktree:cleanup', taskId, repos, org, removeTaskDir),
-    changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }>> =>
+    changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }>> =>
       ipcRenderer.invoke('worktree:changes', taskId, repos),
     runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> =>
       ipcRenderer.invoke('workspace:runCleanupNow')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -203,7 +203,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('worktree:setup', taskId, repos, org, provider),
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> =>
       ipcRenderer.invoke('worktree:cleanup', taskId, repos, org, removeTaskDir),
-    changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string }>> =>
+    changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }>> =>
       ipcRenderer.invoke('worktree:changes', taskId, repos),
     runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> =>
       ipcRenderer.invoke('workspace:runCleanupNow')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -203,7 +203,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('worktree:setup', taskId, repos, org, provider),
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> =>
       ipcRenderer.invoke('worktree:cleanup', taskId, repos, org, removeTaskDir),
-    changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }>> =>
+    changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string; prTitle?: string; ciStatus?: 'passing' | 'failing' | 'pending' | 'none' }>> =>
       ipcRenderer.invoke('worktree:changes', taskId, repos),
     runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> =>
       ipcRenderer.invoke('workspace:runCleanupNow')

--- a/src/renderer/src/components/tasks/ChangesPanel.tsx
+++ b/src/renderer/src/components/tasks/ChangesPanel.tsx
@@ -211,24 +211,40 @@ function FileBlock({ file, viewMode, wrap }: { file: DiffFile; viewMode: ViewMod
   )
 }
 
-export function ChangesPanel({ taskId, repos, className }: { taskId: string; repos: string[]; className?: string }) {
+export interface ChangesSummary { files: number; additions: number; deletions: number }
+
+export function ChangesPanel({ taskId, repos, className, onSummary }: {
+  taskId: string
+  repos: string[]
+  className?: string
+  onSummary?: (s: ChangesSummary) => void
+}) {
   const [data, setData] = useState<RepoChanges[] | null>(null)
   const [loading, setLoading] = useState(false)
   const [viewMode, setViewMode] = useState<ViewMode>(() => (localStorage.getItem('diff-view-mode') as ViewMode) || 'unified')
   const [wrap, setWrap] = useState<boolean>(() => localStorage.getItem('diff-wrap') === '1')
 
+  // Key the fetch on a stable string so unrelated re-renders (new array identity)
+  // don't re-run git diff.
+  const reposKey = repos.join('|')
   const load = useCallback(async () => {
-    if (!repos.length) { setData([]); return }
+    const list = reposKey ? reposKey.split('|') : []
+    if (!list.length) { setData([]); onSummary?.({ files: 0, additions: 0, deletions: 0 }); return }
     setLoading(true)
     try {
-      const res = await worktreeApi.changes(taskId, repos.map((r) => ({ fullName: r })))
-      setData(res.map((r) => ({ repo: r.repo, error: r.error, files: r.diff ? parseUnifiedDiff(r.diff) : [] })))
+      const res = await worktreeApi.changes(taskId, list.map((fullName) => ({ fullName })))
+      const parsed = res.map((r) => ({ repo: r.repo, error: r.error, files: r.diff ? parseUnifiedDiff(r.diff) : [] }))
+      setData(parsed)
+      let a = 0, d = 0, f = 0
+      for (const repo of parsed) for (const file of repo.files) { a += file.additions; d += file.deletions; f++ }
+      onSummary?.({ files: f, additions: a, deletions: d })
     } catch (e) {
       setData([{ repo: '', files: [], error: (e as Error).message }])
+      onSummary?.({ files: 0, additions: 0, deletions: 0 })
     } finally {
       setLoading(false)
     }
-  }, [taskId, repos])
+  }, [taskId, reposKey, onSummary])
 
   useEffect(() => { void load() }, [load])
 
@@ -278,7 +294,7 @@ export function ChangesPanel({ taskId, repos, className }: { taskId: string; rep
         {data && repos.length > 0 && !hasChanges && !loading && (
           <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
             <FileDiff className="h-6 w-6 opacity-40" />
-            No uncommitted changes in the task worktree{repos.length > 1 ? 's' : ''}.
+            No changes in the task worktree{repos.length > 1 ? 's' : ''} yet.
           </div>
         )}
         {data?.map((repo) => {

--- a/src/renderer/src/components/tasks/ChangesPanel.tsx
+++ b/src/renderer/src/components/tasks/ChangesPanel.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import {
+  ChevronRight, RefreshCw, Loader2, FileDiff, Columns2, Rows3, WrapText, GitBranch,
+  FilePlus2, FileMinus2, FilePen, FileSymlink,
+} from 'lucide-react'
+import { worktreeApi } from '@/lib/ipc-client'
+import { parseUnifiedDiff, wordDiff, type DiffFile, type DiffHunk, type DiffLine, type WordSegment, type FileStatus } from '@/lib/diff-parser'
+import { DiffStatLabel } from './DiffStatLabel'
+import { cn } from '@/lib/utils'
+
+interface RepoChanges {
+  repo: string
+  files: DiffFile[]
+  error?: string
+}
+
+type ViewMode = 'unified' | 'split'
+
+// ── Row model (shared by unified + split rendering) ─────────────────────────
+type Row =
+  | { kind: 'context'; line: DiffLine }
+  | { kind: 'del'; line: DiffLine }
+  | { kind: 'add'; line: DiffLine }
+  | { kind: 'pair'; del: DiffLine; add: DiffLine; delSeg: WordSegment[]; addSeg: WordSegment[] }
+
+function alignHunk(hunk: DiffHunk): Row[] {
+  const rows: Row[] = []
+  let dels: DiffLine[] = []
+  let adds: DiffLine[] = []
+
+  const flush = () => {
+    const pairs = Math.min(dels.length, adds.length)
+    for (let i = 0; i < pairs; i++) {
+      const d = dels[i]
+      const a = adds[i]
+      const w = wordDiff(d.content, a.content)
+      rows.push({ kind: 'pair', del: d, add: a, delSeg: w.old, addSeg: w.new })
+    }
+    for (let i = pairs; i < dels.length; i++) rows.push({ kind: 'del', line: dels[i] })
+    for (let i = pairs; i < adds.length; i++) rows.push({ kind: 'add', line: adds[i] })
+    dels = []
+    adds = []
+  }
+
+  for (const line of hunk.lines) {
+    if (line.type === 'delete') dels.push(line)
+    else if (line.type === 'add') adds.push(line)
+    else { flush(); rows.push({ kind: 'context', line }) }
+  }
+  flush()
+  return rows
+}
+
+const STATUS_META: Record<FileStatus, { icon: typeof FilePen; className: string; label: string }> = {
+  added: { icon: FilePlus2, className: 'text-success', label: 'Added' },
+  deleted: { icon: FileMinus2, className: 'text-destructive', label: 'Deleted' },
+  renamed: { icon: FileSymlink, className: 'text-primary', label: 'Renamed' },
+  modified: { icon: FilePen, className: 'text-muted-foreground', label: 'Modified' },
+}
+
+function Segs({ segs, tone }: { segs: WordSegment[]; tone: 'add' | 'del' }) {
+  return (
+    <>
+      {segs.map((s, i) =>
+        s.changed ? (
+          <span key={i} className={tone === 'add' ? 'rounded-sm bg-success/25' : 'rounded-sm bg-destructive/25'}>{s.text}</span>
+        ) : (
+          <span key={i}>{s.text}</span>
+        )
+      )}
+    </>
+  )
+}
+
+const NUM = 'select-none w-10 shrink-0 pr-2 text-right text-muted-foreground/50'
+
+function LineText({ children, wrap }: { children: ReactNode; wrap: boolean }) {
+  return <span className={cn('flex-1 pl-2', wrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre')}>{children}</span>
+}
+
+function UnifiedRows({ rows, wrap }: { rows: Row[]; wrap: boolean }) {
+  const out: ReactNode[] = []
+  rows.forEach((r, i) => {
+    if (r.kind === 'context') {
+      out.push(
+        <div key={i} className="flex text-foreground/70">
+          <span className={NUM}>{r.line.oldLine}</span><span className={NUM}>{r.line.newLine}</span>
+          <LineText wrap={wrap}> {r.line.content}</LineText>
+        </div>
+      )
+    } else if (r.kind === 'del') {
+      out.push(
+        <div key={i} className="flex bg-destructive/10 text-foreground">
+          <span className={NUM}>{r.line.oldLine}</span><span className={NUM} /><LineText wrap={wrap}><span className="text-destructive">-</span>{r.line.content}</LineText>
+        </div>
+      )
+    } else if (r.kind === 'add') {
+      out.push(
+        <div key={i} className="flex bg-success/10 text-foreground">
+          <span className={NUM} /><span className={NUM}>{r.line.newLine}</span><LineText wrap={wrap}><span className="text-success">+</span>{r.line.content}</LineText>
+        </div>
+      )
+    } else {
+      out.push(
+        <div key={`${i}d`} className="flex bg-destructive/10 text-foreground">
+          <span className={NUM}>{r.del.oldLine}</span><span className={NUM} /><LineText wrap={wrap}><span className="text-destructive">-</span><Segs segs={r.delSeg} tone="del" /></LineText>
+        </div>
+      )
+      out.push(
+        <div key={`${i}a`} className="flex bg-success/10 text-foreground">
+          <span className={NUM} /><span className={NUM}>{r.add.newLine}</span><LineText wrap={wrap}><span className="text-success">+</span><Segs segs={r.addSeg} tone="add" /></LineText>
+        </div>
+      )
+    }
+  })
+  return <>{out}</>
+}
+
+function SplitSide({ line, seg, tone, wrap }: { line: DiffLine | null; seg?: WordSegment[]; tone?: 'add' | 'del'; wrap: boolean }) {
+  if (!line) return <div className="flex-1 bg-muted/30" />
+  const bg = tone === 'add' ? 'bg-success/10' : tone === 'del' ? 'bg-destructive/10' : ''
+  const num = tone === 'add' ? line.newLine : tone === 'del' ? line.oldLine : (line.newLine ?? line.oldLine)
+  return (
+    <div className={cn('flex flex-1 min-w-0', bg)}>
+      <span className={NUM}>{num}</span>
+      <LineText wrap={wrap}>{seg ? <Segs segs={seg} tone={tone as 'add' | 'del'} /> : line.content}</LineText>
+    </div>
+  )
+}
+
+function SplitRows({ rows, wrap }: { rows: Row[]; wrap: boolean }) {
+  return (
+    <>
+      {rows.map((r, i) => {
+        if (r.kind === 'context') {
+          return (
+            <div key={i} className="flex text-foreground/70">
+              <SplitSide line={r.line} wrap={wrap} />
+              <div className="w-px shrink-0 bg-border" />
+              <SplitSide line={r.line} wrap={wrap} />
+            </div>
+          )
+        }
+        if (r.kind === 'pair') {
+          return (
+            <div key={i} className="flex">
+              <SplitSide line={r.del} seg={r.delSeg} tone="del" wrap={wrap} />
+              <div className="w-px shrink-0 bg-border" />
+              <SplitSide line={r.add} seg={r.addSeg} tone="add" wrap={wrap} />
+            </div>
+          )
+        }
+        if (r.kind === 'del') {
+          return (
+            <div key={i} className="flex">
+              <SplitSide line={r.line} tone="del" wrap={wrap} />
+              <div className="w-px shrink-0 bg-border" />
+              <SplitSide line={null} wrap={wrap} />
+            </div>
+          )
+        }
+        return (
+          <div key={i} className="flex">
+            <SplitSide line={null} wrap={wrap} />
+            <div className="w-px shrink-0 bg-border" />
+            <SplitSide line={r.line} tone="add" wrap={wrap} />
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+function FileBlock({ file, viewMode, wrap }: { file: DiffFile; viewMode: ViewMode; wrap: boolean }) {
+  const [open, setOpen] = useState(true)
+  const meta = STATUS_META[file.status]
+  const Icon = meta.icon
+  return (
+    <div className="border-b border-border/60">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-accent/50 transition-colors sticky top-0 z-10 bg-card"
+      >
+        <ChevronRight className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', open && 'rotate-90')} />
+        <Icon className={cn('h-3.5 w-3.5 shrink-0', meta.className)} />
+        <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground" title={file.path}>
+          {file.status === 'renamed' && file.oldPath ? `${file.oldPath} → ${file.newPath}` : file.path}
+        </span>
+        {!file.binary && <DiffStatLabel additions={file.additions} deletions={file.deletions} className="text-[11px]" />}
+        {file.binary && <span className="text-[11px] text-muted-foreground">binary</span>}
+      </button>
+      {open && !file.binary && (
+        <div className="overflow-x-auto font-mono text-xs leading-[1.55]">
+          {file.hunks.map((hunk, hi) => {
+            const rows = alignHunk(hunk)
+            return (
+              <div key={hi}>
+                <div className="bg-muted/40 px-3 py-0.5 text-[11px] text-muted-foreground">{hunk.header}</div>
+                {viewMode === 'split' ? <SplitRows rows={rows} wrap={wrap} /> : <UnifiedRows rows={rows} wrap={wrap} />}
+              </div>
+            )
+          })}
+          {file.hunks.length === 0 && (
+            <div className="px-3 py-2 text-[11px] text-muted-foreground">No textual changes.</div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function ChangesPanel({ taskId, repos, className }: { taskId: string; repos: string[]; className?: string }) {
+  const [data, setData] = useState<RepoChanges[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [viewMode, setViewMode] = useState<ViewMode>(() => (localStorage.getItem('diff-view-mode') as ViewMode) || 'unified')
+  const [wrap, setWrap] = useState<boolean>(() => localStorage.getItem('diff-wrap') === '1')
+
+  const load = useCallback(async () => {
+    if (!repos.length) { setData([]); return }
+    setLoading(true)
+    try {
+      const res = await worktreeApi.changes(taskId, repos.map((r) => ({ fullName: r })))
+      setData(res.map((r) => ({ repo: r.repo, error: r.error, files: r.diff ? parseUnifiedDiff(r.diff) : [] })))
+    } catch (e) {
+      setData([{ repo: '', files: [], error: (e as Error).message }])
+    } finally {
+      setLoading(false)
+    }
+  }, [taskId, repos])
+
+  useEffect(() => { void load() }, [load])
+
+  const setMode = (m: ViewMode) => { setViewMode(m); localStorage.setItem('diff-view-mode', m) }
+  const toggleWrap = () => setWrap((w) => { localStorage.setItem('diff-wrap', w ? '0' : '1'); return !w })
+
+  const totals = useMemo(() => {
+    let a = 0, d = 0, f = 0
+    for (const repo of data ?? []) for (const file of repo.files) { a += file.additions; d += file.deletions; f++ }
+    return { additions: a, deletions: d, files: f }
+  }, [data])
+
+  const hasChanges = (data ?? []).some((r) => r.files.length > 0)
+  const showRepoHeaders = (data ?? []).filter((r) => r.files.length > 0).length > 1 || repos.length > 1
+
+  return (
+    <div className={cn('flex h-full flex-col bg-card', className)}>
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2 flex-shrink-0">
+        <FileDiff className="h-4 w-4 text-muted-foreground" />
+        <span className="text-xs font-medium text-foreground">Changes</span>
+        {totals.files > 0 && (
+          <>
+            <span className="text-xs text-muted-foreground">· {totals.files} file{totals.files !== 1 ? 's' : ''}</span>
+            <DiffStatLabel additions={totals.additions} deletions={totals.deletions} className="text-[11px]" />
+          </>
+        )}
+        <div className="flex-1" />
+        <div className="flex items-center gap-0.5 rounded-lg border border-border/60 bg-muted/40 p-0.5">
+          <button onClick={() => setMode('unified')} title="Unified" className={cn('grid h-6 w-6 place-items-center rounded-md transition-colors', viewMode === 'unified' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground')}><Rows3 className="h-3.5 w-3.5" /></button>
+          <button onClick={() => setMode('split')} title="Split" className={cn('grid h-6 w-6 place-items-center rounded-md transition-colors', viewMode === 'split' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground')}><Columns2 className="h-3.5 w-3.5" /></button>
+        </div>
+        <button onClick={toggleWrap} title="Toggle word wrap" className={cn('grid h-7 w-7 place-items-center rounded-lg transition-colors', wrap ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground')}><WrapText className="h-3.5 w-3.5" /></button>
+        <button onClick={() => void load()} disabled={loading} title="Refresh" className="grid h-7 w-7 place-items-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-50">
+          {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {loading && !data && (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground"><Loader2 className="mr-2 h-4 w-4 animate-spin" /> Computing diff…</div>
+        )}
+        {!loading && !repos.length && (
+          <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground">This task has no linked repositories.</div>
+        )}
+        {data && repos.length > 0 && !hasChanges && !loading && (
+          <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
+            <FileDiff className="h-6 w-6 opacity-40" />
+            No uncommitted changes in the task worktree{repos.length > 1 ? 's' : ''}.
+          </div>
+        )}
+        {data?.map((repo) => {
+          if (repo.error) {
+            return <div key={repo.repo} className="px-3 py-2 text-xs text-destructive">{repo.repo}: {repo.error}</div>
+          }
+          if (repo.files.length === 0) return null
+          return (
+            <div key={repo.repo}>
+              {showRepoHeaders && (
+                <div className="flex items-center gap-1.5 bg-muted/30 px-3 py-1.5 text-[11px] font-medium text-muted-foreground sticky top-0 z-20">
+                  <GitBranch className="h-3 w-3" /> {repo.repo}
+                </div>
+              )}
+              {repo.files.map((file, i) => (
+                <FileBlock key={`${repo.repo}:${file.path}:${i}`} file={file} viewMode={viewMode} wrap={wrap} />
+              ))}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/tasks/ChangesPanel.tsx
+++ b/src/renderer/src/components/tasks/ChangesPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import {
   ChevronRight, RefreshCw, Loader2, FileDiff, Columns2, Rows3, WrapText, GitBranch,
-  FilePlus2, FileMinus2, FilePen, FileSymlink,
+  FilePlus2, FileMinus2, FilePen, FileSymlink, FolderGit2,
 } from 'lucide-react'
 import { worktreeApi } from '@/lib/ipc-client'
 import { parseUnifiedDiff, wordDiff, type DiffFile, type DiffHunk, type DiffLine, type WordSegment, type FileStatus } from '@/lib/diff-parser'
@@ -12,6 +12,8 @@ interface RepoChanges {
   repo: string
   files: DiffFile[]
   error?: string
+  noWorktree?: boolean
+  path?: string
 }
 
 type ViewMode = 'unified' | 'split'
@@ -233,7 +235,7 @@ export function ChangesPanel({ taskId, repos, className, onSummary }: {
     setLoading(true)
     try {
       const res = await worktreeApi.changes(taskId, list.map((fullName) => ({ fullName })))
-      const parsed = res.map((r) => ({ repo: r.repo, error: r.error, files: r.diff ? parseUnifiedDiff(r.diff) : [] }))
+      const parsed = res.map((r) => ({ repo: r.repo, error: r.error, noWorktree: r.noWorktree, path: r.path, files: r.diff ? parseUnifiedDiff(r.diff) : [] }))
       setData(parsed)
       let a = 0, d = 0, f = 0
       for (const repo of parsed) for (const file of repo.files) { a += file.additions; d += file.deletions; f++ }
@@ -291,11 +293,22 @@ export function ChangesPanel({ taskId, repos, className, onSummary }: {
         {!loading && !repos.length && (
           <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted-foreground">This task has no linked repositories.</div>
         )}
-        {data && repos.length > 0 && !hasChanges && !loading && (
-          <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
-            <FileDiff className="h-6 w-6 opacity-40" />
-            No changes in the task worktree{repos.length > 1 ? 's' : ''} yet.
-          </div>
+        {data && repos.length > 0 && !hasChanges && !loading && !data.some((r) => r.error) && (
+          data.length > 0 && data.every((r) => r.noWorktree) ? (
+            <div className="flex h-full flex-col items-center justify-center gap-1.5 px-6 text-center text-sm text-muted-foreground">
+              <FolderGit2 className="h-6 w-6 opacity-40" />
+              This task&apos;s worktree isn&apos;t set up yet.
+              <span className="text-xs text-muted-foreground/70">Start the agent on this task to create it.</span>
+              {data.filter((r) => r.path).map((r) => (
+                <code key={r.repo} className="mt-1 max-w-full truncate rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground/60">{r.path}</code>
+              ))}
+            </div>
+          ) : (
+            <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center text-sm text-muted-foreground">
+              <FileDiff className="h-6 w-6 opacity-40" />
+              No changes in the task worktree{repos.length > 1 ? 's' : ''} yet.
+            </div>
+          )
         )}
         {data?.map((repo) => {
           if (repo.error) {

--- a/src/renderer/src/components/tasks/ChangesPanel.tsx
+++ b/src/renderer/src/components/tasks/ChangesPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import {
   ChevronRight, RefreshCw, Loader2, FileDiff, Columns2, Rows3, WrapText, GitBranch,
-  FilePlus2, FileMinus2, FilePen, FileSymlink, FolderGit2,
+  FilePlus2, FileMinus2, FilePen, FileSymlink, FolderGit2, GitPullRequest, ExternalLink,
 } from 'lucide-react'
 import { worktreeApi } from '@/lib/ipc-client'
 import { parseUnifiedDiff, wordDiff, type DiffFile, type DiffHunk, type DiffLine, type WordSegment, type FileStatus } from '@/lib/diff-parser'
@@ -14,6 +14,11 @@ interface RepoChanges {
   error?: string
   noWorktree?: boolean
   path?: string
+  branch?: string
+  pushed?: boolean
+  prNumber?: number
+  prUrl?: string
+  prState?: string
 }
 
 type ViewMode = 'unified' | 'split'
@@ -235,7 +240,11 @@ export function ChangesPanel({ taskId, repos, className, onSummary }: {
     setLoading(true)
     try {
       const res = await worktreeApi.changes(taskId, list.map((fullName) => ({ fullName })))
-      const parsed = res.map((r) => ({ repo: r.repo, error: r.error, noWorktree: r.noWorktree, path: r.path, files: r.diff ? parseUnifiedDiff(r.diff) : [] }))
+      const parsed = res.map((r) => ({
+        repo: r.repo, error: r.error, noWorktree: r.noWorktree, path: r.path,
+        branch: r.branch, pushed: r.pushed, prNumber: r.prNumber, prUrl: r.prUrl, prState: r.prState,
+        files: r.diff ? parseUnifiedDiff(r.diff) : [],
+      }))
       setData(parsed)
       let a = 0, d = 0, f = 0
       for (const repo of parsed) for (const file of repo.files) { a += file.additions; d += file.deletions; f++ }
@@ -260,7 +269,6 @@ export function ChangesPanel({ taskId, repos, className, onSummary }: {
   }, [data])
 
   const hasChanges = (data ?? []).some((r) => r.files.length > 0)
-  const showRepoHeaders = (data ?? []).filter((r) => r.files.length > 0).length > 1 || repos.length > 1
 
   return (
     <div className={cn('flex h-full flex-col bg-card', className)}>
@@ -315,13 +323,32 @@ export function ChangesPanel({ taskId, repos, className, onSummary }: {
             return <div key={repo.repo} className="px-3 py-2 text-xs text-destructive">{repo.repo}: {repo.error}</div>
           }
           if (repo.files.length === 0) return null
+          const repoAdd = repo.files.reduce((s, f) => s + f.additions, 0)
+          const repoDel = repo.files.reduce((s, f) => s + f.deletions, 0)
           return (
             <div key={repo.repo}>
-              {showRepoHeaders && (
-                <div className="flex items-center gap-1.5 bg-muted/30 px-3 py-1.5 text-[11px] font-medium text-muted-foreground sticky top-0 z-20">
-                  <GitBranch className="h-3 w-3" /> {repo.repo}
-                </div>
-              )}
+              {/* Per-repo group header: repo · branch · PR (or local/not-pushed) */}
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-border/50 bg-muted/30 px-3 py-2 text-[11px] sticky top-0 z-20">
+                <GitBranch className="h-3 w-3 text-muted-foreground shrink-0" />
+                <span className="font-medium text-foreground">{repo.repo}</span>
+                {repo.branch && (
+                  <span className="rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground" title="Branch">{repo.branch}</span>
+                )}
+                {repo.prUrl ? (
+                  <button
+                    onClick={() => window.electronAPI?.shell?.openExternal?.(repo.prUrl!)}
+                    className="inline-flex items-center gap-1 text-primary hover:underline cursor-pointer"
+                    title={repo.prUrl}
+                  >
+                    <GitPullRequest className="h-3 w-3" />#{repo.prNumber}
+                    {repo.prState && <span className="text-muted-foreground/70">· {repo.prState.toLowerCase()}</span>}
+                    <ExternalLink className="h-2.5 w-2.5" />
+                  </button>
+                ) : (
+                  <span className="text-muted-foreground/60">{repo.pushed ? 'pushed · no PR' : 'local · not pushed'}</span>
+                )}
+                <DiffStatLabel additions={repoAdd} deletions={repoDel} className="ml-auto text-[10px]" />
+              </div>
               {repo.files.map((file, i) => (
                 <FileBlock key={`${repo.repo}:${file.path}:${i}`} file={file} viewMode={viewMode} wrap={wrap} />
               ))}

--- a/src/renderer/src/components/tasks/ChangesPanel.tsx
+++ b/src/renderer/src/components/tasks/ChangesPanel.tsx
@@ -172,7 +172,9 @@ function SplitRows({ rows, wrap }: { rows: Row[]; wrap: boolean }) {
 }
 
 function FileBlock({ file, viewMode, wrap }: { file: DiffFile; viewMode: ViewMode; wrap: boolean }) {
-  const [open, setOpen] = useState(true)
+  // Files start collapsed — the panel opens as a clean changed-files overview;
+  // click a file to expand its diff.
+  const [open, setOpen] = useState(false)
   const meta = STATUS_META[file.status]
   const Icon = meta.icon
   return (

--- a/src/renderer/src/components/tasks/ChangesPanel.tsx
+++ b/src/renderer/src/components/tasks/ChangesPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react
 import {
   ChevronRight, RefreshCw, Loader2, FileDiff, Columns2, Rows3, WrapText, GitBranch,
   FilePlus2, FileMinus2, FilePen, FileSymlink, FolderGit2, GitPullRequest, ExternalLink,
+  CheckCircle2, XCircle,
 } from 'lucide-react'
 import { worktreeApi } from '@/lib/ipc-client'
 import { parseUnifiedDiff, wordDiff, type DiffFile, type DiffHunk, type DiffLine, type WordSegment, type FileStatus } from '@/lib/diff-parser'
@@ -19,6 +20,8 @@ interface RepoChanges {
   prNumber?: number
   prUrl?: string
   prState?: string
+  prTitle?: string
+  ciStatus?: 'passing' | 'failing' | 'pending' | 'none'
 }
 
 type ViewMode = 'unified' | 'split'
@@ -178,6 +181,13 @@ function SplitRows({ rows, wrap }: { rows: Row[]; wrap: boolean }) {
   )
 }
 
+function CiBadge({ status }: { status?: RepoChanges['ciStatus'] }) {
+  if (!status || status === 'none') return null
+  if (status === 'passing') return <span title="Checks passing" className="inline-flex items-center text-success"><CheckCircle2 className="h-3.5 w-3.5" /></span>
+  if (status === 'failing') return <span title="Checks failing" className="inline-flex items-center text-destructive"><XCircle className="h-3.5 w-3.5" /></span>
+  return <span title="Checks running" className="inline-flex items-center text-warning"><Loader2 className="h-3.5 w-3.5 animate-spin" /></span>
+}
+
 function FileBlock({ file, viewMode, wrap }: { file: DiffFile; viewMode: ViewMode; wrap: boolean }) {
   // Files start collapsed — the panel opens as a clean changed-files overview;
   // click a file to expand its diff.
@@ -243,6 +253,7 @@ export function ChangesPanel({ taskId, repos, className, onSummary }: {
       const parsed = res.map((r) => ({
         repo: r.repo, error: r.error, noWorktree: r.noWorktree, path: r.path,
         branch: r.branch, pushed: r.pushed, prNumber: r.prNumber, prUrl: r.prUrl, prState: r.prState,
+        prTitle: r.prTitle, ciStatus: r.ciStatus,
         files: r.diff ? parseUnifiedDiff(r.diff) : [],
       }))
       setData(parsed)
@@ -327,25 +338,29 @@ export function ChangesPanel({ taskId, repos, className, onSummary }: {
           const repoDel = repo.files.reduce((s, f) => s + f.deletions, 0)
           return (
             <div key={repo.repo}>
-              {/* Per-repo group header: repo · branch · PR (or local/not-pushed) */}
+              {/* Per-repo group header: branch (no PR) — or PR title + link + CI status */}
               <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-border/50 bg-muted/30 px-3 py-2 text-[11px] sticky top-0 z-20">
-                <GitBranch className="h-3 w-3 text-muted-foreground shrink-0" />
-                <span className="font-medium text-foreground">{repo.repo}</span>
-                {repo.branch && (
-                  <span className="rounded border border-border bg-card px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground" title="Branch">{repo.branch}</span>
-                )}
+                <span className="font-medium text-foreground shrink-0">{repo.repo}</span>
                 {repo.prUrl ? (
-                  <button
-                    onClick={() => window.electronAPI?.shell?.openExternal?.(repo.prUrl!)}
-                    className="inline-flex items-center gap-1 text-primary hover:underline cursor-pointer"
-                    title={repo.prUrl}
-                  >
-                    <GitPullRequest className="h-3 w-3" />#{repo.prNumber}
-                    {repo.prState && <span className="text-muted-foreground/70">· {repo.prState.toLowerCase()}</span>}
-                    <ExternalLink className="h-2.5 w-2.5" />
-                  </button>
+                  <>
+                    <button
+                      onClick={() => window.electronAPI?.shell?.openExternal?.(repo.prUrl!)}
+                      className="inline-flex min-w-0 items-center gap-1 text-primary hover:underline cursor-pointer"
+                      title={`${repo.prTitle ?? ''} (${repo.prUrl})`}
+                    >
+                      <GitPullRequest className="h-3 w-3 shrink-0" />
+                      <span className="truncate max-w-[240px]">{repo.prTitle || `Pull request #${repo.prNumber}`}</span>
+                      <span className="shrink-0 text-muted-foreground/70">#{repo.prNumber}</span>
+                      <ExternalLink className="h-2.5 w-2.5 shrink-0" />
+                    </button>
+                    <CiBadge status={repo.ciStatus} />
+                  </>
                 ) : (
-                  <span className="text-muted-foreground/60">{repo.pushed ? 'pushed · no PR' : 'local · not pushed'}</span>
+                  <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                    <GitBranch className="h-3 w-3 shrink-0" />
+                    <span className="font-mono text-[10px] text-foreground/80">{repo.branch ?? 'detached HEAD'}</span>
+                    <span className="text-muted-foreground/60">{repo.pushed ? '· no PR yet' : '· not pushed'}</span>
+                  </span>
                 )}
                 <DiffStatLabel additions={repoAdd} deletions={repoDel} className="ml-auto text-[10px]" />
               </div>

--- a/src/renderer/src/components/tasks/DiffStatLabel.tsx
+++ b/src/renderer/src/components/tasks/DiffStatLabel.tsx
@@ -1,0 +1,29 @@
+import { cn } from '@/lib/utils'
+
+function compact(value: number): string {
+  if (value < 1000) return String(value)
+  if (value < 1_000_000) {
+    const k = value / 1000
+    return `${k < 10 ? k.toFixed(1).replace(/\.0$/, '') : Math.round(k)}k`
+  }
+  const m = value / 1_000_000
+  return `${m < 10 ? m.toFixed(1).replace(/\.0$/, '') : Math.round(m)}m`
+}
+
+/** Compact "+N −M" diff-stat chip. Green additions / red deletions. */
+export function DiffStatLabel({
+  additions,
+  deletions,
+  className,
+}: {
+  additions: number
+  deletions: number
+  className?: string
+}) {
+  return (
+    <span className={cn('inline-flex items-center gap-1.5 font-mono tabular-nums', className)}>
+      <span className="text-success">+{compact(additions)}</span>
+      <span className="text-destructive">−{compact(deletions)}</span>
+    </span>
+  )
+}

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -61,6 +61,7 @@ export function TaskWorkspace({
   const { githubOrg, checkGhCli, checkGlabCli, setGithubOrg, fetchSettings } = useSettingsStore()
 
   const [rightTab, setRightTab] = useState<'transcript' | 'changes'>('transcript')
+  const [changesSummary, setChangesSummary] = useState<{ files: number; additions: number; deletions: number } | null>(null)
   const [showGhSetup, setShowGhSetup] = useState(false)
   const [showOrgPicker, setShowOrgPicker] = useState(false)
   const [showRepoSelector, setShowRepoSelector] = useState(false)
@@ -727,15 +728,21 @@ Update existing skills that were helpful or create new ones for patterns worth r
                 <button
                   key={tab}
                   onClick={() => setRightTab(tab)}
-                  className={`rounded-md px-2.5 py-1 text-xs font-medium capitalize transition-colors cursor-pointer ${
+                  className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer ${
                     rightTab === tab ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'
                   }`}
                 >
-                  {tab}
+                  <span className="capitalize">{tab}</span>
+                  {tab === 'changes' && changesSummary && changesSummary.files > 0 && (
+                    <span className="inline-flex items-center rounded-full bg-primary/15 px-1.5 text-[10px] font-semibold text-primary tabular-nums">
+                      {changesSummary.files}
+                    </span>
+                  )}
                 </button>
               ))}
             </div>
-            {/* Transcript stays mounted (preserves scroll/stream); Changes mounts on demand */}
+            {/* Both panels stay mounted: transcript preserves scroll/stream; Changes
+                fetches its diff so the tab badge reflects changes without opening it. */}
             <div className={rightTab === 'transcript' ? 'flex-1 min-h-0' : 'hidden'}>
               <AgentTranscriptPanel
                 messages={session.messages}
@@ -753,11 +760,9 @@ Update existing skills that were helpful or create new ones for patterns worth r
                 pendingApproval={session.pendingApproval ?? undefined}
               />
             </div>
-            {rightTab === 'changes' && (
-              <div className="flex-1 min-h-0">
-                <ChangesPanel taskId={task.id} repos={task.repos} className="h-full" />
-              </div>
-            )}
+            <div className={rightTab === 'changes' ? 'flex-1 min-h-0' : 'hidden'}>
+              <ChangesPanel taskId={task.id} repos={task.repos} className="h-full" onSummary={setChangesSummary} />
+            </div>
           </div>
         )}
 

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -5,6 +5,7 @@ import { SnoozeDialog } from './SnoozeDialog'
 import { IncompatibleSessionDialog } from './IncompatibleSessionDialog'
 import { TaskDetailView } from './TaskDetailView'
 import { AgentTranscriptPanel } from '@/components/agents/AgentTranscriptPanel'
+import { ChangesPanel } from './ChangesPanel'
 import { AgentApprovalBanner } from '@/components/agents/AgentApprovalBanner'
 import { GhCliSetupDialog } from '@/components/github/GhCliSetupDialog'
 import { OrgPickerDialog } from '@/components/github/OrgPickerDialog'
@@ -59,6 +60,7 @@ export function TaskWorkspace({
   const { removeSession, updateAgent } = useAgentStore()
   const { githubOrg, checkGhCli, checkGlabCli, setGithubOrg, fetchSettings } = useSettingsStore()
 
+  const [rightTab, setRightTab] = useState<'transcript' | 'changes'>('transcript')
   const [showGhSetup, setShowGhSetup] = useState(false)
   const [showOrgPicker, setShowOrgPicker] = useState(false)
   const [showRepoSelector, setShowRepoSelector] = useState(false)
@@ -718,22 +720,44 @@ Update existing skills that were helpful or create new ones for patterns worth r
         )}
 
         {showPanel && panelLayout !== 'task-only' && (
-          <div className="min-h-0 min-w-0 h-full">
-            <AgentTranscriptPanel
-              messages={session.messages}
-              status={session.status}
-              systemStatus={session.systemStatus}
-              onStop={handleAbort}
-              onRestart={handleStartFreshSession}
-              onSend={handleSend}
-              onPickAttachments={handlePickAttachments}
-              onAddAttachmentPaths={handleAddAttachmentPaths}
-              className="h-full"
-              sessionId={session.sessionId}
-              taskId={task.id}
-              agentId={task.agent_id ?? undefined}
-              pendingApproval={session.pendingApproval ?? undefined}
-            />
+          <div className="min-h-0 min-w-0 h-full flex flex-col">
+            {/* Transcript / Changes tab switcher */}
+            <div className="flex items-center gap-1 border-b border-border/60 px-3 pt-2 pb-1 flex-shrink-0">
+              {(['transcript', 'changes'] as const).map((tab) => (
+                <button
+                  key={tab}
+                  onClick={() => setRightTab(tab)}
+                  className={`rounded-md px-2.5 py-1 text-xs font-medium capitalize transition-colors cursor-pointer ${
+                    rightTab === tab ? 'bg-accent text-foreground' : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
+            {/* Transcript stays mounted (preserves scroll/stream); Changes mounts on demand */}
+            <div className={rightTab === 'transcript' ? 'flex-1 min-h-0' : 'hidden'}>
+              <AgentTranscriptPanel
+                messages={session.messages}
+                status={session.status}
+                systemStatus={session.systemStatus}
+                onStop={handleAbort}
+                onRestart={handleStartFreshSession}
+                onSend={handleSend}
+                onPickAttachments={handlePickAttachments}
+                onAddAttachmentPaths={handleAddAttachmentPaths}
+                className="h-full"
+                sessionId={session.sessionId}
+                taskId={task.id}
+                agentId={task.agent_id ?? undefined}
+                pendingApproval={session.pendingApproval ?? undefined}
+              />
+            </div>
+            {rightTab === 'changes' && (
+              <div className="flex-1 min-h-0">
+                <ChangesPanel taskId={task.id} repos={task.repos} className="h-full" />
+              </div>
+            )}
           </div>
         )}
 

--- a/src/renderer/src/lib/diff-parser.test.ts
+++ b/src/renderer/src/lib/diff-parser.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { parseUnifiedDiff, wordDiff } from './diff-parser'
+
+describe('parseUnifiedDiff', () => {
+  it('parses a modified file with counts + line numbers', () => {
+    const diff = [
+      'diff --git a/src/foo.ts b/src/foo.ts',
+      'index 111..222 100644',
+      '--- a/src/foo.ts',
+      '+++ b/src/foo.ts',
+      '@@ -1,3 +1,3 @@',
+      ' const a = 1',
+      '-const b = 2',
+      '+const b = 3',
+      ' const c = 4',
+      '',
+    ].join('\n')
+    const [file] = parseUnifiedDiff(diff)
+    expect(file.path).toBe('src/foo.ts')
+    expect(file.status).toBe('modified')
+    expect(file.additions).toBe(1)
+    expect(file.deletions).toBe(1)
+    expect(file.hunks).toHaveLength(1)
+    const lines = file.hunks[0].lines
+    expect(lines[0]).toMatchObject({ type: 'context', oldLine: 1, newLine: 1 })
+    expect(lines[1]).toMatchObject({ type: 'delete', oldLine: 2, content: 'const b = 2' })
+    expect(lines[2]).toMatchObject({ type: 'add', newLine: 2, content: 'const b = 3' })
+    expect(lines[3]).toMatchObject({ type: 'context', oldLine: 3, newLine: 3 })
+  })
+
+  it('detects added (new) files', () => {
+    const diff = [
+      'diff --git a/new.txt b/new.txt',
+      'new file mode 100644',
+      'index 000..abc',
+      '--- /dev/null',
+      '+++ b/new.txt',
+      '@@ -0,0 +1,2 @@',
+      '+line one',
+      '+line two',
+    ].join('\n')
+    const [file] = parseUnifiedDiff(diff)
+    expect(file.status).toBe('added')
+    expect(file.path).toBe('new.txt')
+    expect(file.additions).toBe(2)
+    expect(file.deletions).toBe(0)
+  })
+
+  it('detects deleted files', () => {
+    const diff = [
+      'diff --git a/gone.txt b/gone.txt',
+      'deleted file mode 100644',
+      '--- a/gone.txt',
+      '+++ /dev/null',
+      '@@ -1,1 +0,0 @@',
+      '-bye',
+    ].join('\n')
+    const [file] = parseUnifiedDiff(diff)
+    expect(file.status).toBe('deleted')
+    expect(file.path).toBe('gone.txt')
+    expect(file.deletions).toBe(1)
+  })
+
+  it('parses multiple files in one patch', () => {
+    const diff = [
+      'diff --git a/a.txt b/a.txt',
+      '--- a/a.txt',
+      '+++ b/a.txt',
+      '@@ -1 +1 @@',
+      '-a',
+      '+A',
+      'diff --git a/b.txt b/b.txt',
+      '--- a/b.txt',
+      '+++ b/b.txt',
+      '@@ -1 +1 @@',
+      '-b',
+      '+B',
+    ].join('\n')
+    const files = parseUnifiedDiff(diff)
+    expect(files.map((f) => f.path)).toEqual(['a.txt', 'b.txt'])
+  })
+
+  it('returns [] for empty input', () => {
+    expect(parseUnifiedDiff('')).toEqual([])
+  })
+})
+
+describe('wordDiff', () => {
+  it('marks only the changed tokens', () => {
+    const { old, new: neu } = wordDiff('const b = 2', 'const b = 3')
+    expect(old.filter((s) => s.changed).map((s) => s.text)).toContain('2')
+    expect(neu.filter((s) => s.changed).map((s) => s.text)).toContain('3')
+    // Unchanged prefix is preserved losslessly.
+    expect(old.map((s) => s.text).join('')).toBe('const b = 2')
+    expect(neu.map((s) => s.text).join('')).toBe('const b = 3')
+  })
+})

--- a/src/renderer/src/lib/diff-parser.ts
+++ b/src/renderer/src/lib/diff-parser.ts
@@ -1,0 +1,183 @@
+/**
+ * Unified-diff parser + word-level diff helper.
+ *
+ * Turns a raw `git diff` patch into a structured model the Changes viewer can
+ * render (files → hunks → lines) with per-file add/delete counts and status.
+ * Standard unified-diff parsing; approach modelled on common diff renderers.
+ */
+
+export type DiffLineType = 'context' | 'add' | 'delete'
+export type FileStatus = 'added' | 'deleted' | 'modified' | 'renamed'
+
+export interface DiffLine {
+  type: DiffLineType
+  oldLine: number | null
+  newLine: number | null
+  content: string // line text without the leading +/-/space marker
+}
+
+export interface DiffHunk {
+  header: string
+  lines: DiffLine[]
+}
+
+export interface DiffFile {
+  oldPath: string | null
+  newPath: string | null
+  /** Display path (new path, or old path for deletions). */
+  path: string
+  status: FileStatus
+  additions: number
+  deletions: number
+  binary: boolean
+  hunks: DiffHunk[]
+}
+
+function stripPrefix(raw: string): string | null {
+  const p = raw.trim()
+  if (p === '/dev/null') return null
+  return p.replace(/^[ab]\//, '')
+}
+
+export function parseUnifiedDiff(diff: string): DiffFile[] {
+  const files: DiffFile[] = []
+  let file: DiffFile | null = null
+  let hunk: DiffHunk | null = null
+  let oldLine = 0
+  let newLine = 0
+
+  const finishFile = () => {
+    if (file) {
+      if (file.newPath === null && file.oldPath !== null) file.status = 'deleted'
+      else if (file.oldPath === null && file.newPath !== null && file.status !== 'renamed') file.status = 'added'
+      file.path = file.newPath ?? file.oldPath ?? file.path
+      files.push(file)
+    }
+    file = null
+    hunk = null
+  }
+
+  const lines = diff.replace(/\r\n/g, '\n').split('\n')
+  for (const line of lines) {
+    if (line.startsWith('diff --git')) {
+      finishFile()
+      const m = line.match(/^diff --git a\/(.+?) b\/(.+)$/)
+      file = {
+        oldPath: m ? m[1] : null,
+        newPath: m ? m[2] : null,
+        path: m ? m[2] : '',
+        status: 'modified',
+        additions: 0,
+        deletions: 0,
+        binary: false,
+        hunks: [],
+      }
+      continue
+    }
+    if (!file) continue
+
+    if (line.startsWith('new file mode')) { file.oldPath = null; file.status = 'added'; continue }
+    if (line.startsWith('deleted file mode')) { file.newPath = null; file.status = 'deleted'; continue }
+    if (line.startsWith('rename from ')) { file.oldPath = line.slice(12); file.status = 'renamed'; continue }
+    if (line.startsWith('rename to ')) { file.newPath = line.slice(10); file.status = 'renamed'; continue }
+    if (line.startsWith('Binary files') || line.startsWith('GIT binary patch')) { file.binary = true; continue }
+    if (line.startsWith('--- ')) { const p = stripPrefix(line.slice(4)); file.oldPath = p; continue }
+    if (line.startsWith('+++ ')) { const p = stripPrefix(line.slice(4)); file.newPath = p; continue }
+
+    if (line.startsWith('@@')) {
+      const m = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+      oldLine = m ? Number(m[1]) : 0
+      newLine = m ? Number(m[2]) : 0
+      hunk = { header: line, lines: [] }
+      file.hunks.push(hunk)
+      continue
+    }
+    if (!hunk) continue
+
+    if (line.startsWith('+')) {
+      hunk.lines.push({ type: 'add', oldLine: null, newLine, content: line.slice(1) })
+      newLine++
+      file.additions++
+    } else if (line.startsWith('-')) {
+      hunk.lines.push({ type: 'delete', oldLine, newLine: null, content: line.slice(1) })
+      oldLine++
+      file.deletions++
+    } else if (line.startsWith('\\')) {
+      // "\ No newline at end of file" — ignore
+    } else {
+      // context (leading space, or empty line inside a hunk)
+      hunk.lines.push({ type: 'context', oldLine, newLine, content: line.slice(1) })
+      oldLine++
+      newLine++
+    }
+  }
+
+  finishFile()
+  return files
+}
+
+// ── Word-level (intra-line) diff ─────────────────────────────────────────────
+
+export interface WordSegment {
+  text: string
+  changed: boolean
+}
+
+function tokenize(s: string): string[] {
+  // Split on word boundaries but keep the delimiters so joins are lossless.
+  return s.match(/(\w+|\s+|[^\w\s])/g) ?? []
+}
+
+/**
+ * Longest-common-subsequence word diff between two strings. Returns the segments
+ * for each side, marking tokens that changed. Cheap enough for line-length input.
+ */
+export function wordDiff(oldStr: string, newStr: string): { old: WordSegment[]; new: WordSegment[] } {
+  const a = tokenize(oldStr)
+  const b = tokenize(newStr)
+  const n = a.length
+  const m = b.length
+
+  // Guard against pathologically long lines.
+  if (n * m > 40000) {
+    return {
+      old: [{ text: oldStr, changed: true }],
+      new: [{ text: newStr, changed: true }],
+    }
+  }
+
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+
+  const oldSeg: WordSegment[] = []
+  const newSeg: WordSegment[] = []
+  const push = (seg: WordSegment[], text: string, changed: boolean) => {
+    const last = seg[seg.length - 1]
+    if (last && last.changed === changed) last.text += text
+    else seg.push({ text, changed })
+  }
+
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      push(oldSeg, a[i], false)
+      push(newSeg, b[j], false)
+      i++; j++
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      push(oldSeg, a[i], true)
+      i++
+    } else {
+      push(newSeg, b[j], true)
+      j++
+    }
+  }
+  while (i < n) { push(oldSeg, a[i], true); i++ }
+  while (j < m) { push(newSeg, b[j], true); j++ }
+
+  return { old: oldSeg, new: newSeg }
+}

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -480,7 +480,7 @@ export const worktreeApi = {
   cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> => {
     return window.electronAPI.worktree.cleanup(taskId, repos, org, removeTaskDir)
   },
-  changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }>> => {
+  changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string; prTitle?: string; ciStatus?: 'passing' | 'failing' | 'pending' | 'none' }>> => {
     return window.electronAPI.worktree.changes(taskId, repos)
   },
   runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> => {

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -480,6 +480,9 @@ export const worktreeApi = {
   cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> => {
     return window.electronAPI.worktree.cleanup(taskId, repos, org, removeTaskDir)
   },
+  changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string }>> => {
+    return window.electronAPI.worktree.changes(taskId, repos)
+  },
   runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> => {
     return window.electronAPI.worktree.runCleanupNow()
   }

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -480,7 +480,7 @@ export const worktreeApi = {
   cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> => {
     return window.electronAPI.worktree.cleanup(taskId, repos, org, removeTaskDir)
   },
-  changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }>> => {
+  changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }>> => {
     return window.electronAPI.worktree.changes(taskId, repos)
   },
   runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> => {

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -480,7 +480,7 @@ export const worktreeApi = {
   cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean): Promise<void> => {
     return window.electronAPI.worktree.cleanup(taskId, repos, org, removeTaskDir)
   },
-  changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string }>> => {
+  changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }>> => {
     return window.electronAPI.worktree.changes(taskId, repos)
   },
   runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> => {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -263,7 +263,7 @@ interface ElectronAPI {
   worktree: {
     setup: (taskId: string, repos: { fullName: string; defaultBranch: string }[], org: string, provider: 'github' | 'gitlab') => Promise<string>
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean) => Promise<void>
-    changes: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }>>
+    changes: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }>>
     runCleanupNow: () => Promise<{ cleaned: number; errors: string[] }>
   }
   taskSources: {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -263,6 +263,7 @@ interface ElectronAPI {
   worktree: {
     setup: (taskId: string, repos: { fullName: string; defaultBranch: string }[], org: string, provider: 'github' | 'gitlab') => Promise<string>
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean) => Promise<void>
+    changes: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; diff: string; error?: string }>>
     runCleanupNow: () => Promise<{ cleaned: number; errors: string[] }>
   }
   taskSources: {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -263,7 +263,7 @@ interface ElectronAPI {
   worktree: {
     setup: (taskId: string, repos: { fullName: string; defaultBranch: string }[], org: string, provider: 'github' | 'gitlab') => Promise<string>
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean) => Promise<void>
-    changes: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; diff: string; error?: string }>>
+    changes: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string }>>
     runCleanupNow: () => Promise<{ cleaned: number; errors: string[] }>
   }
   taskSources: {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -263,7 +263,7 @@ interface ElectronAPI {
   worktree: {
     setup: (taskId: string, repos: { fullName: string; defaultBranch: string }[], org: string, provider: 'github' | 'gitlab') => Promise<string>
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean) => Promise<void>
-    changes: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string }>>
+    changes: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; diff: string; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string; prTitle?: string; ciStatus?: 'passing' | 'failing' | 'pending' | 'none' }>>
     runCleanupNow: () => Promise<{ cleaned: number; errors: string[] }>
   }
   taskSources: {


### PR DESCRIPTION
Adds a **"Changes" tab** to the task workspace so you can see exactly what an agent edited in a task's git worktree(s) — without leaving the app. Approach modelled on how dev tools (and the t3code reference) structure diffs. **Tiers 1 + 2**; per-turn checkpoint snapshots are intentionally out of scope.

## Multi-repo aware
One task spans multiple repos in 20x (a worktree per repo at `workspaces/<taskId>/<repoName>`), so the view **iterates every repo worktree** and groups results by repo. Repos without a worktree yet are skipped; a failure in one repo doesn't hide the others.

## Main process + IPC
- `worktree-manager.getTaskChanges(taskId, repos)` → per-repo unified diff: `git diff HEAD` (tracked changes) + untracked files via `git diff --no-index` (**read-only — never mutates the index**, safe while an agent is running).
- New IPC channel `worktree:changes` wired through preload → `electron.d.ts` → `ipc-client`.

## Renderer
- `lib/diff-parser.ts` — unified-diff parser (files → hunks → lines, add/delete counts, add/delete/modified/renamed status) + an LCS **word-level** diff. **Unit-tested (6 cases, passing).**
- `ChangesPanel` — grouped-by-repo file list with the `+/−` `DiffStatLabel`, per-file collapse, **unified ↔ split** toggle, **word-level intra-line highlighting**, **wrap** toggle, and refresh. Colors use the `success`/`destructive` tokens (theme-aware, light + dark).
- **Transcript / Changes** tab switcher on the task's right panel — the transcript stays mounted (preserves scroll/stream); Changes mounts on demand.

## What's Tier 2 (included) vs later
Included: split view, word-level highlighting, wrap, per-file collapse.
Deferred (Tier 3): git *checkpoint per agent turn* so you can diff a single turn — that's a separate backend project.
Not included (perf, easy follow-up): syntax highlighting + web-worker offload for very large diffs.

## Validation
- `pnpm typecheck` — clean
- `pnpm exec vitest run diff-parser` — 6/6 pass
- `pnpm build` (main + preload + renderer) — succeeds
- eslint clean on new files

Note: verified via unit tests + build; I couldn't drive the live Electron app in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)