### PR TITLE
feat(canvas): open a subtask as a separate window from the subtask list

### DIFF
--- a/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
@@ -1,11 +1,28 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { TaskPanelContent } from './TaskPanelContent'
 
-const { updatePanelMock, selectTaskMock, updateTaskMock, taskList } = vi.hoisted(() => ({
+const {
+  updatePanelMock,
+  selectTaskMock,
+  updateTaskMock,
+  addPanelMock,
+  addEdgeMock,
+  bringToFrontMock,
+  canvasState,
+  taskList,
+} = vi.hoisted(() => ({
   updatePanelMock: vi.fn(),
   selectTaskMock: vi.fn(),
   updateTaskMock: vi.fn(),
+  addPanelMock: vi.fn(() => 'panel-new'),
+  addEdgeMock: vi.fn(),
+  bringToFrontMock: vi.fn(),
+  canvasState: {
+    panels: [
+      { id: 'panel-1', type: 'task', refId: 'task-1', x: 100, y: 200, width: 1020, height: 780 },
+    ] as Array<{ id: string; type: string; refId: string; x: number; y: number; width: number; height: number }>,
+  },
   taskList: [
     {
       id: 'task-1',
@@ -33,17 +50,39 @@ const { updatePanelMock, selectTaskMock, updateTaskMock, taskList } = vi.hoisted
 }))
 
 vi.mock('@/components/tasks/TaskWorkspace', () => ({
-  TaskWorkspace: ({ onNavigateToTask }: { onNavigateToTask?: (taskId: string) => void }) => (
-    <button type="button" onClick={() => onNavigateToTask?.('child-1')}>
-      Navigate to child
-    </button>
+  TaskWorkspace: ({
+    onNavigateToTask,
+    onOpenSubtaskInWindow,
+  }: {
+    onNavigateToTask?: (taskId: string) => void
+    onOpenSubtaskInWindow?: (taskId: string) => void
+  }) => (
+    <>
+      <button type="button" onClick={() => onNavigateToTask?.('child-1')}>
+        Navigate to child
+      </button>
+      <button type="button" onClick={() => onOpenSubtaskInWindow?.('child-1')}>
+        Open child in window
+      </button>
+    </>
   ),
 }))
 
-vi.mock('@/stores/canvas-store', () => ({
-  useCanvasStore: (selector: (state: { updatePanel: typeof updatePanelMock }) => unknown) =>
-    selector({ updatePanel: updatePanelMock }),
-}))
+vi.mock('@/stores/canvas-store', () => {
+  const store = {
+    updatePanel: updatePanelMock,
+    addPanel: addPanelMock,
+    addEdge: addEdgeMock,
+    bringToFront: bringToFrontMock,
+  }
+  const useCanvasStore = (selector: (state: typeof store) => unknown) => selector(store)
+  useCanvasStore.getState = () => ({ ...store, panels: canvasState.panels })
+  return {
+    useCanvasStore,
+    DEFAULT_PANEL_WIDTH: 1020,
+    DEFAULT_PANEL_HEIGHT: 780,
+  }
+})
 
 vi.mock('@/stores/task-store', () => {
   const state = {
@@ -78,8 +117,15 @@ vi.mock('@/stores/task-source-store', () => ({
 }))
 
 describe('TaskPanelContent', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
+    canvasState.panels = [
+      { id: 'panel-1', type: 'task', refId: 'task-1', x: 100, y: 200, width: 1020, height: 780 },
+    ]
   })
 
   it('retargets the current canvas panel when navigating to another task', () => {
@@ -92,5 +138,39 @@ describe('TaskPanelContent', () => {
       title: 'Child Task',
     })
     expect(selectTaskMock).toHaveBeenCalledWith('child-1')
+  })
+
+  it('opens a subtask as a new panel positioned to the right and linked by an edge', () => {
+    render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
+
+    fireEvent.click(screen.getByText('Open child in window'))
+
+    expect(addPanelMock).toHaveBeenCalledWith({
+      type: 'task',
+      title: 'Child Task',
+      refId: 'child-1',
+      x: 100 + 1020 + 40, // current x + width + gap
+      y: 200,
+      width: 1020,
+      height: 780,
+    })
+    expect(addEdgeMock).toHaveBeenCalledWith('panel-1', 'panel-new')
+    // Does not replace the current panel
+    expect(updatePanelMock).not.toHaveBeenCalled()
+  })
+
+  it('brings an existing subtask panel to the front instead of duplicating it', () => {
+    canvasState.panels = [
+      { id: 'panel-1', type: 'task', refId: 'task-1', x: 100, y: 200, width: 1020, height: 780 },
+      { id: 'panel-2', type: 'task', refId: 'child-1', x: 500, y: 500, width: 1020, height: 780 },
+    ]
+
+    render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
+
+    fireEvent.click(screen.getByText('Open child in window'))
+
+    expect(bringToFrontMock).toHaveBeenCalledWith('panel-2')
+    expect(addPanelMock).not.toHaveBeenCalled()
+    expect(addEdgeMock).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/canvas/TaskPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { TaskWorkspace, type TaskWorkspaceLayout } from '@/components/tasks/TaskWorkspace'
-import { useCanvasStore } from '@/stores/canvas-store'
+import { useCanvasStore, DEFAULT_PANEL_WIDTH, DEFAULT_PANEL_HEIGHT } from '@/stores/canvas-store'
 import { useTaskStore } from '@/stores/task-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useUIStore } from '@/stores/ui-store'
@@ -24,6 +24,9 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
   const agents = useAgentStore((s) => s.agents)
   const updateTask = useTaskStore((s) => s.updateTask)
   const updatePanel = useCanvasStore((s) => s.updatePanel)
+  const addPanel = useCanvasStore((s) => s.addPanel)
+  const addEdge = useCanvasStore((s) => s.addEdge)
+  const bringToFront = useCanvasStore((s) => s.bringToFront)
   const { executeAction } = useTaskSourceStore()
   const { openEditModal, openDeleteModal } = useUIStore()
 
@@ -92,6 +95,43 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
     [panelId, updatePanel]
   )
 
+  // Open a subtask as a separate window (a new task panel) on the canvas,
+  // rather than replacing the current panel. Positions the new panel to the
+  // right of this one and links them with an edge. If the subtask is already
+  // open, bring its panel to the front instead of duplicating it.
+  const handleOpenSubtaskInWindow = useCallback(
+    (tid: string) => {
+      const targetTask = useTaskStore.getState().tasks.find((candidate) => candidate.id === tid)
+      if (!targetTask) return
+
+      const { panels } = useCanvasStore.getState()
+
+      const existing = panels.find((p) => p.type === 'task' && p.refId === tid)
+      if (existing) {
+        bringToFront(existing.id)
+        return
+      }
+
+      const currentPanel = panels.find((p) => p.id === panelId)
+      const gap = 40
+      const newX = currentPanel ? currentPanel.x + currentPanel.width + gap : 0
+      const newY = currentPanel ? currentPanel.y : 0
+
+      const newId = addPanel({
+        type: 'task',
+        title: targetTask.title,
+        refId: targetTask.id,
+        x: newX,
+        y: newY,
+        width: DEFAULT_PANEL_WIDTH,
+        height: DEFAULT_PANEL_HEIGHT,
+      })
+
+      if (newId) addEdge(panelId, newId)
+    },
+    [panelId, addPanel, addEdge, bringToFront]
+  )
+
   if (!task) {
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground/50 text-xs">
@@ -113,6 +153,7 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
         onAssignAgent={handleAssignAgent}
         onUpdateTask={handleUpdateTask}
         onNavigateToTask={handleNavigateToTask}
+        onOpenSubtaskInWindow={handleOpenSubtaskInWindow}
         panelLayout={panelLayout}
       />
     </div>

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Pencil, Trash2, Calendar, User, Tag, Clock, Bot, Play, History, GitBranch, Plus, X, BookOpen, AlarmClockOff, BellRing, Folder, Repeat, Star, Sparkles, ListTree, ArrowLeft, ChevronRight, ChevronDown, GripVertical, Layers, Settings2, AlertCircle } from 'lucide-react'
+import { Pencil, Trash2, Calendar, User, Tag, Clock, Bot, Play, History, GitBranch, Plus, X, BookOpen, AlarmClockOff, BellRing, Folder, Repeat, Star, Sparkles, ListTree, ArrowLeft, ChevronRight, ChevronDown, GripVertical, Layers, Settings2, AlertCircle, SquareArrowOutUpRight } from 'lucide-react'
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core'
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -100,7 +100,7 @@ const subtaskStatusDotColor: Record<TaskStatus, string> = {
   [TaskStatus.Completed]: 'bg-emerald-400'
 }
 
-function SortableSubtaskItem({ subtask, onNavigateToTask }: { subtask: WorkfloTask; onNavigateToTask?: (taskId: string) => void }) {
+function SortableSubtaskItem({ subtask, onNavigateToTask, onOpenSubtaskInWindow }: { subtask: WorkfloTask; onNavigateToTask?: (taskId: string) => void; onOpenSubtaskInWindow?: (taskId: string) => void }) {
   const {
     attributes,
     listeners,
@@ -138,13 +138,23 @@ function SortableSubtaskItem({ subtask, onNavigateToTask }: { subtask: WorkfloTa
         <div className="min-w-0 flex-1">
           <div className="text-sm truncate">{subtask.title}</div>
         </div>
-        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
       </button>
+      {onOpenSubtaskInWindow && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onOpenSubtaskInWindow(subtask.id) }}
+          title="Open in a separate window"
+          aria-label="Open subtask in a separate window"
+          className="shrink-0 p-1 rounded text-muted-foreground/50 hover:text-foreground hover:bg-accent transition-colors cursor-pointer"
+        >
+          <SquareArrowOutUpRight className="h-3.5 w-3.5" />
+        </button>
+      )}
+      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
     </div>
   )
 }
 
-function SubtasksSection({ subtasks, onNavigateToTask, onAddSubtask, onReorderSubtasks }: { subtasks: WorkfloTask[]; onNavigateToTask?: (taskId: string) => void; onAddSubtask?: (title: string) => void; onReorderSubtasks?: (orderedIds: string[]) => void }) {
+function SubtasksSection({ subtasks, onNavigateToTask, onOpenSubtaskInWindow, onAddSubtask, onReorderSubtasks }: { subtasks: WorkfloTask[]; onNavigateToTask?: (taskId: string) => void; onOpenSubtaskInWindow?: (taskId: string) => void; onAddSubtask?: (title: string) => void; onReorderSubtasks?: (orderedIds: string[]) => void }) {
   const [isAdding, setIsAdding] = React.useState(false)
   const [newTitle, setNewTitle] = React.useState('')
   const inputRef = React.useRef<HTMLInputElement>(null)
@@ -208,6 +218,7 @@ function SubtasksSection({ subtasks, onNavigateToTask, onAddSubtask, onReorderSu
                 key={subtask.id}
                 subtask={subtask}
                 onNavigateToTask={onNavigateToTask}
+                onOpenSubtaskInWindow={onOpenSubtaskInWindow}
               />
             ))}
           </SortableContext>
@@ -372,11 +383,13 @@ interface TaskDetailViewProps {
   subtasks?: WorkfloTask[]
   parentTask?: WorkfloTask | null
   onNavigateToTask?: (taskId: string) => void
+  /** When provided, each subtask shows an action to open it as a separate window/panel. */
+  onOpenSubtaskInWindow?: (taskId: string) => void
   onAddSubtask?: (title: string) => void
   onReorderSubtasks?: (orderedIds: string[]) => void
 }
 
-export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onAddSkills, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage, onEditAgent, onUpdateDescription, onUpdateAutoFlags, subtasks, parentTask, onNavigateToTask, onAddSubtask, onReorderSubtasks }: TaskDetailViewProps) {
+export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onAddSkills, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage, onEditAgent, onUpdateDescription, onUpdateAutoFlags, subtasks, parentTask, onNavigateToTask, onOpenSubtaskInWindow, onAddSubtask, onReorderSubtasks }: TaskDetailViewProps) {
   const { skills, fetchSkills } = useSkillStore()
   const openTaskOnCanvas = useUIStore((s) => s.openTaskOnCanvas)
   const isActive = task.status !== TaskStatus.Completed
@@ -720,6 +733,7 @@ export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachm
             <SubtasksSection
               subtasks={subtasks || []}
               onNavigateToTask={onNavigateToTask}
+              onOpenSubtaskInWindow={onOpenSubtaskInWindow}
               onAddSubtask={onAddSubtask}
               onReorderSubtasks={onReorderSubtasks}
             />

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -39,6 +39,8 @@ interface TaskWorkspaceProps {
   onAssignAgent: (taskId: string, agentId: string | null) => void
   onUpdateTask?: (taskId: string, data: Partial<WorkfloTask>) => Promise<void>
   onNavigateToTask?: (taskId: string) => void
+  /** When provided, each subtask shows an action to open it as a separate canvas window/panel. */
+  onOpenSubtaskInWindow?: (taskId: string) => void
   /** Override the layout — which panels to show. Default: 'both' */
   panelLayout?: TaskWorkspaceLayout
 }
@@ -54,6 +56,7 @@ export function TaskWorkspace({
   onAssignAgent,
   onUpdateTask,
   onNavigateToTask,
+  onOpenSubtaskInWindow,
   panelLayout = 'both'
 }: TaskWorkspaceProps) {
   const { session, start, resume, abort, stop, sendMessage, approve } = useAgentSession(task?.id)
@@ -714,6 +717,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
             subtasks={subtasks}
             parentTask={parentTask}
             onNavigateToTask={onNavigateToTask}
+            onOpenSubtaskInWindow={onOpenSubtaskInWindow}
             onAddSubtask={handleAddSubtask}
             onReorderSubtasks={handleReorderSubtasks}
           />


### PR DESCRIPTION
## What

Adds the ability to **open a subtask as a separate window in the canvas view** directly from the subtask list.

In the infinite-canvas view, a task is rendered as a floating panel ("window"). Previously, clicking a subtask in that panel's **Subtasks** list navigated *within the same panel* (replacing the parent's content). Now each subtask row also has a dedicated **"open in a separate window"** action that opens the subtask as its **own task panel** on the canvas — enabling multi-tasking across subtasks side-by-side.

## Behavior

- New panel is placed to the **right** of the current panel (40px gap) and **linked with an edge** to show the parent→subtask relationship (mirrors the existing browser-panel spawn pattern).
- If the subtask is **already open** on the canvas, its panel is **brought to the front** instead of being duplicated.
- Row-click still does the in-place navigation as before (unchanged).
- The action **only appears in the canvas context** (when `onOpenSubtaskInWindow` is provided by `TaskPanelContent`), so the standalone task-detail screen and mobile are unaffected.

## Design note

The canvas is itself a window manager (floating panels are the "windows"). Implementing "a separate window in a canvas view" as a **new canvas panel** — rather than a detached Electron `BrowserWindow` — is the coherent fit: the app is intentionally single-window, and a second `BrowserWindow` would share/clobber the per-renderer persisted `canvas_state` and require new routing/bootstrap infra. The panel approach is low-risk, additive, and matches existing UX.

## Changes

- `components/canvas/TaskPanelContent.tsx` — `handleOpenSubtaskInWindow` (dedupe → bring-to-front / add task panel to the right + edge); passes new callback to `TaskWorkspace`.
- `components/tasks/TaskWorkspace.tsx` — thread `onOpenSubtaskInWindow` through to `TaskDetailView`.
- `components/tasks/TaskDetailView.tsx` — new optional prop; renders a `SquareArrowOutUpRight` action button per subtask row when the callback is present.
- `components/canvas/TaskPanelContent.test.tsx` — added coverage for open-as-new-panel, positioning/edge, and existing-panel bring-to-front (dedupe).

## Validation

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm vitest run` (canvas store + TaskPanelContent) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)