### PR TITLE
fix: force main window to 100% zoom on first load (dev opens zoomed out)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -161,6 +161,19 @@ function createWindow(): void {
     }, 60_000)
   })
 
+  // Force the main window to 100% zoom on first load. Chromium persists page
+  // zoom per host, so an accidental Cmd+- gets remembered — and because `pnpm dev`
+  // loads from `localhost`, a stray zoom level stays applied on every dev launch
+  // (the app opens zoomed out/in with no obvious way back). Reset once per launch;
+  // in-session Cmd+/Cmd- still works. Embedded <webview> contents have their own
+  // webContents and are unaffected.
+  let didResetZoom = false
+  mainWindow.webContents.on('did-finish-load', () => {
+    if (didResetZoom) return
+    didResetZoom = true
+    mainWindow?.webContents.setZoomLevel(0)
+  })
+
   // Auto-reload on renderer crash (blank screen recovery)
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
     console.error(`[Main] Renderer crashed: reason=${details.reason}, exitCode=${details.exitCode}`)


### PR DESCRIPTION
## Problem
Running `pnpm dev` opens the app zoomed out, with no obvious way back to 100% (menu Cmd+0 doesn't reliably fix it).

## Root cause
Chromium persists page zoom **per host** in the app's `Preferences`. On the reporting machine:
```
per_host_zoom_levels: { ..., "localhost": -2.5, "file:///.../index.html": 1.0, ... }
```
`pnpm dev` loads the renderer from `localhost`, so a stray zoom level (from an accidental Cmd+-) is re-applied on **every** dev launch and sticks. (The many other hosts at -2.5 are embedded `<webview>` sites.)

## Fix
Reset the **main window's** zoom level to 0 once per launch, on the first `did-finish-load`. In-session Cmd+/Cmd- still works; embedded `<webview>` contents have their own webContents and are unaffected. This also self-heals the persisted per-host value going forward.

## Note
Purely a main-process window-lifecycle change; no renderer/UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)