### PR TITLE
fix: cloudflared tunnel connects fast behind VPN (IPv4 edge) + restore 120s timeout/logging

### DIFF
--- a/src/main/tunnel-manager.test.ts
+++ b/src/main/tunnel-manager.test.ts
@@ -42,6 +42,9 @@ describe('tunnel-manager', () => {
     const p = startTunnel(20620)
     const t = lastTunnel!
 
+    // Forces the IPv4 edge to avoid the slow/broken IPv6 DNS path behind VPNs.
+    expect(mocks.quick).toHaveBeenCalledWith('http://localhost:20620', { '--edge-ip-version': 4 })
+
     // URL is printed by cloudflared before the edge connection is up.
     t.emit('url', URL)
     await Promise.resolve()
@@ -63,7 +66,7 @@ describe('tunnel-manager', () => {
     const t = lastTunnel!
     t.emit('url', URL)
 
-    vi.advanceTimersByTime(30_000)
+    vi.advanceTimersByTime(120_000)
 
     await expect(p).rejects.toThrow(/never connected/i)
     expect(t.stop).toHaveBeenCalled()

--- a/src/main/tunnel-manager.ts
+++ b/src/main/tunnel-manager.ts
@@ -3,23 +3,42 @@ import { Tunnel } from 'cloudflared'
 let activeTunnel: Tunnel | null = null
 let tunnelUrl: string | null = null
 
+// cloudflared can be slow to register its first edge connection when the local
+// DNS resolver is degraded — e.g. a VPN like Tailscale MagicDNS intercepting DNS
+// makes every `*.argotunnel.com` lookup time out (~20–40s each) before cloudflared
+// falls back, so a working tunnel can take 60–80s to actually connect. Give it
+// enough headroom that a genuinely-working-but-slow environment isn't rejected.
+const CONNECT_TIMEOUT_MS = 120_000
+
 export async function startTunnel(port: number): Promise<string> {
   if (activeTunnel && tunnelUrl) return tunnelUrl
 
   return new Promise((resolve, reject) => {
-    const t = Tunnel.quick(`http://localhost:${port}`)
+    // `--edge-ip-version 4`: cloudflared otherwise resolves/dials Cloudflare's edge
+    // over IPv6 first. On machines behind a VPN (notably Tailscale MagicDNS at
+    // fd7a:115c:a1e0::53) the IPv6 DNS path for *.argotunnel.com times out, which
+    // pushes first-connection to ~70–80s. Forcing the IPv4 edge sidesteps that
+    // resolver entirely and connects in a few seconds. build_options() uses the
+    // key verbatim, so the flag must include the leading dashes.
+    const t = Tunnel.quick(`http://localhost:${port}`, { '--edge-ip-version': 4 })
 
     // cloudflared prints the public https://<...>.trycloudflare.com URL to its
-    // output BEFORE it has actually registered any connections with Cloudflare's
+    // output BEFORE it has actually registered any connection with Cloudflare's
     // edge. If we hand that URL back immediately (on the `url` event), opening it
     // returns a Cloudflare "Argo Tunnel error" (1033/530) until the edge
-    // connections come up a few seconds later — and NEVER works at all if the
-    // outbound connection can't be established (e.g. QUIC/UDP 7844 or the HTTP2
-    // fallback is blocked by a firewall). That is the "URL is generated but
-    // doesn't work" symptom. So we capture the URL on `url` but only resolve
-    // once at least one connection is `connected`.
+    // connection comes up — and NEVER works if the connection can't be
+    // established at all. That is the "URL is generated but doesn't work"
+    // symptom. So we capture the URL on `url` but only resolve once at least one
+    // connection is `connected`.
     let pendingUrl: string | null = null
     let settled = false
+    const recentOutput: string[] = []
+    const remember = (line: string): void => {
+      const trimmed = line.trim()
+      if (!trimmed) return
+      recentOutput.push(trimmed)
+      if (recentOutput.length > 8) recentOutput.shift()
+    }
 
     const timer = setTimeout(() => {
       if (settled) return
@@ -27,15 +46,21 @@ export async function startTunnel(port: number): Promise<string> {
       t.stop()
       activeTunnel = null
       tunnelUrl = null
+      const tail = recentOutput.length ? ` Last cloudflared output:\n${recentOutput.join('\n')}` : ''
       reject(
         new Error(
           pendingUrl
-            ? 'Tunnel URL was created but never connected to Cloudflare within 30s. ' +
-              'The network/firewall may be blocking cloudflared (UDP 7844 / outbound HTTPS).'
-            : 'Tunnel start timed out after 30s'
+            ? `Tunnel URL was created but never connected to Cloudflare within ${CONNECT_TIMEOUT_MS / 1000}s. ` +
+              'A firewall may be blocking cloudflared (outbound UDP 7844 / HTTPS), or a VPN such as ' +
+              'Tailscale MagicDNS may be blocking DNS for *.argotunnel.com.' + tail
+            : `Tunnel start timed out after ${CONNECT_TIMEOUT_MS / 1000}s.` + tail
         )
       )
-    }, 30000)
+    }, CONNECT_TIMEOUT_MS)
+
+    // Surface cloudflared's own logs so connection failures are diagnosable.
+    t.on('stdout', (data) => { remember(data); console.log('[cloudflared]', data.trim()) })
+    t.on('stderr', (data) => { remember(data); console.log('[cloudflared]', data.trim()) })
 
     t.on('url', (url) => {
       pendingUrl = url


### PR DESCRIPTION
Follow-up to #403.

## Why
#403 made `startTunnel()` wait for cloudflared's `connected` event (correct), but two things remained:

1. **Its squash merge dropped a commit** — `main` shipped only the 30s timeout, without the longer timeout + cloudflared log capture.
2. **The real slowness wasn't addressed.** Live repro on the reporting machine (behind **Tailscale MagicDNS**, `fd7a:115c:a1e0::53`) showed cloudflared resolving Cloudflare's edge over **IPv6 first**, and every `*.argotunnel.com` lookup times out on the VPN resolver — so the first connection only registers after **~70–80s**:
   ```
   ERR Failed to fetch features ... "lookup cfd-features.argotunnel.com on [fd7a:115c:a1e0::53]:53: dial udp ...: i/o timeout"
   INF Registered tunnel connection ... location=sin06 protocol=quic   # ~78s
   ```

## Fix (measured)
Forcing the **IPv4 edge** (`--edge-ip-version 4`) sidesteps the broken IPv6 DNS path entirely:

| variant | first connection |
|---|---|
| default (IPv6-first) | **~78s** |
| `--edge-ip-version 4` | **~9s** ✅ |

Verified end-to-end with the real cloudflared binary (v2026.7.1) on the affected Mac.

Also restores the dropped improvements:
- connect timeout **30s → 120s** (headroom for any residual DNS slowness),
- capture cloudflared `stdout`/`stderr` and include the tail in the timeout error,
- error message points at the real causes (firewall UDP 7844 / VPN MagicDNS).

## Notes
- `build_options()` in the `cloudflared` lib uses the option key verbatim, so the flag is passed as `{ '--edge-ip-version': 4 }`.
- Tests updated: assert the IPv4-edge option is passed; timeout test uses 120s.
- IPv4 edge is broadly supported by Cloudflare and is the safe default for quick tunnels; no downside for non-VPN users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)