### PR TITLE
fix(ui): top bar alignment, dashboard horizontal scroll, canvas add button radius

### DIFF
--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -7,6 +7,7 @@ import type { AgentMessage } from '@/hooks/use-agent-session'
 import { SessionStatus } from '@/stores/agent-store'
 import { serializeTranscriptForDebug, type RawTranscriptMessage } from '@/lib/serialize-transcript-debug'
 import { agentSessionApi } from '@/lib/ipc-client'
+import { cn } from '@/lib/utils'
 
 enum ViewMode {
   MARKDOWN = 'markdown',
@@ -899,7 +900,7 @@ export function AgentTranscriptPanel({
   }
 
   return (
-    <div ref={panelRef} tabIndex={-1} className={`flex flex-col min-h-0 bg-background border-l border-border relative ${className ?? ''}`}>
+    <div ref={panelRef} tabIndex={-1} className={cn('flex flex-col min-h-0 bg-background border-l border-border relative', className)}>
       {/* Debug copy toast — only visible briefly after copy */}
       {debugCopyToast && (
         <div className="absolute top-12 left-1/2 -translate-x-1/2 z-50 bg-card border border-border rounded-md px-3 py-1.5 text-xs text-foreground shadow-lg animate-in fade-in duration-150">
@@ -908,7 +909,7 @@ export function AgentTranscriptPanel({
       )}
       {/* Header — windows-titlebar-safe adds right padding on Windows to avoid title bar overlay */}
       <div
-        className="flex items-center justify-between px-4 py-3 border-b border-border/50 shrink-0 windows-titlebar-safe"
+        className="flex items-center justify-between px-4 py-3 border-b border-border/60 shrink-0 windows-titlebar-safe"
         onContextMenu={handleHeaderContextMenu}
         title="Right-click to copy debug info"
       >

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -562,7 +562,7 @@ export function InfiniteCanvas() {
       <div className="absolute top-3 left-3 z-10">
         <Button
           size="sm"
-          className="h-8 px-3 bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm text-xs gap-1.5"
+          className="h-8 px-3 rounded-xl bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm text-xs gap-1.5"
           onClick={(e) => {
             const btn = e.currentTarget.getBoundingClientRect()
             const rect = containerRef.current?.getBoundingClientRect()

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -138,7 +138,7 @@ export function DashboardWorkspace() {
       </div>
 
       {/* Full-width sections below — constrained + centered to align with kanban */}
-      <div className="max-w-screen-xl mx-auto px-6 space-y-6 pb-8">
+      <div className="max-w-screen-2xl mx-auto px-6 space-y-6 pb-8">
         {/* Cloud connect prompt — when not authenticated */}
         {!isAuthenticated && (
           <>

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -118,7 +118,7 @@ export function DashboardWorkspace() {
   }, [setShowOrchestrator])
 
   return (
-    <div className="h-full overflow-y-auto">
+    <div className="h-full overflow-y-auto overflow-x-hidden">
       {/* Command center — centered narrow column */}
       <div className="max-w-2xl mx-auto px-6 pt-8 pb-6 space-y-5">
         {/* 1. Hero — Recent Mastermind Messages */}

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.tsx
@@ -138,7 +138,7 @@ export function DashboardWorkspace() {
       </div>
 
       {/* Full-width sections below — constrained + centered to align with kanban */}
-      <div className="max-w-screen-2xl mx-auto px-6 space-y-6 pb-8">
+      <div className="max-w-[1600px] mx-auto px-6 space-y-6 pb-8">
         {/* Cloud connect prompt — when not authenticated */}
         {!isAuthenticated && (
           <>

--- a/src/renderer/src/components/dashboard/TaskBoard.tsx
+++ b/src/renderer/src/components/dashboard/TaskBoard.tsx
@@ -365,7 +365,7 @@ export function TaskBoard() {
       </div>
 
       {isLoading ? (
-        <div className="flex gap-3 pb-2">
+        <div className="flex gap-3 pb-2 overflow-x-auto">
           {COLUMNS.map((col) => (
             <div key={col.key} className={`min-w-[230px] max-w-[280px] flex-1 rounded-xl ${col.columnBg} border border-border/15`}>
               <div className="px-3 py-2.5 border-b border-border/15">
@@ -393,7 +393,7 @@ export function TaskBoard() {
           </p>
         </div>
       ) : (
-        <div className="flex gap-3 pb-2">
+        <div className="flex gap-3 pb-2 overflow-x-auto">
           {COLUMNS.map((col) => (
             <BoardColumn
               key={col.key}

--- a/src/renderer/src/components/dashboard/TaskBoard.tsx
+++ b/src/renderer/src/components/dashboard/TaskBoard.tsx
@@ -270,7 +270,7 @@ const ColumnHeader = memo(function ColumnHeader({ column, count }: { column: Sta
 
 const BoardColumn = memo(function BoardColumn({ column, tasks, onSelect, agentMap }: { column: StatusColumn; tasks: WorkfloTask[]; onSelect: (id: string) => void; agentMap: Map<string, Agent> }) {
   return (
-    <div className={`min-w-[230px] max-w-[280px] flex-1 flex flex-col rounded-xl ${column.columnBg} border border-border/15`}>
+    <div className={`min-w-[230px] max-w-[320px] flex-1 flex flex-col rounded-xl ${column.columnBg} border border-border/15`}>
       {/* Sticky header within column */}
       <div className={`sticky top-0 z-10 ${column.columnBg} backdrop-blur-md rounded-t-xl border-b border-border/15`}>
         <ColumnHeader column={column} count={tasks.length} />
@@ -367,7 +367,7 @@ export function TaskBoard() {
       {isLoading ? (
         <div className="flex gap-3 pb-2 overflow-x-auto">
           {COLUMNS.map((col) => (
-            <div key={col.key} className={`min-w-[230px] max-w-[280px] flex-1 rounded-xl ${col.columnBg} border border-border/15`}>
+            <div key={col.key} className={`min-w-[230px] max-w-[320px] flex-1 rounded-xl ${col.columnBg} border border-border/15`}>
               <div className="px-3 py-2.5 border-b border-border/15">
                 <div className="flex items-center gap-2">
                   <div className={`h-2.5 w-2.5 rounded-full ${col.dotColor} opacity-40`} />

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -209,7 +209,7 @@ export function AppLayout() {
   return (
     <>
       {/* ── Top bar: drag region with logo (left) + nav switcher (center) + actions (right) ── */}
-      <div className="drag-region bg-background h-8 flex-shrink-0 flex items-center justify-center px-3 pt-0.5 windows-titlebar-pad">
+      <div className="drag-region bg-background h-8 flex-shrink-0 flex items-center justify-center px-3 pt-2.5 windows-titlebar-pad">
         {/* Logo + wordmark + update indicator — pinned left. The white logo mark
             always sits on a brand-gradient tile, so it stays visible in both themes. */}
         <div className="no-drag absolute left-3 flex items-center gap-1.5 macos-titlebar-pad">

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -247,7 +247,7 @@ function ParentTaskContext({ parentTask, onNavigateToTask }: { parentTask: Workf
       <div className="flex items-center gap-2">
         <button
           onClick={() => setIsExpanded(!isExpanded)}
-          className="flex-1 flex items-center gap-2 px-3 py-2.5 text-left cursor-pointer hover:bg-accent/50 rounded-lg transition-colors"
+          className="flex-1 min-w-0 flex items-center gap-2 px-3 py-2.5 text-left cursor-pointer hover:bg-accent/50 rounded-lg transition-colors"
         >
           {isExpanded ? (
             <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -397,7 +397,7 @@ export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachm
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between border-b px-6 py-4 shrink-0">
+      <div className="flex items-center justify-between border-b border-border/60 px-6 py-4 shrink-0">
         <div className="flex items-center gap-2.5">
           <TaskStatusBadge status={task.status} />
           <TaskTypeBadge type={task.type} />

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -721,9 +721,9 @@ Update existing skills that were helpful or create new ones for patterns worth r
         )}
 
         {showPanel && panelLayout !== 'task-only' && (
-          <div className="min-h-0 min-w-0 h-full flex flex-col">
+          <div className={`min-h-0 min-w-0 h-full flex flex-col ${panelLayout !== 'transcript-only' ? 'border-l border-border/60' : ''}`}>
             {/* Transcript / Changes tab switcher */}
-            <div className="flex items-center gap-1 border-b border-border/60 px-3 pt-2 pb-1 flex-shrink-0">
+            <div className="flex items-center gap-1 px-3 pt-2 pb-1 flex-shrink-0">
               {(['transcript', 'changes'] as const).map((tab) => (
                 <button
                   key={tab}
@@ -753,11 +753,11 @@ Update existing skills that were helpful or create new ones for patterns worth r
                 onSend={handleSend}
                 onPickAttachments={handlePickAttachments}
                 onAddAttachmentPaths={handleAddAttachmentPaths}
-                className="h-full"
                 sessionId={session.sessionId}
                 taskId={task.id}
                 agentId={task.agent_id ?? undefined}
                 pendingApproval={session.pendingApproval ?? undefined}
+                className="h-full bg-card border-l-0"
               />
             </div>
             <div className={rightTab === 'changes' ? 'flex-1 min-h-0' : 'hidden'}>

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -267,7 +267,7 @@ body, .theme-transition {
 
 /* macOS: push left-pinned elements past the traffic lights (constant physical gap). */
 [data-platform="darwin"] .macos-titlebar-pad {
-  margin-left: calc(80px / var(--zoom-factor, 1));
+  margin-left: calc(92px / var(--zoom-factor, 1));
 }
 
 /* Windows title-bar overlay safe areas */


### PR DESCRIPTION
Minor UI tweaks (follow-up to the Aperture redesign, parent PR #399).

### 1. Dashboard horizontal scroll
The dashboard showed a page-level horizontal scrollbar. Root cause: the Task Board kanban has 5 fixed-width columns (`min-w-[230px]`, ~1198px total) that can't shrink below their min width; whenever the workspace card is narrower than that (smaller windows, or Mastermind drawer open) they overflow, and `overflow-y-auto` computes `overflow-x` to `auto`, surfacing a horizontal scrollbar for the whole page.
- Added `overflow-x-hidden` to the dashboard scroll container.
- Added `overflow-x-auto` to the kanban row (loading + populated states) so the board scrolls *within its own row* rather than pushing the page.

### 2. Top bar spacing & alignment
- **Gap:** logo chip + "20x" wordmark were crammed against the macOS traffic lights. Increased the traffic-light left padding `80px → 92px` (still divided by `--zoom-factor` to keep a constant *physical* gap across zoom levels).
- **Vertical:** all top-bar components sat ~4px higher than the traffic lights. Nudged the top-bar content down (`pt-0.5 → pt-2.5`) so it centers on the traffic-light line. Traffic light position itself is unchanged.

### 3. Canvas "Add" button radius
Matched the "Add" HUD button corner radius to the canvas panel (`rounded-lg` 14px → `rounded-xl` 18px).

### 4. Task screen — Transcript panel chrome (dividers at different levels/colors)
The **Transcript** tab rendered as a mismatched, inset box: it used `bg-background` (vs the card surface), a full-opacity `border-l` that started mid-height (below the tab bar), and a `/50` header border — so its dividers sat at different levels and colors than the **Changes** tab and the task-detail header.
- Moved the column divider onto the right-column wrapper so the vertical line runs full height (split view only), instead of on the transcript panel.
- Blended the transcript panel with the card surface (`bg-card`, no own left border) to match `ChangesPanel`.
- Unified header border colors to `border-border/60` (transcript header + task-detail header) and dropped the redundant tab-bar border so each tab shows a single, consistent header line.
- Switched `AgentTranscriptPanel` root to `cn()` so callers can override bg/border (canvas & Mastermind usages keep their existing chrome).

### Notes
Changes are className / CSS-value only (no logic). Vertical alignment magnitude (#2) was derived from measuring the attached screenshot; **please eyeball the top bar + task screen on macOS** to confirm. `typecheck`/`lint` can't run in this workspace (node_modules not installed — zustand/vitest/typescript-eslint unresolved), but the edits have no type surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)