### PR TITLE
fix: suppress app server watchdog transcript alerts

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1920,6 +1920,58 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
     expect(abortPrompt).toHaveBeenCalledOnce()
   })
 
+  it('suppresses auto-abort transcript messages for Codex app-server tools', async () => {
+    const mgr = buildManager()
+    const abortPrompt = vi.fn(async () => undefined)
+    const adapter = {
+      pollMessages: vi.fn(async () => [] as any[]),
+      getStatus: vi.fn(async () => ({ type: SessionStatusType.BUSY })),
+      getRunningTools: vi.fn(async () => [{
+        partId: 'tool-call-1',
+        toolName: 'commandExecution',
+        startTime: Date.now() - 240_000,
+        input: {}
+      }]),
+      abortPrompt,
+    }
+    Object.defineProperty(adapter, 'constructor', {
+      value: { name: 'CodexAppServerAdapter' },
+    })
+
+    const session = {
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      status: 'working',
+      createdAt: new Date(),
+      seenMessageIds: new Set<string>(),
+      seenPartIds: new Set<string>(),
+      partContentLengths: new Map<string, string>(),
+      adapter,
+      pollingStarted: true,
+    }
+    ;(mgr as any).sessions.set('session-1', session)
+
+    ;(mgr as any).startAdapterPolling(
+      'session-1',
+      adapter,
+      { agentId: 'agent-1', taskId: 'task-1', workspaceDir: '/tmp/ws' },
+      undefined,
+      session
+    )
+
+    const entry = (mgr as any).pollingEntries.get('session-1')
+    await (mgr as any).pollSingleSession(entry)
+
+    const sendSpy = vi.mocked((mgr as any).sendToRenderer)
+    const autoAbortMessages = sendSpy.mock.calls.filter(([channel, payload]) => (
+      channel === 'agent:output' &&
+      String((payload as any).data?.content || '').startsWith('Session auto-aborted:')
+    ))
+
+    expect(autoAbortMessages).toHaveLength(0)
+    expect(abortPrompt).toHaveBeenCalledOnce()
+  })
+
   it('pollSingleSession does not inject a duplicate status error when the poll already emitted the same error text', async () => {
     const mgr = buildManager()
     const errorMessage = 'API Error: Server is temporarily limiting requests (not your usage limit) - Rate limited'

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -82,6 +82,10 @@ function hasUserSuppliedAuthHeader(headers?: Record<string, string>): boolean {
   return false
 }
 
+function isCodexAppServerAdapter(adapter: CodingAgentAdapter): boolean {
+  return adapter instanceof CodexAppServerAdapter || adapter.constructor?.name === 'CodexAppServerAdapter'
+}
+
 /**
  * The MCP server that 20x should auto-manage (URL canonicalisation + JWT
  * injection via mcp-auth-proxy) is exactly: an enterprise-sourced row whose
@@ -1593,10 +1597,12 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     session: AgentSession,
     taskId: string,
     idPrefix: string,
-    content: string
+    content: string,
+    suppressTranscript = false
   ): boolean {
     if (session.autoAbortNotified) return false
     session.autoAbortNotified = true
+    if (suppressTranscript) return true
     this.sendToRenderer('agent:output', {
       sessionId,
       taskId,
@@ -2049,7 +2055,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
                     session,
                     config.taskId,
                     'stuck-tool',
-                    `Session auto-aborted: ${reason}. You can send a new message to continue.`
+                    `Session auto-aborted: ${reason}. You can send a new message to continue.`,
+                    isCodexAppServerAdapter(adapter)
                   )
                   if (!shouldAbort) return
                   console.warn(`[AgentManager] Session ${sessionId}: ${reason}. Aborting.`)
@@ -2127,7 +2134,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
                 session,
                 config.taskId,
                 'stuck-abort',
-                `Session auto-aborted: no activity for ${Math.round(silentDuration / 1000)}s. A tool call may have hung. You can send a new message to continue.`
+                `Session auto-aborted: no activity for ${Math.round(silentDuration / 1000)}s. A tool call may have hung. You can send a new message to continue.`,
+                isCodexAppServerAdapter(adapter)
               )
               if (!shouldAbort) return
               console.warn(


### PR DESCRIPTION
## Summary
- suppress user-facing auto-abort transcript messages for Codex app-server sessions
- keep watchdog console logging and abort attempts intact
- add regression coverage for stuck commandExecution tools under Codex app-server

## Verification
- pnpm test:run src/main/agent-manager.test.ts src/main/adapters/codex-app-server-adapter.test.ts
- pnpm typecheck

Stacked on #412 so this PR only contains the watchdog-alert suppression delta.