### PR TITLE
fix: stop Codex app-server transcript repeating older messages after idle

### DIFF
--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -284,6 +284,59 @@ describe('CodexAppServerAdapter', () => {
     ])
   })
 
+  it('does not repeat id-less thread items after each completed turn reconcile', async () => {
+    // Regression: Codex thread items such as function_call_output /
+    // custom_tool_call_output / user+developer input messages have NO top-level
+    // `id` (only `call_id`). reconcileCompletedTurn() re-lists the whole thread
+    // on every turn/completed. Because bufferedThreadItemIds only registered
+    // items that had `item.id` and extractItemId fell back to `item-${Date.now()}`,
+    // these id-less items were re-buffered and re-emitted with a brand new part id
+    // on every idle — so the transcript repeated older messages after each turn.
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    adapter.sessions.set('thread-1', session)
+
+    // Mirrors a codex function_call_output item: no `id`, only `call_id`.
+    const idLessToolOutput = {
+      type: 'commandExecution',
+      call_id: 'call_abc123',
+      command: 'ls -la',
+      aggregatedOutput: 'file1\nfile2',
+      turnId: 'turn-1'
+    }
+
+    const reconcileTurn = async (turnId: string): Promise<void> => {
+      session.status = SessionStatusType.BUSY
+      adapter.handleRpcMessage(session, {
+        jsonrpc: '2.0',
+        method: 'turn/completed',
+        params: { threadId: 'thread-1', turnId }
+      })
+      // Resolve the newest thread/items/list request, mirroring how the real
+      // JSON-RPC response handler settles + removes it.
+      const entries = Array.from(session.pendingRequests.entries())
+      const [id, pending] = entries[entries.length - 1]
+      session.pendingRequests.delete(id)
+      pending.resolve({ data: [idLessToolOutput], nextCursor: null })
+      await flushPromises()
+    }
+
+    await reconcileTurn('turn-1')
+    await reconcileTurn('turn-2')
+    await reconcileTurn('turn-3')
+
+    // The same tool output must only ever be buffered once, no matter how many
+    // turns complete afterwards. Buffering it again re-emits it to the renderer
+    // with a fresh (Date.now-based) part id that dedup can't collapse.
+    const bufferedCopies = session.permanentMessages.filter((event) => {
+      const item = (event as { params?: { item?: { call_id?: string } } })?.params?.item
+      return item?.call_id === 'call_abc123'
+    })
+    expect(bufferedCopies).toHaveLength(1)
+    expect(session.bufferedThreadItemIds.size).toBeGreaterThan(0)
+  })
+
   it('keeps the session busy when a completed turn is followed by an active thread status', async () => {
     const adapterInstance = new CodexAppServerAdapter()
     const adapter = adapterPrivate(adapterInstance)

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -114,9 +114,49 @@ function extractThreadId(value: unknown): string | null {
   return null
 }
 
+/**
+ * Deterministic 32-bit string hash (djb2). Used to build stable dedup keys for
+ * thread items that carry no id — never use Date.now()/random here, or the same
+ * item would produce a new key on every reconcile pass and be re-emitted.
+ */
+function hashString(value: string): string {
+  let hash = 5381
+  for (let i = 0; i < value.length; i++) {
+    hash = ((hash << 5) + hash + value.charCodeAt(i)) | 0
+  }
+  return (hash >>> 0).toString(36)
+}
+
+/**
+ * Derives a STABLE identity for a Codex thread item. Many item types
+ * (function_call_output, custom_tool_call_output, tool_search_output, and
+ * user/developer input messages) have no top-level `id` — only a `call_id`, or
+ * nothing at all. This must return the same value across reconcile passes for the
+ * same logical item, otherwise the transcript repeats older messages after every
+ * idle. Returns null when no id-like field exists (caller falls back to a
+ * content-based key).
+ */
+function deriveItemIdentity(item: Record<string, unknown> | undefined): string | null {
+  if (!item) return null
+  const direct = asString(item.id) || asString(item.itemId) || asString(item.item_id)
+  if (direct) return direct
+  const callId = asString(item.call_id) || asString(item.callId)
+  if (callId) {
+    const type = asString(item.type) || 'item'
+    return `${type}:${callId}`
+  }
+  return null
+}
+
 function extractItemId(params: Record<string, unknown>): string {
   const item = isObject(params.item) ? params.item : undefined
-  return asString(params.itemId) || asString(item?.id) || `item-${Date.now()}`
+  const identity = asString(params.itemId) || deriveItemIdentity(item)
+  if (identity) return identity
+  // Last resort: a deterministic key derived from the item's content so the same
+  // item maps to the same part id across reconciles (was `item-${Date.now()}`,
+  // which minted a new id every pass and duplicated the message on each idle).
+  const fingerprint = item ? `${asString(item.type) || 'item'}:${extractText(item)}` : 'item'
+  return `item-${hashString(fingerprint)}`
 }
 
 function extractText(value: unknown): string {
@@ -961,22 +1001,52 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
   private bufferThreadItems(session: AppServerSession, result: unknown): void {
     const items = isObject(result) && Array.isArray(result.data) ? result.data : []
     for (const item of items) {
-      if (isObject(item)) {
-        const itemId = asString(item.id)
-        if (itemId) {
-          if (session.bufferedThreadItemIds.has(itemId)) continue
-          session.bufferedThreadItemIds.add(itemId)
-        }
-      }
-      this.addEvent(session, {
-        method: 'item/completed',
-        params: {
-          threadId: session.threadId,
-          turnId: isObject(item) ? asString(item.turnId) : undefined,
-          item
-        }
-      })
+      this.bufferReconciledThreadItem(session, item, isObject(item) ? asString(item.turnId) : undefined)
     }
+  }
+
+  /**
+   * Buffers a single thread item from a reconcile pass, skipping it if it has
+   * already been buffered. reconcileCompletedTurn() re-lists the entire thread on
+   * every turn/completed, so this MUST be idempotent for every item — including
+   * the many Codex item types that carry no top-level `id` (function_call_output,
+   * custom_tool_call_output, tool_search_output, user/developer messages). We key
+   * off a stable identity (id/itemId/call_id) or, failing that, a deterministic
+   * content hash, and forward that key as `itemId` so the derived part id stays
+   * stable across passes. Without this, id-less items were re-emitted with a fresh
+   * id on every idle and the transcript repeated older messages.
+   */
+  private bufferReconciledThreadItem(
+    session: AppServerSession,
+    item: unknown,
+    turnId: string | undefined
+  ): void {
+    let stableItemId: string | undefined
+    if (isObject(item)) {
+      stableItemId = this.computeThreadItemKey(item, turnId)
+      if (session.bufferedThreadItemIds.has(stableItemId)) return
+      session.bufferedThreadItemIds.add(stableItemId)
+    }
+    this.addEvent(session, {
+      method: 'item/completed',
+      params: {
+        threadId: session.threadId,
+        turnId,
+        item,
+        ...(stableItemId ? { itemId: stableItemId } : {})
+      }
+    })
+  }
+
+  private computeThreadItemKey(item: Record<string, unknown>, turnId: string | undefined): string {
+    const identity = deriveItemIdentity(item)
+    if (identity) return identity
+    // No id-like field (e.g. user/developer input messages). Build a deterministic
+    // key from turn + type + role + content so the same item maps to the same key
+    // across reconcile passes instead of duplicating.
+    const type = asString(item.type) || 'item'
+    const role = extractRole(item)
+    return `synthetic:${turnId || 'noturn'}:${type}:${role}:${hashString(extractText(item))}`
   }
 
   private async bufferAllThreadItems(session: AppServerSession, threadId: string): Promise<void> {
@@ -1024,21 +1094,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       for (const turn of turns) {
         if (!isObject(turn) || !Array.isArray(turn.items)) continue
         for (const item of turn.items) {
-          if (isObject(item)) {
-            const itemId = asString(item.id)
-            if (itemId) {
-              if (session.bufferedThreadItemIds.has(itemId)) continue
-              session.bufferedThreadItemIds.add(itemId)
-            }
-          }
-          this.addEvent(session, {
-            method: 'item/completed',
-            params: {
-              threadId: session.threadId,
-              turnId: asString(turn.id),
-              item
-            }
-          })
+          this.bufferReconciledThreadItem(session, item, asString(turn.id))
         }
       }
       cursor = isObject(result) ? (asString(result.nextCursor) || null) : null


### PR DESCRIPTION
## Problem

In the Codex agent transcript, **older messages get repeated after the last ongoing idle** — every time a Codex turn completes and the thread goes idle, previously-shown messages are re-appended to the transcript, so the conversation keeps growing with duplicates.

## Root cause

`CodexAppServerAdapter.reconcileCompletedTurn()` (added in #412) re-lists the **entire** thread via `thread/items/list` on **every** `turn/completed`, to make sure the final assistant message isn't lost. Re-buffering the whole history is only safe if it's idempotent — and it wasn't:

- The dedup guard `bufferedThreadItemIds` only registered an item when `asString(item.id)` was truthy.
- `extractItemId()` fell back to `` `item-${Date.now()}` `` when no id was found.

But many Codex thread item types have **no top-level `id`** — only a `call_id`, or nothing at all. Verified against real Codex rollout logs (`~/.codex/sessions/.../rollout-*.jsonl`) for the referenced task `pf-web: analyse slow mongodb queries` (thread `019f4a0d-e8c7-73f3-8592-6b5f312d1b5b`, 12 turns):

| item type | has `id` |
|---|---|
| `function_call_output` (168×) | ❌ (only `call_id`) |
| `custom_tool_call_output` | ❌ |
| `tool_search_output` | ❌ |
| user/developer input `message` | ❌ |

So on every reconcile those id-less items bypassed the dedup, got re-buffered, and were re-emitted to the renderer with a **fresh** `item-${Date.now()}` part id that neither `seenPartIds` nor the renderer's id-keyed dedup could collapse → the transcript repeated older messages after each idle.

## Fix

Make reconcile buffering idempotent for **every** item:

- `deriveItemIdentity()` derives a stable identity from `id` / `itemId` / `call_id`.
- `computeThreadItemKey()` falls back to a **deterministic** content hash (turn + type + role + text) when there's no id-like field.
- `bufferReconciledThreadItem()` (shared by `bufferThreadItems` and `bufferAllThreadTurns`) skips already-buffered items by that key and forwards it as `itemId`, so the derived part id stays stable across passes.
- `extractItemId()` no longer uses `Date.now()` — it uses the same stable identity, then a deterministic content hash.

## Reproduction / test

Added a regression test that fires three `turn/completed` reconciles returning the same id-less tool output and asserts it is buffered **exactly once** (was 3× before the fix).

- New + existing `codex-app-server-adapter` tests: 19 passing
- Full pre-commit suite: 1533 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)