### PR TITLE
feat: add PostHog telemetry

### DIFF
--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -20,6 +20,7 @@ import { getTaskApiPort, waitForTaskApiServer } from './task-api-server'
 import { randomUUID } from 'crypto'
 import { registerSecretSession, unregisterSecretSession, getSecretBrokerPort, writeSecretShellWrapper } from './secret-broker'
 import { registerMcpProxyTarget, getMcpAuthProxyPort } from './mcp-auth-proxy'
+import { analytics } from './analytics-service'
 
 // Coding agent backend type enum
 enum CodingAgentType {
@@ -84,6 +85,10 @@ function hasUserSuppliedAuthHeader(headers?: Record<string, string>): boolean {
 
 function isCodexAppServerAdapter(adapter: CodingAgentAdapter): boolean {
   return adapter instanceof CodexAppServerAdapter || adapter.constructor?.name === 'CodexAppServerAdapter'
+}
+
+function getAgentProvider(agent: { config?: { coding_agent?: string } } | null | undefined): string {
+  return agent?.config?.coding_agent || CodingAgentType.OPENCODE
 }
 
 /**
@@ -1281,6 +1286,16 @@ export class AgentManager extends EventEmitter {
     // Create session via adapter
     const adapterSessionId = await adapter.createSession(sessionConfig)
     console.log(`[AgentManager] Session created: ${adapterSessionId}, workspaceDir=${workspaceDir}`)
+    analytics()?.record('provider.session.started', {
+      provider: getAgentProvider(agent),
+      runtimeMode: sessionConfig.sandboxMode,
+      hasResumeCursor: false,
+      hasCwd: typeof workspaceDir === 'string' && workspaceDir.trim().length > 0,
+      hasModel: typeof sessionConfig.model === 'string' && sessionConfig.model.trim().length > 0,
+      isTriageSession,
+      isSubtask,
+      skipInitialPrompt: !!skipInitialPrompt
+    })
 
     // Store session in sessions map
     this.sessions.set(adapterSessionId, {
@@ -2474,6 +2489,11 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       taskId,
       status: 'idle'
     })
+    analytics()?.record('provider.session.recovered', {
+      provider: getAgentProvider(agent),
+      strategy: 'resume-thread',
+      hasResumeCursor: true
+    })
 
     return adapterSessionId
   }
@@ -3181,6 +3201,10 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     }
 
     console.log(`[AgentManager] Destroying session ${sessionId} (resetTaskStatus=${resetTaskStatus})`)
+    analytics()?.record('provider.session.stopped', {
+      provider: getAgentProvider(this.db.getAgent(session.agentId)),
+      resetTaskStatus
+    })
 
     // Stop polling for this session
     this.stopAdapterPolling(sessionId)
@@ -3448,6 +3472,13 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     const promptText = this.buildMessageWithAttachmentContext(session, message, attachments)
     const parts: MessagePart[] = [{ type: MessagePartType.TEXT, text: promptText }]
     await session.adapter.sendPrompt(sessionId, parts, sessionConfig)
+    analytics()?.record('provider.turn.sent', {
+      provider: getAgentProvider(this.db.getAgent(session.agentId)),
+      model: sessionConfig.model,
+      interactionMode: 'message',
+      attachmentCount: attachments?.length ?? 0,
+      hasInput: typeof message === 'string' && message.trim().length > 0
+    })
 
     // Start polling if not already started (for Claude Code after resume)
     if (!session.pollingStarted) {
@@ -3474,6 +3505,10 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       }
     }
     if (!session) throw new Error(`Session not found: ${sessionId}`)
+    analytics()?.record('provider.request.responded', {
+      provider: getAgentProvider(this.db.getAgent(session.agentId)),
+      decision: approved ? 'approved' : 'rejected'
+    })
 
     const adapter = this.getAdapter(session.agentId)
 
@@ -3577,6 +3612,9 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
 
   async stopAllSessions(): Promise<void> {
     console.log(`[AgentManager] Stopping all ${this.sessions.size} sessions`)
+    analytics()?.record('provider.sessions.stopped_all', {
+      sessionCount: this.sessions.size
+    })
 
     // Stop the centralized polling coordinator first
     if (this.pollingTimer) {

--- a/src/main/analytics-service.ts
+++ b/src/main/analytics-service.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from 'crypto'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { app } from 'electron'
+import packageJson from '../../package.json'
+
+interface BufferedAnalyticsEvent {
+  event: string
+  properties?: Record<string, unknown>
+  capturedAt: string
+}
+
+export interface AnalyticsServiceOptions {
+  posthogKey?: string
+  posthogHost?: string
+  enabled?: boolean
+  flushBatchSize?: number
+  maxBufferedEvents?: number
+  flushIntervalMs?: number
+}
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
+const DEFAULT_FLUSH_BATCH_SIZE = 20
+const DEFAULT_MAX_BUFFERED_EVENTS = 1_000
+const DEFAULT_FLUSH_INTERVAL_MS = 1_000
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback
+  return !['0', 'false', 'no', 'off'].includes(value.trim().toLowerCase())
+}
+
+function parseNumber(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function readOrCreateAnonymousId(): string | null {
+  try {
+    const filePath = join(app.getPath('userData'), 'analytics', 'anonymous-id')
+    if (existsSync(filePath)) {
+      const existing = readFileSync(filePath, 'utf8').trim()
+      if (existing) return existing
+    }
+
+    mkdirSync(dirname(filePath), { recursive: true })
+    const id = randomUUID()
+    writeFileSync(filePath, id, { encoding: 'utf8', mode: 0o600 })
+    return id
+  } catch (error) {
+    console.warn('[Analytics] Failed to initialize anonymous id:', error)
+    return null
+  }
+}
+
+export class AnalyticsService {
+  private readonly posthogKey: string
+  private readonly posthogHost: string
+  private readonly enabled: boolean
+  private readonly flushBatchSize: number
+  private readonly maxBufferedEvents: number
+  private readonly distinctId: string | null
+  private readonly buffer: BufferedAnalyticsEvent[] = []
+  private flushTimer: ReturnType<typeof setInterval> | null = null
+  private isFlushing = false
+
+  constructor(options: AnalyticsServiceOptions = {}) {
+    this.posthogKey = options.posthogKey ?? process.env['POSTHOG_KEY'] ?? ''
+    this.posthogHost = (options.posthogHost ?? process.env['POSTHOG_HOST'] ?? DEFAULT_POSTHOG_HOST).replace(/\/+$/, '')
+    this.enabled = options.enabled ?? parseBoolean(process.env['TELEMETRY_ENABLED'], true)
+    this.flushBatchSize = options.flushBatchSize ?? parseNumber(process.env['TELEMETRY_FLUSH_BATCH_SIZE'], DEFAULT_FLUSH_BATCH_SIZE)
+    this.maxBufferedEvents = options.maxBufferedEvents ?? parseNumber(process.env['TELEMETRY_MAX_BUFFERED_EVENTS'], DEFAULT_MAX_BUFFERED_EVENTS)
+    this.distinctId = this.enabled && this.posthogKey ? readOrCreateAnonymousId() : null
+
+    if (this.enabled && this.distinctId) {
+      this.flushTimer = setInterval(() => {
+        void this.flush()
+      }, options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS)
+      this.flushTimer.unref?.()
+    }
+  }
+
+  record(event: string, properties?: Record<string, unknown>): void {
+    if (!this.enabled || !this.distinctId) return
+
+    this.buffer.push({
+      event,
+      properties,
+      capturedAt: new Date().toISOString()
+    })
+
+    if (this.buffer.length > this.maxBufferedEvents) {
+      this.buffer.splice(0, this.buffer.length - this.maxBufferedEvents)
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (!this.enabled || !this.distinctId || this.isFlushing || this.buffer.length === 0) return
+
+    this.isFlushing = true
+    const batch = this.buffer.splice(0, this.flushBatchSize)
+
+    try {
+      const response = await fetch(`${this.posthogHost}/batch/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: this.posthogKey,
+          batch: batch.map((item) => ({
+            event: item.event,
+            distinct_id: this.distinctId,
+            timestamp: item.capturedAt,
+            properties: {
+              ...item.properties,
+              $process_person_profile: false,
+              platform: process.platform,
+              arch: process.arch,
+              appVersion: packageJson.version,
+              clientType: 'desktop-app'
+            }
+          }))
+        })
+      })
+
+      if (!response.ok) {
+        throw new Error(`PostHog batch failed with ${response.status}`)
+      }
+    } catch (error) {
+      this.buffer.unshift(...batch)
+      console.warn('[Analytics] Failed to flush events:', error)
+    } finally {
+      this.isFlushing = false
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer)
+      this.flushTimer = null
+    }
+    await this.flush()
+  }
+}
+
+let analyticsService: AnalyticsService | null = null
+
+export function initAnalytics(options?: AnalyticsServiceOptions): AnalyticsService {
+  analyticsService ??= new AnalyticsService(options)
+  return analyticsService
+}
+
+export function analytics(): AnalyticsService | null {
+  return analyticsService
+}
+
+export async function shutdownAnalytics(): Promise<void> {
+  await analyticsService?.shutdown()
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ import { registerUpdaterIpc, initAutoUpdater, isUpdateDownloaded, getPendingVers
 import { initCrashLogger } from './crash-logger'
 import { installProcessStreamErrorHandlers } from './process-stream-errors'
 import { getWindowsPathEntries, prependMissingWindowsPaths } from './windows-runtime-paths'
+import { initAnalytics, shutdownAnalytics } from './analytics-service'
 
 /**
  * Validate that a URL is safe to open via shell.openExternal.
@@ -78,6 +79,7 @@ async function shutdownAppServices(): Promise<void> {
   workspaceCleanupScheduler?.stop()
 
   await agentManager?.stopAllSessions()
+  await shutdownAnalytics()
   await agentManager?.stopServer()
 
   mcpToolCaller?.destroy()
@@ -671,6 +673,7 @@ app.commandLine.appendSwitch('disable-features', [
 installProcessStreamErrorHandlers()
 
 app.whenReady().then(async () => {
+  const analytics = initAnalytics()
   // Register protocol handler: app-attachment://taskId/attachmentId
   // Serves local attachment files from the attachments directory.
   protocol.handle('app-attachment', (request) => {
@@ -702,6 +705,10 @@ app.whenReady().then(async () => {
 
   db = new DatabaseManager()
   db.initialize()
+  analytics.record('server.boot.heartbeat', {
+    taskCount: db.getTasks().length,
+    agentCount: db.getAgents().length
+  })
 
   // Ensure PATH is ready before creating managers that may spawn child processes
   await pathFixPromise

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -35,6 +35,7 @@ import type { EnterpriseAuth } from './enterprise-auth'
 import type { ClaudePluginManager } from './claude-plugin-manager'
 import type { EnterpriseHeartbeat } from './enterprise-heartbeat'
 import type { EnterpriseStateSync } from './enterprise-state-sync'
+import { analytics } from './analytics-service'
 
 const MIME_MAP: Record<string, string> = {
   '.pdf': 'application/pdf',
@@ -103,6 +104,19 @@ export function registerIpcHandlers(
     // Notify renderer so auto-start hook can trigger triage for UI-created tasks
     if (task) {
       event.sender.send('task:created', { task })
+      analytics()?.record('task.created', {
+        taskType: task.type,
+        priority: task.priority,
+        status: task.status,
+        labelCount: task.labels?.length ?? 0,
+        repoCount: task.repos?.length ?? 0,
+        attachmentCount: task.attachments?.length ?? 0,
+        outputFieldCount: task.output_fields?.length ?? 0,
+        hasAgent: !!task.agent_id,
+        hasSource: !!task.source_id,
+        isRecurring: !!task.is_recurring,
+        isSubtask: !!task.parent_task_id
+      })
     }
     return task
   })
@@ -110,7 +124,7 @@ export function registerIpcHandlers(
   ipcMain.handle('db:updateTask', (_, id: string, data: UpdateTaskData) => {
     // Capture previous status before updating (for enterprise sync)
     let previousStatus: string | undefined
-    if (enterpriseStateSync && data.status) {
+    if (data.status) {
       const existing = db.getTask(id)
       if (existing && existing.status !== data.status) {
         previousStatus = existing.status
@@ -139,19 +153,46 @@ export function registerIpcHandlers(
         enterpriseStateSync.recordTaskStatusChange(updated, previousStatus, data.status)
       }
     }
+    if (updated && data.status) {
+      analytics()?.record('task.status_changed', {
+        previousStatus,
+        status: data.status,
+        taskType: updated.type,
+        priority: updated.priority,
+        hasAgent: !!updated.agent_id,
+        hasSource: !!updated.source_id,
+        isSubtask: !!updated.parent_task_id
+      })
+    }
 
     // Record feedback event for enterprise sync
     if (enterpriseStateSync && data.feedback_rating && updated) {
       enterpriseStateSync.recordFeedbackSubmitted(updated, data.feedback_rating)
+    }
+    if (updated && data.feedback_rating) {
+      analytics()?.record('task.feedback_submitted', {
+        rating: data.feedback_rating,
+        taskType: updated.type,
+        hasSource: !!updated.source_id
+      })
     }
 
     return updated
   })
 
   ipcMain.handle('db:deleteTask', (event, id: string) => {
+    const existing = db.getTask(id)
     const success = db.deleteTask(id)
     if (success) {
       event.sender.send('task:deleted', { taskId: id })
+      analytics()?.record('task.deleted', {
+        taskType: existing?.type,
+        status: existing?.status,
+        priority: existing?.priority,
+        hasAgent: !!existing?.agent_id,
+        hasSource: !!existing?.source_id,
+        isSubtask: !!existing?.parent_task_id
+      })
     }
     return success
   })


### PR DESCRIPTION
## Summary
- Add a main-process PostHog telemetry service with an installation-scoped anonymous id, periodic batching, bounded buffering, and shutdown flush.
- Record boot, task lifecycle, agent session lifecycle, user turn, approval response, and stop-all telemetry with aggregate metadata only.
- Keep telemetry inert unless `POSTHOG_KEY` is configured; `POSTHOG_HOST` and telemetry buffering controls can be overridden through environment variables.

## Local setup
- Export a PostHog project key before starting the Electron app: `export POSTHOG_KEY=<project-key>`.
- Optional overrides: `export POSTHOG_HOST=https://us.i.posthog.com`, `export TELEMETRY_ENABLED=true`, `export TELEMETRY_FLUSH_BATCH_SIZE=20`, `export TELEMETRY_MAX_BUFFERED_EVENTS=1000`.
- Start the app normally with `pnpm dev`; events flush from the main process to `${POSTHOG_HOST}/batch/`.
- To disable telemetry locally, run with `TELEMETRY_ENABLED=false` or omit `POSTHOG_KEY`.

## Release environment setup
- In GitHub, add `POSTHOG_KEY` as a repository or environment secret for the release environment.
- Add non-sensitive defaults as repository or environment variables if needed: `POSTHOG_HOST`, `TELEMETRY_ENABLED`, `TELEMETRY_FLUSH_BATCH_SIZE`, and `TELEMETRY_MAX_BUFFERED_EVENTS`.
- Wire the release workflow job to expose those values to the app build/release step, for example: `env: { POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}, POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}, TELEMETRY_ENABLED: ${{ vars.TELEMETRY_ENABLED }}}`.
- GitHub Actions env vars are available to the release runner. If the packaged desktop app must include the key for end-user installs, the release pipeline must explicitly inject it into the packaged runtime environment or build-time config.

## Test plan
- `pnpm typecheck`
- `node node_modules/eslint/bin/eslint.js src/main/analytics-service.ts src/main/index.ts src/main/agent-manager.ts src/main/ipc-handlers.ts` (passes with one existing warning in `src/main/agent-manager.ts`)

Generated with Codex