### PR TITLE
test: fix opencode autoApprovePermission V2 test timeout (races async SDK import → real fetch to :4096)

### DIFF
--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -797,6 +797,13 @@ describe('OpencodeAdapter', () => {
 
     it('autoApprovePermission calls V2 SDK permission.reply with correct args including directory', async () => {
       const adapter = new OpencodeAdapter()
+      // The SDK is imported asynchronously in the constructor (fire-and-forget).
+      // autoApprovePermission only uses the mocked v2Client once the module-level
+      // OpenCodeV2Client has finished loading; otherwise it falls through to a real
+      // fetch() to DEFAULT_SERVER_URL (localhost:4096), which hangs the test if an
+      // OpenCode server happens to be running locally. Await the load so the V2
+      // path is taken deterministically (fixes the local 5s timeout / CI flake).
+      await (adapter as any).sdkLoading
       const mockReply = vi.fn().mockResolvedValue({ data: {}, error: null })
       const mockV2Client = {
         permission: { reply: mockReply, list: vi.fn() }
@@ -805,7 +812,15 @@ describe('OpencodeAdapter', () => {
       // Set the workspace directory for the session
       ;(adapter as any).sessionWorkspaceDirs.set('ses_abc', '/workspace/task_1')
 
-      await (adapter as any).autoApprovePermission('ses_abc', 'per_123')
+      // Safety net: if the SDK failed to load, keep the raw-fetch fallback path
+      // from making a real network call that would hang the test.
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, text: async () => '{}' })
+      vi.stubGlobal('fetch', mockFetch)
+      try {
+        await (adapter as any).autoApprovePermission('ses_abc', 'per_123')
+      } finally {
+        vi.unstubAllGlobals()
+      }
 
       // If OpenCodeV2Client is loaded (it is in test env since we import the module),
       // it should try to use v2Client. If OpenCodeV2Client is null (dynamic import


### PR DESCRIPTION
## Symptom
`src/main/adapters/opencode-adapter.test.ts > … > autoApprovePermission calls V2 SDK permission.reply with correct args including directory` **times out at 5000ms locally** (and is flaky in CI).

## Root cause (reproduced + verified locally)
`OpencodeAdapter` imports the SDK **asynchronously in its constructor** (`this.sdkLoading = this.loadSDK()`, fire-and-forget). `autoApprovePermission` only takes the V2 path (using the mocked `this.v2Client`) when the **module-level** `OpenCodeV2Client` has finished loading. The test sets `this.v2Client` and immediately calls `autoApprovePermission`, racing the import:

- import not resolved yet → V2 block skipped → falls through to a **real** `fetch('http://localhost:4096/permission/per_123/reply')` (`DEFAULT_SERVER_URL`).
- On a dev machine an OpenCode server is usually running on `4096`, so that POST for a bogus permission **hangs** → 5000ms timeout.
- In CI nothing listens on 4096 → `fetch` fails fast → the test "passed". Hence *flaky in CI, always times out locally*.

Confirmed by reproducing in the local checkout (5005ms timeout with an OpenCode server live on `[::1]:4096`).

## Fix (test-only)
- `await (adapter as any).sdkLoading` so the dynamic import completes and the V2 mock path is taken deterministically (the assertion now actually runs).
- Stub `fetch` as a safety net so the raw-fetch fallback can never make a real network call.

## Verification
Local run of just this test: **5005ms timeout → passes in ~24ms**, log shows `Auto-approved permission per_123 via V2 API (dir=/workspace/task_1)` (V2 path exercised). No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
