### PR TITLE
feat: add agent transcript search

### DIFF
--- a/src/mobile/components/MessageBubble.tsx
+++ b/src/mobile/components/MessageBubble.tsx
@@ -1,9 +1,35 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { Markdown } from '@/components/ui/Markdown'
 import { cn } from '../lib/utils'
 import type { AgentMessage } from '../stores/agent-store'
 
-function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessage; onAnswer?: (answer: string) => void; canAnswer: boolean }) {
+function HighlightedText({ text, query }: { text: string; query?: string }) {
+  const normalizedQuery = query?.trim()
+  if (!normalizedQuery) return <>{text}</>
+
+  const lowerText = text.toLowerCase()
+  const lowerQuery = normalizedQuery.toLowerCase()
+  const parts: ReactNode[] = []
+  let cursor = 0
+  let matchIndex = lowerText.indexOf(lowerQuery)
+
+  while (matchIndex !== -1) {
+    if (matchIndex > cursor) parts.push(text.slice(cursor, matchIndex))
+    const match = text.slice(matchIndex, matchIndex + normalizedQuery.length)
+    parts.push(
+      <mark key={`${matchIndex}-${match}`} className="rounded-sm bg-yellow-300/80 px-0.5 text-black">
+        {match}
+      </mark>
+    )
+    cursor = matchIndex + normalizedQuery.length
+    matchIndex = lowerText.indexOf(lowerQuery, cursor)
+  }
+
+  if (cursor < text.length) parts.push(text.slice(cursor))
+  return <>{parts}</>
+}
+
+function QuestionMessage({ message, onAnswer, canAnswer, searchQuery }: { message: AgentMessage; onAnswer?: (answer: string) => void; canAnswer: boolean; searchQuery?: string }) {
   const questions = message.tool?.questions || []
   const [answers, setAnswers] = useState<Record<number, string>>({})
   const [submitted, setSubmitted] = useState(false)
@@ -28,11 +54,11 @@ function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessa
         <div key={qi} className="space-y-2">
           {q.header && (
             <div className="px-4 py-2 border-b border-border/30">
-              <span className="text-[10px] text-primary font-medium uppercase tracking-wide">{q.header}</span>
+              <span className="text-[10px] text-primary font-medium uppercase tracking-wide"><HighlightedText text={q.header} query={searchQuery} /></span>
             </div>
           )}
           <div className="px-4 py-3">
-            <p className="text-xs text-foreground">{q.question}</p>
+            <p className="text-xs text-foreground"><HighlightedText text={q.question} query={searchQuery} /></p>
           </div>
           {q.options?.length > 0 && (
             <div className="px-4 pb-3 space-y-1.5">
@@ -51,8 +77,8 @@ function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessa
                       isLocked && 'opacity-50 cursor-default'
                     )}
                   >
-                    <div className="font-medium">{opt.label}</div>
-                    {opt.description && <div className="text-muted-foreground mt-0.5">{opt.description}</div>}
+                    <div className="font-medium"><HighlightedText text={opt.label} query={searchQuery} /></div>
+                    {opt.description && <div className="text-muted-foreground mt-0.5"><HighlightedText text={opt.description} query={searchQuery} /></div>}
                   </button>
                 )
               })}
@@ -74,7 +100,7 @@ function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessa
   )
 }
 
-function TodoList({ message }: { message: AgentMessage }) {
+function TodoList({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const todos = message.tool?.todos || []
   return (
     <div className="rounded-md bg-card border border-border/50 overflow-hidden">
@@ -97,7 +123,7 @@ function TodoList({ message }: { message: AgentMessage }) {
               t.status === 'completed' && 'opacity-60 line-through text-muted-foreground',
               t.status !== 'completed' && 'text-foreground'
             )}>
-              {t.content}
+              <HighlightedText text={t.content} query={searchQuery} />
             </span>
           </div>
         ))}
@@ -106,7 +132,7 @@ function TodoList({ message }: { message: AgentMessage }) {
   )
 }
 
-function PlanReviewMessage({ message }: { message: AgentMessage }) {
+function PlanReviewMessage({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const tool = message.tool
   const label = tool?.title || message.content || 'Plan mode'
   const rawOutput = tool?.output || ''
@@ -120,12 +146,12 @@ function PlanReviewMessage({ message }: { message: AgentMessage }) {
         <svg className="h-3 w-3 text-muted-foreground shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/>
         </svg>
-        <span className="text-foreground">{label}</span>
+        <span className="text-foreground"><HighlightedText text={label} query={searchQuery} /></span>
       </div>
       {details && (
         <div className="px-3 py-2 border-t border-border/30 max-h-[50vh] overflow-y-auto">
           <div className="break-words">
-            <Markdown size="xs">{details}</Markdown>
+            <Markdown size="xs" highlightQuery={searchQuery}>{details}</Markdown>
           </div>
         </div>
       )}
@@ -240,7 +266,7 @@ export function isCompactActivityMessage(message: AgentMessage): boolean {
   return (message.partType === 'tool' && !!message.tool?.name) || message.partType === 'reasoning'
 }
 
-function TaskProgressMessage({ message }: { message: AgentMessage }) {
+function TaskProgressMessage({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const [expanded, setExpanded] = useState(false)
   const tp = message.taskProgress!
   const isRunning = tp.status === 'started' || tp.status === 'running'
@@ -263,9 +289,9 @@ function TaskProgressMessage({ message }: { message: AgentMessage }) {
         <svg className="h-3 w-3 text-blue-400 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <polyline points="4 17 10 11 4 5" /><line x1="12" x2="20" y1="19" y2="19" />
         </svg>
-        <span className="text-foreground font-medium truncate">{tp.description || 'Subagent task'}</span>
+        <span className="text-foreground font-medium truncate"><HighlightedText text={tp.description || 'Subagent task'} query={searchQuery} /></span>
         {tp.lastToolName && isRunning && (
-          <span className="text-muted-foreground text-[10px] truncate">· {tp.lastToolName}</span>
+          <span className="text-muted-foreground text-[10px] truncate">· <HighlightedText text={tp.lastToolName} query={searchQuery} /></span>
         )}
         <span className="ml-auto flex items-center gap-1.5 shrink-0">
           {tp.usage && (
@@ -298,7 +324,7 @@ function TaskProgressMessage({ message }: { message: AgentMessage }) {
         <div className="border-t border-border/30 px-3 py-2 space-y-2">
           {tp.summary && (
             <div className="text-xs">
-              <Markdown size="sm">{tp.summary}</Markdown>
+              <Markdown size="sm" highlightQuery={searchQuery}>{tp.summary}</Markdown>
             </div>
           )}
           {tp.usage && (
@@ -317,7 +343,7 @@ function TaskProgressMessage({ message }: { message: AgentMessage }) {
   )
 }
 
-function ToolCallMessage({ message }: { message: AgentMessage }) {
+function ToolCallMessage({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const [expanded, setExpanded] = useState(false)
   const tool = message.tool!
   const isRunning = !tool.status || tool.status === 'in_progress' || tool.status === 'running' || tool.status === 'pending'
@@ -339,8 +365,8 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
         <svg className="h-3 w-3 text-muted-foreground shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
         </svg>
-        <span className="text-foreground/80 font-medium shrink-0">{tool.name}</span>
-        {subtitle && <span className="min-w-0 flex-1 text-muted-foreground truncate">{subtitle}</span>}
+        <span className="text-foreground/80 font-medium shrink-0"><HighlightedText text={tool.name} query={searchQuery} /></span>
+        {subtitle && <span className="min-w-0 flex-1 text-muted-foreground truncate"><HighlightedText text={subtitle} query={searchQuery} /></span>}
         {!subtitle && <span className="flex-1" />}
         <span className="w-20 shrink-0 text-right text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover/tool:opacity-100">
           {message.timestamp.toLocaleTimeString()}
@@ -361,25 +387,25 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
           {command && (
             <div>
               <div className="text-muted-foreground mb-0.5">Command</div>
-              <pre className="overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words text-muted-foreground">{command}</pre>
+              <pre className="overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words text-muted-foreground"><HighlightedText text={command} query={searchQuery} /></pre>
             </div>
           )}
           {tool.input && (
             <div>
               <div className="text-muted-foreground mb-0.5">Input</div>
-              <pre className="overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words text-muted-foreground">{sanitizeToolContent(tool.input)}</pre>
+              <pre className="overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words text-muted-foreground"><HighlightedText text={sanitizeToolContent(tool.input)} query={searchQuery} /></pre>
             </div>
           )}
           {tool.output && (
             <div>
               <div className="text-muted-foreground mb-0.5">Output</div>
-              <pre className="overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words text-muted-foreground">{sanitizeToolContent(tool.output)}</pre>
+              <pre className="overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-words text-muted-foreground"><HighlightedText text={sanitizeToolContent(tool.output)} query={searchQuery} /></pre>
             </div>
           )}
           {tool.error && (
             <div>
               <div className="text-red-400 mb-0.5">Error</div>
-              <pre className="text-red-300 whitespace-pre-wrap break-words">{tool.error}</pre>
+              <pre className="text-red-300 whitespace-pre-wrap break-words"><HighlightedText text={tool.error} query={searchQuery} /></pre>
             </div>
           )}
         </div>
@@ -388,7 +414,7 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
   )
 }
 
-function ReasoningMessage({ message }: { message: AgentMessage }) {
+function ReasoningMessage({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const [expanded, setExpanded] = useState(false)
   const summary = message.content.split('\n').map((line) => line.trim()).find(Boolean) || 'Thinking'
 
@@ -403,34 +429,34 @@ function ReasoningMessage({ message }: { message: AgentMessage }) {
           expanded && 'rotate-90'
         )}>▶</span>
         <span className="shrink-0 text-teal-700 dark:text-teal-300">Thinking</span>
-        <span className="min-w-0 flex-1 truncate text-muted-foreground">{summary}</span>
+        <span className="min-w-0 flex-1 truncate text-muted-foreground"><HighlightedText text={summary} query={searchQuery} /></span>
         <span className="w-20 shrink-0 text-right text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover/tool:opacity-100">
           {message.timestamp.toLocaleTimeString()}
         </span>
       </button>
       {expanded && (
         <div className="ml-5 border-l border-teal-500/30 pl-3 py-1.5 text-foreground/75">
-          <Markdown size="sm">{message.content}</Markdown>
+          <Markdown size="sm" highlightQuery={searchQuery}>{message.content}</Markdown>
         </div>
       )}
     </div>
   )
 }
 
-export function MessageActivityGroup({ messages }: { messages: AgentMessage[] }) {
+export function MessageActivityGroup({ messages, searchQuery }: { messages: AgentMessage[]; searchQuery?: string }) {
   return (
     <div className="w-full border-l border-border/30 pl-2 py-0.5">
       {messages.map((message) => {
         if (message.partType === 'reasoning') {
-          return <ReasoningMessage key={message.id} message={message} />
+          return <ReasoningMessage key={message.id} message={message} searchQuery={searchQuery} />
         }
-        return <ToolCallMessage key={message.id} message={message} />
+        return <ToolCallMessage key={message.id} message={message} searchQuery={searchQuery} />
       })}
     </div>
   )
 }
 
-function TaskNotificationMessage({ message }: { message: AgentMessage }) {
+function TaskNotificationMessage({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const tool = message.tool
   const status = tool?.status || 'completed'
   const summary = tool?.output || message.content || 'Task completed'
@@ -462,7 +488,7 @@ function TaskNotificationMessage({ message }: { message: AgentMessage }) {
       </div>
       {summary && (
         <div className={cn('px-3 pb-2', isError ? 'text-red-200' : 'text-foreground/80')}>
-          <Markdown size="sm">{summary}</Markdown>
+          <Markdown size="sm" highlightQuery={searchQuery}>{summary}</Markdown>
         </div>
       )}
     </div>
@@ -473,37 +499,38 @@ interface MessageBubbleProps {
   message: AgentMessage
   onAnswer?: (answer: string) => void
   canAnswerQuestion?: boolean
+  searchQuery?: string
 }
 
-export function MessageBubble({ message, onAnswer, canAnswerQuestion = false }: MessageBubbleProps) {
+export function MessageBubble({ message, onAnswer, canAnswerQuestion = false, searchQuery }: MessageBubbleProps) {
   // Question — check by data content so it renders correctly regardless of partType
   if (message.tool?.questions && message.tool.questions.length > 0) {
-    return <QuestionMessage message={message} onAnswer={onAnswer} canAnswer={canAnswerQuestion} />
+    return <QuestionMessage message={message} onAnswer={onAnswer} canAnswer={canAnswerQuestion} searchQuery={searchQuery} />
   }
 
   // Todo list — check by data content so it renders correctly regardless of partType
   if (message.tool?.todos && message.tool.todos.length > 0) {
-    return <TodoList message={message} />
+    return <TodoList message={message} searchQuery={searchQuery} />
   }
 
   // Plan review
   if (message.partType === 'planreview') {
-    return <PlanReviewMessage message={message} />
+    return <PlanReviewMessage message={message} searchQuery={searchQuery} />
   }
 
   // Tool call — require a name to avoid rendering ghost entries with no tool name
   if (isCompactActivityMessage(message)) {
-    return <MessageActivityGroup messages={[message]} />
+    return <MessageActivityGroup messages={[message]} searchQuery={searchQuery} />
   }
 
   // Task progress — live subagent task tracking
   if (message.partType === 'task_progress' && message.taskProgress) {
-    return <TaskProgressMessage message={message} />
+    return <TaskProgressMessage message={message} searchQuery={searchQuery} />
   }
 
   // Task notification — subtask completion/failure/stopped
   if (message.partType === 'task-notification') {
-    return <TaskNotificationMessage message={message} />
+    return <TaskNotificationMessage message={message} searchQuery={searchQuery} />
   }
 
   // Step markers and system status — skip (absorbed by store)
@@ -527,7 +554,7 @@ export function MessageBubble({ message, onAnswer, canAnswerQuestion = false }: 
         !isUser && !isSystem && !isError && 'w-full py-1 text-foreground/80'
       )}>
         <div className="break-words min-w-0">
-          <Markdown size="sm">{message.content}</Markdown>
+          <Markdown size="sm" highlightQuery={searchQuery}>{message.content}</Markdown>
         </div>
         {message.stepMeta && (
           <div className="flex items-center gap-2 mt-1 text-[10px] text-muted-foreground">

--- a/src/mobile/pages/ConversationPage.tsx
+++ b/src/mobile/pages/ConversationPage.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useCallback, useMemo, useState } from 'react'
 import { useTaskStore } from '../stores/task-store'
-import { useAgentStore, SessionStatus } from '../stores/agent-store'
+import { useAgentStore, SessionStatus, type AgentMessage } from '../stores/agent-store'
 import { api } from '../api/client'
 import { useSessionControls } from '../hooks/useSessionControls'
 import { MessageActivityGroup, MessageBubble, isCompactActivityMessage } from '../components/MessageBubble'
@@ -8,20 +8,62 @@ import { ChatInput, type ChatInputAttachment } from '../components/ChatInput'
 import { cn } from '../lib/utils'
 import type { Route } from '../App'
 
+function collectSearchableText(value: unknown, output: string[]): void {
+  if (value == null) return
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    output.push(String(value))
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectSearchableText(item, output))
+    return
+  }
+  if (typeof value === 'object') {
+    Object.values(value as Record<string, unknown>).forEach((item) => collectSearchableText(item, output))
+  }
+}
+
+function getMessageSearchText(message: AgentMessage): string {
+  const parts: string[] = []
+  collectSearchableText(message.role, parts)
+  collectSearchableText(message.partType, parts)
+  collectSearchableText(message.content, parts)
+  collectSearchableText(message.tool, parts)
+  collectSearchableText(message.taskProgress, parts)
+  return parts.join('\n').toLowerCase()
+}
+
 export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNavigate: (route: Route) => void }) {
   const task = useTaskStore((s) => s.tasks.find((t) => t.id === taskId))
   const session = useAgentStore((s) => s.sessions.get(taskId))
   const initSession = useAgentStore((s) => s.initSession)
 
   const scrollRef = useRef<HTMLDivElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
+  const messageNodeRefs = useRef(new Map<number, HTMLDivElement>())
   const isAtBottomRef = useRef(true)
   const [todosExpanded, setTodosExpanded] = useState(false)
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [activeSearchResult, setActiveSearchResult] = useState(0)
   const [showAttachmentPicker, setShowAttachmentPicker] = useState(false)
   const [messageAttachments, setMessageAttachments] = useState<ChatInputAttachment[]>([])
 
   const messages = session?.messages || []
   const lastMessage = messages[messages.length - 1]
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase()
+
+  const searchResultIndexes = useMemo(() => {
+    if (!normalizedSearchQuery) return []
+    return messages.reduce<number[]>((matches, message, index) => {
+      if (getMessageSearchText(message).includes(normalizedSearchQuery)) {
+        matches.push(index)
+      }
+      return matches
+    }, [])
+  }, [messages, normalizedSearchQuery])
+  const activeSearchMessageIndex = searchResultIndexes[activeSearchResult] ?? -1
 
   // Determine if the agent is actively working
   const isWorking = session?.status === SessionStatus.WORKING
@@ -135,6 +177,16 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
     setMessageAttachments((prev) => prev.filter((att) => validIds.has(att.id)))
   }, [taskAttachments])
 
+  useEffect(() => {
+    setActiveSearchResult(0)
+  }, [normalizedSearchQuery])
+
+  useEffect(() => {
+    if (activeSearchResult >= searchResultIndexes.length) {
+      setActiveSearchResult(Math.max(searchResultIndexes.length - 1, 0))
+    }
+  }, [activeSearchResult, searchResultIndexes.length])
+
   // Session controls (shared hook provides double-click protection and rollback)
   const { handleStart: _startSession, handleResume: _resumeSession, handleStop: _stopSession, handleRestart: _restartSession } = useSessionControls(taskId)
 
@@ -156,10 +208,19 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
 
   // Auto-scroll to bottom when new messages arrive (only if user is at bottom)
   useEffect(() => {
+    if (activeSearchMessageIndex >= 0) return
     if (isAtBottomRef.current && scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
-  }, [messages.length, lastMessage?.content])
+  }, [activeSearchMessageIndex, messages.length, lastMessage?.content])
+
+  useEffect(() => {
+    if (activeSearchMessageIndex < 0) return
+    const node = messageNodeRefs.current.get(activeSearchMessageIndex)
+    node?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    isAtBottomRef.current = false
+    setShowScrollToBottom(true)
+  }, [activeSearchMessageIndex])
 
   // Track scroll position
   const handleScroll = useCallback(() => {
@@ -175,6 +236,25 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
       scrollRef.current.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' })
       isAtBottomRef.current = true
       setShowScrollToBottom(false)
+    }
+  }, [])
+
+  const goToSearchResult = useCallback((direction: 1 | -1) => {
+    if (searchResultIndexes.length === 0) return
+    setActiveSearchResult((current) => (current + direction + searchResultIndexes.length) % searchResultIndexes.length)
+  }, [searchResultIndexes.length])
+
+  const closeSearch = useCallback(() => {
+    setSearchQuery('')
+    setIsSearchOpen(false)
+    setActiveSearchResult(0)
+  }, [])
+
+  const setMessageNode = useCallback((index: number, node: HTMLDivElement | null) => {
+    if (node) {
+      messageNodeRefs.current.set(index, node)
+    } else {
+      messageNodeRefs.current.delete(index)
     }
   }, [])
 
@@ -226,6 +306,21 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
           )}
           {/* Icon buttons — matches desktop AgentTranscriptPanel */}
           <div className="flex items-center gap-1">
+            <button
+              onClick={() => {
+                setIsSearchOpen((open) => {
+                  const nextOpen = !open
+                  if (nextOpen) requestAnimationFrame(() => searchInputRef.current?.focus())
+                  return nextOpen
+                })
+              }}
+              title="Search transcript"
+              className="inline-flex items-center justify-center h-7 w-7 rounded-md text-muted-foreground hover:bg-white/5 hover:text-foreground active:opacity-60 transition-colors"
+            >
+              <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>
+              </svg>
+            </button>
             {/* Restart — matches desktop RotateCcw icon */}
             {messages.length > 0 && hasSession && (
               <button
@@ -277,6 +372,63 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
           </div>
         </div>
       </div>
+
+      {isSearchOpen && (
+        <div className="shrink-0 flex items-center gap-2 px-4 py-2 border-b border-border/50">
+          <div className="relative min-w-0 flex-1">
+            <svg className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>
+            </svg>
+            <input
+              ref={searchInputRef}
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') closeSearch()
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  goToSearchResult(e.shiftKey ? -1 : 1)
+                }
+              }}
+              placeholder="Search transcript..."
+              className="h-8 w-full rounded-md border border-input bg-transparent pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring/30"
+            />
+          </div>
+          <span className="w-14 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+            {normalizedSearchQuery ? `${searchResultIndexes.length ? activeSearchResult + 1 : 0}/${searchResultIndexes.length}` : '0/0'}
+          </span>
+          <button
+            onClick={() => goToSearchResult(-1)}
+            disabled={searchResultIndexes.length === 0}
+            title="Previous result"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-white/5 hover:text-foreground disabled:opacity-40"
+          >
+            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m18 15-6-6-6 6"/>
+            </svg>
+          </button>
+          <button
+            onClick={() => goToSearchResult(1)}
+            disabled={searchResultIndexes.length === 0}
+            title="Next result"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-white/5 hover:text-foreground disabled:opacity-40"
+          >
+            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m6 9 6 6 6-6"/>
+            </svg>
+          </button>
+          <button
+            onClick={closeSearch}
+            title="Close search"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-white/5 hover:text-foreground"
+          >
+            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+            </svg>
+          </button>
+        </div>
+      )}
 
       {/* Pinned todo summary — matches desktop TodoSummary subheader */}
       {latestTodos && (
@@ -394,21 +546,48 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
           {messages.map((msg, index) => {
             if (!isCompactActivityMessage(msg)) {
               return (
-                <MessageBubble
+                <div
                   key={msg.id}
-                  message={msg}
-                  onAnswer={handleAnswer}
-                  canAnswerQuestion={msg.id === activeQuestionId}
-                />
+                  ref={(node) => setMessageNode(index, node)}
+                  className={cn(
+                    'rounded-md transition-colors',
+                    normalizedSearchQuery && searchResultIndexes.includes(index) && 'bg-yellow-500/5',
+                    index === activeSearchMessageIndex && 'ring-1 ring-yellow-400/60 bg-yellow-500/10'
+                  )}
+                >
+                  <MessageBubble
+                    message={msg}
+                    onAnswer={handleAnswer}
+                    canAnswerQuestion={msg.id === activeQuestionId}
+                  />
+                </div>
               )
             }
             if (index > 0 && isCompactActivityMessage(messages[index - 1])) return null
 
             const group = [msg]
+            const groupIndexes = [index]
             for (let nextIndex = index + 1; nextIndex < messages.length && isCompactActivityMessage(messages[nextIndex]); nextIndex += 1) {
               group.push(messages[nextIndex])
+              groupIndexes.push(nextIndex)
             }
-            return <MessageActivityGroup key={group.map((item) => item.id).join(':')} messages={group} />
+            const hasSearchMatch = normalizedSearchQuery && groupIndexes.some((itemIndex) => searchResultIndexes.includes(itemIndex))
+            const hasActiveSearchMatch = groupIndexes.includes(activeSearchMessageIndex)
+            return (
+              <div
+                key={group.map((item) => item.id).join(':')}
+                ref={(node) => {
+                  groupIndexes.forEach((itemIndex) => setMessageNode(itemIndex, node))
+                }}
+                className={cn(
+                  'rounded-md transition-colors',
+                  hasSearchMatch && 'bg-yellow-500/5',
+                  hasActiveSearchMatch && 'ring-1 ring-yellow-400/60 bg-yellow-500/10'
+                )}
+              >
+                <MessageActivityGroup messages={group} />
+              </div>
+            )
           })}
 
           {/* Working indicator */}

--- a/src/mobile/pages/ConversationPage.tsx
+++ b/src/mobile/pages/ConversationPage.tsx
@@ -549,16 +549,13 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
                 <div
                   key={msg.id}
                   ref={(node) => setMessageNode(index, node)}
-                  className={cn(
-                    'rounded-md transition-colors',
-                    normalizedSearchQuery && searchResultIndexes.includes(index) && 'bg-yellow-500/5',
-                    index === activeSearchMessageIndex && 'ring-1 ring-yellow-400/60 bg-yellow-500/10'
-                  )}
+                  className="rounded-md"
                 >
                   <MessageBubble
                     message={msg}
                     onAnswer={handleAnswer}
                     canAnswerQuestion={msg.id === activeQuestionId}
+                    searchQuery={normalizedSearchQuery}
                   />
                 </div>
               )
@@ -571,21 +568,15 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
               group.push(messages[nextIndex])
               groupIndexes.push(nextIndex)
             }
-            const hasSearchMatch = normalizedSearchQuery && groupIndexes.some((itemIndex) => searchResultIndexes.includes(itemIndex))
-            const hasActiveSearchMatch = groupIndexes.includes(activeSearchMessageIndex)
             return (
               <div
                 key={group.map((item) => item.id).join(':')}
                 ref={(node) => {
                   groupIndexes.forEach((itemIndex) => setMessageNode(itemIndex, node))
                 }}
-                className={cn(
-                  'rounded-md transition-colors',
-                  hasSearchMatch && 'bg-yellow-500/5',
-                  hasActiveSearchMatch && 'ring-1 ring-yellow-400/60 bg-yellow-500/10'
-                )}
+                className="rounded-md"
               >
-                <MessageActivityGroup messages={group} />
+                <MessageActivityGroup messages={group} searchQuery={normalizedSearchQuery} />
               </div>
             )
           })}

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
@@ -233,6 +233,33 @@ describe('AgentTranscriptPanel message layout', () => {
     expect(screen.queryByText('hidden needle output')).toBeNull()
   })
 
+  it('highlights the matched word instead of the whole message', () => {
+    render(
+      <AgentTranscriptPanel
+        messages={[
+          {
+            id: 'agent-1',
+            role: 'assistant',
+            content: 'Search should highlight only this needle word',
+            timestamp: new Date(),
+            partType: 'text'
+          }
+        ]}
+        status={SessionStatus.IDLE}
+        onStop={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByTitle('Search transcript'))
+    fireEvent.change(screen.getByPlaceholderText('Search transcript...'), {
+      target: { value: 'needle' }
+    })
+
+    const highlightedMatch = screen.getByText('needle')
+    expect(highlightedMatch.tagName).toBe('MARK')
+    expect(highlightedMatch.closest('.ring-1')).toBeNull()
+  })
+
   it('shows tool descriptions in compact rows and exact commands in expanded details', () => {
     const command = `cd "/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/vebrwpyobv88637krcachtxa/workflow-builder" && git add packages/ui/app/business-context/graph/page.tsx && git commit -q -F - <<'MSG'
 fix(ui): move custom-property editor from Overview into the Properties tab

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
@@ -192,6 +192,47 @@ describe('AgentTranscriptPanel message layout', () => {
     expect(screen.getByText('pass')).toBeInTheDocument()
   })
 
+  it('searches collapsed tool details without filtering transcript context', () => {
+    render(
+      <AgentTranscriptPanel
+        messages={[
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: 'Visible context',
+            timestamp: new Date(),
+            partType: 'text'
+          },
+          {
+            id: 'tool-1',
+            role: 'assistant',
+            content: 'Bash',
+            timestamp: new Date(),
+            partType: 'tool',
+            tool: {
+              name: 'Bash',
+              status: 'success',
+              title: 'pnpm test',
+              input: 'pnpm test',
+              output: 'hidden needle output'
+            }
+          }
+        ]}
+        status={SessionStatus.IDLE}
+        onStop={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByTitle('Search transcript'))
+    fireEvent.change(screen.getByPlaceholderText('Search transcript...'), {
+      target: { value: 'needle' }
+    })
+
+    expect(screen.getByText('1/1')).toBeInTheDocument()
+    expect(screen.getByText('Visible context')).toBeInTheDocument()
+    expect(screen.queryByText('hidden needle output')).toBeNull()
+  })
+
   it('shows tool descriptions in compact rows and exact commands in expanded details', () => {
     const command = `cd "/Users/dmitryvedenyapin/Library/Application Support/20x/workspaces/vebrwpyobv88637krcachtxa/workflow-builder" && git add packages/ui/app/business-context/graph/page.tsx && git commit -q -F - <<'MSG'
 fix(ui): move custom-property editor from Overview into the Properties tab

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -185,6 +185,32 @@ function getTranscriptItemSearchText(item: TranscriptItem): string {
   return getMessageSearchText(item.message)
 }
 
+function HighlightedText({ text, query }: { text: string; query?: string }) {
+  const normalizedQuery = query?.trim()
+  if (!normalizedQuery) return <>{text}</>
+
+  const lowerText = text.toLowerCase()
+  const lowerQuery = normalizedQuery.toLowerCase()
+  const parts: React.ReactNode[] = []
+  let cursor = 0
+  let matchIndex = lowerText.indexOf(lowerQuery)
+
+  while (matchIndex !== -1) {
+    if (matchIndex > cursor) parts.push(text.slice(cursor, matchIndex))
+    const match = text.slice(matchIndex, matchIndex + normalizedQuery.length)
+    parts.push(
+      <mark key={`${matchIndex}-${match}`} className="rounded-sm bg-yellow-300/80 px-0.5 text-black">
+        {match}
+      </mark>
+    )
+    cursor = matchIndex + normalizedQuery.length
+    matchIndex = lowerText.indexOf(lowerQuery, cursor)
+  }
+
+  if (cursor < text.length) parts.push(text.slice(cursor))
+  return <>{parts}</>
+}
+
 
 interface AgentTranscriptPanelProps {
   title?: string
@@ -213,7 +239,7 @@ export interface ComposerAttachment {
   mime_type: string
 }
 
-function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessage; onAnswer?: (answer: string) => void; canAnswer: boolean }) {
+function QuestionMessage({ message, onAnswer, canAnswer, searchQuery }: { message: AgentMessage; onAnswer?: (answer: string) => void; canAnswer: boolean; searchQuery?: string }) {
   const questions = message.tool?.questions || []
   const [answers, setAnswers] = useState<Record<number, string>>({})
   const [textInputs, setTextInputs] = useState<Record<number, string>>({})
@@ -251,8 +277,8 @@ function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessa
         const hasOptions = q.options && q.options.length > 0
         return (
           <div key={qi} className="px-4 py-3 space-y-2.5">
-            {q.header && <span className="text-[10px] text-primary font-medium uppercase tracking-wide">{q.header}</span>}
-            <p className="text-xs text-foreground">{q.question}</p>
+            {q.header && <span className="text-[10px] text-primary font-medium uppercase tracking-wide"><HighlightedText text={q.header} query={searchQuery} /></span>}
+            <p className="text-xs text-foreground"><HighlightedText text={q.question} query={searchQuery} /></p>
             {hasOptions ? (
               <div className="space-y-1.5">
                 {q.options.map((opt, oi) => {
@@ -270,9 +296,9 @@ function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessa
                             : 'border-border/50 hover:bg-white/5 hover:border-border text-foreground/80 cursor-pointer'
                       }`}
                     >
-                      <span className="font-medium">{opt.label}</span>
+                      <span className="font-medium"><HighlightedText text={opt.label} query={searchQuery} /></span>
                       {opt.description && (
-                        <span className="block text-[11px] text-muted-foreground mt-0.5">{opt.description}</span>
+                        <span className="block text-[11px] text-muted-foreground mt-0.5"><HighlightedText text={opt.description} query={searchQuery} /></span>
                       )}
                     </button>
                   )
@@ -314,7 +340,7 @@ function QuestionMessage({ message, onAnswer, canAnswer }: { message: AgentMessa
   )
 }
 
-function TodoWriteMessage({ message }: { message: AgentMessage }) {
+function TodoWriteMessage({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const todos = message.tool?.todos || []
   const completed = todos.filter((t) => t.status === 'completed').length
 
@@ -342,7 +368,7 @@ function TodoWriteMessage({ message }: { message: AgentMessage }) {
           >
             {statusIcon(todo.status)}
             <span className={`${todo.status === 'completed' ? 'line-through text-muted-foreground' : 'text-foreground'}`}>
-              {todo.content}
+              <HighlightedText text={todo.content} query={searchQuery} />
             </span>
           </div>
         ))}
@@ -354,7 +380,7 @@ function TodoWriteMessage({ message }: { message: AgentMessage }) {
   )
 }
 
-function PlanReviewMessage({ message }: { message: AgentMessage }) {
+function PlanReviewMessage({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const tool = message.tool
   const label = tool?.title || message.content || 'Plan mode'
   const rawOutput = tool?.output || ''
@@ -365,11 +391,11 @@ function PlanReviewMessage({ message }: { message: AgentMessage }) {
     <div className="rounded-md bg-card border border-border/50 overflow-hidden">
       <div className="flex items-center gap-2 px-3 py-2 text-xs font-mono">
         <FileText className="h-3 w-3 text-muted-foreground shrink-0" />
-        <span className="text-foreground">{label}</span>
+        <span className="text-foreground"><HighlightedText text={label} query={searchQuery} /></span>
       </div>
       {details && (
         <div className="px-3 py-2 border-t border-border/30 max-h-[60vh] overflow-y-auto">
-          <Markdown size="xs">{details}</Markdown>
+          <Markdown size="xs" highlightQuery={searchQuery}>{details}</Markdown>
         </div>
       )}
     </div>
@@ -384,7 +410,7 @@ function formatDuration(ms: number): string {
   return `${minutes}m ${remainingSeconds}s`
 }
 
-function TaskProgressMessage({ message }: { message: AgentMessage }) {
+function TaskProgressMessage({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const [expanded, setExpanded] = useState(false)
   const tp = message.taskProgress!
   const isRunning = tp.status === 'started' || tp.status === 'running'
@@ -402,9 +428,9 @@ function TaskProgressMessage({ message }: { message: AgentMessage }) {
       >
         <ChevronRight className={`h-3 w-3 text-muted-foreground shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`} />
         <Terminal className="h-3 w-3 text-blue-400 shrink-0" />
-        <span className="text-foreground truncate">{tp.description || 'Subagent task'}</span>
+        <span className="text-foreground truncate"><HighlightedText text={tp.description || 'Subagent task'} query={searchQuery} /></span>
         {tp.lastToolName && isRunning && (
-          <span className="text-muted-foreground text-[10px] truncate">· {tp.lastToolName}</span>
+          <span className="text-muted-foreground text-[10px] truncate">· <HighlightedText text={tp.lastToolName} query={searchQuery} /></span>
         )}
         <span className="ml-auto flex items-center gap-1.5 shrink-0">
           {tp.usage && (
@@ -421,7 +447,7 @@ function TaskProgressMessage({ message }: { message: AgentMessage }) {
         <div className="border-t border-border/30 px-3 py-2 space-y-2">
           {tp.summary && (
             <div className="text-xs">
-              <Markdown size="sm">{tp.summary}</Markdown>
+              <Markdown size="sm" highlightQuery={searchQuery}>{tp.summary}</Markdown>
             </div>
           )}
           {tp.usage && (
@@ -440,7 +466,7 @@ function TaskProgressMessage({ message }: { message: AgentMessage }) {
   )
 }
 
-function ToolCallMessage({ message }: { message: AgentMessage }) {
+function ToolCallMessage({ message, searchQuery }: { message: AgentMessage; searchQuery?: string }) {
   const [expanded, setExpanded] = useState(false)
   const tool = message.tool!
   const isRunning = !tool.status || tool.status === 'in_progress' || tool.status === 'running' || tool.status === 'pending'
@@ -456,8 +482,8 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
       >
         <ChevronRight className={`h-3 w-3 text-muted-foreground shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`} />
         <Wrench className="h-3 w-3 text-muted-foreground shrink-0" />
-        <span className="text-foreground/80 shrink-0">{tool.name}</span>
-        {subtitle && <span className="min-w-0 flex-1 truncate text-muted-foreground">{subtitle}</span>}
+        <span className="text-foreground/80 shrink-0"><HighlightedText text={tool.name} query={searchQuery} /></span>
+        {subtitle && <span className="min-w-0 flex-1 truncate text-muted-foreground"><HighlightedText text={subtitle} query={searchQuery} /></span>}
         {!subtitle && <span className="flex-1" />}
         <span className="w-20 shrink-0 text-right text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover/tool:opacity-100">
           {message.timestamp.toLocaleTimeString()}
@@ -470,25 +496,25 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
           {command && (
             <div>
               <span className="text-muted-foreground">Command:</span>
-              <pre className="mt-0.5 text-muted-foreground whitespace-pre-wrap break-words max-h-40 overflow-y-auto">{command}</pre>
+              <pre className="mt-0.5 text-muted-foreground whitespace-pre-wrap break-words max-h-40 overflow-y-auto"><HighlightedText text={command} query={searchQuery} /></pre>
             </div>
           )}
           {tool.input && (
             <div>
               <span className="text-muted-foreground">Input:</span>
-              <pre className="mt-0.5 text-muted-foreground whitespace-pre-wrap break-words max-h-40 overflow-y-auto">{sanitizeToolContent(tool.input)}</pre>
+              <pre className="mt-0.5 text-muted-foreground whitespace-pre-wrap break-words max-h-40 overflow-y-auto"><HighlightedText text={sanitizeToolContent(tool.input)} query={searchQuery} /></pre>
             </div>
           )}
           {tool.output && (
             <div>
               <span className="text-muted-foreground">Output:</span>
-              <pre className="mt-0.5 text-muted-foreground whitespace-pre-wrap break-words max-h-40 overflow-y-auto">{sanitizeToolContent(tool.output)}</pre>
+              <pre className="mt-0.5 text-muted-foreground whitespace-pre-wrap break-words max-h-40 overflow-y-auto"><HighlightedText text={sanitizeToolContent(tool.output)} query={searchQuery} /></pre>
             </div>
           )}
           {tool.error && (
             <div>
               <span className="text-red-400">Error:</span>
-              <pre className="mt-0.5 text-red-300 whitespace-pre-wrap break-words">{tool.error}</pre>
+              <pre className="mt-0.5 text-red-300 whitespace-pre-wrap break-words"><HighlightedText text={tool.error} query={searchQuery} /></pre>
             </div>
           )}
         </div>
@@ -497,7 +523,7 @@ function ToolCallMessage({ message }: { message: AgentMessage }) {
   )
 }
 
-function ReasoningMessage({ message, viewMode }: { message: AgentMessage; viewMode?: ViewMode }) {
+function ReasoningMessage({ message, viewMode, searchQuery }: { message: AgentMessage; viewMode?: ViewMode; searchQuery?: string }) {
   const [expanded, setExpanded] = useState(false)
   const summary = message.content.split('\n').map((line) => line.trim()).find(Boolean) || 'Thinking'
 
@@ -509,7 +535,7 @@ function ReasoningMessage({ message, viewMode }: { message: AgentMessage; viewMo
       >
         <ChevronRight className={`h-3 w-3 shrink-0 text-teal-600/70 dark:text-teal-300/60 transition-transform ${expanded ? 'rotate-90' : ''}`} />
         <span className="shrink-0 text-teal-700 dark:text-teal-300">Thinking</span>
-        <span className="min-w-0 flex-1 truncate text-muted-foreground">{summary}</span>
+        <span className="min-w-0 flex-1 truncate text-muted-foreground"><HighlightedText text={summary} query={searchQuery} /></span>
         <span className="w-20 shrink-0 text-right text-[10px] text-muted-foreground opacity-0 transition-opacity group-hover/tool:opacity-100">
           {message.timestamp.toLocaleTimeString()}
         </span>
@@ -517,9 +543,9 @@ function ReasoningMessage({ message, viewMode }: { message: AgentMessage; viewMo
       {expanded && (
         <div className="ml-5 border-l border-teal-500/30 pl-3 py-1.5 text-foreground/75">
           {viewMode === ViewMode.MARKDOWN ? (
-            <Markdown size="sm">{message.content}</Markdown>
+            <Markdown size="sm" highlightQuery={searchQuery}>{message.content}</Markdown>
           ) : (
-            <pre className="whitespace-pre-wrap break-words font-mono text-xs">{message.content}</pre>
+            <pre className="whitespace-pre-wrap break-words font-mono text-xs"><HighlightedText text={message.content} query={searchQuery} /></pre>
           )}
         </div>
       )}
@@ -527,38 +553,38 @@ function ReasoningMessage({ message, viewMode }: { message: AgentMessage; viewMo
   )
 }
 
-function ActivityMessageGroup({ messages, viewMode }: { messages: AgentMessage[]; viewMode?: ViewMode }) {
+function ActivityMessageGroup({ messages, viewMode, searchQuery }: { messages: AgentMessage[]; viewMode?: ViewMode; searchQuery?: string }) {
   return (
     <div className="w-full border-l border-border/30 pl-2 py-0.5">
       {messages.map((message) => {
         if (message.partType === 'reasoning') {
-          return <ReasoningMessage key={message.id} message={message} viewMode={viewMode} />
+          return <ReasoningMessage key={message.id} message={message} viewMode={viewMode} searchQuery={searchQuery} />
         }
-        return <ToolCallMessage key={message.id} message={message} />
+        return <ToolCallMessage key={message.id} message={message} searchQuery={searchQuery} />
       })}
     </div>
   )
 }
 
-function MessageBubble({ message, onAnswer, viewMode, canAnswerQuestion = false }: { message: AgentMessage; onAnswer?: (answer: string) => void; viewMode?: ViewMode; canAnswerQuestion?: boolean }) {
+function MessageBubble({ message, onAnswer, viewMode, canAnswerQuestion = false, searchQuery }: { message: AgentMessage; onAnswer?: (answer: string) => void; viewMode?: ViewMode; canAnswerQuestion?: boolean; searchQuery?: string }) {
   if (message.partType === 'question' && message.tool?.questions) {
-    return <QuestionMessage message={message} onAnswer={onAnswer} canAnswer={canAnswerQuestion} />
+    return <QuestionMessage message={message} onAnswer={onAnswer} canAnswer={canAnswerQuestion} searchQuery={searchQuery} />
   }
 
   if (message.partType === 'todowrite' && message.tool?.todos) {
-    return <TodoWriteMessage message={message} />
+    return <TodoWriteMessage message={message} searchQuery={searchQuery} />
   }
 
   if (message.partType === 'planreview') {
-    return <PlanReviewMessage message={message} />
+    return <PlanReviewMessage message={message} searchQuery={searchQuery} />
   }
 
   if (isCompactActivityMessage(message)) {
-    return <ActivityMessageGroup messages={[message]} viewMode={viewMode} />
+    return <ActivityMessageGroup messages={[message]} viewMode={viewMode} searchQuery={searchQuery} />
   }
 
   if (message.partType === 'task_progress' && message.taskProgress) {
-    return <TaskProgressMessage message={message} />
+    return <TaskProgressMessage message={message} searchQuery={searchQuery} />
   }
 
   // Step markers are absorbed into message stepMeta — skip if any slip through
@@ -590,10 +616,10 @@ function MessageBubble({ message, onAnswer, viewMode, canAnswerQuestion = false 
           </span>
         )}
         {viewMode === ViewMode.MARKDOWN ? (
-          <Markdown size="sm">{message.content}</Markdown>
+          <Markdown size="sm" highlightQuery={searchQuery}>{message.content}</Markdown>
         ) : (
           <pre className="whitespace-pre-wrap break-words font-mono text-xs">
-            {message.content}
+            <HighlightedText text={message.content} query={searchQuery} />
           </pre>
         )}
         <div className={`flex items-center gap-2 mt-1 ${!isUser ? 'opacity-70' : ''}`}>
@@ -1165,19 +1191,16 @@ export function AgentTranscriptPanel({
                       transform: `translateY(${virtualRow.start}px)`,
                     }}
                   >
-                    <div className={cn(
-                      'pb-2 rounded-md transition-colors',
-                      normalizedSearchQuery && searchResultIndexes.includes(virtualRow.index) && 'bg-yellow-500/5',
-                      virtualRow.index === activeSearchItemIndex && 'ring-1 ring-yellow-400/60 bg-yellow-500/10'
-                    )}>
+                    <div className="pb-2">
                       {item.type === 'activity' ? (
-                        <ActivityMessageGroup messages={item.messages} viewMode={viewMode} />
+                        <ActivityMessageGroup messages={item.messages} viewMode={viewMode} searchQuery={normalizedSearchQuery} />
                       ) : (
                         <MemoizedMessageBubble
                           message={item.message}
                           onAnswer={onSend}
                           viewMode={viewMode}
                           canAnswerQuestion={item.message.id === activeQuestionId}
+                          searchQuery={normalizedSearchQuery}
                         />
                       )}
                     </div>

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState, useMemo, useCallback } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { StopCircle, Loader2, Terminal, Send, ChevronRight, ChevronDown, Wrench, AlertTriangle, CheckCircle2, Circle, Clock, RotateCcw, Code2, Eye, ListTodo, FileText, ArrowDown, Paperclip, X } from 'lucide-react'
+import { StopCircle, Loader2, Terminal, Send, ChevronRight, ChevronDown, Wrench, AlertTriangle, CheckCircle2, Circle, Clock, RotateCcw, Code2, Eye, ListTodo, FileText, ArrowDown, ArrowUp, Paperclip, Search, X } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Markdown } from '@/components/ui/Markdown'
 import type { AgentMessage } from '@/hooks/use-agent-session'
@@ -152,6 +152,38 @@ function isCompactActivityMessage(message: AgentMessage): boolean {
 type TranscriptItem =
   | { type: 'message'; key: string; message: AgentMessage }
   | { type: 'activity'; key: string; messages: AgentMessage[] }
+
+function collectSearchableText(value: unknown, output: string[]): void {
+  if (value == null) return
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    output.push(String(value))
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectSearchableText(item, output))
+    return
+  }
+  if (typeof value === 'object') {
+    Object.values(value as Record<string, unknown>).forEach((item) => collectSearchableText(item, output))
+  }
+}
+
+function getMessageSearchText(message: AgentMessage): string {
+  const parts: string[] = []
+  collectSearchableText(message.role, parts)
+  collectSearchableText(message.partType, parts)
+  collectSearchableText(message.content, parts)
+  collectSearchableText(message.tool, parts)
+  collectSearchableText(message.taskProgress, parts)
+  return parts.join('\n').toLowerCase()
+}
+
+function getTranscriptItemSearchText(item: TranscriptItem): string {
+  if (item.type === 'activity') {
+    return item.messages.map(getMessageSearchText).join('\n')
+  }
+  return getMessageSearchText(item.message)
+}
 
 
 interface AgentTranscriptPanelProps {
@@ -667,7 +699,11 @@ export function AgentTranscriptPanel({
   const scrollRef = useRef<HTMLDivElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const [viewMode, setViewMode] = useState<ViewMode>(ViewMode.MARKDOWN)
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [activeSearchResult, setActiveSearchResult] = useState(0)
   const [pendingAttachments, setPendingAttachments] = useState<ComposerAttachment[]>([])
   const [isDragOverComposer, setIsDragOverComposer] = useState(false)
   const [debugCopyToast, setDebugCopyToast] = useState(false)
@@ -709,6 +745,12 @@ export function AgentTranscriptPanel({
         if (!panelRef.current?.contains(document.activeElement) && document.activeElement !== panelRef.current) return
         e.preventDefault()
         copyDebugInfo()
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'f') {
+        if (!panelRef.current?.contains(document.activeElement) && document.activeElement !== panelRef.current) return
+        e.preventDefault()
+        setIsSearchOpen(true)
+        requestAnimationFrame(() => searchInputRef.current?.focus())
       }
     }
     window.addEventListener('keydown', handleKeyDown)
@@ -790,6 +832,28 @@ export function AgentTranscriptPanel({
     return items
   }, [messages])
 
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase()
+  const searchResultIndexes = useMemo(() => {
+    if (!normalizedSearchQuery) return []
+    return transcriptItems.reduce<number[]>((matches, item, index) => {
+      if (getTranscriptItemSearchText(item).includes(normalizedSearchQuery)) {
+        matches.push(index)
+      }
+      return matches
+    }, [])
+  }, [normalizedSearchQuery, transcriptItems])
+  const activeSearchItemIndex = searchResultIndexes[activeSearchResult] ?? -1
+
+  useEffect(() => {
+    setActiveSearchResult(0)
+  }, [normalizedSearchQuery])
+
+  useEffect(() => {
+    if (activeSearchResult >= searchResultIndexes.length) {
+      setActiveSearchResult(Math.max(searchResultIndexes.length - 1, 0))
+    }
+  }, [activeSearchResult, searchResultIndexes.length])
+
   const virtualizer = useVirtualizer({
     count: transcriptItems.length,
     getScrollElement: () => scrollRef.current,
@@ -818,10 +882,30 @@ export function AgentTranscriptPanel({
   }, [transcriptItems.length, virtualizer])
 
   useEffect(() => {
+    if (activeSearchItemIndex >= 0) return
     if (transcriptItems.length > 0 && atBottomRef.current) {
       virtualizer.scrollToIndex(transcriptItems.length - 1, { align: 'end' })
     }
-  }, [transcriptItems.length, virtualizer])
+  }, [activeSearchItemIndex, transcriptItems.length, virtualizer])
+
+  useEffect(() => {
+    if (activeSearchItemIndex >= 0) {
+      virtualizer.scrollToIndex(activeSearchItemIndex, { align: 'center' })
+      atBottomRef.current = false
+      setShowScrollToBottom(true)
+    }
+  }, [activeSearchItemIndex, virtualizer])
+
+  const goToSearchResult = useCallback((direction: 1 | -1) => {
+    if (searchResultIndexes.length === 0) return
+    setActiveSearchResult((current) => (current + direction + searchResultIndexes.length) % searchResultIndexes.length)
+  }, [searchResultIndexes.length])
+
+  const closeSearch = useCallback(() => {
+    setSearchQuery('')
+    setIsSearchOpen(false)
+    setActiveSearchResult(0)
+  }, [])
 
   const getStatusColor = () => {
     switch (status) {
@@ -931,6 +1015,21 @@ export function AgentTranscriptPanel({
             <Button
               variant="ghost"
               size="sm"
+              onClick={() => {
+                setIsSearchOpen((open) => {
+                  const nextOpen = !open
+                  if (nextOpen) requestAnimationFrame(() => searchInputRef.current?.focus())
+                  return nextOpen
+                })
+              }}
+              className="h-7 px-2"
+              title="Search transcript"
+            >
+              <Search className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => setViewMode(viewMode === ViewMode.MARKDOWN ? ViewMode.RAW : ViewMode.MARKDOWN)}
               className="h-7 px-2"
               title={viewMode === ViewMode.MARKDOWN ? 'Show raw content' : 'Show markdown'}
@@ -956,6 +1055,57 @@ export function AgentTranscriptPanel({
           </div>
         </div>
       </div>
+
+      {isSearchOpen && (
+        <div className="flex items-center gap-2 border-b border-border/50 px-4 py-2 shrink-0">
+          <div className="relative min-w-0 flex-1">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <input
+              ref={searchInputRef}
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') closeSearch()
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  goToSearchResult(e.shiftKey ? -1 : 1)
+                }
+              }}
+              placeholder="Search transcript..."
+              className="h-8 w-full rounded-md border border-input bg-transparent pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring/30"
+            />
+          </div>
+          <span className="w-16 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+            {normalizedSearchQuery ? `${searchResultIndexes.length ? activeSearchResult + 1 : 0}/${searchResultIndexes.length}` : '0/0'}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => goToSearchResult(-1)}
+            disabled={searchResultIndexes.length === 0}
+            className="h-8 w-8"
+            title="Previous result"
+          >
+            <ArrowUp className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => goToSearchResult(1)}
+            disabled={searchResultIndexes.length === 0}
+            className="h-8 w-8"
+            title="Next result"
+          >
+            <ArrowDown className="h-3.5 w-3.5" />
+          </Button>
+          <Button type="button" variant="ghost" size="icon" onClick={closeSearch} className="h-8 w-8" title="Close search">
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      )}
 
       {/* Error banner */}
       {showErrorBanner && lastErrorMessage && (
@@ -1015,7 +1165,11 @@ export function AgentTranscriptPanel({
                       transform: `translateY(${virtualRow.start}px)`,
                     }}
                   >
-                    <div className="pb-2">
+                    <div className={cn(
+                      'pb-2 rounded-md transition-colors',
+                      normalizedSearchQuery && searchResultIndexes.includes(virtualRow.index) && 'bg-yellow-500/5',
+                      virtualRow.index === activeSearchItemIndex && 'ring-1 ring-yellow-400/60 bg-yellow-500/10'
+                    )}>
                       {item.type === 'activity' ? (
                         <ActivityMessageGroup messages={item.messages} viewMode={viewMode} />
                       ) : (

--- a/src/renderer/src/components/ui/Markdown.tsx
+++ b/src/renderer/src/components/ui/Markdown.tsx
@@ -5,7 +5,7 @@
  * Used in: task descriptions, agent transcripts, plugin documentation.
  */
 
-import { memo, useMemo, useState } from 'react'
+import React, { Fragment, memo, useMemo, useState } from 'react'
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Check, Copy } from 'lucide-react'
@@ -23,6 +23,7 @@ interface MarkdownProps {
   children: string
   size?: MarkdownSize
   className?: string
+  highlightQuery?: string
 }
 
 // Hoisted to module scope to prevent recreation on every render
@@ -60,6 +61,53 @@ function CopyCodeButton({ text }: { text: string }) {
       {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
     </button>
   )
+}
+
+function splitHighlightedText(text: string, query?: string): React.ReactNode {
+  const normalizedQuery = query?.trim()
+  if (!normalizedQuery) return text
+
+  const lowerText = text.toLowerCase()
+  const lowerQuery = normalizedQuery.toLowerCase()
+  const parts: React.ReactNode[] = []
+  let cursor = 0
+  let matchIndex = lowerText.indexOf(lowerQuery)
+
+  while (matchIndex !== -1) {
+    if (matchIndex > cursor) {
+      parts.push(text.slice(cursor, matchIndex))
+    }
+    const match = text.slice(matchIndex, matchIndex + normalizedQuery.length)
+    parts.push(
+      <mark key={`${matchIndex}-${match}`} className="rounded-sm bg-yellow-300/80 px-0.5 text-black">
+        {match}
+      </mark>
+    )
+    cursor = matchIndex + normalizedQuery.length
+    matchIndex = lowerText.indexOf(lowerQuery, cursor)
+  }
+
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor))
+  }
+
+  return parts.length > 0 ? parts : text
+}
+
+function highlightReactNode(node: React.ReactNode, query?: string): React.ReactNode {
+  if (node == null || typeof node === 'boolean') return node
+  if (typeof node === 'string') return splitHighlightedText(node, query)
+  if (typeof node === 'number') return splitHighlightedText(String(node), query)
+  if (Array.isArray(node)) {
+    return node.map((child, index) => <Fragment key={index}>{highlightReactNode(child, query)}</Fragment>)
+  }
+  if (typeof node === 'object' && 'props' in node) {
+    const element = node as React.ReactElement<{ children?: React.ReactNode }>
+    return React.cloneElement(element, {
+      children: highlightReactNode(element.props.children, query)
+    })
+  }
+  return node
 }
 
 // Size-based class mappings — hoisted to module scope (static data)
@@ -125,7 +173,7 @@ const SIZE_CLASSES = {
  * (e.g., the agent transcript) where parent scrolling would otherwise trigger
  * recreation of the components config object on every frame.
  */
-export const Markdown = memo(function Markdown({ children, size = 'sm', className }: MarkdownProps) {
+export const Markdown = memo(function Markdown({ children, size = 'sm', className, highlightQuery }: MarkdownProps) {
   const classes = SIZE_CLASSES[size]
 
   // Memoize the components config object per `size` to avoid creating a new
@@ -133,17 +181,17 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
   const components = useMemo(() => ({
     // Headings
     h1: ({ children, ...props }: React.ComponentPropsWithoutRef<'h1'>) => (
-      <h1 className={cn(classes.h1, 'text-foreground')} {...props}>{children}</h1>
+      <h1 className={cn(classes.h1, 'text-foreground')} {...props}>{highlightReactNode(children, highlightQuery)}</h1>
     ),
     h2: ({ children, ...props }: React.ComponentPropsWithoutRef<'h2'>) => (
-      <h2 className={cn(classes.h2, 'text-foreground')} {...props}>{children}</h2>
+      <h2 className={cn(classes.h2, 'text-foreground')} {...props}>{highlightReactNode(children, highlightQuery)}</h2>
     ),
     h3: ({ children, ...props }: React.ComponentPropsWithoutRef<'h3'>) => (
-      <h3 className={cn(classes.h3, 'text-foreground')} {...props}>{children}</h3>
+      <h3 className={cn(classes.h3, 'text-foreground')} {...props}>{highlightReactNode(children, highlightQuery)}</h3>
     ),
     // Paragraphs
     p: ({ children, ...props }: React.ComponentPropsWithoutRef<'p'>) => (
-      <p className={cn(classes.p, 'text-foreground/90')} {...props}>{children}</p>
+      <p className={cn(classes.p, 'text-foreground/90')} {...props}>{highlightReactNode(children, highlightQuery)}</p>
     ),
     // Lists
     ul: ({ children, ...props }: React.ComponentPropsWithoutRef<'ul'>) => (
@@ -153,7 +201,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
       <ol className={cn('list-decimal list-outside', classes.list, 'text-foreground/90')} {...props}>{children}</ol>
     ),
     li: ({ children, ...props }: React.ComponentPropsWithoutRef<'li'>) => (
-      <li className={cn(classes.li, 'text-foreground/90')} {...props}>{children}</li>
+      <li className={cn(classes.li, 'text-foreground/90')} {...props}>{highlightReactNode(children, highlightQuery)}</li>
     ),
     // Code - CRITICAL: inline code must always be inline, block code must be block
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -162,7 +210,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
       if (isCodeBlock || inline === false) {
         return (
           <code className={cn('block font-mono text-foreground whitespace-pre', codeClassName)} {...props}>
-            {children}
+            {highlightReactNode(children, highlightQuery)}
           </code>
         )
       }
@@ -172,7 +220,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
           style={{ display: 'inline !important' } as React.CSSProperties}
           {...props}
         >
-          {children}
+          {highlightReactNode(children, highlightQuery)}
         </code>
       )
     },
@@ -188,7 +236,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
     },
     // Links
     a: ({ children, ...props }: React.ComponentPropsWithoutRef<'a'>) => (
-      <a className="text-primary hover:underline cursor-pointer" target="_blank" rel="noopener noreferrer" {...props}>{children}</a>
+      <a className="text-primary hover:underline cursor-pointer" target="_blank" rel="noopener noreferrer" {...props}>{highlightReactNode(children, highlightQuery)}</a>
     ),
     // Images
     img: ({ alt, src, ...props }: React.ComponentPropsWithoutRef<'img'>) => (
@@ -196,7 +244,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
     ),
     // Blockquotes
     blockquote: ({ children, ...props }: React.ComponentPropsWithoutRef<'blockquote'>) => (
-      <blockquote className={cn('border-l-2 border-border italic text-foreground/80', classes.blockquote)} {...props}>{children}</blockquote>
+      <blockquote className={cn('border-l-2 border-border italic text-foreground/80', classes.blockquote)} {...props}>{highlightReactNode(children, highlightQuery)}</blockquote>
     ),
     // Horizontal rules
     hr: ({ ...props }: React.ComponentPropsWithoutRef<'hr'>) => <hr className={cn('border-border', classes.hr)} {...props} />,
@@ -210,10 +258,10 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
       <thead className="bg-muted" {...props}>{children}</thead>
     ),
     th: ({ children, ...props }: React.ComponentPropsWithoutRef<'th'>) => (
-      <th className={cn('border border-border text-left font-semibold text-foreground', classes.th)} {...props}>{children}</th>
+      <th className={cn('border border-border text-left font-semibold text-foreground', classes.th)} {...props}>{highlightReactNode(children, highlightQuery)}</th>
     ),
     td: ({ children, ...props }: React.ComponentPropsWithoutRef<'td'>) => (
-      <td className={cn('border border-border text-foreground/90', classes.td)} {...props}>{children}</td>
+      <td className={cn('border border-border text-foreground/90', classes.td)} {...props}>{highlightReactNode(children, highlightQuery)}</td>
     ),
     tbody: ({ children, ...props }: React.ComponentPropsWithoutRef<'tbody'>) => (
       <tbody {...props}>{children}</tbody>
@@ -221,7 +269,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
     tr: ({ children, ...props }: React.ComponentPropsWithoutRef<'tr'>) => (
       <tr className="hover:bg-muted/50 transition-colors" {...props}>{children}</tr>
     ),
-  }), [size]) // Only recreate when size changes
+  }), [classes, highlightQuery]) // Only recreate when rendered styling or highlight changes
 
   return (
     <div className={cn('markdown-content min-w-0', classes.base, className)}>


### PR DESCRIPTION
## Summary
- Add transcript search controls to the desktop agent transcript panel with Cmd/Ctrl+F focus, result counts, and previous/next navigation.
- Mirror transcript search on the mobile conversation page using inline SVG controls and native scroll-to-result behavior.
- Index visible message text plus nested tool/question/todo/task-progress payloads so collapsed tool details can be found.
- Highlight exact visible search terms with inline marks instead of tinting the whole transcript message.

## Test plan
- pnpm typecheck
- pnpm test:renderer -- src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx --runInBand
- pnpm exec eslint src/renderer/src/components/agents/AgentTranscriptPanel.tsx src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx src/renderer/src/components/ui/Markdown.tsx src/mobile/pages/ConversationPage.tsx src/mobile/components/MessageBubble.tsx

Generated with Codex