### PR TITLE
fix: inject PostHog config into release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build app
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          TELEMETRY_ENABLED: ${{ vars.TELEMETRY_ENABLED }}
+          TELEMETRY_FLUSH_BATCH_SIZE: ${{ vars.TELEMETRY_FLUSH_BATCH_SIZE }}
+          TELEMETRY_MAX_BUFFERED_EVENTS: ${{ vars.TELEMETRY_MAX_BUFFERED_EVENTS }}
         run: pnpm build
 
       - name: Validate signing secrets
@@ -150,6 +156,7 @@ jobs:
     # which the bundled node-gyp 11.5.0 can't detect, breaking the from-source
     # rebuild of better-sqlite3. windows-2022 has VS 2022 + the C++ workload.
     runs-on: windows-2022
+    environment: release
     permissions:
       contents: write
 
@@ -170,6 +177,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build app
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          TELEMETRY_ENABLED: ${{ vars.TELEMETRY_ENABLED }}
+          TELEMETRY_FLUSH_BATCH_SIZE: ${{ vars.TELEMETRY_FLUSH_BATCH_SIZE }}
+          TELEMETRY_MAX_BUFFERED_EVENTS: ${{ vars.TELEMETRY_MAX_BUFFERED_EVENTS }}
         run: pnpm build
 
       - name: Package for Windows
@@ -193,6 +206,7 @@ jobs:
 
   build-linux:
     runs-on: ubicloud-standard-2
+    environment: release
     permissions:
       contents: write
 
@@ -213,6 +227,12 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build app
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+          TELEMETRY_ENABLED: ${{ vars.TELEMETRY_ENABLED }}
+          TELEMETRY_FLUSH_BATCH_SIZE: ${{ vars.TELEMETRY_FLUSH_BATCH_SIZE }}
+          TELEMETRY_MAX_BUFFERED_EVENTS: ${{ vars.TELEMETRY_MAX_BUFFERED_EVENTS }}
         run: pnpm build
 
       - name: Package for Linux

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -3,8 +3,19 @@ import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+function defineEnv(name: string): string {
+  return JSON.stringify(process.env[name] ?? '')
+}
+
 export default defineConfig({
   main: {
+    define: {
+      __POSTHOG_KEY__: defineEnv('POSTHOG_KEY'),
+      __POSTHOG_HOST__: defineEnv('POSTHOG_HOST'),
+      __TELEMETRY_ENABLED__: defineEnv('TELEMETRY_ENABLED'),
+      __TELEMETRY_FLUSH_BATCH_SIZE__: defineEnv('TELEMETRY_FLUSH_BATCH_SIZE'),
+      __TELEMETRY_MAX_BUFFERED_EVENTS__: defineEnv('TELEMETRY_MAX_BUFFERED_EVENTS')
+    },
     plugins: [externalizeDepsPlugin({
       exclude: [
         '@electron-toolkit/utils',

--- a/src/main/analytics-service.ts
+++ b/src/main/analytics-service.ts
@@ -4,6 +4,12 @@ import { dirname, join } from 'path'
 import { app } from 'electron'
 import packageJson from '../../package.json'
 
+declare const __POSTHOG_KEY__: string | undefined
+declare const __POSTHOG_HOST__: string | undefined
+declare const __TELEMETRY_ENABLED__: string | undefined
+declare const __TELEMETRY_FLUSH_BATCH_SIZE__: string | undefined
+declare const __TELEMETRY_MAX_BUFFERED_EVENTS__: string | undefined
+
 interface BufferedAnalyticsEvent {
   event: string
   properties?: Record<string, unknown>
@@ -23,6 +29,30 @@ const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
 const DEFAULT_FLUSH_BATCH_SIZE = 20
 const DEFAULT_MAX_BUFFERED_EVENTS = 1_000
 const DEFAULT_FLUSH_INTERVAL_MS = 1_000
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value && value.trim() ? value : undefined
+}
+
+function buildPosthogKey(): string | undefined {
+  return typeof __POSTHOG_KEY__ === 'undefined' ? undefined : __POSTHOG_KEY__
+}
+
+function buildPosthogHost(): string | undefined {
+  return typeof __POSTHOG_HOST__ === 'undefined' ? undefined : __POSTHOG_HOST__
+}
+
+function buildTelemetryEnabled(): string | undefined {
+  return typeof __TELEMETRY_ENABLED__ === 'undefined' ? undefined : __TELEMETRY_ENABLED__
+}
+
+function buildTelemetryFlushBatchSize(): string | undefined {
+  return typeof __TELEMETRY_FLUSH_BATCH_SIZE__ === 'undefined' ? undefined : __TELEMETRY_FLUSH_BATCH_SIZE__
+}
+
+function buildTelemetryMaxBufferedEvents(): string | undefined {
+  return typeof __TELEMETRY_MAX_BUFFERED_EVENTS__ === 'undefined' ? undefined : __TELEMETRY_MAX_BUFFERED_EVENTS__
+}
 
 function parseBoolean(value: string | undefined, fallback: boolean): boolean {
   if (value === undefined) return fallback
@@ -65,11 +95,22 @@ export class AnalyticsService {
   private isFlushing = false
 
   constructor(options: AnalyticsServiceOptions = {}) {
-    this.posthogKey = options.posthogKey ?? process.env['POSTHOG_KEY'] ?? ''
-    this.posthogHost = (options.posthogHost ?? process.env['POSTHOG_HOST'] ?? DEFAULT_POSTHOG_HOST).replace(/\/+$/, '')
-    this.enabled = options.enabled ?? parseBoolean(process.env['TELEMETRY_ENABLED'], true)
-    this.flushBatchSize = options.flushBatchSize ?? parseNumber(process.env['TELEMETRY_FLUSH_BATCH_SIZE'], DEFAULT_FLUSH_BATCH_SIZE)
-    this.maxBufferedEvents = options.maxBufferedEvents ?? parseNumber(process.env['TELEMETRY_MAX_BUFFERED_EVENTS'], DEFAULT_MAX_BUFFERED_EVENTS)
+    this.posthogKey = options.posthogKey ?? nonEmpty(process.env['POSTHOG_KEY']) ?? nonEmpty(buildPosthogKey()) ?? ''
+    this.posthogHost = (
+      options.posthogHost ??
+      nonEmpty(process.env['POSTHOG_HOST']) ??
+      nonEmpty(buildPosthogHost()) ??
+      DEFAULT_POSTHOG_HOST
+    ).replace(/\/+$/, '')
+    this.enabled = options.enabled ?? parseBoolean(nonEmpty(process.env['TELEMETRY_ENABLED']) ?? nonEmpty(buildTelemetryEnabled()), true)
+    this.flushBatchSize = options.flushBatchSize ?? parseNumber(
+      nonEmpty(process.env['TELEMETRY_FLUSH_BATCH_SIZE']) ?? nonEmpty(buildTelemetryFlushBatchSize()),
+      DEFAULT_FLUSH_BATCH_SIZE
+    )
+    this.maxBufferedEvents = options.maxBufferedEvents ?? parseNumber(
+      nonEmpty(process.env['TELEMETRY_MAX_BUFFERED_EVENTS']) ?? nonEmpty(buildTelemetryMaxBufferedEvents()),
+      DEFAULT_MAX_BUFFERED_EVENTS
+    )
     this.distinctId = this.enabled && this.posthogKey ? readOrCreateAnonymousId() : null
 
     if (this.enabled && this.distinctId) {


### PR DESCRIPTION
## Summary
- Inline PostHog telemetry configuration into the Electron main bundle at build time through `electron.vite.config.ts`.
- Pass `POSTHOG_KEY` and telemetry settings into all release `pnpm build` jobs for macOS, Windows, and Linux.
- Attach Windows and Linux release jobs to the `release` environment so environment-scoped secrets and vars are available consistently.
- Preserve runtime environment overrides for local/dev runs.

## Release setup
- Add `POSTHOG_KEY` as a GitHub Environment secret on the `release` environment.
- Optional GitHub Environment variables: `POSTHOG_HOST`, `TELEMETRY_ENABLED`, `TELEMETRY_FLUSH_BATCH_SIZE`, `TELEMETRY_MAX_BUFFERED_EVENTS`.
- Release builds now compile those values into the packaged app during `pnpm build`; runtime env vars can still override them when present.

## Test plan
- `pnpm install --frozen-lockfile --ignore-scripts` (local Node 26 workaround; CI uses Node 22 with scripts enabled)
- `pnpm typecheck`
- `pnpm exec eslint electron.vite.config.ts src/main/analytics-service.ts`
- `POSTHOG_KEY=phc_build_test POSTHOG_HOST=https://us.i.posthog.com TELEMETRY_ENABLED=true TELEMETRY_FLUSH_BATCH_SIZE=20 TELEMETRY_MAX_BUFFERED_EVENTS=1000 pnpm build`
- Verified the built main bundle contains the dummy build key, confirming build-time inlining works.

Generated with Codex