### PR TITLE
fix(ui): consistent light-mode background for task output fields

### DIFF
--- a/src/renderer/src/components/ui/Textarea.tsx
+++ b/src/renderer/src/components/ui/Textarea.tsx
@@ -6,7 +6,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaHTMLAttributes<HTMLText
     return (
       <textarea
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 resize-y',
+          'flex min-h-[80px] w-full rounded-lg border border-input bg-card px-3 py-2 text-sm text-foreground shadow-xs transition-all placeholder:text-muted-foreground focus:border-ring focus:ring-2 focus:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50 resize-y',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Problem
In **light mode**, task **Output Fields** rendered with inconsistent backgrounds: single-line fields (text/number/url via `Input`) showed a **white** surface, while multiline fields (`textarea` type via `Textarea`) showed a **grey** surface.

## Cause
The shared `Input` primitive uses `bg-card` (white in light mode), but the shared `Textarea` primitive used `bg-transparent`, letting the grey panel behind it show through.

## Fix
Aligned the `Textarea` primitive with `Input`'s styling so both share the same surface in light and dark mode:
- `bg-transparent` → `bg-card`
- `rounded-md` → `rounded-lg`
- added `shadow-xs transition-all`
- focus ring matched to `Input` (`focus:ring-2 focus:ring-ring/20`)

This is a shared UI primitive, so every form textarea (output fields, task form, feedback dialog, etc.) now matches its sibling inputs.

## Validation
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (pre-existing warnings only)
- No existing tests assert the old Textarea styling

Part of parent: **20x: redesign + light mode** (PR #399 Aperture design system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)