### PR TITLE
fix: resolve Changes PR by current branch (not stale local ref)

### DIFF
--- a/src/main/worktree-manager.ts
+++ b/src/main/worktree-manager.ts
@@ -367,13 +367,16 @@ export class WorktreeManager {
           } catch { /* branch not on remote yet */ }
         }
 
-        // Best-effort PR/MR lookup (only when the branch is pushed).
+        // Best-effort PR/MR lookup for the branch checked out in this worktree.
+        // `gh pr view` (no branch arg) resolves the current branch's PR directly,
+        // so it works even when the local origin/<branch> tracking ref is stale
+        // (i.e. the branch is pushed but this worktree hasn't fetched it).
         let prNumber: number | undefined
         let prUrl: string | undefined
         let prState: string | undefined
         let prTitle: string | undefined
         let ciStatus: 'passing' | 'failing' | 'pending' | 'none' | undefined
-        if (branch && pushed) {
+        if (branch) {
           let provider: 'github' | 'gitlab' | 'other' = 'other'
           try {
             const { stdout } = await execFileAsync('git', ['remote', 'get-url', 'origin'], { cwd: wtPath, ...gitOpts })
@@ -385,7 +388,7 @@ export class WorktreeManager {
           try {
             if (provider === 'github') {
               const { stdout } = await execFileAsync(
-                'gh', ['pr', 'view', branch, '--json', 'number,url,state,title,statusCheckRollup'],
+                'gh', ['pr', 'view', '--json', 'number,url,state,title,statusCheckRollup'],
                 { cwd: wtPath, timeout: 8000, ...gitOpts }
               )
               const j = JSON.parse(stdout) as {
@@ -415,6 +418,11 @@ export class WorktreeManager {
             }
           } catch { /* no PR/MR, or CLI unavailable */ }
         }
+        // A resolved PR implies the branch is pushed, even if the local
+        // origin/<branch> tracking ref is missing/stale.
+        pushed = pushed || Boolean(prUrl)
+
+        console.log(`[WorktreeManager] getTaskChanges ${repo.fullName}: branch=${branch ?? '(detached)'} pushed=${pushed} pr=${prNumber ?? 'none'} ci=${ciStatus ?? 'n/a'}`)
 
         results.push({ repo: repo.fullName, diff: tracked + untracked, branch, pushed, prNumber, prUrl, prState, prTitle, ciStatus })
       } catch (e) {


### PR DESCRIPTION
Follow-up fix to the Task Changes feature (#402, merged).

## Problem
The per-repo PR lookup was gated on the **local `origin/<branch>` tracking ref** existing. A task worktree often hasn't fetched that ref even when the branch *is* pushed and has an open PR — so it was treated as "not pushed" and the PR lookup was **skipped entirely**, showing no PR / CI even though one existed. This is why some tasks didn't pick up their PR.

## Fix
- Attempt the PR lookup **whenever there's a branch** (removed the local-ref gate).
- Use `gh pr view --json …` **with no branch argument**, so `gh` resolves the **current branch's** PR directly from the remote — no branch-name matching, no dependence on local tracking refs.
- `pushed` is now also inferred from a resolved PR.
- Added a main-process diagnostic log per repo: `branch=… pushed=… pr=… ci=…`.

One file changed (`src/main/worktree-manager.ts`). Cherry-picked cleanly onto `main`.

## Validation
- `pnpm build` (main + preload + renderer) — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)