### PR TITLE
fix: render app server role-based final messages

### DIFF
--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -140,6 +140,37 @@ describe('CodexAppServerAdapter', () => {
     })
   })
 
+  it('converts generic assistant message items into final text parts', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const parts = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        item: {
+          id: 'final-1',
+          type: 'message',
+          role: 'assistant',
+          content: 'Here is the app: https://3050-example.runworkflo.com/?exec=abc'
+        },
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatchObject({
+      id: 'agent-final-1',
+      type: MessagePartType.TEXT,
+      text: 'Here is the app: https://3050-example.runworkflo.com/?exec=abc',
+      role: MessageRole.ASSISTANT
+    })
+    expect(parts[0].tool).toBeUndefined()
+  })
+
   it('tracks running tool items and clears them on completion', () => {
     const adapter = adapterPrivate(new CodexAppServerAdapter())
     const session = createSession()

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -128,6 +128,10 @@ function extractText(value: unknown): string {
   return ''
 }
 
+function extractRole(item: Record<string, unknown>): string {
+  return (asString(item.role) || asString(item.author) || asString(item.sender) || '').toLowerCase()
+}
+
 function extractToolName(item: Record<string, unknown>): string {
   const server = asString(item.server)
   const tool = asString(item.tool)
@@ -1121,9 +1125,10 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
   ): MessagePart[] {
     const itemId = extractItemId(params)
     const type = asString(item.type) || ''
+    const role = extractRole(item)
     const text = extractText(item)
 
-    if (type.includes('user') || type === 'user_message') {
+    if (role === 'user' || type.includes('user') || type === 'user_message') {
       const partId = `user-${itemId}`
       if (seenPartIds.has(partId)) return []
       seenPartIds.add(partId)
@@ -1136,7 +1141,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       }]
     }
 
-    if (type.includes('agent') || type.includes('assistant') || (!type && text)) {
+    if (role === 'assistant' || type.includes('agent') || type.includes('assistant') || (!type && text)) {
       const partId = `agent-${itemId}`
       if (seenPartIds.has(partId) && method !== 'item/completed') return []
       seenPartIds.add(partId)


### PR DESCRIPTION
## Summary
- classify Codex App Server thread items by role as well as type
- render generic role=assistant message items as assistant text instead of tool entries
- add regression coverage for final assistant messages containing app URLs

## Test plan
- pnpm test:run src/main/adapters/codex-app-server-adapter.test.ts
- pnpm typecheck