### PR TITLE
fix: reconcile app server final messages before idle

### DIFF
--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -74,6 +74,7 @@ interface AppServerSessionForTest {
   lastError: string | null
   config: { permissionMode?: 'ask' | 'allow'; sandboxMode?: 'read-only' | 'workspace-write' | 'danger-full-access' }
   streamedTextByItemId: Map<string, string>
+  assistantTextKeysByTurn: Map<string, Set<string>>
   runningTools: Map<string, {
     partId: string
     toolName: string
@@ -108,6 +109,7 @@ function createSession(): AppServerSessionForTest {
     lastError: null,
     config: { permissionMode: 'ask' },
     streamedTextByItemId: new Map(),
+    assistantTextKeysByTurn: new Map(),
     runningTools: new Map(),
     codexUseApiKey: false,
     codexAuthSummary: ''
@@ -181,6 +183,52 @@ describe('CodexAppServerAdapter', () => {
       role: MessageRole.ASSISTANT
     })
     expect(parts[0].tool).toBeUndefined()
+  })
+
+  it('deduplicates identical assistant final messages from different item ids in the same turn', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+    const finalText = 'Updated and verified.\n\nLatest link:\nhttps://3050-example.runworkflo.com/?exec=abc'
+
+    const first = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        item: {
+          id: 'agent-message-final',
+          type: 'agent_message',
+          role: 'assistant',
+          content: finalText
+        },
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    const duplicate = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        item: {
+          id: 'response-item-message-final',
+          type: 'message',
+          role: 'assistant',
+          content: finalText
+        },
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(first).toHaveLength(1)
+    expect(first[0]).toMatchObject({
+      id: 'agent-agent-message-final',
+      type: MessagePartType.TEXT,
+      text: finalText,
+      role: MessageRole.ASSISTANT
+    })
+    expect(duplicate).toHaveLength(0)
   })
 
   it('reconciles completed turns before reporting idle so final text is not lost', async () => {

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -61,6 +61,8 @@ interface AppServerSessionForTest {
   status: SessionStatusType
   messageBuffer: unknown[]
   permanentMessages: unknown[]
+  bufferedThreadItemIds: Set<string>
+  pendingCompletionRefreshes: number
   pendingRequests: Map<string | number, {
     resolve: (value: unknown) => void
     reject: (error: Error) => void
@@ -94,6 +96,8 @@ function createSession(): AppServerSessionForTest {
     status: SessionStatusType.IDLE,
     messageBuffer: [],
     permanentMessages: [],
+    bufferedThreadItemIds: new Set(),
+    pendingCompletionRefreshes: 0,
     pendingRequests: new Map(),
     pendingApproval: null,
     nextRequestId: 1,
@@ -104,6 +108,10 @@ function createSession(): AppServerSessionForTest {
     codexUseApiKey: false,
     codexAuthSummary: ''
   }
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
 }
 
 describe('CodexAppServerAdapter', () => {
@@ -169,6 +177,59 @@ describe('CodexAppServerAdapter', () => {
       role: MessageRole.ASSISTANT
     })
     expect(parts[0].tool).toBeUndefined()
+  })
+
+  it('reconciles completed turns before reporting idle so final text is not lost', async () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    session.status = SessionStatusType.BUSY
+    adapter.sessions.set('thread-1', session)
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    })
+
+    expect(session.status).toBe(SessionStatusType.BUSY)
+    expect(session.pendingCompletionRefreshes).toBe(1)
+    expect(session.pendingRequests.size).toBe(1)
+
+    const pending = Array.from(session.pendingRequests.values())[0]
+    pending.resolve({
+      data: [{
+        id: 'final-1',
+        type: 'message',
+        role: 'assistant',
+        content: 'Done: https://3050-example.runworkflo.com/?exec=abc',
+        turnId: 'turn-1'
+      }]
+    })
+    await flushPromises()
+
+    expect(session.pendingCompletionRefreshes).toBe(0)
+    expect(session.status).toBe(SessionStatusType.IDLE)
+
+    const parts = await adapterInstance.pollMessages(
+      'thread-1',
+      new Set(),
+      new Set(),
+      new Map(),
+      {} as never
+    )
+
+    expect(parts).toEqual([
+      expect.objectContaining({
+        id: 'agent-final-1',
+        type: MessagePartType.TEXT,
+        role: MessageRole.ASSISTANT,
+        text: 'Done: https://3050-example.runworkflo.com/?exec=abc'
+      })
+    ])
   })
 
   it('tracks running tool items and clears them on completion', () => {

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -63,6 +63,8 @@ interface AppServerSessionForTest {
   permanentMessages: unknown[]
   bufferedThreadItemIds: Set<string>
   pendingCompletionRefreshes: number
+  sawThreadStatusNotification: boolean
+  pendingThreadIdle: boolean
   pendingRequests: Map<string | number, {
     resolve: (value: unknown) => void
     reject: (error: Error) => void
@@ -98,6 +100,8 @@ function createSession(): AppServerSessionForTest {
     permanentMessages: [],
     bufferedThreadItemIds: new Set(),
     pendingCompletionRefreshes: 0,
+    sawThreadStatusNotification: false,
+    pendingThreadIdle: false,
     pendingRequests: new Map(),
     pendingApproval: null,
     nextRequestId: 1,
@@ -228,6 +232,73 @@ describe('CodexAppServerAdapter', () => {
         type: MessagePartType.TEXT,
         role: MessageRole.ASSISTANT,
         text: 'Done: https://3050-example.runworkflo.com/?exec=abc'
+      })
+    ])
+  })
+
+  it('keeps the session busy when a completed turn is followed by an active thread status', async () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    session.status = SessionStatusType.BUSY
+    adapter.sessions.set('thread-1', session)
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'thread/status/changed',
+      params: {
+        threadId: 'thread-1',
+        status: { type: 'active', activeFlags: ['model'] }
+      }
+    })
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1'
+      }
+    })
+
+    const pending = Array.from(session.pendingRequests.values())[0]
+    pending.resolve({
+      data: [{
+        id: 'progress-after-turn',
+        type: 'message',
+        role: 'assistant',
+        content: 'Still checking the result',
+        turnId: 'turn-1'
+      }]
+    })
+    await flushPromises()
+
+    expect(session.status).toBe(SessionStatusType.BUSY)
+    expect(session.pendingCompletionRefreshes).toBe(0)
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'thread/status/changed',
+      params: {
+        threadId: 'thread-1',
+        status: { type: 'idle' }
+      }
+    })
+
+    expect(session.status).toBe(SessionStatusType.IDLE)
+
+    const parts = await adapterInstance.pollMessages(
+      'thread-1',
+      new Set(),
+      new Set(),
+      new Map(),
+      {} as never
+    )
+
+    expect(parts).toEqual([
+      expect.objectContaining({
+        id: 'agent-progress-after-turn',
+        text: 'Still checking the result'
       })
     ])
   })

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -72,6 +72,8 @@ interface AppServerSession {
   status: SessionStatusType
   messageBuffer: unknown[]
   permanentMessages: unknown[]
+  bufferedThreadItemIds: Set<string>
+  pendingCompletionRefreshes: number
   pendingRequests: Map<string | number, {
     resolve: (value: unknown) => void
     reject: (error: Error) => void
@@ -551,6 +553,8 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       status: SessionStatusType.IDLE,
       messageBuffer: [],
       permanentMessages: [],
+      bufferedThreadItemIds: new Set(),
+      pendingCompletionRefreshes: 0,
       pendingRequests: new Map(),
       pendingApproval: null,
       nextRequestId: 1,
@@ -800,8 +804,13 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     }
 
     if (notification.method === 'turn/completed') {
-      session.status = SessionStatusType.IDLE
       session.activeTurnId = null
+      if (session.threadId) {
+        session.pendingCompletionRefreshes += 1
+        void this.reconcileCompletedTurn(session)
+      } else {
+        session.status = SessionStatusType.IDLE
+      }
     }
 
     if (notification.method === 'error') {
@@ -922,6 +931,13 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
   private bufferThreadItems(session: AppServerSession, result: unknown): void {
     const items = isObject(result) && Array.isArray(result.data) ? result.data : []
     for (const item of items) {
+      if (isObject(item)) {
+        const itemId = asString(item.id)
+        if (itemId) {
+          if (session.bufferedThreadItemIds.has(itemId)) continue
+          session.bufferedThreadItemIds.add(itemId)
+        }
+      }
       this.addEvent(session, {
         method: 'item/completed',
         params: {
@@ -978,6 +994,13 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       for (const turn of turns) {
         if (!isObject(turn) || !Array.isArray(turn.items)) continue
         for (const item of turn.items) {
+          if (isObject(item)) {
+            const itemId = asString(item.id)
+            if (itemId) {
+              if (session.bufferedThreadItemIds.has(itemId)) continue
+              session.bufferedThreadItemIds.add(itemId)
+            }
+          }
           this.addEvent(session, {
             method: 'item/completed',
             params: {
@@ -992,6 +1015,21 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       if (!cursor) return
     }
     console.warn('[CodexAppServerAdapter] Stopped thread/turns pagination after 20 pages')
+  }
+
+  private async reconcileCompletedTurn(session: AppServerSession): Promise<void> {
+    try {
+      if (!session.threadId) return
+      await this.bufferAllThreadItems(session, session.threadId)
+    } catch (error) {
+      console.warn('[CodexAppServerAdapter] Failed to reconcile completed turn items:', error)
+    } finally {
+      session.pendingCompletionRefreshes = Math.max(0, session.pendingCompletionRefreshes - 1)
+      if (session.pendingCompletionRefreshes === 0 && !session.activeTurnId && session.status !== SessionStatusType.ERROR) {
+        session.status = SessionStatusType.IDLE
+        this.onDataAvailable?.(session.threadId || session.sessionId)
+      }
+    }
   }
 
   private convertEventToMessageParts(

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -74,6 +74,8 @@ interface AppServerSession {
   permanentMessages: unknown[]
   bufferedThreadItemIds: Set<string>
   pendingCompletionRefreshes: number
+  sawThreadStatusNotification: boolean
+  pendingThreadIdle: boolean
   pendingRequests: Map<string | number, {
     resolve: (value: unknown) => void
     reject: (error: Error) => void
@@ -555,6 +557,8 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       permanentMessages: [],
       bufferedThreadItemIds: new Set(),
       pendingCompletionRefreshes: 0,
+      sawThreadStatusNotification: false,
+      pendingThreadIdle: false,
       pendingRequests: new Map(),
       pendingApproval: null,
       nextRequestId: 1,
@@ -801,6 +805,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     if (notification.method === 'turn/started') {
       session.status = SessionStatusType.BUSY
       session.activeTurnId = asString(params.turnId) || session.activeTurnId
+      session.pendingThreadIdle = false
     }
 
     if (notification.method === 'turn/completed') {
@@ -810,6 +815,22 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
         void this.reconcileCompletedTurn(session)
       } else {
         session.status = SessionStatusType.IDLE
+      }
+    }
+
+    if (notification.method === 'thread/status/changed') {
+      session.sawThreadStatusNotification = true
+      const status = isObject(params.status) ? asString(params.status.type) : ''
+      if (status === 'active') {
+        session.status = SessionStatusType.BUSY
+        session.pendingThreadIdle = false
+      } else if (status === 'idle') {
+        session.activeTurnId = null
+        session.pendingThreadIdle = true
+        this.markIdleIfSettled(session)
+      } else if (status === 'systemError') {
+        session.status = SessionStatusType.ERROR
+        session.lastError = 'Codex app-server thread entered system error state'
       }
     }
 
@@ -1025,11 +1046,19 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       console.warn('[CodexAppServerAdapter] Failed to reconcile completed turn items:', error)
     } finally {
       session.pendingCompletionRefreshes = Math.max(0, session.pendingCompletionRefreshes - 1)
-      if (session.pendingCompletionRefreshes === 0 && !session.activeTurnId && session.status !== SessionStatusType.ERROR) {
-        session.status = SessionStatusType.IDLE
-        this.onDataAvailable?.(session.threadId || session.sessionId)
-      }
+      this.markIdleIfSettled(session)
     }
+  }
+
+  private markIdleIfSettled(session: AppServerSession): void {
+    if (session.status === SessionStatusType.ERROR) return
+    if (session.pendingCompletionRefreshes > 0) return
+    if (session.activeTurnId) return
+    if (session.sawThreadStatusNotification && !session.pendingThreadIdle) return
+
+    session.pendingThreadIdle = false
+    session.status = SessionStatusType.IDLE
+    this.onDataAvailable?.(session.threadId || session.sessionId)
   }
 
   private convertEventToMessageParts(

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -85,6 +85,7 @@ interface AppServerSession {
   lastError: string | null
   config: SessionConfig
   streamedTextByItemId: Map<string, string>
+  assistantTextKeysByTurn: Map<string, Set<string>>
   runningTools: Map<string, {
     partId: string
     toolName: string
@@ -402,14 +403,20 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     const partContentLengths = new Map<string, string>()
     const partsByIdAndRole = new Map<string, MessagePart>()
 
-    for (const event of session.permanentMessages) {
-      const parts = this.convertEventToMessageParts(event, seenMessageIds, seenPartIds, partContentLengths, session)
-      for (const part of parts) {
-        const key = `${part.id || `part-${partsByIdAndRole.size}`}-${part.role || MessageRole.ASSISTANT}`
-        if (!partsByIdAndRole.has(key) || part.update) {
-          partsByIdAndRole.set(key, part)
+    const assistantTextKeysByTurn = session.assistantTextKeysByTurn
+    session.assistantTextKeysByTurn = new Map()
+    try {
+      for (const event of session.permanentMessages) {
+        const parts = this.convertEventToMessageParts(event, seenMessageIds, seenPartIds, partContentLengths, session)
+        for (const part of parts) {
+          const key = `${part.id || `part-${partsByIdAndRole.size}`}-${part.role || MessageRole.ASSISTANT}`
+          if (!partsByIdAndRole.has(key) || part.update) {
+            partsByIdAndRole.set(key, part)
+          }
         }
       }
+    } finally {
+      session.assistantTextKeysByTurn = assistantTextKeysByTurn
     }
 
     const messages: SessionMessage[] = []
@@ -468,6 +475,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     session.permanentMessages.length = 0
     session.pendingRequests.clear()
     session.streamedTextByItemId.clear()
+    session.assistantTextKeysByTurn.clear()
     session.runningTools.clear()
     this.sessions.delete(sessionId)
   }
@@ -565,6 +573,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       lastError: null,
       config,
       streamedTextByItemId: new Map(),
+      assistantTextKeysByTurn: new Map(),
       runningTools: new Map(),
       codexUseApiKey: authEnv.usesApiKey,
       codexAuthSummary: authEnv.summary
@@ -1211,8 +1220,15 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     if (role === 'assistant' || type.includes('agent') || type.includes('assistant') || (!type && text)) {
       const partId = `agent-${itemId}`
       if (seenPartIds.has(partId) && method !== 'item/completed') return []
-      seenPartIds.add(partId)
       const finalText = text || session.streamedTextByItemId.get(itemId) || ''
+      const alreadySeen = seenPartIds.has(partId)
+      if (!alreadySeen && method === 'item/completed' && this.hasSeenAssistantTextForTurn(session, params, item, finalText)) {
+        return []
+      }
+      seenPartIds.add(partId)
+      if (method === 'item/completed') {
+        this.markAssistantTextForTurn(session, params, item, finalText)
+      }
       partContentLengths.set(partId, String(finalText.length))
       return [{
         id: partId,
@@ -1257,6 +1273,40 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
 
     partContentLengths.set(partId, `${part.tool?.status}:${toolName}`)
     return [part]
+  }
+
+  private hasSeenAssistantTextForTurn(
+    session: AppServerSession,
+    params: Record<string, unknown>,
+    item: Record<string, unknown>,
+    text: string
+  ): boolean {
+    const key = this.buildAssistantTextKey(text)
+    if (!key) return false
+    const turnKey = this.extractTurnKey(params, item)
+    return session.assistantTextKeysByTurn.get(turnKey)?.has(key) ?? false
+  }
+
+  private markAssistantTextForTurn(
+    session: AppServerSession,
+    params: Record<string, unknown>,
+    item: Record<string, unknown>,
+    text: string
+  ): void {
+    const key = this.buildAssistantTextKey(text)
+    if (!key) return
+    const turnKey = this.extractTurnKey(params, item)
+    const seenForTurn = session.assistantTextKeysByTurn.get(turnKey) ?? new Set<string>()
+    seenForTurn.add(key)
+    session.assistantTextKeysByTurn.set(turnKey, seenForTurn)
+  }
+
+  private extractTurnKey(params: Record<string, unknown>, item: Record<string, unknown>): string {
+    return asString(params.turnId) || asString(item.turnId) || asString(params.threadId) || 'unknown-turn'
+  }
+
+  private buildAssistantTextKey(text: string): string {
+    return text.trim().replace(/\s+/g, ' ')
   }
 
   private sendRpcRequest(session: AppServerSession, method: string, params?: unknown): Promise<unknown> {

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1155,6 +1155,44 @@ describe('AgentManager transitionToIdle — enterprise task completion after fee
     expect(sessionWithAdapter.seenPartIds.has('final-part')).toBe(true)
   })
 
+  it('keeps polling and does not mark ready when adapter is still busy after transcript replay', async () => {
+    const mockDb = createEnterpriseTaskDb({
+      status: TaskStatus.AgentWorking,
+      output_fields: [],
+      source_id: null,
+    })
+    const { mgr, session } = setupManager(mockDb)
+    const adapter = {
+      getAllMessages: vi.fn(async () => ([
+        {
+          id: 'msg-1',
+          role: MessageRole.ASSISTANT,
+          parts: [
+            { id: 'late-progress', type: MessagePartType.TEXT, text: 'Still verifying', content: 'Still verifying' }
+          ]
+        }
+      ])),
+      getStatus: vi.fn(async () => ({ type: SessionStatusType.BUSY })),
+      pollMessages: vi.fn(async () => [] as any[]),
+    }
+
+    const sessionWithAdapter = {
+      ...session,
+      adapter: adapter as any,
+      workspaceDir: '/tmp/test-workspace'
+    }
+    vi.spyOn(mgr as any, 'extractOutputValues').mockResolvedValue(undefined)
+    vi.spyOn(mgr as any, 'ensurePollingCoordinator').mockImplementation(() => undefined)
+
+    await (mgr as any).transitionToIdle('session-1', sessionWithAdapter)
+
+    expect(adapter.getAllMessages).toHaveBeenCalledOnce()
+    expect(adapter.getStatus).toHaveBeenCalledOnce()
+    expect(mockDb.updateTask).not.toHaveBeenCalledWith('task-1', { status: TaskStatus.ReadyForReview })
+    expect((mgr as any).pollingEntries.has('session-1')).toBe(true)
+    expect(sessionWithAdapter.status).toBe('working')
+  })
+
   it('stores actual text content in partContentLengths, not string length (regression: number prefix bug)', async () => {
     // Regression: partContentLengths stored String(text.length) (e.g. "133")
     // instead of actual text. When chunk accumulation read it back, the number

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1920,6 +1920,58 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
     expect(abortPrompt).toHaveBeenCalledOnce()
   })
 
+  it('suppresses auto-abort transcript messages for Codex app-server tools', async () => {
+    const mgr = buildManager()
+    const abortPrompt = vi.fn(async () => undefined)
+    const adapter = {
+      pollMessages: vi.fn(async () => [] as any[]),
+      getStatus: vi.fn(async () => ({ type: SessionStatusType.BUSY })),
+      getRunningTools: vi.fn(async () => [{
+        partId: 'tool-call-1',
+        toolName: 'commandExecution',
+        startTime: Date.now() - 240_000,
+        input: {}
+      }]),
+      abortPrompt,
+    }
+    Object.defineProperty(adapter, 'constructor', {
+      value: { name: 'CodexAppServerAdapter' },
+    })
+
+    const session = {
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      status: 'working',
+      createdAt: new Date(),
+      seenMessageIds: new Set<string>(),
+      seenPartIds: new Set<string>(),
+      partContentLengths: new Map<string, string>(),
+      adapter,
+      pollingStarted: true,
+    }
+    ;(mgr as any).sessions.set('session-1', session)
+
+    ;(mgr as any).startAdapterPolling(
+      'session-1',
+      adapter,
+      { agentId: 'agent-1', taskId: 'task-1', workspaceDir: '/tmp/ws' },
+      undefined,
+      session
+    )
+
+    const entry = (mgr as any).pollingEntries.get('session-1')
+    await (mgr as any).pollSingleSession(entry)
+
+    const sendSpy = vi.mocked((mgr as any).sendToRenderer)
+    const autoAbortMessages = sendSpy.mock.calls.filter(([channel, payload]) => (
+      channel === 'agent:output' &&
+      String((payload as any).data?.content || '').startsWith('Session auto-aborted:')
+    ))
+
+    expect(autoAbortMessages).toHaveLength(0)
+    expect(abortPrompt).toHaveBeenCalledOnce()
+  })
+
   it('pollSingleSession does not inject a duplicate status error when the poll already emitted the same error text', async () => {
     const mgr = buildManager()
     const errorMessage = 'API Error: Server is temporarily limiting requests (not your usage limit) - Rate limited'

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -2829,8 +2829,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
    * Extracts output field values BEFORE notifying so the renderer
    * picks up the updated task data on re-fetch.
    */
-  private async replayMissedTranscriptPartsBeforeIdle(sessionId: string, session: AgentSession): Promise<void> {
-    if (!session.adapter?.getAllMessages) return
+  private async replayMissedTranscriptPartsBeforeIdle(sessionId: string, session: AgentSession): Promise<number> {
+    if (!session.adapter?.getAllMessages) return 0
 
     try {
       const config: SessionConfig = {
@@ -2880,9 +2880,38 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           messages: batchMessages
         })
       }
+      return batchMessages.length
     } catch (err) {
       console.error(`[AgentManager] replayMissedTranscriptPartsBeforeIdle error for ${sessionId}:`, err)
+      return 0
     }
+  }
+
+  private resumeAdapterPollingAfterPrematureIdle(sessionId: string, session: AgentSession): void {
+    if (!session.adapter) return
+
+    const sessionConfig: SessionConfig = {
+      agentId: session.agentId,
+      taskId: session.taskId,
+      workspaceDir: session.workspaceDir || this.db.getWorkspaceDir(session.taskId)
+    }
+
+    session.status = 'working'
+    session.pollingStarted = true
+    this.startAdapterPolling(sessionId, session.adapter, sessionConfig, true, session)
+
+    const pollingEntry = this.pollingEntries.get(sessionId)
+    if (pollingEntry) {
+      pollingEntry.hasSeenWork = true
+      pollingEntry.lastPartReceivedAt = Date.now()
+    }
+
+    this.sendToRenderer('agent:status', {
+      sessionId,
+      agentId: session.agentId,
+      taskId: session.taskId,
+      status: 'working'
+    })
   }
 
   private async transitionToIdle(sessionId: string, session: AgentSession): Promise<void> {
@@ -2890,8 +2919,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       console.log(`[AgentManager] transitionToIdle: session ${sessionId} already idle, skipping`)
       return
     }
-    session.status = 'idle'
-    console.log(`[AgentManager] Session ${sessionId} → idle`)
+    console.log(`[AgentManager] Session ${sessionId} preparing to transition idle`)
 
     // Helper: yield event loop between synchronous DB operations so IPC,
     // timers and rendering callbacks can run.  transitionToIdle chains many
@@ -2900,10 +2928,14 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     const yieldEventLoop = (): Promise<void> => new Promise((r) => setImmediate(r))
 
     // In learning mode, skip output extraction, task status, and renderer notification
-    if (session.learningMode) return
+    if (session.learningMode) {
+      session.status = 'idle'
+      return
+    }
 
     // In triage mode, set status back to NotStarted (now with agent_id assigned) and return early
     if (session.isTriageSession) {
+      session.status = 'idle'
       console.log(`[AgentManager] Triage session completed for task ${session.taskId}, reverting to NotStarted`)
       this.db.updateTask(session.taskId, { status: TaskStatus.NotStarted, session_id: null })
       await yieldEventLoop()
@@ -2926,8 +2958,31 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     // Polling can observe IDLE in the same tick that the adapter persists the
     // final assistant message. Reconcile once against the stored transcript so
     // the UI doesn't miss the last response.
-    await this.replayMissedTranscriptPartsBeforeIdle(sessionId, session)
+    const replayedPartCount = await this.replayMissedTranscriptPartsBeforeIdle(sessionId, session)
     await yieldEventLoop()
+
+    if (session.adapter) {
+      try {
+        const config: SessionConfig = {
+          agentId: session.agentId,
+          taskId: session.taskId,
+          workspaceDir: session.workspaceDir || this.db.getWorkspaceDir(session.taskId)
+        }
+        const statusAfterReplay = await session.adapter.getStatus(sessionId, config)
+        if (statusAfterReplay.type !== SessionStatusType.IDLE) {
+          console.log(
+            `[AgentManager] Idle transition for ${sessionId} deferred after replay: replayed=${replayedPartCount}, adapterStatus=${statusAfterReplay.type}`
+          )
+          this.resumeAdapterPollingAfterPrematureIdle(sessionId, session)
+          return
+        }
+      } catch (err) {
+        console.error(`[AgentManager] Failed to re-check adapter status before idle for ${sessionId}:`, err)
+      }
+    }
+
+    session.status = 'idle'
+    console.log(`[AgentManager] Session ${sessionId} → idle`)
 
     // Check if task exists (e.g., orchestrator-session doesn't have a real task)
     const task = this.db.getTask(session.taskId)

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -82,6 +82,10 @@ function hasUserSuppliedAuthHeader(headers?: Record<string, string>): boolean {
   return false
 }
 
+function isCodexAppServerAdapter(adapter: CodingAgentAdapter): boolean {
+  return adapter instanceof CodexAppServerAdapter || adapter.constructor?.name === 'CodexAppServerAdapter'
+}
+
 /**
  * The MCP server that 20x should auto-manage (URL canonicalisation + JWT
  * injection via mcp-auth-proxy) is exactly: an enterprise-sourced row whose
@@ -1593,10 +1597,12 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     session: AgentSession,
     taskId: string,
     idPrefix: string,
-    content: string
+    content: string,
+    suppressTranscript = false
   ): boolean {
     if (session.autoAbortNotified) return false
     session.autoAbortNotified = true
+    if (suppressTranscript) return true
     this.sendToRenderer('agent:output', {
       sessionId,
       taskId,
@@ -2049,7 +2055,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
                     session,
                     config.taskId,
                     'stuck-tool',
-                    `Session auto-aborted: ${reason}. You can send a new message to continue.`
+                    `Session auto-aborted: ${reason}. You can send a new message to continue.`,
+                    isCodexAppServerAdapter(adapter)
                   )
                   if (!shouldAbort) return
                   console.warn(`[AgentManager] Session ${sessionId}: ${reason}. Aborting.`)
@@ -2127,7 +2134,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
                 session,
                 config.taskId,
                 'stuck-abort',
-                `Session auto-aborted: no activity for ${Math.round(silentDuration / 1000)}s. A tool call may have hung. You can send a new message to continue.`
+                `Session auto-aborted: no activity for ${Math.round(silentDuration / 1000)}s. A tool call may have hung. You can send a new message to continue.`,
+                isCodexAppServerAdapter(adapter)
               )
               if (!shouldAbort) return
               console.warn(


### PR DESCRIPTION
## Summary
- reconcile completed Codex app-server turns before reporting idle so final assistant text is not lost
- dedupe buffered thread items while replaying completed turn history
- suppress noisy user-facing auto-abort transcript alerts for Codex app-server watchdog aborts while keeping abort attempts/logging

## Verification
- pnpm test:run src/main/agent-manager.test.ts src/main/adapters/codex-app-server-adapter.test.ts
- pnpm typecheck