### PR TITLE
fix: cloudflared ENOENT in packaged app + custom remote URL option

### DIFF
--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -4,7 +4,8 @@ vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
   dialog: { showOpenDialog: vi.fn() },
   shell: { openPath: vi.fn(), showItemInFolder: vi.fn() },
-  Notification: vi.fn().mockImplementation(() => ({ show: vi.fn() }))
+  Notification: vi.fn().mockImplementation(() => ({ show: vi.fn() })),
+  app: { isPackaged: false }
 }))
 
 const { mockChildKill, mockSpawn } = vi.hoisted(() => {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -835,15 +835,23 @@ export function registerIpcHandlers(
     return enabled
   })
 
-  // Mobile web UI info — QR contains one-time init code, not the session token
-  ipcMain.handle('mobile:getInfo', () => {
-    const port = 20620
-
-    // Generate a fresh init code (5 min expiry)
+  const generateInitCode = (): string => {
     const initCode = randomUUID()
     const expiresAt = Math.floor(Date.now() / 1000) + 300
     db.setSetting(`mobile_init_code_${initCode}`, '1')
     db.setSetting(`mobile_init_code_${initCode}_exp`, String(expiresAt))
+    return initCode
+  }
+
+  const getRemoteMode = (): 'quick' | 'custom' =>
+    db.getSetting('mobile_remote_mode') === 'custom' ? 'custom' : 'quick'
+
+  const getCustomUrl = (): string | null => db.getSetting('mobile_custom_url') || null
+
+  // Mobile web UI info — QR contains one-time init code, not the session token
+  ipcMain.handle('mobile:getInfo', () => {
+    const port = 20620
+    const initCode = generateInitCode()
 
     // Get LAN IP
     const nets = networkInterfaces()
@@ -858,8 +866,11 @@ export function registerIpcHandlers(
       if (lanIp !== 'localhost') break
     }
 
+    const remoteMode = getRemoteMode()
+    const customUrl = getCustomUrl()
     const tunnelUrl = getTunnelUrl()
-    const baseUrl = tunnelUrl ?? `http://${lanIp}:${port}`
+    const remoteBaseUrl = remoteMode === 'custom' ? customUrl : tunnelUrl
+    const baseUrl = remoteBaseUrl ?? `http://${lanIp}:${port}`
     const pairUrl = `${baseUrl}/pair?code=${initCode}`
     const lanPairUrl = `http://${lanIp}:${port}/pair?code=${initCode}`
 
@@ -867,24 +878,41 @@ export function registerIpcHandlers(
       url: pairUrl,
       port,
       lanUrl: lanPairUrl,
-      tunnelUrl: tunnelUrl ? `${tunnelUrl}/pair?code=${initCode}` : null,
-      tunnelActive: isTunnelActive()
+      tunnelUrl: remoteBaseUrl ? `${remoteBaseUrl}/pair?code=${initCode}` : null,
+      tunnelActive: remoteMode === 'custom' ? Boolean(customUrl) : isTunnelActive(),
+      remoteMode,
+      customUrl
     }
   })
 
   ipcMain.handle('mobile:startTunnel', async () => {
     const port = 20620
+    db.setSetting('mobile_remote_mode', 'quick')
     const url = await startTunnel(port)
-    // Generate fresh init code for the new tunnel URL
-    const initCode = randomUUID()
-    const expiresAt = Math.floor(Date.now() / 1000) + 300
-    db.setSetting(`mobile_init_code_${initCode}`, '1')
-    db.setSetting(`mobile_init_code_${initCode}_exp`, String(expiresAt))
+    const initCode = generateInitCode()
     return { tunnelUrl: `${url}/pair?code=${initCode}` }
   })
 
   ipcMain.handle('mobile:stopTunnel', () => {
     stopTunnel()
+    return { success: true }
+  })
+
+  ipcMain.handle('mobile:setCustomUrl', (_, rawUrl: string) => {
+    const url = rawUrl.trim().replace(/\/+$/, '')
+    if (!/^https?:\/\/.+/i.test(url)) {
+      throw new Error('Enter a valid URL starting with http:// or https://')
+    }
+    stopTunnel()
+    db.setSetting('mobile_remote_mode', 'custom')
+    db.setSetting('mobile_custom_url', url)
+    const initCode = generateInitCode()
+    return { url: `${url}/pair?code=${initCode}` }
+  })
+
+  ipcMain.handle('mobile:clearCustomUrl', () => {
+    db.setSetting('mobile_remote_mode', 'quick')
+    db.deleteSetting('mobile_custom_url')
     return { success: true }
   })
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -887,8 +887,12 @@ export function registerIpcHandlers(
 
   ipcMain.handle('mobile:startTunnel', async () => {
     const port = 20620
-    db.setSetting('mobile_remote_mode', 'quick')
     const url = await startTunnel(port)
+    // Only persist 'quick' mode once the tunnel actually connects — if
+    // startTunnel() throws, the mode setting must stay whatever it was before
+    // (e.g. a still-valid 'custom' mode/URL shouldn't be clobbered by a
+    // failed quick-tunnel attempt).
+    db.setSetting('mobile_remote_mode', 'quick')
     const initCode = generateInitCode()
     return { tunnelUrl: `${url}/pair?code=${initCode}` }
   })
@@ -899,10 +903,16 @@ export function registerIpcHandlers(
   })
 
   ipcMain.handle('mobile:setCustomUrl', (_, rawUrl: string) => {
-    const url = rawUrl.trim().replace(/\/+$/, '')
-    if (!/^https?:\/\/.+/i.test(url)) {
+    let parsed: URL
+    try {
+      parsed = new URL(rawUrl.trim())
+    } catch {
       throw new Error('Enter a valid URL starting with http:// or https://')
     }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('Enter a valid URL starting with http:// or https://')
+    }
+    const url = parsed.href.replace(/\/+$/, '')
     stopTunnel()
     db.setSetting('mobile_remote_mode', 'custom')
     db.setSetting('mobile_custom_url', url)

--- a/src/main/tunnel-manager.ts
+++ b/src/main/tunnel-manager.ts
@@ -1,7 +1,23 @@
-import { Tunnel } from 'cloudflared'
-import { writeFileSync } from 'fs'
-import { join } from 'path'
+import { Tunnel, DEFAULT_CLOUDFLARED_BIN, use as useCloudflaredBin } from 'cloudflared'
+import { writeFileSync, existsSync } from 'fs'
+import { join, sep } from 'path'
 import { tmpdir } from 'os'
+import { app } from 'electron'
+
+// The cloudflared package resolves its bundled binary via `__dirname`, which
+// in a packaged app points inside app.asar. Electron's fs APIs are
+// asar-transparent for reads, but spawning a binary from inside the asar
+// fails (ENOENT) — electron-builder's asarUnpack only extracts the real file
+// to the sibling `app.asar.unpacked` directory, so spawn must be told to use
+// that path explicitly.
+if (app.isPackaged) {
+  const unpackedBin = DEFAULT_CLOUDFLARED_BIN.replace(`app.asar${sep}`, `app.asar.unpacked${sep}`)
+  if (existsSync(unpackedBin)) {
+    useCloudflaredBin(unpackedBin)
+  } else {
+    console.warn('[tunnel] expected unpacked cloudflared binary not found at', unpackedBin)
+  }
+}
 
 let activeTunnel: Tunnel | null = null
 let tunnelUrl: string | null = null

--- a/src/main/tunnel-manager.ts
+++ b/src/main/tunnel-manager.ts
@@ -1,6 +1,6 @@
-import { Tunnel, DEFAULT_CLOUDFLARED_BIN, use as useCloudflaredBin } from 'cloudflared'
+import { Tunnel, use as useCloudflaredBin } from 'cloudflared'
 import { writeFileSync, existsSync } from 'fs'
-import { join, sep } from 'path'
+import { join } from 'path'
 import { tmpdir } from 'os'
 import { app } from 'electron'
 
@@ -9,17 +9,33 @@ import { app } from 'electron'
 // asar-transparent for reads, but spawning a binary from inside the asar
 // fails (ENOENT) — electron-builder's asarUnpack only extracts the real file
 // to the sibling `app.asar.unpacked` directory, so spawn must be told to use
-// that path explicitly.
+// that path explicitly. Resolved via process.resourcesPath (same approach as
+// binary-manager.ts) rather than string-replacing the package's own default
+// path, since that default can vary in shape across platforms/versions.
+let cloudflaredBinError: string | null = null
 if (app.isPackaged) {
-  const unpackedBin = DEFAULT_CLOUDFLARED_BIN.replace(`app.asar${sep}`, `app.asar.unpacked${sep}`)
+  const unpackedBin = join(
+    process.resourcesPath,
+    'app.asar.unpacked',
+    'node_modules',
+    'cloudflared',
+    'bin',
+    process.platform === 'win32' ? 'cloudflared.exe' : 'cloudflared'
+  )
   if (existsSync(unpackedBin)) {
     useCloudflaredBin(unpackedBin)
   } else {
-    console.warn('[tunnel] expected unpacked cloudflared binary not found at', unpackedBin)
+    cloudflaredBinError = `cloudflared binary not found at ${unpackedBin}. Remote access via Cloudflare tunnel is unavailable in this build.`
+    console.error('[tunnel]', cloudflaredBinError)
   }
 }
 
 let activeTunnel: Tunnel | null = null
+// The in-flight tunnel between Tunnel.quick() and its 'connected' event —
+// tracked separately from activeTunnel so stopTunnel() (e.g. from a mode
+// switch) can cancel a connection attempt that hasn't resolved yet, instead
+// of only being able to stop a tunnel that already finished connecting.
+let pendingTunnel: Tunnel | null = null
 let tunnelUrl: string | null = null
 
 /**
@@ -48,6 +64,7 @@ const CONNECT_TIMEOUT_MS = 120_000
 
 export async function startTunnel(port: number): Promise<string> {
   if (activeTunnel && tunnelUrl) return tunnelUrl
+  if (cloudflaredBinError) throw new Error(cloudflaredBinError)
 
   return new Promise((resolve, reject) => {
     // Options passed to cloudflared. build_options() uses the key verbatim, so
@@ -71,6 +88,7 @@ export async function startTunnel(port: number): Promise<string> {
       console.warn('[tunnel] could not write isolated cloudflared config, using default:', e)
     }
     const t = Tunnel.quick(`http://127.0.0.1:${port}`, options)
+    pendingTunnel = t
 
     // cloudflared prints the public https://<...>.trycloudflare.com URL to its
     // output BEFORE it has actually registered any connection with Cloudflare's
@@ -94,6 +112,7 @@ export async function startTunnel(port: number): Promise<string> {
       if (settled) return
       settled = true
       t.stop()
+      if (t === pendingTunnel) pendingTunnel = null
       activeTunnel = null
       tunnelUrl = null
       const tail = recentOutput.length ? ` Last cloudflared output:\n${recentOutput.join('\n')}` : ''
@@ -118,9 +137,17 @@ export async function startTunnel(port: number): Promise<string> {
 
     t.on('connected', () => {
       if (settled || !pendingUrl) return
+      // stopTunnel() was called (e.g. user switched to Custom URL) while this
+      // connection was still in flight — don't resurrect it as the active
+      // tunnel now that it's finally connected.
+      if (t !== pendingTunnel) {
+        t.stop()
+        return
+      }
       settled = true
       clearTimeout(timer)
       activeTunnel = t
+      pendingTunnel = null
       tunnelUrl = pendingUrl
       resolve(pendingUrl)
     })
@@ -130,6 +157,7 @@ export async function startTunnel(port: number): Promise<string> {
       settled = true
       clearTimeout(timer)
       t.stop()
+      if (t === pendingTunnel) pendingTunnel = null
       activeTunnel = null
       tunnelUrl = null
       reject(err)
@@ -142,13 +170,16 @@ export async function startTunnel(port: number): Promise<string> {
         activeTunnel = null
         tunnelUrl = null
       }
+      if (t === pendingTunnel) pendingTunnel = null
     })
   })
 }
 
 export function stopTunnel(): void {
   activeTunnel?.stop()
+  pendingTunnel?.stop()
   activeTunnel = null
+  pendingTunnel = null
   tunnelUrl = null
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -350,12 +350,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('app:setMinimizeToTray', enabled)
   },
   mobile: {
-    getInfo: (): Promise<{ url: string; port: number; lanUrl: string; tunnelUrl: string | null; tunnelActive: boolean }> =>
-      ipcRenderer.invoke('mobile:getInfo'),
+    getInfo: (): Promise<{
+      url: string
+      port: number
+      lanUrl: string
+      tunnelUrl: string | null
+      tunnelActive: boolean
+      remoteMode: 'quick' | 'custom'
+      customUrl: string | null
+    }> => ipcRenderer.invoke('mobile:getInfo'),
     startTunnel: (): Promise<{ tunnelUrl: string }> =>
       ipcRenderer.invoke('mobile:startTunnel'),
     stopTunnel: (): Promise<{ success: boolean }> =>
       ipcRenderer.invoke('mobile:stopTunnel'),
+    setCustomUrl: (url: string): Promise<{ url: string }> =>
+      ipcRenderer.invoke('mobile:setCustomUrl', url),
+    clearCustomUrl: (): Promise<{ success: boolean }> =>
+      ipcRenderer.invoke('mobile:clearCustomUrl'),
     getPendingPin: (): Promise<{ pin: string; pairCodeId: string; expiresAt: number } | null> =>
       ipcRenderer.invoke('mobile:getPendingPin'),
     getSessions: (): Promise<{ id: string; device_name: string; paired_at: number; last_seen: number }[]> =>

--- a/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
@@ -5,6 +5,8 @@ import { SettingsSection } from '../SettingsSection'
 import { Label } from '@/components/ui/Label'
 import { Switch } from '@/components/ui/Switch'
 import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { Select } from '@/components/ui/Select'
 import { OnboardingWizard } from '@/components/onboarding/OnboardingWizard'
 import { settingsApi, mobileApi, updaterApi, worktreeApi, onWorkspaceCleanupProgress } from '@/lib/ipc-client'
 
@@ -18,6 +20,8 @@ export function GeneralSettings() {
   const [tunnelActive, setTunnelActive] = useState(false)
   const [tunnelLoading, setTunnelLoading] = useState(false)
   const [tunnelError, setTunnelError] = useState<string | null>(null)
+  const [remoteMode, setRemoteMode] = useState<'quick' | 'custom'>('quick')
+  const [customUrlInput, setCustomUrlInput] = useState('')
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null)
   const [pairingPin, setPairingPin] = useState<string | null>(null)
   const [pinSecondsLeft, setPinSecondsLeft] = useState(0)
@@ -135,6 +139,8 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
         setMobileLanUrl(info.lanUrl)
         setMobileTunnelUrl(info.tunnelUrl)
         setTunnelActive(info.tunnelActive)
+        setRemoteMode(info.remoteMode)
+        if (info.customUrl) setCustomUrlInput(info.customUrl)
         const qrUrl = info.tunnelUrl ?? info.lanUrl ?? info.url
         if (qrUrl) {
           const dataUrl = await QRCode.toDataURL(qrUrl, { width: 200, margin: 1 })
@@ -306,49 +312,129 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
           )}
         </div>
 
-        {/* Remote access toggle */}
+        {/* Remote access method */}
         <div className="flex items-center justify-between py-2 border-b border-border">
           <div className="space-y-0.5">
-            <Label>Remote access</Label>
-            <p className="text-xs text-muted-foreground">
-              {tunnelActive
-                ? 'Accessible from anywhere via Cloudflare tunnel'
-                : 'Enable to access from outside your network'}
-            </p>
+            <Label>Remote access method</Label>
+            <p className="text-xs text-muted-foreground">Cloudflare quick tunnel, or bring your own URL</p>
           </div>
-          <Switch
-            checked={tunnelActive}
+          <Select
+            value={remoteMode}
             disabled={tunnelLoading}
-            onCheckedChange={async (checked) => {
-              setTunnelLoading(true)
+            onChange={async (e) => {
+              const mode = e.target.value as 'quick' | 'custom'
               setTunnelError(null)
+              if (mode === 'custom') {
+                setRemoteMode('custom')
+                return
+              }
+              setTunnelLoading(true)
               try {
-                if (checked) {
-                  const { tunnelUrl: url } = await mobileApi.startTunnel()
-                  setMobileTunnelUrl(url)
-                  setTunnelActive(true)
-                  if (url) {
-                    const dataUrl = await QRCode.toDataURL(url, { width: 200, margin: 1 })
-                    setQrDataUrl(dataUrl)
-                  }
-                } else {
-                  await mobileApi.stopTunnel()
-                  setMobileTunnelUrl(null)
-                  setTunnelActive(false)
-                  if (mobileLanUrl) {
-                    const dataUrl = await QRCode.toDataURL(mobileLanUrl, { width: 200, margin: 1 })
-                    setQrDataUrl(dataUrl)
-                  }
+                await mobileApi.clearCustomUrl()
+                setRemoteMode('quick')
+                setMobileTunnelUrl(null)
+                setTunnelActive(false)
+                if (mobileLanUrl) {
+                  const dataUrl = await QRCode.toDataURL(mobileLanUrl, { width: 200, margin: 1 })
+                  setQrDataUrl(dataUrl)
                 }
               } catch (err) {
-                console.error('Tunnel toggle failed:', err)
-                setTunnelError(err instanceof Error ? err.message : 'Failed to start remote access')
+                setTunnelError(err instanceof Error ? err.message : 'Failed to switch remote access method')
               } finally {
                 setTunnelLoading(false)
               }
             }}
+            options={[
+              { value: 'quick', label: 'Cloudflare Quick Tunnel' },
+              { value: 'custom', label: 'Custom URL' }
+            ]}
+            className="w-auto"
           />
         </div>
+
+        {remoteMode === 'quick' ? (
+          <div className="flex items-center justify-between py-2 border-b border-border">
+            <div className="space-y-0.5">
+              <Label>Remote access</Label>
+              <p className="text-xs text-muted-foreground">
+                {tunnelActive
+                  ? 'Accessible from anywhere via Cloudflare tunnel'
+                  : 'Enable to access from outside your network'}
+              </p>
+            </div>
+            <Switch
+              checked={tunnelActive}
+              disabled={tunnelLoading}
+              onCheckedChange={async (checked) => {
+                setTunnelLoading(true)
+                setTunnelError(null)
+                try {
+                  if (checked) {
+                    const { tunnelUrl: url } = await mobileApi.startTunnel()
+                    setMobileTunnelUrl(url)
+                    setTunnelActive(true)
+                    if (url) {
+                      const dataUrl = await QRCode.toDataURL(url, { width: 200, margin: 1 })
+                      setQrDataUrl(dataUrl)
+                    }
+                  } else {
+                    await mobileApi.stopTunnel()
+                    setMobileTunnelUrl(null)
+                    setTunnelActive(false)
+                    if (mobileLanUrl) {
+                      const dataUrl = await QRCode.toDataURL(mobileLanUrl, { width: 200, margin: 1 })
+                      setQrDataUrl(dataUrl)
+                    }
+                  }
+                } catch (err) {
+                  console.error('Tunnel toggle failed:', err)
+                  setTunnelError(err instanceof Error ? err.message : 'Failed to start remote access')
+                } finally {
+                  setTunnelLoading(false)
+                }
+              }}
+            />
+          </div>
+        ) : (
+          <div className="flex items-center justify-between py-2 border-b border-border gap-3">
+            <div className="space-y-0.5">
+              <Label>Custom URL</Label>
+              <p className="text-xs text-muted-foreground">Your own tunnel or reverse proxy pointed at 20x</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                value={customUrlInput}
+                onChange={(e) => setCustomUrlInput(e.target.value)}
+                placeholder="https://my-tunnel.example.com"
+                className="w-56"
+                disabled={tunnelLoading}
+              />
+              <Button
+                size="sm"
+                disabled={tunnelLoading || !customUrlInput.trim()}
+                onClick={async () => {
+                  setTunnelLoading(true)
+                  setTunnelError(null)
+                  try {
+                    const { url } = await mobileApi.setCustomUrl(customUrlInput.trim())
+                    setMobileTunnelUrl(url)
+                    setTunnelActive(true)
+                    if (url) {
+                      const dataUrl = await QRCode.toDataURL(url, { width: 200, margin: 1 })
+                      setQrDataUrl(dataUrl)
+                    }
+                  } catch (err) {
+                    setTunnelError(err instanceof Error ? err.message : 'Failed to set custom URL')
+                  } finally {
+                    setTunnelLoading(false)
+                  }
+                }}
+              >
+                {tunnelActive ? 'Update' : 'Enable'}
+              </Button>
+            </div>
+          </div>
+        )}
         {tunnelError && (
           <p className="text-xs text-destructive -mt-1 mb-2">{tunnelError}</p>
         )}

--- a/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
@@ -140,7 +140,7 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
         setMobileTunnelUrl(info.tunnelUrl)
         setTunnelActive(info.tunnelActive)
         setRemoteMode(info.remoteMode)
-        if (info.customUrl) setCustomUrlInput(info.customUrl)
+        setCustomUrlInput(info.customUrl ?? '')
         const qrUrl = info.tunnelUrl ?? info.lanUrl ?? info.url
         if (qrUrl) {
           const dataUrl = await QRCode.toDataURL(qrUrl, { width: 200, margin: 1 })
@@ -222,6 +222,20 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
       setMinimizeToTray(checked)
     } catch (error) {
       console.error('Failed to update minimize to tray:', error)
+    }
+  }
+
+  // Applies a new active remote URL (or falls back to the LAN URL when null)
+  // to the QR code and tunnel state. Shared by the quick-tunnel switch, the
+  // custom-URL button, and the mode-switch-back-to-quick handler so all three
+  // stay in sync instead of drifting apart.
+  const applyRemoteUrl = async (url: string | null) => {
+    setMobileTunnelUrl(url)
+    setTunnelActive(Boolean(url))
+    const qrUrl = url ?? mobileLanUrl
+    if (qrUrl) {
+      const dataUrl = await QRCode.toDataURL(qrUrl, { width: 200, margin: 1 })
+      setQrDataUrl(dataUrl)
     }
   }
 
@@ -330,14 +344,10 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
               }
               setTunnelLoading(true)
               try {
+                await mobileApi.stopTunnel()
                 await mobileApi.clearCustomUrl()
                 setRemoteMode('quick')
-                setMobileTunnelUrl(null)
-                setTunnelActive(false)
-                if (mobileLanUrl) {
-                  const dataUrl = await QRCode.toDataURL(mobileLanUrl, { width: 200, margin: 1 })
-                  setQrDataUrl(dataUrl)
-                }
+                await applyRemoteUrl(null)
               } catch (err) {
                 setTunnelError(err instanceof Error ? err.message : 'Failed to switch remote access method')
               } finally {
@@ -371,20 +381,10 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
                 try {
                   if (checked) {
                     const { tunnelUrl: url } = await mobileApi.startTunnel()
-                    setMobileTunnelUrl(url)
-                    setTunnelActive(true)
-                    if (url) {
-                      const dataUrl = await QRCode.toDataURL(url, { width: 200, margin: 1 })
-                      setQrDataUrl(dataUrl)
-                    }
+                    await applyRemoteUrl(url)
                   } else {
                     await mobileApi.stopTunnel()
-                    setMobileTunnelUrl(null)
-                    setTunnelActive(false)
-                    if (mobileLanUrl) {
-                      const dataUrl = await QRCode.toDataURL(mobileLanUrl, { width: 200, margin: 1 })
-                      setQrDataUrl(dataUrl)
-                    }
+                    await applyRemoteUrl(null)
                   }
                 } catch (err) {
                   console.error('Tunnel toggle failed:', err)
@@ -417,12 +417,7 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
                   setTunnelError(null)
                   try {
                     const { url } = await mobileApi.setCustomUrl(customUrlInput.trim())
-                    setMobileTunnelUrl(url)
-                    setTunnelActive(true)
-                    if (url) {
-                      const dataUrl = await QRCode.toDataURL(url, { width: 200, margin: 1 })
-                      setQrDataUrl(dataUrl)
-                    }
+                    await applyRemoteUrl(url)
                   } catch (err) {
                     setTunnelError(err instanceof Error ? err.message : 'Failed to set custom URL')
                   } finally {

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -269,14 +269,31 @@ export const updaterApi = {
 }
 
 export const mobileApi = {
-  getInfo: (): Promise<{ url: string; port: number; lanUrl: string; tunnelUrl: string | null; tunnelActive: boolean }> => {
-    return window.electronAPI?.mobile?.getInfo() ?? Promise.resolve({ url: '', port: 0, lanUrl: '', tunnelUrl: null, tunnelActive: false })
+  getInfo: (): Promise<{
+    url: string
+    port: number
+    lanUrl: string
+    tunnelUrl: string | null
+    tunnelActive: boolean
+    remoteMode: 'quick' | 'custom'
+    customUrl: string | null
+  }> => {
+    return (
+      window.electronAPI?.mobile?.getInfo() ??
+      Promise.resolve({ url: '', port: 0, lanUrl: '', tunnelUrl: null, tunnelActive: false, remoteMode: 'quick', customUrl: null })
+    )
   },
   startTunnel: (): Promise<{ tunnelUrl: string }> => {
     return window.electronAPI?.mobile?.startTunnel() ?? Promise.resolve({ tunnelUrl: '' })
   },
   stopTunnel: (): Promise<{ success: boolean }> => {
     return window.electronAPI?.mobile?.stopTunnel() ?? Promise.resolve({ success: false })
+  },
+  setCustomUrl: (url: string): Promise<{ url: string }> => {
+    return window.electronAPI?.mobile?.setCustomUrl(url) ?? Promise.resolve({ url: '' })
+  },
+  clearCustomUrl: (): Promise<{ success: boolean }> => {
+    return window.electronAPI?.mobile?.clearCustomUrl() ?? Promise.resolve({ success: false })
   },
   getPendingPin: (): Promise<{ pin: string; pairCodeId: string; expiresAt: number } | null> => {
     return window.electronAPI?.mobile?.getPendingPin() ?? Promise.resolve(null)

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -336,9 +336,19 @@ interface ElectronAPI {
     setMinimizeToTray: (enabled: boolean) => Promise<boolean>
   }
   mobile: {
-    getInfo: () => Promise<{ url: string; port: number; lanUrl: string; tunnelUrl: string | null; tunnelActive: boolean }>
+    getInfo: () => Promise<{
+      url: string
+      port: number
+      lanUrl: string
+      tunnelUrl: string | null
+      tunnelActive: boolean
+      remoteMode: 'quick' | 'custom'
+      customUrl: string | null
+    }>
     startTunnel: () => Promise<{ tunnelUrl: string }>
     stopTunnel: () => Promise<{ success: boolean }>
+    setCustomUrl: (url: string) => Promise<{ url: string }>
+    clearCustomUrl: () => Promise<{ success: boolean }>
     getPendingPin: () => Promise<{ pin: string; pairCodeId: string; expiresAt: number } | null>
     getSessions: () => Promise<{ id: string; device_name: string; paired_at: number; last_seen: number }[]>
     revokeSession: (sessionId: string) => Promise<{ success: boolean }>


### PR DESCRIPTION
## Summary
- Fixes `Error: spawn ...\resources\app.asar\node_modules\cloudflared\bin\cloudflared.exe ENOENT` when toggling Remote access in the packaged/installed app. The `cloudflared` npm package resolves its binary path via `__dirname` at import time, which points inside `app.asar`. Electron's asar transparency covers `fs` reads, not spawning binaries — `electron-builder`'s `asarUnpack` extracts the real file to `app.asar.unpacked`, but nothing tells the package to look there. Fixed in `tunnel-manager.ts` by calling `cloudflared`'s exported `use()` to repoint the binary at the unpacked path when `app.isPackaged`.
- Adds a **Custom URL** remote access mode as an alternative to the default Cloudflare Quick Tunnel, for users who want to bring their own tunnel/reverse proxy (e.g. to sidestep Cloudflare/Tailscale DNS conflicts). QR generation, PIN pairing, and session handling are already URL-agnostic, so no changes were needed there — only the base URL embedded in the QR/pairing link changes.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test:run --project main` — same 11 pre-existing unrelated failures as base branch (opencode-config Windows mocks, ipc-handlers terminal:kill mock); no new failures
- [x] Manually reproduced the ENOENT with a locally packaged Windows build, confirmed the unpacked binary path resolves correctly and the tunnel starts successfully after the fix
- [x] Manually tested via `pnpm dev`: scanned QR from phone, PIN now displays on desktop and pairing completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)