### PR TITLE
feat(canvas): color code task map by status

### DIFF
--- a/src/renderer/src/components/canvas/CanvasMinimap.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useRef, useState, useMemo } from 'react'
 import { useCanvasStore, type CanvasPanelData, MIN_ZOOM, MAX_ZOOM } from '@/stores/canvas-store'
+import { useTaskStore } from '@/stores/task-store'
 import { Minus, Plus, Maximize2, ChevronDown, ChevronUp } from 'lucide-react'
+import { getCanvasTaskStatusStyle } from './canvas-status-style'
 
 // ── Constants ─────────────────────────────────────────────
 const MINIMAP_W = 180
@@ -9,12 +11,12 @@ const MINIMAP_PAD = 12 // padding inside the minimap
 
 // Panel type → color mapping
 const PANEL_COLORS: Record<string, string> = {
-  task: 'rgba(30,150,235,0.7)',     // indigo
+  task: 'rgba(59,130,246,0.7)',     // fallback blue when a task status is unavailable
   browser: 'rgba(249,115,22,0.7)',  // orange
-  terminal: 'rgba(34,197,94,0.7)',  // green
+  terminal: 'rgba(139,92,246,0.7)',  // violet
   app: 'rgba(20,184,166,0.7)',      // teal
-  transcript: 'rgba(59,130,246,0.6)', // blue
-  webpage: 'rgba(236,72,153,0.6)',  // pink
+  transcript: 'rgba(6,182,212,0.62)', // cyan
+  webpage: 'rgba(14,165,233,0.62)',  // sky
   placeholder: 'rgba(107,114,128,0.4)', // gray
 }
 
@@ -39,6 +41,7 @@ export function CanvasMinimap({
   const panels = useCanvasStore((s) => s.panels)
   const viewport = useCanvasStore((s) => s.viewport)
   const edges = useCanvasStore((s) => s.edges)
+  const tasks = useTaskStore((s) => s.tasks)
   const setViewport = useCanvasStore((s) => s.setViewport)
   const zoomTo = useCanvasStore((s) => s.zoomTo)
   const fitToContent = useCanvasStore((s) => s.fitToContent)
@@ -147,6 +150,12 @@ export function CanvasMinimap({
     return map
   }, [panels])
 
+  const taskStatusMap = useMemo(() => {
+    const map = new Map<string, (typeof tasks)[number]['status']>()
+    for (const task of tasks) map.set(task.id, task.status)
+    return map
+  }, [tasks])
+
   const zoomPercent = Math.round(viewport.zoom * 100)
 
   if (panels.length === 0) return null
@@ -217,7 +226,8 @@ export function CanvasMinimap({
 
             {/* Panel rectangles */}
             {panels.map((p) => {
-              const color = PANEL_COLORS[p.type] || 'rgba(148,163,184,0.5)'
+              const taskStatusStyle = p.type === 'task' ? getCanvasTaskStatusStyle(taskStatusMap.get(p.refId ?? '')) : null
+              const color = taskStatusStyle?.miniFill ?? PANEL_COLORS[p.type] ?? 'rgba(148,163,184,0.5)'
               const px = toMiniX(p.x)
               const py = toMiniY(p.y)
               const pw = Math.max(3, p.width * scale)

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useEffect, memo, useMemo } from 'react'
+import { useCallback, useRef, useState, useEffect, memo, useMemo, type CSSProperties } from 'react'
 import {
   useCanvasStore,
   calculateSnap,
@@ -17,6 +17,7 @@ import { AppPanelContent } from './AppPanelContent'
 import { WebPagePanelContent } from './WebPagePanelContent'
 import { TerminalPanelContent } from './TerminalPanelContent'
 import { BrowserPanelContent } from './BrowserPanelContent'
+import { getCanvasTaskStatusStyle, shouldPulseCanvasTaskStatusTransition } from './canvas-status-style'
 
 interface CanvasPanelProps {
   panel: CanvasPanelData
@@ -53,8 +54,10 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   const [isResizing, setIsResizing] = useState(false)
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [taskLayout, setTaskLayout] = useState<TaskWorkspaceLayout>('both')
+  const [statusPulse, setStatusPulse] = useState<{ status: TaskStatus; key: number } | null>(null)
   const dragStart = useRef({ x: 0, y: 0, panelX: 0, panelY: 0 })
   const resizeStart = useRef({ x: 0, y: 0, w: 0, h: 0 })
+  const previousTaskStatusRef = useRef<TaskStatus | undefined>(undefined)
 
   // ── Drag handling ─────────────────────────────────────────
   const handleDragStart = useCallback(
@@ -284,6 +287,26 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     [panel.type, panel.refId])
   )
 
+  useEffect(() => {
+    if (panel.type !== 'task') {
+      previousTaskStatusRef.current = undefined
+      setStatusPulse(null)
+      return
+    }
+
+    const previous = previousTaskStatusRef.current
+    previousTaskStatusRef.current = taskStatus
+    if (shouldPulseCanvasTaskStatusTransition(previous, taskStatus) && taskStatus) {
+      const key = Date.now()
+      setStatusPulse({ status: taskStatus, key })
+      const timeout = window.setTimeout(() => {
+        setStatusPulse((current) => (current?.key === key ? null : current))
+      }, 1800)
+      return () => window.clearTimeout(timeout)
+    }
+    return undefined
+  }, [panel.type, taskStatus])
+
   // ── Create connected browser panel (from side handle click) ──
   const handleCreateBrowser = useCallback(
     (e: React.MouseEvent) => {
@@ -326,32 +349,33 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   const cfg = useMemo(() => {
     const TYPE_CONFIG: Record<string, { label: string; color: string; border: string; bg: string }> = {
       task: { label: 'Task', color: 'bg-blue-500/20 text-blue-400', border: 'border-blue-500/40', bg: 'bg-[var(--canvas-panel)]' },
-      transcript: { label: 'Transcript', color: 'bg-teal-500/20 text-teal-400', border: 'border-teal-500/40', bg: 'bg-[var(--canvas-panel)]' },
-      app: { label: 'App', color: 'bg-green-500/20 text-green-400', border: 'border-green-500/40', bg: 'bg-[var(--canvas-panel)]' },
+      transcript: { label: 'Transcript', color: 'bg-cyan-500/20 text-cyan-300', border: 'border-cyan-500/40', bg: 'bg-[var(--canvas-panel)]' },
+      app: { label: 'App', color: 'bg-teal-500/20 text-teal-300', border: 'border-teal-500/40', bg: 'bg-[var(--canvas-panel)]' },
       webpage: { label: 'Web', color: 'bg-cyan-500/20 text-cyan-400', border: 'border-cyan-500/40', bg: 'bg-[var(--canvas-panel)]' },
-      terminal: { label: 'Terminal', color: 'bg-amber-500/20 text-amber-400', border: 'border-amber-500/50', bg: 'bg-[var(--canvas-panel)]' },
-      browser: { label: 'Browser', color: 'bg-orange-500/20 text-orange-400', border: 'border-orange-500/40', bg: 'bg-[var(--canvas-panel)]' },
+      terminal: { label: 'Terminal', color: 'bg-violet-500/20 text-violet-300', border: 'border-violet-500/45', bg: 'bg-[var(--canvas-panel)]' },
+      browser: { label: 'Browser', color: 'bg-orange-500/20 text-orange-300', border: 'border-orange-500/40', bg: 'bg-[var(--canvas-panel)]' },
     }
 
-    if (panel.type === 'task' && taskStatus) {
-      switch (taskStatus) {
-        case TaskStatus.AgentLearning:
-          return { label: 'Learning', color: 'bg-blue-500/20 text-blue-400', border: 'border-blue-500/50', bg: 'bg-blue-500/10' }
-        case TaskStatus.AgentWorking:
-          return { label: 'Working', color: 'bg-amber-500/20 text-amber-400', border: 'border-amber-500/50', bg: 'bg-amber-500/10' }
-        case TaskStatus.Completed:
-          return { label: 'Completed', color: 'bg-green-500/20 text-green-400', border: 'border-green-500/50', bg: 'bg-green-500/10' }
-        case TaskStatus.Triaging:
-          return { label: 'Triaging', color: 'bg-slate-500/20 text-slate-400', border: 'border-slate-500/50', bg: 'bg-slate-500/10' }
-        case TaskStatus.ReadyForReview:
-          return { label: 'Review', color: 'bg-pink-500/20 text-pink-400', border: 'border-pink-500/50', bg: 'bg-pink-500/10' }
-        default:
-          return TYPE_CONFIG.task
-      }
+    if (panel.type === 'task') {
+      return getCanvasTaskStatusStyle(taskStatus) ?? TYPE_CONFIG.task
     }
 
     return TYPE_CONFIG[panel.type] ?? { label: 'Panel', color: 'bg-muted/30 text-muted-foreground', border: 'border-border/50', bg: 'bg-[var(--canvas-panel)]' }
   }, [panel.type, taskStatus])
+
+  const pulseStyle = statusPulse
+    ? getCanvasTaskStatusStyle(statusPulse.status)
+    : null
+  const panelStyle: CSSProperties = {
+    left: panel.x,
+    top: panel.y,
+    width: panel.width,
+    height: isCollapsed ? 'auto' : panel.height,
+    zIndex: panel.zIndex,
+    minWidth: panel.minWidth ?? 200,
+    minHeight: isCollapsed ? undefined : (panel.minHeight ?? 150),
+    '--canvas-status-rgb': pulseStyle?.rgb ?? '59,130,246',
+  } as CSSProperties
 
   return (
     <div
@@ -365,18 +389,21 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       } ${isConnectingLocal ? 'ring-2 ring-orange-500/50' : ''} ${
         isProximityTarget ? 'ring-2 ring-orange-500/60 shadow-orange-500/20 shadow-2xl' : ''
       }`}
-      style={{
-        left: panel.x,
-        top: panel.y,
-        width: panel.width,
-        height: isCollapsed ? 'auto' : panel.height,
-        zIndex: panel.zIndex,
-        minWidth: panel.minWidth ?? 200,
-        minHeight: isCollapsed ? undefined : (panel.minHeight ?? 150),
-      }}
+      style={panelStyle}
     >
+      {statusPulse && panel.type === 'task' && (
+        <div
+          key={statusPulse.key}
+          className="pointer-events-none absolute -inset-2 z-0 rounded-[18px] canvas-status-transition-flash"
+          aria-hidden="true"
+        >
+          <span className="canvas-status-transition-wave" />
+          <span className="canvas-status-transition-wave canvas-status-transition-wave-delay" />
+        </div>
+      )}
+
       {/* Inner wrapper — clips content within rounded corners */}
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden rounded-[11px]">
+      <div className="relative z-[1] flex flex-col flex-1 min-h-0 overflow-hidden rounded-[11px]">
       {/* Title bar — drag handle */}
       <div
         className={`flex items-center gap-2 px-3 py-2 border-b border-border/40 flex-shrink-0 cursor-grab active:cursor-grabbing group select-none ${cfg.bg}`}

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -2,12 +2,19 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { InfiniteCanvas } from './InfiniteCanvas'
 import { useCanvasStore } from '@/stores/canvas-store'
+import { TaskStatus } from '@/types'
+
+const taskStoreState = vi.hoisted(() => ({
+  tasks: [] as Array<{ id: string; title: string; status: TaskStatus }>,
+  selectedTaskId: null as string | null,
+  isLoading: false,
+  error: null as string | null,
+}))
 
 // Mock the child components that depend on external stores
 vi.mock('@/stores/task-store', () => ({
   useTaskStore: vi.fn((selector) => {
-    const state = { tasks: [], selectedTaskId: null, isLoading: false, error: null }
-    return selector ? selector(state) : state
+    return selector ? selector(taskStoreState) : taskStoreState
   }),
 }))
 
@@ -44,6 +51,10 @@ describe('InfiniteCanvas', () => {
       connectingFromId: null,
       isLoaded: true, // Skip async load in tests
     })
+    taskStoreState.tasks = []
+    taskStoreState.selectedTaskId = null
+    taskStoreState.isLoading = false
+    taskStoreState.error = null
   })
 
   afterEach(cleanup)
@@ -75,6 +86,53 @@ describe('InfiniteCanvas', () => {
     render(<InfiniteCanvas />)
     expect(screen.getByText('My Task Panel')).toBeTruthy()
     expect(screen.getByText('Task')).toBeTruthy()
+  })
+
+  it('uses task status color coding for task panels and minimap rectangles', () => {
+    taskStoreState.tasks = [
+      { id: 'task-123', title: 'Working Task', status: TaskStatus.AgentWorking },
+    ]
+    useCanvasStore.getState().addPanel({
+      type: 'task',
+      title: 'Working Task',
+      refId: 'task-123',
+      x: 100,
+      y: 100,
+      width: 400,
+      height: 300,
+    })
+
+    const { container } = render(<InfiniteCanvas />)
+
+    const statusBadge = screen.getByText('Working')
+    expect(statusBadge.className).toContain('text-amber-300')
+    const taskPanel = container.querySelector('[data-canvas-panel="true"]')
+    expect(taskPanel?.className).toContain('border-amber-500/55')
+    expect(container.querySelector('svg rect[fill="rgba(245,158,11,0.86)"]')).toBeTruthy()
+  })
+
+  it('keeps browser and terminal colors distinct from task status colors', () => {
+    useCanvasStore.getState().addPanel({
+      type: 'browser',
+      title: 'Browser',
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 300,
+    })
+    useCanvasStore.getState().addPanel({
+      type: 'terminal',
+      title: 'Terminal',
+      x: 460,
+      y: 0,
+      width: 400,
+      height: 300,
+    })
+
+    render(<InfiniteCanvas />)
+
+    expect(screen.getByText('Browser').className).toContain('text-orange-300')
+    expect(screen.getByText('Terminal').className).toContain('text-violet-300')
   })
 
   it('should hide empty state when panels exist', () => {

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -188,9 +188,9 @@ describe('InfiniteCanvas', () => {
       expect(container.querySelector('[data-canvas-status-edge-highlight="true"]')).toBeTruthy()
     })
     const popup = container.querySelector('[data-canvas-status-edge-highlight="true"]') as HTMLElement
-    expect(popup.dataset.direction).toBe('bottom')
+    expect(popup.dataset.direction).toBe('bottom-left')
     expect(parseFloat(popup.style.left)).toBeGreaterThanOrEqual(170)
-    expect(popup.querySelector('.lucide-arrow-down')).toBeTruthy()
+    expect(popup.querySelector('.lucide-arrow-down-left')).toBeTruthy()
 
     fireEvent.click(screen.getByTitle('Jump to Reviewing Task'))
     expect(useCanvasStore.getState().viewport.x).not.toBe(0)

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -170,7 +170,7 @@ describe('InfiniteCanvas', () => {
       type: 'task',
       title: 'Reviewing Task',
       refId: 'task-123',
-      x: 1200,
+      x: -1000,
       y: 900,
       width: 400,
       height: 300,
@@ -187,9 +187,11 @@ describe('InfiniteCanvas', () => {
     await waitFor(() => {
       expect(container.querySelector('[data-canvas-status-edge-highlight="true"]')).toBeTruthy()
     })
+    const popup = container.querySelector('[data-canvas-status-edge-highlight="true"]') as HTMLElement
+    expect(parseFloat(popup.style.left)).toBeGreaterThanOrEqual(170)
 
     fireEvent.click(screen.getByTitle('Jump to Reviewing Task'))
-    expect(useCanvasStore.getState().viewport.x).toBeLessThan(0)
+    expect(useCanvasStore.getState().viewport.x).not.toBe(0)
 
     globalThis.ResizeObserver = originalResizeObserver
   })

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -188,7 +188,9 @@ describe('InfiniteCanvas', () => {
       expect(container.querySelector('[data-canvas-status-edge-highlight="true"]')).toBeTruthy()
     })
     const popup = container.querySelector('[data-canvas-status-edge-highlight="true"]') as HTMLElement
+    expect(popup.dataset.direction).toBe('bottom')
     expect(parseFloat(popup.style.left)).toBeGreaterThanOrEqual(170)
+    expect(popup.querySelector('.lucide-arrow-down')).toBeTruthy()
 
     fireEvent.click(screen.getByTitle('Jump to Reviewing Task'))
     expect(useCanvasStore.getState().viewport.x).not.toBe(0)

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import { InfiniteCanvas } from './InfiniteCanvas'
 import { useCanvasStore } from '@/stores/canvas-store'
 import { TaskStatus } from '@/types'
@@ -147,6 +147,51 @@ describe('InfiniteCanvas', () => {
     const taskPanel = container.querySelector('[data-canvas-panel="true"]')
     expect(taskPanel?.className).toContain('border-amber-500/55')
     expect(container.querySelector('svg rect[fill="rgba(245,158,11,0.86)"]')).toBeTruthy()
+  })
+
+  it('shows an off-screen jump popup when a transitioned task is outside the viewport', async () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+    globalThis.ResizeObserver = class {
+      private callback: ResizeObserverCallback
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback
+      }
+      observe() {
+        this.callback([{ contentRect: { width: 800, height: 600 } } as ResizeObserverEntry], this as ResizeObserver)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+
+    taskStoreState.tasks = [
+      makeTask({ id: 'task-123', title: 'Reviewing Task', status: TaskStatus.AgentWorking }),
+    ]
+    useCanvasStore.getState().addPanel({
+      type: 'task',
+      title: 'Reviewing Task',
+      refId: 'task-123',
+      x: 1200,
+      y: 900,
+      width: 400,
+      height: 300,
+    })
+
+    const { container, rerender } = render(<InfiniteCanvas />)
+    expect(container.querySelector('[data-canvas-status-edge-highlight="true"]')).toBeNull()
+
+    taskStoreState.tasks = [
+      makeTask({ id: 'task-123', title: 'Reviewing Task', status: TaskStatus.ReadyForReview }),
+    ]
+    rerender(<InfiniteCanvas />)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-canvas-status-edge-highlight="true"]')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByTitle('Jump to Reviewing Task'))
+    expect(useCanvasStore.getState().viewport.x).toBeLessThan(0)
+
+    globalThis.ResizeObserver = originalResizeObserver
   })
 
   it('keeps browser and terminal colors distinct from task status colors', () => {

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -3,13 +3,51 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { InfiniteCanvas } from './InfiniteCanvas'
 import { useCanvasStore } from '@/stores/canvas-store'
 import { TaskStatus } from '@/types'
+import type { WorkfloTask } from '@/types'
 
 const taskStoreState = vi.hoisted(() => ({
-  tasks: [] as Array<{ id: string; title: string; status: TaskStatus }>,
+  tasks: [] as WorkfloTask[],
   selectedTaskId: null as string | null,
   isLoading: false,
   error: null as string | null,
 }))
+
+const makeTask = (overrides: Partial<WorkfloTask> = {}): WorkfloTask => ({
+  id: 'task-123',
+  title: 'Task',
+  description: '',
+  type: 'coding',
+  priority: 'medium',
+  status: TaskStatus.NotStarted,
+  assignee: '',
+  due_date: null,
+  labels: [],
+  attachments: [],
+  repos: [],
+  output_fields: [],
+  agent_id: null,
+  session_id: null,
+  external_id: null,
+  source_id: null,
+  source: 'manual',
+  skill_ids: null,
+  snoozed_until: null,
+  resolution: null,
+  feedback_rating: null,
+  feedback_comment: null,
+  is_recurring: false,
+  recurrence_pattern: null,
+  recurrence_parent_id: null,
+  last_occurrence_at: null,
+  next_occurrence_at: null,
+  auto_start_agent: false,
+  auto_complete_without_review: false,
+  parent_task_id: null,
+  sort_order: 0,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+})
 
 // Mock the child components that depend on external stores
 vi.mock('@/stores/task-store', () => ({
@@ -90,7 +128,7 @@ describe('InfiniteCanvas', () => {
 
   it('uses task status color coding for task panels and minimap rectangles', () => {
     taskStoreState.tasks = [
-      { id: 'task-123', title: 'Working Task', status: TaskStatus.AgentWorking },
+      makeTask({ id: 'task-123', title: 'Working Task', status: TaskStatus.AgentWorking }),
     ]
     useCanvasStore.getState().addPanel({
       type: 'task',
@@ -131,8 +169,8 @@ describe('InfiniteCanvas', () => {
 
     render(<InfiniteCanvas />)
 
-    expect(screen.getByText('Browser').className).toContain('text-orange-300')
-    expect(screen.getByText('Terminal').className).toContain('text-violet-300')
+    expect(screen.getAllByText('Browser')[0].className).toContain('text-orange-300')
+    expect(screen.getAllByText('Terminal')[0].className).toContain('text-violet-300')
   })
 
   it('should hide empty state when panels exist', () => {

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState, useEffect, useMemo } from 'react'
+import { useCallback, useRef, useState, useEffect, useMemo, type CSSProperties } from 'react'
 import { useCanvasStore, DEFAULT_PANEL_WIDTH, DEFAULT_PANEL_HEIGHT } from '@/stores/canvas-store'
 import type { SnapGuide, CanvasPanelData, Viewport } from '@/stores/canvas-store'
 import { useUIStore } from '@/stores/ui-store'
@@ -7,8 +7,10 @@ import { CanvasPanel } from './CanvasPanel'
 import { CanvasConnections } from './CanvasConnections'
 import { CanvasContextMenu } from './CanvasContextMenu'
 import { CanvasMinimap } from './CanvasMinimap'
-import { Move, ZoomIn, ZoomOut, RotateCcw, Plus } from 'lucide-react'
+import { LocateFixed, Move, ZoomIn, ZoomOut, RotateCcw, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
+import { TaskStatus } from '@/types'
+import { getCanvasTaskStatusStyle, shouldPulseCanvasTaskStatusTransition } from './canvas-status-style'
 
 /**
  * Check if a panel is visible in the current viewport (with generous margin).
@@ -44,6 +46,61 @@ function isPanelVisible(
 
 // Grid dot spacing in canvas-space pixels
 const GRID_SIZE = 40
+const STATUS_HIGHLIGHT_MS = 5_000
+
+interface StatusHighlight {
+  id: string
+  taskId: string
+  panelId: string
+  title: string
+  rgb: string
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+function getPanelScreenRect(panel: StatusHighlight, viewport: Viewport) {
+  return {
+    left: panel.x * viewport.zoom + viewport.x,
+    top: panel.y * viewport.zoom + viewport.y,
+    width: panel.width * viewport.zoom,
+    height: panel.height * viewport.zoom,
+  }
+}
+
+function getOffscreenBeaconStyle(
+  highlight: StatusHighlight,
+  viewport: Viewport,
+  containerWidth: number,
+  containerHeight: number
+): CSSProperties | null {
+  if (!containerWidth || !containerHeight) return null
+
+  const rect = getPanelScreenRect(highlight, viewport)
+  const centerX = rect.left + rect.width / 2
+  const centerY = rect.top + rect.height / 2
+  const isVisible =
+    rect.left < containerWidth &&
+    rect.left + rect.width > 0 &&
+    rect.top < containerHeight &&
+    rect.top + rect.height > 0
+
+  if (isVisible) return null
+
+  const pad = 28
+  const x = Math.min(containerWidth - pad, Math.max(pad, centerX))
+  const y = Math.min(containerHeight - pad, Math.max(pad, centerY))
+  const angle = Math.atan2(centerY - containerHeight / 2, centerX - containerWidth / 2)
+
+  return {
+    left: x,
+    top: y,
+    transform: 'translate(-50%, -50%)',
+    '--canvas-status-rgb': highlight.rgb,
+    '--canvas-status-popup-angle': `${angle}rad`,
+  } as CSSProperties
+}
 
 /**
  * InfiniteCanvas — the main canvas screen.
@@ -61,6 +118,7 @@ const GRID_SIZE = 40
  */
 export function InfiniteCanvas() {
   const containerRef = useRef<HTMLDivElement>(null)
+  const previousTaskStatusRef = useRef(new Map<string, TaskStatus>())
   const viewport = useCanvasStore((s) => s.viewport)
   const panels = useCanvasStore((s) => s.panels)
   const snapGuides = useCanvasStore((s) => s.snapGuides)
@@ -70,6 +128,7 @@ export function InfiniteCanvas() {
   const zoomTo = useCanvasStore((s) => s.zoomTo)
   const resetViewport = useCanvasStore((s) => s.resetViewport)
   const fitToContent = useCanvasStore((s) => s.fitToContent)
+  const focusPanel = useCanvasStore((s) => s.focusPanel)
   const addPanel = useCanvasStore((s) => s.addPanel)
   const loadCanvas = useCanvasStore((s) => s.loadCanvas)
 
@@ -102,6 +161,7 @@ export function InfiniteCanvas() {
     canvasX: number
     canvasY: number
   } | null>(null)
+  const [statusHighlights, setStatusHighlights] = useState<StatusHighlight[]>([])
 
   // Connection drawing state
   const connectingFromId = useCanvasStore((s) => s.connectingFromId)
@@ -138,6 +198,43 @@ export function InfiniteCanvas() {
   const canvasPendingApp = useUIStore((s) => s.canvasPendingApp)
   const clearCanvasPendingApp = useUIStore((s) => s.clearCanvasPendingApp)
   const allTasks = useTaskStore((s) => s.tasks)
+
+  useEffect(() => {
+    const previousStatuses = previousTaskStatusRef.current
+    const taskPanels = new Map<string, CanvasPanelData>()
+    for (const panel of panels) {
+      if (panel.type === 'task' && panel.refId) taskPanels.set(panel.refId, panel)
+    }
+
+    for (const task of allTasks) {
+      const previous = previousStatuses.get(task.id)
+      previousStatuses.set(task.id, task.status)
+
+      if (!shouldPulseCanvasTaskStatusTransition(previous, task.status)) {
+        continue
+      }
+
+      const panel = taskPanels.get(task.id)
+      if (!panel) continue
+      const statusStyle = getCanvasTaskStatusStyle(task.status)
+
+      const highlight: StatusHighlight = {
+        id: `${task.id}-${Date.now()}`,
+        taskId: task.id,
+        panelId: panel.id,
+        title: task.title,
+        rgb: statusStyle?.rgb ?? '59,130,246',
+        x: panel.x,
+        y: panel.y,
+        width: panel.width,
+        height: panel.height,
+      }
+      setStatusHighlights((current) => [...current.filter((item) => item.taskId !== task.id), highlight])
+      window.setTimeout(() => {
+        setStatusHighlights((current) => current.filter((item) => item.id !== highlight.id))
+      }, STATUS_HIGHLIGHT_MS)
+    }
+  }, [allTasks, panels])
 
   useEffect(() => {
     if (!canvasPendingTaskId) return
@@ -522,6 +619,34 @@ export function InfiniteCanvas() {
         {/* Click target for background */}
         <div data-canvas-bg="true" className="absolute inset-0" style={{ zIndex: -1 }} />
       </div>
+
+      {statusHighlights.map((highlight) => {
+        const beaconStyle = getOffscreenBeaconStyle(highlight, viewport, containerSize.width, containerSize.height)
+        if (!beaconStyle) return null
+        return (
+          <div
+            key={`${highlight.id}-beacon`}
+            data-canvas-status-edge-highlight="true"
+            className="absolute z-10"
+            style={beaconStyle}
+            title={highlight.title}
+          >
+            <button
+              type="button"
+              className="canvas-status-jump-popup flex h-9 w-9 items-center justify-center rounded-full border border-white/20 text-white shadow-lg backdrop-blur-sm"
+              onClick={(e) => {
+                e.stopPropagation()
+                focusPanel(highlight.panelId, containerSize.width, containerSize.height)
+                setStatusHighlights((current) => current.filter((item) => item.id !== highlight.id))
+              }}
+              title={`Jump to ${highlight.title}`}
+            >
+              <LocateFixed className="h-4 w-4" />
+              <span className="canvas-status-jump-popup-arrow" />
+            </button>
+          </div>
+        )
+      })}
 
       {/* ── HUD: zoom controls ── */}
       <div className="absolute bottom-4 left-4 flex items-center gap-1 bg-[var(--canvas-toolbar)] backdrop-blur-sm border border-border/40 rounded-lg p-1 z-10">

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -7,7 +7,7 @@ import { CanvasPanel } from './CanvasPanel'
 import { CanvasConnections } from './CanvasConnections'
 import { CanvasContextMenu } from './CanvasContextMenu'
 import { CanvasMinimap } from './CanvasMinimap'
-import { LocateFixed, Move, ZoomIn, ZoomOut, RotateCcw, Plus } from 'lucide-react'
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Move, ZoomIn, ZoomOut, RotateCcw, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { TaskStatus } from '@/types'
 import { getCanvasTaskStatusStyle, shouldPulseCanvasTaskStatusTransition } from './canvas-status-style'
@@ -74,12 +74,14 @@ function getPanelScreenRect(panel: StatusHighlight, viewport: Viewport) {
   }
 }
 
-function getOffscreenBeaconStyle(
+type StatusPopupDirection = 'left' | 'right' | 'top' | 'bottom'
+
+function getOffscreenBeacon(
   highlight: StatusHighlight,
   viewport: Viewport,
   containerWidth: number,
   containerHeight: number
-): CSSProperties | null {
+): { style: CSSProperties; direction: StatusPopupDirection } | null {
   if (!containerWidth || !containerHeight) return null
 
   const rect = getPanelScreenRect(highlight, viewport)
@@ -117,15 +119,15 @@ function getOffscreenBeaconStyle(
     : side === 'bottom'
       ? containerHeight - STATUS_POPUP_EDGE_PAD
       : Math.min(safeMaxY, Math.max(safeMinY, centerY))
-  const angle = Math.atan2(centerY - containerHeight / 2, centerX - containerWidth / 2)
-
   return {
-    left: x,
-    top: y,
-    transform: 'translate(-50%, -50%)',
-    '--canvas-status-rgb': highlight.rgb,
-    '--canvas-status-popup-angle': `${angle}rad`,
-  } as CSSProperties
+    direction: side,
+    style: {
+      left: x,
+      top: y,
+      transform: 'translate(-50%, -50%)',
+      '--canvas-status-rgb': highlight.rgb,
+    } as CSSProperties,
+  }
 }
 
 /**
@@ -647,14 +649,22 @@ export function InfiniteCanvas() {
       </div>
 
       {statusHighlights.map((highlight) => {
-        const beaconStyle = getOffscreenBeaconStyle(highlight, viewport, containerSize.width, containerSize.height)
-        if (!beaconStyle) return null
+        const beacon = getOffscreenBeacon(highlight, viewport, containerSize.width, containerSize.height)
+        if (!beacon) return null
+        const DirectionIcon = beacon.direction === 'left'
+          ? ArrowLeft
+          : beacon.direction === 'right'
+            ? ArrowRight
+            : beacon.direction === 'top'
+              ? ArrowUp
+              : ArrowDown
         return (
           <div
             key={`${highlight.id}-beacon`}
             data-canvas-status-edge-highlight="true"
+            data-direction={beacon.direction}
             className="absolute z-10"
-            style={beaconStyle}
+            style={beacon.style}
             title={highlight.title}
           >
             <button
@@ -667,8 +677,7 @@ export function InfiniteCanvas() {
               }}
               title={`Jump to ${highlight.title}`}
             >
-              <LocateFixed className="h-4 w-4" />
-              <span className="canvas-status-jump-popup-arrow" />
+              <DirectionIcon className="h-4 w-4" />
             </button>
           </div>
         )

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -7,7 +7,7 @@ import { CanvasPanel } from './CanvasPanel'
 import { CanvasConnections } from './CanvasConnections'
 import { CanvasContextMenu } from './CanvasContextMenu'
 import { CanvasMinimap } from './CanvasMinimap'
-import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Move, ZoomIn, ZoomOut, RotateCcw, Plus } from 'lucide-react'
+import { ArrowDown, ArrowDownLeft, ArrowDownRight, ArrowLeft, ArrowRight, ArrowUp, ArrowUpLeft, ArrowUpRight, Move, ZoomIn, ZoomOut, RotateCcw, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { TaskStatus } from '@/types'
 import { getCanvasTaskStatusStyle, shouldPulseCanvasTaskStatusTransition } from './canvas-status-style'
@@ -74,7 +74,22 @@ function getPanelScreenRect(panel: StatusHighlight, viewport: Viewport) {
   }
 }
 
-type StatusPopupDirection = 'left' | 'right' | 'top' | 'bottom'
+type StatusPopupDirection = 'left' | 'right' | 'top' | 'bottom' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+
+function getVectorDirection(deltaX: number, deltaY: number): StatusPopupDirection {
+  const deadZone = 0.35
+  const absX = Math.abs(deltaX)
+  const absY = Math.abs(deltaY)
+
+  if (absX > absY * deadZone && absY > absX * deadZone) {
+    if (deltaX < 0 && deltaY < 0) return 'top-left'
+    if (deltaX > 0 && deltaY < 0) return 'top-right'
+    if (deltaX < 0 && deltaY > 0) return 'bottom-left'
+    return 'bottom-right'
+  }
+  if (absX >= absY) return deltaX < 0 ? 'left' : 'right'
+  return deltaY < 0 ? 'top' : 'bottom'
+}
 
 function getOffscreenBeacon(
   highlight: StatusHighlight,
@@ -119,8 +134,9 @@ function getOffscreenBeacon(
     : side === 'bottom'
       ? containerHeight - STATUS_POPUP_EDGE_PAD
       : Math.min(safeMaxY, Math.max(safeMinY, centerY))
+  const direction = getVectorDirection(centerX - containerWidth / 2, centerY - containerHeight / 2)
   return {
-    direction: side,
+    direction,
     style: {
       left: x,
       top: y,
@@ -657,7 +673,15 @@ export function InfiniteCanvas() {
             ? ArrowRight
             : beacon.direction === 'top'
               ? ArrowUp
-              : ArrowDown
+              : beacon.direction === 'top-left'
+                ? ArrowUpLeft
+                : beacon.direction === 'top-right'
+                  ? ArrowUpRight
+                  : beacon.direction === 'bottom-left'
+                    ? ArrowDownLeft
+                    : beacon.direction === 'bottom-right'
+                      ? ArrowDownRight
+                      : ArrowDown
         return (
           <div
             key={`${highlight.id}-beacon`}

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -47,6 +47,11 @@ function isPanelVisible(
 // Grid dot spacing in canvas-space pixels
 const GRID_SIZE = 40
 const STATUS_HIGHLIGHT_MS = 5_000
+const STATUS_POPUP_EDGE_PAD = 28
+const STATUS_POPUP_TOP_SAFE = 70
+const STATUS_POPUP_BOTTOM_SAFE = 150
+const STATUS_POPUP_LEFT_SAFE = 170
+const STATUS_POPUP_RIGHT_SAFE = 220
 
 interface StatusHighlight {
   id: string
@@ -88,9 +93,30 @@ function getOffscreenBeaconStyle(
 
   if (isVisible) return null
 
-  const pad = 28
-  const x = Math.min(containerWidth - pad, Math.max(pad, centerX))
-  const y = Math.min(containerHeight - pad, Math.max(pad, centerY))
+  const safeMinX = Math.min(containerWidth - STATUS_POPUP_EDGE_PAD, Math.max(STATUS_POPUP_EDGE_PAD, STATUS_POPUP_LEFT_SAFE))
+  const safeMaxX = Math.max(STATUS_POPUP_EDGE_PAD, containerWidth - STATUS_POPUP_RIGHT_SAFE)
+  const safeMinY = Math.min(containerHeight - STATUS_POPUP_EDGE_PAD, Math.max(STATUS_POPUP_EDGE_PAD, STATUS_POPUP_TOP_SAFE))
+  const safeMaxY = Math.max(STATUS_POPUP_EDGE_PAD, containerHeight - STATUS_POPUP_BOTTOM_SAFE)
+  const leftDistance = Math.abs(centerX)
+  const rightDistance = Math.abs(centerX - containerWidth)
+  const topDistance = Math.abs(centerY)
+  const bottomDistance = Math.abs(centerY - containerHeight)
+  const nearest = Math.min(leftDistance, rightDistance, topDistance, bottomDistance)
+  const side =
+    nearest === leftDistance ? 'left'
+      : nearest === rightDistance ? 'right'
+        : nearest === topDistance ? 'top'
+          : 'bottom'
+  const x = side === 'left'
+    ? STATUS_POPUP_EDGE_PAD
+    : side === 'right'
+      ? containerWidth - STATUS_POPUP_EDGE_PAD
+      : Math.min(safeMaxX, Math.max(safeMinX, centerX))
+  const y = side === 'top'
+    ? STATUS_POPUP_EDGE_PAD
+    : side === 'bottom'
+      ? containerHeight - STATUS_POPUP_EDGE_PAD
+      : Math.min(safeMaxY, Math.max(safeMinY, centerY))
   const angle = Math.atan2(centerY - containerHeight / 2, centerX - containerWidth / 2)
 
   return {

--- a/src/renderer/src/components/canvas/canvas-status-style.ts
+++ b/src/renderer/src/components/canvas/canvas-status-style.ts
@@ -1,0 +1,72 @@
+import { TaskStatus } from '@/types'
+
+export interface CanvasTaskStatusStyle {
+  label: string
+  color: string
+  border: string
+  bg: string
+  miniFill: string
+  rgb: string
+}
+
+export const CANVAS_TASK_STATUS_STYLES: Record<TaskStatus, CanvasTaskStatusStyle> = {
+  [TaskStatus.NotStarted]: {
+    label: 'Not Started',
+    color: 'bg-zinc-500/20 text-zinc-300',
+    border: 'border-zinc-500/45',
+    bg: 'bg-zinc-500/10',
+    miniFill: 'rgba(113,113,122,0.78)',
+    rgb: '113,113,122',
+  },
+  [TaskStatus.Triaging]: {
+    label: 'Triaging',
+    color: 'bg-slate-500/20 text-slate-300',
+    border: 'border-slate-500/50',
+    bg: 'bg-slate-500/10',
+    miniFill: 'rgba(100,116,139,0.82)',
+    rgb: '100,116,139',
+  },
+  [TaskStatus.AgentWorking]: {
+    label: 'Working',
+    color: 'bg-amber-500/20 text-amber-300',
+    border: 'border-amber-500/55',
+    bg: 'bg-amber-500/10',
+    miniFill: 'rgba(245,158,11,0.86)',
+    rgb: '245,158,11',
+  },
+  [TaskStatus.ReadyForReview]: {
+    label: 'Review',
+    color: 'bg-pink-500/20 text-pink-300',
+    border: 'border-pink-500/55',
+    bg: 'bg-pink-500/10',
+    miniFill: 'rgba(236,72,153,0.86)',
+    rgb: '236,72,153',
+  },
+  [TaskStatus.AgentLearning]: {
+    label: 'Learning',
+    color: 'bg-blue-500/20 text-blue-300',
+    border: 'border-blue-500/55',
+    bg: 'bg-blue-500/10',
+    miniFill: 'rgba(59,130,246,0.86)',
+    rgb: '59,130,246',
+  },
+  [TaskStatus.Completed]: {
+    label: 'Completed',
+    color: 'bg-emerald-500/20 text-emerald-300',
+    border: 'border-emerald-500/55',
+    bg: 'bg-emerald-500/10',
+    miniFill: 'rgba(16,185,129,0.86)',
+    rgb: '16,185,129',
+  },
+}
+
+export function getCanvasTaskStatusStyle(status: TaskStatus | undefined): CanvasTaskStatusStyle | null {
+  return status ? CANVAS_TASK_STATUS_STYLES[status] ?? null : null
+}
+
+export function shouldPulseCanvasTaskStatusTransition(previous: TaskStatus | undefined, next: TaskStatus | undefined): boolean {
+  return (
+    (previous === TaskStatus.Triaging && next === TaskStatus.NotStarted) ||
+    (previous === TaskStatus.AgentWorking && next === TaskStatus.ReadyForReview)
+  )
+}

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -318,3 +318,45 @@ input[type="search"]::-webkit-search-cancel-button { -webkit-appearance: none; }
   background: color-mix(in oklab, var(--primary) 26%, transparent);
   color: var(--foreground);
 }
+
+@keyframes canvas-status-flash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(var(--canvas-status-rgb), 0.48);
+    opacity: 1;
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(var(--canvas-status-rgb), 0);
+    opacity: 0.7;
+  }
+  100% {
+    box-shadow: 0 0 0 18px rgba(var(--canvas-status-rgb), 0);
+    opacity: 0;
+  }
+}
+
+@keyframes canvas-status-wave {
+  0% {
+    transform: scale(0.96);
+    opacity: 0.55;
+  }
+  100% {
+    transform: scale(1.08);
+    opacity: 0;
+  }
+}
+
+.canvas-status-transition-flash {
+  animation: canvas-status-flash 1.6s ease-out both;
+}
+
+.canvas-status-transition-wave {
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(var(--canvas-status-rgb), 0.5);
+  border-radius: inherit;
+  animation: canvas-status-wave 1.4s ease-out both;
+}
+
+.canvas-status-transition-wave-delay {
+  animation-delay: 0.22s;
+}

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -360,3 +360,29 @@ input[type="search"]::-webkit-search-cancel-button { -webkit-appearance: none; }
 .canvas-status-transition-wave-delay {
   animation-delay: 0.22s;
 }
+
+@keyframes canvas-status-jump-popup {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(var(--canvas-status-rgb), 0.48), 0 10px 26px rgba(0, 0, 0, 0.32);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(var(--canvas-status-rgb), 0), 0 10px 30px rgba(var(--canvas-status-rgb), 0.28);
+  }
+}
+
+.canvas-status-jump-popup {
+  background: rgba(var(--canvas-status-rgb), 0.9);
+  animation: canvas-status-jump-popup 1.4s ease-in-out infinite;
+}
+
+.canvas-status-jump-popup-arrow {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: translate(-50%, -50%) rotate(calc(var(--canvas-status-popup-angle) + 45deg)) translateX(24px);
+  opacity: 0.9;
+}

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -374,15 +374,3 @@ input[type="search"]::-webkit-search-cancel-button { -webkit-appearance: none; }
   background: rgba(var(--canvas-status-rgb), 0.9);
   animation: canvas-status-jump-popup 1.4s ease-in-out infinite;
 }
-
-.canvas-status-jump-popup-arrow {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 8px;
-  height: 8px;
-  border-right: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
-  transform: translate(-50%, -50%) rotate(calc(var(--canvas-status-popup-angle) + 45deg)) translateX(24px);
-  opacity: 0.9;
-}


### PR DESCRIPTION
## Summary
- add a shared canvas task status palette and apply it to task panel chrome plus minimap task rectangles
- keep browser and terminal canvas colors distinct from task status colors
- keep the original transition effects for Triaging -> Not Started and Agent Working -> Ready for Review
- when one of those transitioned task panels is off-screen, show a temporary 5-second popup icon at a control-safe viewport edge; clicking it jumps/focuses the task panel
- clamp the popup away from existing canvas HUD controls: Add, coordinate readout, zoom controls, and minimap
- use deterministic 8-way directional arrows based on the task vector, so an 8 o'clock task shows a down-left arrow even when the popup is clamped onto the bottom safe lane
- cover task status color mapping, non-status browser/terminal colors, and off-screen jump popup behavior in canvas tests

## Test plan
- pnpm exec tsc --noEmit --pretty false --project tsconfig.web.json
- pnpm exec eslint src/renderer/src/components/canvas/InfiniteCanvas.tsx src/renderer/src/components/canvas/CanvasPanel.tsx src/renderer/src/components/canvas/CanvasMinimap.tsx src/renderer/src/components/canvas/canvas-status-style.ts src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
- pnpm exec vitest run --project renderer src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
- pnpm test:renderer -- src/renderer/src/components/canvas/InfiniteCanvas.test.tsx (blocked locally: Electron binary unavailable after --ignore-scripts install; normal install fails compiling better-sqlite3 on Node 26)