### PR TITLE
feat: add PostHog analytics tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "electron-updater": "^6.8.3",
     "js-yaml": "^4.1.1",
     "node-pty": "^1.1.0",
+    "posthog-js": "^1.404.1",
     "qrcode": "^1.5.4",
     "undici": "^7.21.0",
     "ws": "^8.19.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      posthog-js:
+        specifier: ^1.404.1
+        version: 1.404.1
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -987,6 +990,12 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@posthog/core@1.43.1':
+    resolution: {integrity: sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==}
+
+  '@posthog/types@1.397.0':
+    resolution: {integrity: sha512-Pa7FtsBo3V0XrhY4y8Xquwp8U07syuZ2IGQdlsRyxhz0yejQLceFjI58UssCXE5zDCDj3km5l7H3ufD6rHChCg==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1965,6 +1974,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -2626,6 +2638,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -2772,6 +2787,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -3058,6 +3076,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -4238,6 +4259,17 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.404.1:
+    resolution: {integrity: sha512-ck/HOMKuZ6yefUk5OX+h2s9mUWBsnu0mGDUAWjIwAmQQrloZPShzOhOWuEuZQuMnCKORBFRVGsBAuzsl66cBJA==}
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -4306,6 +4338,9 @@ packages:
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -5025,6 +5060,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
@@ -5899,6 +5937,12 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@posthog/core@1.43.1':
+    dependencies:
+      '@posthog/types': 1.397.0
+
+  '@posthog/types@1.397.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6893,6 +6937,9 @@ snapshots:
     dependencies:
       '@types/node': 25.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -7664,6 +7711,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  core-js@3.49.0: {}
+
   core-util-is@1.0.2:
     optional: true
 
@@ -7817,6 +7866,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -8211,6 +8264,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.4.8: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -9598,6 +9653,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.404.1:
+    dependencies:
+      '@posthog/core': 1.43.1
+      '@posthog/types': 1.397.0
+      core-js: 3.49.0
+      dompurify: 3.4.12
+      fflate: 0.4.8
+      preact: 10.29.7
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  preact@10.29.7: {}
+
   prebuild-install@7.1.3:
     dependencies:
       detect-libc: 2.1.2
@@ -9664,6 +9734,8 @@ snapshots:
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   quick-lru@5.1.1: {}
 
@@ -10461,6 +10533,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@4.0.2: {}
 

--- a/src/mobile/App.tsx
+++ b/src/mobile/App.tsx
@@ -11,6 +11,7 @@ import { SkillSelectorPage } from './pages/SkillSelectorPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { PairPage } from './pages/PairPage'
 import { getPairCodeFromUrl, hasSessionToken } from './api/auth'
+import { captureAnalyticsEvent, capturePageView } from '@/lib/analytics'
 
 export type Route =
   | { page: 'list' }
@@ -31,6 +32,10 @@ export function App() {
   // Navigation that pushes browser history so back button works
   const navigate = useCallback((next: Route) => {
     setRoute(next)
+    captureAnalyticsEvent('mobile_route_selected', {
+      page: next.page,
+      task_id: 'taskId' in next ? next.taskId : undefined
+    })
     if (!isPopRef.current) {
       history.pushState(next, '', null)
     }
@@ -41,6 +46,12 @@ export function App() {
     const onPopState = (e: PopStateEvent) => {
       isPopRef.current = true
       setRoute((e.state as Route) || { page: 'list' })
+      const next = (e.state as Route) || { page: 'list' }
+      captureAnalyticsEvent('mobile_route_selected', {
+        page: next.page,
+        task_id: 'taskId' in next ? next.taskId : undefined,
+        source: 'history'
+      })
       isPopRef.current = false
     }
     // Seed initial history entry
@@ -82,6 +93,14 @@ export function App() {
       syncActiveSessions()
     })
   }, [connect, fetchTasks, fetchAgents, fetchSkills, syncActiveSessions, setOnReconnect, setOnFirstConnect, setOnVisibilityReconnect])
+
+  useEffect(() => {
+    capturePageView(route.page, {
+      route_page: route.page,
+      task_id: 'taskId' in route ? route.taskId : undefined,
+      paired
+    })
+  }, [route, paired])
 
   // Poll tasks every 10s as a fallback
   useEffect(() => {

--- a/src/mobile/hooks/useSessionControls.ts
+++ b/src/mobile/hooks/useSessionControls.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from 'react'
 import { useAgentStore } from '../stores/agent-store'
 import { api } from '../api/client'
+import { captureAnalyticsEvent } from '@/lib/analytics'
 
 /**
  * Shared session control handlers used by both ConversationPage and TaskDetailPage.
@@ -19,6 +20,11 @@ export function useSessionControls(taskId: string) {
     try {
       const { sessionId } = await api.sessions.start(agentId, taskId)
       initSession(taskId, sessionId, agentId)
+      captureAnalyticsEvent('agent_session_started', {
+        task_id: taskId,
+        agent_id: agentId,
+        session_id: sessionId
+      })
     } catch (e) {
       console.error('Failed to start session:', e)
       endSession(taskId)
@@ -35,6 +41,12 @@ export function useSessionControls(taskId: string) {
     try {
       const { sessionId } = await api.sessions.resume(existingSessionId, agentId, taskId)
       initSession(taskId, sessionId, agentId)
+      captureAnalyticsEvent('agent_session_resumed', {
+        task_id: taskId,
+        agent_id: agentId,
+        session_id: sessionId,
+        previous_session_id: existingSessionId
+      })
     } catch (e) {
       console.error('Failed to resume session:', e)
       endSession(taskId)
@@ -49,6 +61,10 @@ export function useSessionControls(taskId: string) {
     try {
       await api.sessions.stop(sessionId)
       endSession(taskId)
+      captureAnalyticsEvent('agent_session_stopped', {
+        task_id: taskId,
+        session_id: sessionId
+      })
     } catch (e) {
       console.error('Failed to stop session:', e)
     } finally {
@@ -66,6 +82,12 @@ export function useSessionControls(taskId: string) {
       initSession(taskId, '', agentId)
       const { sessionId } = await api.sessions.start(agentId, taskId)
       initSession(taskId, sessionId, agentId)
+      captureAnalyticsEvent('agent_session_restarted', {
+        task_id: taskId,
+        agent_id: agentId,
+        previous_session_id: currentSessionId,
+        session_id: sessionId
+      })
     } catch (e) {
       console.error('Failed to restart session:', e)
       endSession(taskId)

--- a/src/mobile/main.tsx
+++ b/src/mobile/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App'
 import './styles/globals.css'
+import { initAnalytics } from '@/lib/analytics'
+
+initAnalytics('mobile')
 
 // Resolve light/dark before render. Mobile follows the OS by default (its CSP
 // blocks an inline pre-paint script), honouring a stored preference if present.

--- a/src/mobile/pages/ConversationPage.tsx
+++ b/src/mobile/pages/ConversationPage.tsx
@@ -6,6 +6,7 @@ import { useSessionControls } from '../hooks/useSessionControls'
 import { MessageActivityGroup, MessageBubble, isCompactActivityMessage } from '../components/MessageBubble'
 import { ChatInput, type ChatInputAttachment } from '../components/ChatInput'
 import { cn } from '../lib/utils'
+import { captureAnalyticsEvent } from '@/lib/analytics'
 import type { Route } from '../App'
 
 function collectSearchableText(value: unknown, output: string[]): void {
@@ -123,6 +124,13 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
       try {
         if (isQuestion) {
           await api.sessions.approve(currentSession.sessionId, true, message)
+          captureAnalyticsEvent('agent_approval_responded', {
+            task_id: taskId,
+            agent_id: currentSession.agentId,
+            session_id: currentSession.sessionId,
+            approved: true,
+            has_message: Boolean(message)
+          })
         } else {
           const result = await api.sessions.send(
             currentSession.sessionId,
@@ -134,6 +142,13 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
           if (result.newSessionId && taskId) {
             initSession(taskId, result.newSessionId, currentSession.agentId)
           }
+          captureAnalyticsEvent('agent_message_sent', {
+            task_id: taskId,
+            agent_id: currentSession.agentId,
+            session_id: result.newSessionId || currentSession.sessionId,
+            attachment_count: options?.attachments?.length ?? 0,
+            recovered_session: Boolean(result.newSessionId)
+          })
         }
         setMessageAttachments([])
         setShowAttachmentPicker(false)
@@ -152,6 +167,14 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
       if (!currentSession?.sessionId || !activeQuestionId) return
       try {
         await api.sessions.approve(currentSession.sessionId, true, answer)
+        captureAnalyticsEvent('agent_approval_responded', {
+          task_id: taskId,
+          agent_id: currentSession.agentId,
+          session_id: currentSession.sessionId,
+          approved: true,
+          has_message: Boolean(answer),
+          source: 'question_option'
+        })
       } catch (e) {
         console.error('Failed to send answer:', e)
       }

--- a/src/mobile/stores/agent-store.ts
+++ b/src/mobile/stores/agent-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { api } from '../api/client'
 import { onEvent } from '../api/websocket'
+import { captureAnalyticsEvent, getAgentMessageProperties } from '@/lib/analytics'
 
 // ── Message types (mirrors desktop agent-store) ──────────────
 
@@ -133,11 +134,22 @@ export const useAgentStore = create<AgentState>((set, get) => {
       const session = findBySessionId(state.sessions, event.sessionId)
         || state.sessions.get(event.taskId)
       if (!session) return state
+      const previousStatus = session.status
 
       const updated = { ...session, status: event.status }
       // Patch in real sessionId when session was pre-registered with empty string
       // or when the main process re-keyed the session (temp ID → real ID)
       if (event.sessionId && session.sessionId !== event.sessionId) updated.sessionId = event.sessionId
+      if (previousStatus !== event.status) {
+        captureAnalyticsEvent('agent_session_status_changed', {
+          task_id: session.taskId,
+          agent_id: event.agentId || session.agentId,
+          session_id: event.sessionId,
+          previous_status: previousStatus,
+          next_status: event.status,
+          source: 'backend'
+        })
+      }
       return { sessions: new Map(state.sessions).set(session.taskId, updated) }
     })
   })
@@ -243,6 +255,18 @@ export const useAgentStore = create<AgentState>((set, get) => {
       if (seen.has(msgId)) return state
       seen.add(msgId)
 
+      captureAnalyticsEvent('agent_message_received', {
+        task_id: taskId,
+        agent_id: resolvedSession.agentId,
+        session_id: resolvedSession.sessionId,
+        ...getAgentMessageProperties({
+          role,
+          partType: data.partType as string,
+          tool: data.tool as AgentMessage['tool'],
+          taskProgress: data.taskProgress as AgentMessage['taskProgress']
+        })
+      })
+
       return {
         sessions: new Map(state.sessions).set(taskId, {
           ...resolvedSession,
@@ -282,6 +306,9 @@ export const useAgentStore = create<AgentState>((set, get) => {
       let messages = [...resolvedSession.messages]
       let changed = false
       let systemStatusUpdate: string | null | undefined = undefined
+      let newMessageCount = 0
+      let taskProgressCount = 0
+      const toolNames = new Set<string>()
 
       for (const msg of event.messages) {
         const role: AgentMessage['role'] = msg.role === 'user' ? 'user' : msg.role === 'assistant' ? 'assistant' : 'system'
@@ -355,10 +382,21 @@ export const useAgentStore = create<AgentState>((set, get) => {
           tool: msg.tool as AgentMessage['tool'],
           taskProgress: (msg as Record<string, unknown>).taskProgress as AgentMessage['taskProgress']
         })
+        newMessageCount += 1
+        if ((msg as Record<string, unknown>).taskProgress) taskProgressCount += 1
+        if ((msg.tool as AgentMessage['tool'])?.name) toolNames.add((msg.tool as AgentMessage['tool'])!.name)
         changed = true
       }
 
       if (!changed) return state
+      captureAnalyticsEvent('agent_output_batch_received', {
+        task_id: taskId,
+        agent_id: resolvedSession.agentId,
+        session_id: resolvedSession.sessionId,
+        message_count: newMessageCount,
+        task_progress_count: taskProgressCount,
+        tool_names: Array.from(toolNames).sort()
+      })
 
       return {
         sessions: new Map(state.sessions).set(taskId, {

--- a/src/mobile/stores/task-store.ts
+++ b/src/mobile/stores/task-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { api } from '../api/client'
 import { onEvent } from '../api/websocket'
 import type { TaskStatus } from '@shared/constants'
+import { captureAnalyticsEvent, getTaskAnalyticsProperties, getTaskMutationProperties } from '@/lib/analytics'
 
 // Re-export for convenience
 export type { TaskStatus }
@@ -68,6 +69,7 @@ export const useTaskStore = create<TaskState>((set, get) => {
   // Listen to WebSocket events
   onEvent('task:updated', (payload) => {
     const { taskId, updates } = payload as { taskId: string; updates: Partial<Task> }
+    const previousTask = get().tasks.find((t) => t.id === taskId)
     const found = get().tasks.some((t) => t.id === taskId)
     if (found) {
       set((state) => ({
@@ -79,6 +81,14 @@ export const useTaskStore = create<TaskState>((set, get) => {
       // Task not yet in the list (created on desktop) — fetch to pick it up
       get().fetchTasks()
     }
+    if (updates.status && previousTask?.status !== updates.status) {
+      captureAnalyticsEvent('task_status_changed', {
+        task_id: taskId,
+        previous_status: previousTask?.status,
+        next_status: updates.status,
+        source: 'backend'
+      })
+    }
   })
 
   onEvent('task:created', (payload) => {
@@ -86,6 +96,10 @@ export const useTaskStore = create<TaskState>((set, get) => {
     set((state) => {
       // Deduplicate — task may already exist from a concurrent fetchTasks()
       if (state.tasks.some((t) => t.id === task.id)) return state
+      captureAnalyticsEvent('task_created', {
+        ...getTaskAnalyticsProperties(task),
+        source: 'backend'
+      })
       return { tasks: [task, ...state.tasks] }
     })
   })
@@ -128,6 +142,10 @@ export const useTaskStore = create<TaskState>((set, get) => {
           if (state.tasks.some((t) => t.id === task.id)) return state
           return { tasks: [task, ...state.tasks] }
         })
+        captureAnalyticsEvent('task_created', {
+          ...getTaskAnalyticsProperties(task),
+          ...getTaskMutationProperties(data)
+        })
         return task
       } catch (e) {
         console.error('Failed to create task:', e)
@@ -141,6 +159,10 @@ export const useTaskStore = create<TaskState>((set, get) => {
         set((state) => ({
           tasks: state.tasks.map((t) => (t.id === id ? updated : t))
         }))
+        captureAnalyticsEvent('task_updated', {
+          ...getTaskAnalyticsProperties(updated),
+          ...getTaskMutationProperties(data)
+        })
         return true
       } catch (e) {
         console.error('Failed to update task:', e)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,30 @@
 import { AppLayout } from '@/components/layout/AppLayout'
+import { useEffect } from 'react'
+import { identifyAnalyticsUser, resetAnalyticsUser } from '@/lib/analytics'
+import { useEnterpriseStore } from '@/stores/enterprise-store'
+import { useUserStore } from '@/stores/user-store'
 
 export default function App() {
+  const isAuthenticated = useEnterpriseStore((s) => s.isAuthenticated)
+  const userId = useEnterpriseStore((s) => s.userId)
+  const userEmail = useEnterpriseStore((s) => s.userEmail)
+  const currentTenant = useEnterpriseStore((s) => s.currentTenant)
+  const currentUserEmail = useUserStore((s) => s.currentUserEmail)
+
+  useEffect(() => {
+    const distinctId = userId || userEmail || currentUserEmail
+    if (distinctId) {
+      identifyAnalyticsUser(distinctId, {
+        user_id: userId || undefined,
+        email: userEmail || currentUserEmail || undefined,
+        tenant_id: currentTenant?.id,
+        tenant_name: currentTenant?.name,
+        is_enterprise_authenticated: isAuthenticated
+      })
+    } else if (!isAuthenticated) {
+      resetAnalyticsUser()
+    }
+  }, [isAuthenticated, userId, userEmail, currentUserEmail, currentTenant?.id, currentTenant?.name])
+
   return <AppLayout />
 }

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -23,6 +23,7 @@ import { useOverdueNotifications } from '@/hooks/use-overdue-notifications'
 import { attachmentApi, worktreeApi, settingsApi, updaterApi } from '@/lib/ipc-client'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { isOverdue, isSnoozed } from '@/lib/utils'
+import { captureAnalyticsEvent, capturePageView } from '@/lib/analytics'
 import { TaskStatus, PluginActionId } from '@/types'
 import type { FileAttachment } from '@/types'
 import { MessageSquare, ExternalLink, LayoutDashboard, CheckSquare, Zap, Settings, Layers, PanelLeftClose, PanelLeftOpen, Search } from 'lucide-react'
@@ -105,6 +106,14 @@ export function AppLayout() {
       cleanupMenu()
     }
   }, [])
+
+  useEffect(() => {
+    capturePageView(activeModal === 'settings' ? 'settings' : sidebarView, {
+      sidebar_view: sidebarView,
+      active_modal: activeModal,
+      selected_task_id: selectedTask?.id
+    })
+  }, [sidebarView, activeModal, selectedTask?.id])
 
   const editingTask = useMemo(
     () => editingTaskId ? allTasks.find((t) => t.id === editingTaskId) : undefined,
@@ -193,6 +202,7 @@ export function AppLayout() {
       if (e.key.toLowerCase() === 'k') {
         e.preventDefault()
         setCmdOpen((v) => !v)
+        captureAnalyticsEvent('command_palette_toggled', { source: 'keyboard' })
         return
       }
       const n = Number(e.key)
@@ -200,6 +210,10 @@ export function AppLayout() {
         e.preventDefault()
         if (activeModal === 'settings') closeModal()
         setSidebarView(NAV_ITEMS[n - 1].key)
+        captureAnalyticsEvent('workspace_view_selected', {
+          view: NAV_ITEMS[n - 1].key,
+          source: 'keyboard'
+        })
       }
     }
     window.addEventListener('keydown', onKey)
@@ -217,7 +231,13 @@ export function AppLayout() {
             <img src={logo20x} className="h-3 w-3" alt="20x" />
             {updateAvailableVersion && (
               <button
-                onClick={() => setUpdateDialogOpen(true)}
+                onClick={() => {
+                  setUpdateDialogOpen(true)
+                  captureAnalyticsEvent('update_dialog_opened', {
+                    version: updateAvailableVersion,
+                    source: 'indicator'
+                  })
+                }}
                 className="absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-warning ring-2 ring-[var(--chrome-solid)] cursor-pointer animate-pulse"
                 title={`Update available: v${updateAvailableVersion}`}
               />
@@ -255,7 +275,10 @@ export function AppLayout() {
 
         {/* Centered command/search launcher (⌘K) */}
         <button
-          onClick={() => setCmdOpen(true)}
+          onClick={() => {
+            setCmdOpen(true)
+            captureAnalyticsEvent('command_palette_toggled', { source: 'top_bar' })
+          }}
           title="Search or run a command"
           className="no-drag flex h-7 w-[230px] max-w-[34vw] items-center gap-2 rounded-lg border border-border/60 bg-muted/40 px-2.5 text-[11px] text-muted-foreground shadow-xs transition-colors hover:bg-accent hover:text-foreground cursor-pointer"
         >
@@ -302,6 +325,10 @@ export function AppLayout() {
                 onClick={() => {
                   if (activeModal === 'settings') closeModal()
                   setSidebarView(key)
+                  captureAnalyticsEvent('workspace_view_selected', {
+                    view: key,
+                    source: 'nav'
+                  })
                 }}
                 aria-label={label}
                 className={`group relative grid h-8 w-8 place-items-center rounded-lg transition-all duration-150 cursor-pointer ${

--- a/src/renderer/src/hooks/use-agent-session.ts
+++ b/src/renderer/src/hooks/use-agent-session.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { agentSessionApi } from '@/lib/ipc-client'
 import { useAgentStore, SessionStatus } from '@/stores/agent-store'
+import { captureAnalyticsEvent } from '@/lib/analytics'
 import type { AgentApprovalRequest } from '@/types/electron'
 
 export type { AgentMessage } from '@/stores/agent-store'
@@ -53,6 +54,13 @@ export function useAgentSession(taskId: string | undefined) {
       const { sessionId } = await agentSessionApi.start(agentId, tId, workspaceDir, skipInitialPrompt)
       // Update with the real sessionId (preserves any messages that arrived early)
       initSession(tId, sessionId, agentId)
+      captureAnalyticsEvent('agent_session_started', {
+        task_id: tId,
+        agent_id: agentId,
+        session_id: sessionId,
+        has_workspace_dir: Boolean(workspaceDir),
+        skip_initial_prompt: Boolean(skipInitialPrompt)
+      })
       return sessionId
     },
     [initSession]
@@ -69,9 +77,20 @@ export function useAgentSession(taskId: string | undefined) {
       if (result.ended) {
         // Session ended normally (task completed) — clean up the pre-registered session
         removeSession(tId)
+        captureAnalyticsEvent('agent_session_resume_ended', {
+          task_id: tId,
+          agent_id: agentId,
+          previous_session_id: ocSessionId
+        })
         return ''
       }
       initSession(tId, result.sessionId, agentId)
+      captureAnalyticsEvent('agent_session_resumed', {
+        task_id: tId,
+        agent_id: agentId,
+        session_id: result.sessionId,
+        previous_session_id: ocSessionId
+      })
       return result.sessionId
     },
     [initSession, clearMessageDedup, removeSession]
@@ -81,6 +100,11 @@ export function useAgentSession(taskId: string | undefined) {
     const currentSession = useAgentStore.getState().sessions.get(taskId!)
     if (!currentSession?.sessionId) return
     await agentSessionApi.abort(currentSession.sessionId)
+    captureAnalyticsEvent('agent_session_aborted', {
+      task_id: taskId,
+      agent_id: currentSession.agentId,
+      session_id: currentSession.sessionId
+    })
   }, [taskId])
 
   const stop = useCallback(async () => {
@@ -89,11 +113,21 @@ export function useAgentSession(taskId: string | undefined) {
     if (currentSession?.sessionId) {
       console.log('[use-agent-session] stop() called for session:', currentSession.sessionId)
       await agentSessionApi.stop(currentSession.sessionId)
+      captureAnalyticsEvent('agent_session_stopped', {
+        task_id: taskId,
+        agent_id: currentSession.agentId,
+        session_id: currentSession.sessionId,
+        fallback: false
+      })
     } else {
       // Fallback: session mapping lost in renderer — ask the backend
       // to find and stop the session by taskId directly.
       console.log('[use-agent-session] stop() no sessionId, falling back to stopByTaskId:', taskId)
       await agentSessionApi.stopByTaskId(taskId)
+      captureAnalyticsEvent('agent_session_stopped', {
+        task_id: taskId,
+        fallback: true
+      })
     }
     endSession(taskId)
   }, [taskId, endSession])
@@ -109,6 +143,13 @@ export function useAgentSession(taskId: string | undefined) {
         if (result.newSessionId && taskId) {
           initSession(taskId, result.newSessionId, currentSession.agentId)
         }
+        captureAnalyticsEvent('agent_message_sent', {
+          task_id: taskId,
+          agent_id: currentSession.agentId,
+          session_id: result.newSessionId || currentSession.sessionId,
+          attachment_count: options?.attachments?.length ?? 0,
+          recovered_session: Boolean(result.newSessionId)
+        })
       } else {
         // Fallback: session mapping lost in renderer — ask the backend
         // to find (or resume/create) the session by taskId directly.
@@ -119,6 +160,12 @@ export function useAgentSession(taskId: string | undefined) {
         if (resolvedSessionId) {
           initSession(taskId, resolvedSessionId, currentSession?.agentId ?? '')
         }
+        captureAnalyticsEvent('agent_message_sent', {
+          task_id: taskId,
+          session_id: resolvedSessionId,
+          attachment_count: options?.attachments?.length ?? 0,
+          fallback: true
+        })
       }
     },
     [taskId, initSession]
@@ -129,6 +176,13 @@ export function useAgentSession(taskId: string | undefined) {
       const currentSession = useAgentStore.getState().sessions.get(taskId!)
       if (!currentSession?.sessionId) throw new Error('No active session')
       await agentSessionApi.approve(currentSession.sessionId, approved, message)
+      captureAnalyticsEvent('agent_approval_responded', {
+        task_id: taskId,
+        agent_id: currentSession.agentId,
+        session_id: currentSession.sessionId,
+        approved,
+        has_message: Boolean(message)
+      })
     },
     [taskId]
   )

--- a/src/renderer/src/lib/analytics.ts
+++ b/src/renderer/src/lib/analytics.ts
@@ -1,0 +1,150 @@
+import posthog from 'posthog-js'
+import type { Properties } from 'posthog-js'
+
+type AnalyticsProperties = Properties
+type AnalyticsPlatform = 'desktop' | 'mobile'
+
+const POSTHOG_KEY = import.meta.env.VITE_POSTHOG_KEY
+const POSTHOG_HOST = import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com'
+const POSTHOG_RECORD_SESSIONS = import.meta.env.VITE_POSTHOG_RECORD_SESSIONS !== 'false'
+
+let initialized = false
+let identifiedId: string | null = null
+let appPlatform: AnalyticsPlatform = 'desktop'
+
+function isEnabled(): boolean {
+  return typeof window !== 'undefined' && Boolean(POSTHOG_KEY)
+}
+
+export function initAnalytics(platform: AnalyticsPlatform = 'desktop'): void {
+  appPlatform = platform
+  if (!isEnabled() || initialized) return
+
+  posthog.init(POSTHOG_KEY, {
+    api_host: POSTHOG_HOST,
+    capture_pageview: false,
+    capture_pageleave: true,
+    autocapture: true,
+    disable_session_recording: !POSTHOG_RECORD_SESSIONS,
+    loaded: (client) => {
+      if (POSTHOG_RECORD_SESSIONS) client.startSessionRecording()
+    },
+    persistence: 'localStorage+cookie'
+  })
+
+  initialized = true
+}
+
+export function identifyAnalyticsUser(
+  distinctId: string | null | undefined,
+  properties: AnalyticsProperties = {}
+): void {
+  initAnalytics(appPlatform)
+  if (!isEnabled() || !distinctId || identifiedId === distinctId) return
+
+  posthog.identify(distinctId, cleanProperties({
+    ...properties,
+    app_platform: appPlatform
+  }))
+  identifiedId = distinctId
+}
+
+export function resetAnalyticsUser(): void {
+  if (!isEnabled() || !initialized) return
+  posthog.reset()
+  identifiedId = null
+}
+
+export function captureAnalyticsEvent(event: string, properties: AnalyticsProperties = {}): void {
+  initAnalytics(appPlatform)
+  if (!isEnabled()) return
+
+  posthog.capture(event, cleanProperties({
+    ...properties,
+    app_platform: appPlatform
+  }))
+}
+
+export function capturePageView(name: string, properties: AnalyticsProperties = {}): void {
+  captureAnalyticsEvent('$pageview', {
+    page_name: name,
+    path: typeof window !== 'undefined' ? window.location.pathname : undefined,
+    ...properties
+  })
+}
+
+export function getTaskAnalyticsProperties(task: {
+  id?: string
+  type?: string
+  priority?: string
+  status?: string
+  labels?: unknown[]
+  attachments?: unknown[]
+  repos?: unknown[]
+  output_fields?: unknown[]
+  agent_id?: string | null
+  source?: string | null
+  source_id?: string | null
+  parent_task_id?: string | null
+  is_recurring?: boolean | number
+  heartbeat_enabled?: boolean | number | null
+  auto_start_agent?: boolean | number
+  auto_complete_without_review?: boolean | number
+}): AnalyticsProperties {
+  return {
+    task_id: task.id,
+    task_type: task.type,
+    task_priority: task.priority,
+    task_status: task.status,
+    task_label_count: task.labels?.length ?? 0,
+    task_attachment_count: task.attachments?.length ?? 0,
+    task_repo_count: task.repos?.length ?? 0,
+    task_output_field_count: task.output_fields?.length ?? 0,
+    has_agent: Boolean(task.agent_id),
+    agent_id: task.agent_id || undefined,
+    task_source: task.source,
+    has_source: Boolean(task.source_id),
+    is_subtask: Boolean(task.parent_task_id),
+    is_recurring: Boolean(task.is_recurring),
+    heartbeat_enabled: Boolean(task.heartbeat_enabled),
+    auto_start_agent: Boolean(task.auto_start_agent),
+    auto_complete_without_review: Boolean(task.auto_complete_without_review)
+  }
+}
+
+export function getTaskMutationProperties(data: Record<string, unknown>): AnalyticsProperties {
+  return {
+    changed_fields: Object.keys(data).filter((key) => !key.startsWith('_')).sort(),
+    includes_attachments: Array.isArray(data.attachments) || Array.isArray(data._pendingFiles),
+    includes_repos: Array.isArray(data.repos),
+    includes_output_fields: Array.isArray(data.output_fields),
+    includes_agent_assignment: Object.prototype.hasOwnProperty.call(data, 'agent_id'),
+    includes_status: Object.prototype.hasOwnProperty.call(data, 'status')
+  }
+}
+
+export function getAgentMessageProperties(message: {
+  role?: string
+  partType?: string
+  tool?: { name?: string; status?: string; questions?: unknown[]; todos?: unknown[] }
+  taskProgress?: { status?: string; usage?: { total_tokens?: number; tool_uses?: number; duration_ms?: number } }
+}): AnalyticsProperties {
+  return {
+    message_role: message.role,
+    part_type: message.partType,
+    tool_name: message.tool?.name,
+    tool_status: message.tool?.status,
+    question_count: message.tool?.questions?.length,
+    todo_count: message.tool?.todos?.length,
+    task_progress_status: message.taskProgress?.status,
+    total_tokens: message.taskProgress?.usage?.total_tokens,
+    tool_uses: message.taskProgress?.usage?.tool_uses,
+    duration_ms: message.taskProgress?.usage?.duration_ms
+  }
+}
+
+function cleanProperties(properties: AnalyticsProperties): AnalyticsProperties {
+  return Object.fromEntries(
+    Object.entries(properties).filter(([, value]) => value !== undefined && value !== null && value !== '')
+  )
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './styles/globals.css'
+import { initAnalytics } from '@/lib/analytics'
 // Eagerly boot the theme store so it applies the persisted theme and starts
 // listening for OS-level light/dark changes before first paint.
 import '@/stores/theme-store'
+
+initAnalytics('desktop')
 
 // Suppress xterm.js internal "toFixed is not a function" crash.
 // xterm's _reportWindowsOptions() calls .toFixed() on dimension values that

--- a/src/renderer/src/stores/agent-store.ts
+++ b/src/renderer/src/stores/agent-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { Agent, CreateAgentDTO, UpdateAgentDTO } from '@/types'
 import { agentApi, agentSessionApi, onAgentOutput, onAgentOutputBatch, onAgentStatus, onAgentApproval } from '@/lib/ipc-client'
 import type { AgentOutputEvent, AgentOutputBatchEvent, AgentStatusEvent, AgentApprovalRequest } from '@/types/electron'
+import { captureAnalyticsEvent, getAgentMessageProperties } from '@/lib/analytics'
 
 // ── Message type ──────────────────────────────────────────────
 
@@ -173,6 +174,7 @@ export const useAgentStore = create<AgentState>((set, get) => {
     const state = get()
     const session = findBySessionId(state.sessions, event.sessionId)
       || state.sessions.get(event.taskId)
+    const previousStatus = session?.status
 
     // Auto-create session entry when a session is started remotely (e.g., from mobile)
     // so the desktop app can track and display it
@@ -188,6 +190,14 @@ export const useAgentStore = create<AgentState>((set, get) => {
             pendingApproval: null
           })
         })
+        captureAnalyticsEvent('agent_session_status_changed', {
+          task_id: event.taskId,
+          agent_id: event.agentId,
+          session_id: event.sessionId,
+          previous_status: undefined,
+          next_status: event.status,
+          source: 'backend'
+        })
       }
       return
     }
@@ -199,6 +209,16 @@ export const useAgentStore = create<AgentState>((set, get) => {
     // Clear pending approval when session goes idle
     if (event.status === SessionStatus.IDLE) updated.pendingApproval = null
     set({ sessions: new Map(state.sessions).set(session.taskId, updated) })
+    if (previousStatus !== event.status) {
+      captureAnalyticsEvent('agent_session_status_changed', {
+        task_id: session.taskId,
+        agent_id: event.agentId || session.agentId,
+        session_id: event.sessionId,
+        previous_status: previousStatus,
+        next_status: event.status,
+        source: 'backend'
+      })
+    }
   })
 
   onAgentOutput((event: AgentOutputEvent) => {
@@ -335,6 +355,17 @@ export const useAgentStore = create<AgentState>((set, get) => {
         ]
       })
     })
+    captureAnalyticsEvent('agent_message_received', {
+      task_id: taskId,
+      agent_id: resolvedSession.agentId,
+      session_id: resolvedSession.sessionId,
+      ...getAgentMessageProperties({
+        role,
+        partType,
+        tool: data.tool as AgentMessage['tool'],
+        taskProgress: data.taskProgress as AgentMessage['taskProgress']
+      })
+    })
   })
 
   // ── Batched output handler with microtask debouncing ──
@@ -372,6 +403,9 @@ export const useAgentStore = create<AgentState>((set, get) => {
 
       let messages = [...resolvedSession.messages]
       let messagesChanged = false
+      let newMessageCount = 0
+      let taskProgressCount = 0
+      const toolNames = new Set<string>()
 
       for (const msg of event.messages) {
         const role: AgentMessage['role'] = msg.role === 'user' ? 'user' : msg.role === 'assistant' ? 'assistant' : 'system'
@@ -458,12 +492,24 @@ export const useAgentStore = create<AgentState>((set, get) => {
           tool: msg.tool as AgentMessage['tool'],
           taskProgress: (msg as Record<string, unknown>).taskProgress as AgentMessage['taskProgress']
         })
+        newMessageCount += 1
+        if ((msg as Record<string, unknown>).taskProgress) taskProgressCount += 1
+        const tool = msg.tool as AgentMessage['tool'] | undefined
+        if (tool?.name) toolNames.add(tool.name)
         messagesChanged = true
       }
 
       if (messagesChanged) {
         nextSessions.set(taskId, { ...resolvedSession, messages, systemStatus: null })
         changed = true
+        captureAnalyticsEvent('agent_output_batch_received', {
+          task_id: taskId,
+          agent_id: resolvedSession.agentId,
+          session_id: resolvedSession.sessionId,
+          message_count: newMessageCount,
+          task_progress_count: taskProgressCount,
+          tool_names: Array.from(toolNames).sort()
+        })
       }
     }
 
@@ -492,6 +538,13 @@ export const useAgentStore = create<AgentState>((set, get) => {
         status: SessionStatus.WAITING_APPROVAL
       })
     })
+    captureAnalyticsEvent('agent_approval_requested', {
+      task_id: session.taskId,
+      agent_id: session.agentId,
+      session_id: event.sessionId,
+      action: event.action,
+      has_description: Boolean(event.description)
+    })
   })
 
   // ── Return store ──
@@ -516,6 +569,12 @@ export const useAgentStore = create<AgentState>((set, get) => {
       try {
         const agent = await agentApi.create(data)
         set((state) => ({ agents: [...state.agents, agent] }))
+        captureAnalyticsEvent('agent_created', {
+          agent_id: agent.id,
+          coding_agent: agent.config?.coding_agent,
+          model: agent.config?.model,
+          is_default: agent.is_default
+        })
         return agent
       } catch (err) {
         set({ error: String(err) })
@@ -528,6 +587,13 @@ export const useAgentStore = create<AgentState>((set, get) => {
         const updated = await agentApi.update(id, data)
         if (updated) {
           set((state) => ({ agents: state.agents.map((a) => (a.id === id ? updated : a)) }))
+          captureAnalyticsEvent('agent_updated', {
+            agent_id: updated.id,
+            coding_agent: updated.config?.coding_agent,
+            model: updated.config?.model,
+            is_default: updated.is_default,
+            changed_fields: Object.keys(data).sort()
+          })
         }
         return updated || null
       } catch (err) {
@@ -541,6 +607,7 @@ export const useAgentStore = create<AgentState>((set, get) => {
         const success = await agentApi.delete(id)
         if (success) {
           set((state) => ({ agents: state.agents.filter((a) => a.id !== id) }))
+          captureAnalyticsEvent('agent_deleted', { agent_id: id })
         }
         return success
       } catch (err) {
@@ -616,6 +683,12 @@ export const useAgentStore = create<AgentState>((set, get) => {
       if (session?.sessionId) {
         try {
           await agentSessionApi.stop(session.sessionId)
+          captureAnalyticsEvent('agent_session_stopped', {
+            task_id: taskId,
+            agent_id: session.agentId,
+            session_id: session.sessionId,
+            source: 'task_cleanup'
+          })
         } catch (err) {
           console.error('Failed to stop session:', err)
         }

--- a/src/renderer/src/stores/task-store.ts
+++ b/src/renderer/src/stores/task-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type { WorkfloTask, CreateTaskDTO, UpdateTaskDTO, OutputField, OutputFieldType } from '@/types'
 import { taskApi, taskSourceApi, onTaskUpdated, onTaskCreated, onTaskDeleted, onTasksRefresh } from '@/lib/ipc-client'
+import { captureAnalyticsEvent, getTaskAnalyticsProperties, getTaskMutationProperties } from '@/lib/analytics'
 
 const VALID_OUTPUT_FIELD_TYPES = new Set<OutputFieldType>([
   'text',
@@ -82,6 +83,10 @@ export const useTaskStore = create<TaskState>((set) => ({
   createTask: async (data) => {
     try {
       const task = normalizeTask(await taskApi.create(data))
+      captureAnalyticsEvent('task_created', {
+        ...getTaskAnalyticsProperties(task),
+        ...getTaskMutationProperties(data as unknown as Record<string, unknown>)
+      })
       return task
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -99,6 +104,10 @@ export const useTaskStore = create<TaskState>((set) => ({
           tasks: state.tasks.map((t) => (t.id === id ? updated : t)),
           error: null
         }))
+        captureAnalyticsEvent('task_updated', {
+          ...getTaskAnalyticsProperties(updated),
+          ...getTaskMutationProperties(data as Record<string, unknown>)
+        })
         // Fire background export if task has a source
         if (updated.source_id && updated.external_id) {
           taskSourceApi.exportUpdate(id, data as Record<string, unknown>).catch(console.error)
@@ -116,11 +125,16 @@ export const useTaskStore = create<TaskState>((set) => ({
     try {
       const success = await taskApi.delete(id)
       if (success) {
+        const deletedTask = useTaskStore.getState().tasks.find((t) => t.id === id)
         set((state) => ({
           tasks: state.tasks.filter((t) => t.id !== id),
           selectedTaskId: state.selectedTaskId === id ? null : state.selectedTaskId,
           error: null
         }))
+        captureAnalyticsEvent('task_deleted', deletedTask
+          ? getTaskAnalyticsProperties(deletedTask)
+          : { task_id: id }
+        )
       }
       return success
     } catch (err) {
@@ -135,11 +149,21 @@ export const useTaskStore = create<TaskState>((set) => ({
 
 // Listen for task updates from the backend (e.g., when agent changes task status)
 onTaskUpdated((event) => {
+  const previousTask = useTaskStore.getState().tasks.find((t) => t.id === event.taskId)
   useTaskStore.setState((state) => ({
     tasks: state.tasks.map((t) =>
       t.id === event.taskId ? normalizeTask({ ...t, ...event.updates }) : t
     )
   }))
+  const nextStatus = (event.updates as { status?: string }).status
+  if (nextStatus && previousTask?.status !== nextStatus) {
+    captureAnalyticsEvent('task_status_changed', {
+      task_id: event.taskId,
+      previous_status: previousTask?.status,
+      next_status: nextStatus,
+      source: 'backend'
+    })
+  }
 })
 
 // Listen for tasks created externally (e.g., via task-management MCP server)
@@ -147,6 +171,10 @@ onTaskCreated((event) => {
   useTaskStore.setState((state) => {
     // Avoid duplicates
     if (state.tasks.some((t) => t.id === event.task.id)) return state
+    captureAnalyticsEvent('task_created', {
+      ...getTaskAnalyticsProperties(event.task),
+      source: 'backend'
+    })
     return { tasks: [normalizeTask(event.task), ...state.tasks] }
   })
 })
@@ -154,10 +182,15 @@ onTaskCreated((event) => {
 // Listen for task deletions from backend (UI-initiated or external MCP)
 onTaskDeleted((event) => {
   const taskId = event.taskId
+  const deletedTask = useTaskStore.getState().tasks.find((t) => t.id === taskId)
   useTaskStore.setState((state) => ({
     tasks: state.tasks.filter((t) => t.id !== taskId),
     selectedTaskId: state.selectedTaskId === taskId ? null : state.selectedTaskId
   }))
+  captureAnalyticsEvent('task_deleted', deletedTask
+    ? { ...getTaskAnalyticsProperties(deletedTask), source: 'backend' }
+    : { task_id: taskId, source: 'backend' }
+  )
 
   // Automatically remove from canvas if it was added.
   // Dynamic import avoids circular dependency and ensures canvas store is only loaded if needed.


### PR DESCRIPTION
## Summary
- Add PostHog browser SDK initialization for desktop renderer and mobile web, gated by VITE_POSTHOG_KEY with configurable host and session recording toggle.
- Track page views, workspace navigation, task lifecycle events, agent/session lifecycle events, approvals, and transcript activity metadata without sending message bodies.
- Identify users from enterprise identity or the locally configured current user when available.

## Test plan
- pnpm exec tsc --build --noEmit
- pnpm run lint
- pnpm run build
- pnpm exec vitest run src/renderer/src/stores/task-store.test.ts src/renderer/src/stores/agent-store.test.ts src/renderer/src/hooks/use-agent-session.test.tsx src/mobile/stores/task-store.test.ts src/mobile/stores/agent-store.test.ts