### PR TITLE
fix: cloudflared tunnel returns 404 for all requests (ignore user ~/.cloudflared/config.yml)

### DIFF
--- a/src/main/tunnel-manager.test.ts
+++ b/src/main/tunnel-manager.test.ts
@@ -42,8 +42,13 @@ describe('tunnel-manager', () => {
     const p = startTunnel(20620)
     const t = lastTunnel!
 
-    // Forces the IPv4 edge to avoid the slow/broken IPv6 DNS path behind VPNs.
-    expect(mocks.quick).toHaveBeenCalledWith('http://localhost:20620', { '--edge-ip-version': 4 })
+    // Origin dials 127.0.0.1 (IPv4-only server). Passes an isolated --config so
+    // a user's ~/.cloudflared/config.yml (ingress -> http_status:404) is ignored,
+    // and --edge-ip-version 4 to avoid the slow/broken IPv6 DNS path behind VPNs.
+    expect(mocks.quick).toHaveBeenCalledWith(
+      'http://127.0.0.1:20620',
+      expect.objectContaining({ '--edge-ip-version': 4, '--config': expect.stringContaining('cloudflared') })
+    )
 
     // URL is printed by cloudflared before the edge connection is up.
     t.emit('url', URL)

--- a/src/main/tunnel-manager.ts
+++ b/src/main/tunnel-manager.ts
@@ -1,7 +1,27 @@
 import { Tunnel } from 'cloudflared'
+import { writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 
 let activeTunnel: Tunnel | null = null
 let tunnelUrl: string | null = null
+
+/**
+ * cloudflared auto-loads a default config file (~/.cloudflared/config.yml, etc.)
+ * even for `--url` quick tunnels. If the user has one from another tool (e.g. a
+ * `daytona_proxy` named tunnel), its `ingress:` rules take over and the quick
+ * tunnel's hostname matches none of them, so every request falls through to the
+ * catch-all `service: http_status:404` — the tunnel connects and the URL is
+ * generated, but every request returns 404 and never reaches our local server.
+ * Point cloudflared at our own empty config so it ignores the user's file and
+ * uses the plain `--url` quick-tunnel ingress. Returns the config path.
+ */
+function ensureIsolatedConfig(): string {
+  const path = join(tmpdir(), '20x-cloudflared-empty.yml')
+  // Empty file → no ingress rules → quick tunnel proxies `--url` normally.
+  writeFileSync(path, '')
+  return path
+}
 
 // cloudflared can be slow to register its first edge connection when the local
 // DNS resolver is degraded — e.g. a VPN like Tailscale MagicDNS intercepting DNS
@@ -14,13 +34,27 @@ export async function startTunnel(port: number): Promise<string> {
   if (activeTunnel && tunnelUrl) return tunnelUrl
 
   return new Promise((resolve, reject) => {
-    // `--edge-ip-version 4`: cloudflared otherwise resolves/dials Cloudflare's edge
-    // over IPv6 first. On machines behind a VPN (notably Tailscale MagicDNS at
-    // fd7a:115c:a1e0::53) the IPv6 DNS path for *.argotunnel.com times out, which
-    // pushes first-connection to ~70–80s. Forcing the IPv4 edge sidesteps that
-    // resolver entirely and connects in a few seconds. build_options() uses the
-    // key verbatim, so the flag must include the leading dashes.
-    const t = Tunnel.quick(`http://localhost:${port}`, { '--edge-ip-version': 4 })
+    // Options passed to cloudflared. build_options() uses the key verbatim, so
+    // each flag must include the leading dashes.
+    //  --config <empty>: ignore any user ~/.cloudflared/config.yml whose ingress
+    //    rules would otherwise route every request to `http_status:404` (see
+    //    ensureIsolatedConfig). This is the root-cause fix for "URL generates but
+    //    doesn't work" — without it the tunnel connects but returns 404 for all
+    //    requests.
+    //  --edge-ip-version 4: cloudflared otherwise resolves/dials Cloudflare's edge
+    //    over IPv6 first. On machines behind a VPN (notably Tailscale MagicDNS at
+    //    fd7a:115c:a1e0::53) the IPv6 DNS path for *.argotunnel.com times out,
+    //    pushing first-connection to ~70–80s. Forcing the IPv4 edge connects in
+    //    a few seconds.
+    // Origin uses 127.0.0.1 (not `localhost`) because the mobile server binds
+    // IPv4 only (0.0.0.0); `localhost` can resolve to ::1 first and fail to dial.
+    let options: Record<string, string | number> = { '--edge-ip-version': 4 }
+    try {
+      options = { '--config': ensureIsolatedConfig(), ...options }
+    } catch (e) {
+      console.warn('[tunnel] could not write isolated cloudflared config, using default:', e)
+    }
+    const t = Tunnel.quick(`http://127.0.0.1:${port}`, options)
 
     // cloudflared prints the public https://<...>.trycloudflare.com URL to its
     // output BEFORE it has actually registered any connection with Cloudflare's


### PR DESCRIPTION
Follow-up to #403/#405. Proven end-to-end with cloudflared debug logs + an external client (not guessed).

## The real reason the tunnel "generates a URL but doesn't work"
The app runs `cloudflared tunnel --url http://localhost:20620`, but cloudflared **auto-loads the default config file** `~/.cloudflared/config.yml`. On this machine that file exists from another tool (a `daytona_proxy` named tunnel):

```yaml
tunnel: daytona_proxy
ingress:
  - hostname: "*.runworkflo.com"  # -> http://localhost:2000
  - hostname: "runworkflo.com"    # -> http://localhost:2000
  - service: http_status:404      # catch-all
```

Those ingress rules take over even for the `--url` quick tunnel. The quick-tunnel hostname (`*.trycloudflare.com`) matches **none** of them, so every request falls through to `service: http_status:404`. cloudflared debug log:

```
GET https://<quick>.trycloudflare.com/...  ingressRule=2 originService=http_status:404
404 Not Found                              ingressRule=2 originService=http_status:404
```

So the tunnel connects, the URL is minted, but **every request returns 404 and never reaches the mobile server** — matching the report exactly. (Direct `curl localhost:20620` returns 200/401; the origin was always fine.)

## Fix
Pass an **isolated empty `--config`** so cloudflared ignores the user's file and uses the plain `--url` quick-tunnel ingress. Also dial the origin at `127.0.0.1` (the mobile server binds IPv4-only `0.0.0.0`; `localhost` can resolve to `::1` first and fail).

## Verification (external client, Tailscale off)
After the change, cloudflared debug log:

```
GET .../?cb=fix1            ingressRule=0 originService=http://127.0.0.1:20620  200 OK
GET .../assets/index-*.js   ingressRule=0 originService=http://127.0.0.1:20620  200 OK
GET .../assets/index-*.css  ingressRule=0 originService=http://127.0.0.1:20620  200 OK
```

metrics: `response_by_code{200}=3, request_errors=0`. An external fetch of the public URL now returns the **20x mobile SPA** ("Connecting…", "No tasks found") instead of a 404.

## Notes
- Combined with #405 (fast IPv4-edge connect) and #403 (wait for `connected`), the tunnel now connects in ~6s and actually serves the app.
- Verified with cloudflared v2026.7.1 on the reporting machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
