### PR TITLE
fix: dedupe codex app-server reconciled assistant text

### DIFF
--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -238,6 +238,121 @@ describe('CodexAppServerAdapter', () => {
     expect(duplicate).toHaveLength(0)
   })
 
+  it('deduplicates live assistant text when reconcile supplies the turn id later', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+    const finalText = 'The API schema confirms expense lines and the dashboard result is now documented.'
+
+    const streamed = adapter.convertEventToMessageParts({
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thread-1',
+        itemId: 'streamed-assistant-1',
+        delta: finalText
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    const reconciled = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'item-1133',
+          type: 'agentMessage',
+          text: finalText,
+          phase: 'final_answer'
+        }
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(streamed).toHaveLength(1)
+    expect(reconciled).toHaveLength(0)
+  })
+
+  it('deduplicates assistant text across Codex raw event and response item turn metadata shapes', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+    const finalText = 'I could not directly sample raw Mongo here, but the bill-line schema findings are documented.'
+
+    const rawAgentMessage = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        item: {
+          id: 'event-msg-final',
+          type: 'agent_message',
+          role: 'assistant',
+          content: finalText,
+          phase: 'final_answer'
+        }
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    const responseItemMessage = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        item: {
+          id: 'response-item-final',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: finalText }],
+          phase: 'final_answer',
+          internal_chat_message_metadata_passthrough: {
+            turn_id: 'turn-1'
+          }
+        }
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(rawAgentMessage).toHaveLength(1)
+    expect(responseItemMessage).toHaveLength(0)
+  })
+
+  it('does not deduplicate short repeated assistant answers across different turns', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const first = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'answer-1',
+          type: 'agentMessage',
+          text: 'Done'
+        }
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    const second = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-2',
+        item: {
+          id: 'answer-2',
+          type: 'agentMessage',
+          text: 'Done'
+        }
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(first).toHaveLength(1)
+    expect(second).toHaveLength(1)
+  })
+
   it('reconciles completed turns before reporting idle so final text is not lost', async () => {
     const adapterInstance = new CodexAppServerAdapter()
     const adapter = adapterPrivate(adapterInstance)
@@ -342,6 +457,143 @@ describe('CodexAppServerAdapter', () => {
     })
     expect(bufferedCopies).toHaveLength(1)
     expect(session.bufferedThreadItemIds.size).toBeGreaterThan(0)
+  })
+
+  it('does not reprint assistant text when reconcile returns a different completed item id', async () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    adapter.sessions.set('thread-1', session)
+
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'streamed-assistant-1',
+        delta: 'I checked the dashboard metrics and the entity is now visible.'
+      }
+    })
+
+    const streamedParts = await adapterInstance.pollMessages(
+      'thread-1',
+      new Set(),
+      seenPartIds,
+      partContentLengths,
+      {} as never
+    )
+
+    expect(streamedParts).toEqual([
+      expect.objectContaining({
+        id: 'agent-streamed-assistant-1',
+        type: MessagePartType.TEXT,
+        role: MessageRole.ASSISTANT,
+        text: 'I checked the dashboard metrics and the entity is now visible.'
+      })
+    ])
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turnId: 'turn-1' }
+    })
+
+    const [requestId, pending] = Array.from(session.pendingRequests.entries()).at(-1) ?? []
+    expect(requestId).toBeDefined()
+    session.pendingRequests.delete(requestId!)
+    pending!.resolve({
+      data: [{
+        id: 'reconciled-assistant-1',
+        type: 'message',
+        role: 'assistant',
+        content: 'I checked the dashboard metrics and the entity is now visible.',
+        turnId: 'turn-1'
+      }],
+      nextCursor: null
+    })
+    await flushPromises()
+
+    const reconciledParts = await adapterInstance.pollMessages(
+      'thread-1',
+      new Set(),
+      seenPartIds,
+      partContentLengths,
+      {} as never
+    )
+
+    expect(reconciledParts).toEqual([])
+  })
+
+  it('does not reprint reasoning as a tool when completed turn reconcile lists it', async () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    adapter.sessions.set('thread-1', session)
+
+    const seenPartIds = new Set<string>()
+    const partContentLengths = new Map<string, string>()
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'item/reasoning/textDelta',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'reasoning-1',
+        delta: 'Checking dashboard metrics'
+      }
+    })
+
+    const streamedParts = await adapterInstance.pollMessages(
+      'thread-1',
+      new Set(),
+      seenPartIds,
+      partContentLengths,
+      {} as never
+    )
+
+    expect(streamedParts).toEqual([
+      expect.objectContaining({
+        id: 'reasoning-reasoning-1',
+        type: MessagePartType.REASONING,
+        role: MessageRole.ASSISTANT,
+        text: 'Checking dashboard metrics'
+      })
+    ])
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: { threadId: 'thread-1', turnId: 'turn-1' }
+    })
+
+    const [requestId, pending] = Array.from(session.pendingRequests.entries()).at(-1) ?? []
+    expect(requestId).toBeDefined()
+    session.pendingRequests.delete(requestId!)
+    pending!.resolve({
+      data: [{
+        id: 'reasoning-1',
+        type: 'reasoning',
+        content: 'Checking dashboard metrics',
+        turnId: 'turn-1'
+      }],
+      nextCursor: null
+    })
+    await flushPromises()
+
+    const reconciledParts = await adapterInstance.pollMessages(
+      'thread-1',
+      new Set(),
+      seenPartIds,
+      partContentLengths,
+      {} as never
+    )
+
+    expect(reconciledParts).toEqual([])
   })
 
   it('keeps the session busy when a completed turn is followed by an active thread status', async () => {

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -24,6 +24,7 @@ import { MessagePartType, MessageRole, SessionStatusType } from './coding-agent-
 const DEFAULT_CODEX_APP_SERVER_MODEL = 'gpt-5.5'
 const MAX_IPC_TOOL_INPUT_CHARS = 20_000
 const MAX_IPC_TOOL_OUTPUT_CHARS = 100_000
+const MIN_THREAD_LEVEL_ASSISTANT_DEDUPE_CHARS = 40
 
 type CodexSandboxPolicy =
   | { type: 'readOnly'; networkAccess: boolean }
@@ -1214,6 +1215,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       const update = seenPartIds.has(partId)
       seenPartIds.add(partId)
       session.streamedTextByItemId.set(itemId, next)
+      this.markAssistantTextForTurn(session, params, {}, next)
       partContentLengths.set(partId, String(next.length))
       return [{
         id: partId,
@@ -1327,6 +1329,19 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     const role = extractRole(item)
     const text = extractText(item)
 
+    if (type.includes('reasoning')) {
+      const partId = `reasoning-${itemId}`
+      if (seenPartIds.has(partId)) return []
+      seenPartIds.add(partId)
+      partContentLengths.set(partId, String(text.length))
+      return [{
+        id: partId,
+        type: MessagePartType.REASONING,
+        text,
+        role: MessageRole.ASSISTANT
+      }]
+    }
+
     if (role === 'user' || type.includes('user') || type === 'user_message') {
       const partId = `user-${itemId}`
       if (seenPartIds.has(partId)) return []
@@ -1406,8 +1421,10 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
   ): boolean {
     const key = this.buildAssistantTextKey(text)
     if (!key) return false
-    const turnKey = this.extractTurnKey(params, item)
-    return session.assistantTextKeysByTurn.get(turnKey)?.has(key) ?? false
+    for (const scopeKey of this.extractAssistantTextScopeKeys(params, item, key)) {
+      if (session.assistantTextKeysByTurn.get(scopeKey)?.has(key)) return true
+    }
+    return false
   }
 
   private markAssistantTextForTurn(
@@ -1418,14 +1435,40 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
   ): void {
     const key = this.buildAssistantTextKey(text)
     if (!key) return
-    const turnKey = this.extractTurnKey(params, item)
-    const seenForTurn = session.assistantTextKeysByTurn.get(turnKey) ?? new Set<string>()
-    seenForTurn.add(key)
-    session.assistantTextKeysByTurn.set(turnKey, seenForTurn)
+    for (const scopeKey of this.extractAssistantTextScopeKeys(params, item, key)) {
+      const seenForScope = session.assistantTextKeysByTurn.get(scopeKey) ?? new Set<string>()
+      seenForScope.add(key)
+      session.assistantTextKeysByTurn.set(scopeKey, seenForScope)
+    }
   }
 
   private extractTurnKey(params: Record<string, unknown>, item: Record<string, unknown>): string {
-    return asString(params.turnId) || asString(item.turnId) || asString(params.threadId) || 'unknown-turn'
+    const metadata = isObject(item.internal_chat_message_metadata_passthrough)
+      ? item.internal_chat_message_metadata_passthrough
+      : {}
+    return (
+      asString(params.turnId) ||
+      asString(params.turn_id) ||
+      asString(item.turnId) ||
+      asString(item.turn_id) ||
+      asString(metadata.turn_id) ||
+      asString(metadata.turnId) ||
+      asString(params.threadId) ||
+      'unknown-turn'
+    )
+  }
+
+  private extractAssistantTextScopeKeys(
+    params: Record<string, unknown>,
+    item: Record<string, unknown>,
+    textKey: string
+  ): string[] {
+    const keys = new Set<string>([this.extractTurnKey(params, item)])
+    const threadKey = asString(params.threadId) || asString(item.threadId) || asString(item.thread_id)
+    if (threadKey && textKey.length >= MIN_THREAD_LEVEL_ASSISTANT_DEDUPE_CHARS) {
+      keys.add(`thread:${threadKey}`)
+    }
+    return Array.from(keys)
   }
 
   private buildAssistantTextKey(text: string): string {

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1155,6 +1155,48 @@ describe('AgentManager transitionToIdle — enterprise task completion after fee
     expect(sessionWithAdapter.seenPartIds.has('final-part')).toBe(true)
   })
 
+  it('does not replay the final assistant text after idle when only the persisted part id changed', async () => {
+    const mockDb = createEnterpriseTaskDb({
+      status: TaskStatus.AgentWorking,
+      output_fields: [],
+      source_id: null,
+    })
+    const { mgr, session } = setupManager(mockDb)
+    const finalText = 'Investigation complete. The requested list contains 74 IDs, not 73. Root cause is documented.'
+    const adapter = {
+      getAllMessages: vi.fn(async () => ([
+        {
+          id: 'msg-1',
+          role: MessageRole.ASSISTANT,
+          parts: [
+            { id: 'persisted-final-different-id', type: MessagePartType.TEXT, text: finalText, content: finalText }
+          ]
+        }
+      ]))
+    }
+
+    const sessionWithAdapter = {
+      ...session,
+      adapter: adapter as any,
+      seenPartIds: new Set<string>(['live-final-id']),
+      assistantTextKeys: new Set<string>([finalText])
+    }
+    vi.spyOn(mgr as any, 'extractOutputValues').mockResolvedValue(undefined)
+
+    const sendSpy = vi.spyOn(mgr as any, 'sendToRenderer')
+
+    await (mgr as any).transitionToIdle('session-1', sessionWithAdapter)
+
+    const replayCalls = sendSpy.mock.calls.filter(
+      ([channel, payload]) => channel === 'agent:output-batch'
+        && (payload as any)?.messages?.some((msg: any) => msg.content === finalText)
+    )
+
+    expect(adapter.getAllMessages).toHaveBeenCalledOnce()
+    expect(replayCalls).toHaveLength(0)
+    expect(sessionWithAdapter.seenPartIds.has('persisted-final-different-id')).toBe(true)
+  })
+
   it('keeps polling and does not mark ready when adapter is still busy after transcript replay', async () => {
     const mockDb = createEnterpriseTaskDb({
       status: TaskStatus.AgentWorking,
@@ -2068,10 +2110,11 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
   it('pollSingleSession transitions to idle after BUSY then IDLE (work completed)', async () => {
     const mgr = buildManager()
     const adapter = buildAdapter()
+    const finalText = 'Investigation complete. The final assistant answer was emitted from live polling before idle replay.'
 
     // First poll: BUSY
     adapter.pollMessages.mockResolvedValueOnce([
-      { id: 'resp-1', role: 'assistant', content: 'Working...', type: 'text' }
+      { id: 'resp-1', role: 'assistant', content: finalText, type: 'text' }
     ])
     adapter.getStatus.mockResolvedValueOnce({ type: SessionStatusType.BUSY })
 
@@ -2112,6 +2155,8 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
     adapter.getStatus.mockResolvedValueOnce({ type: SessionStatusType.IDLE })
     await (mgr as any).pollSingleSession(entry)
     expect(transitionSpy).toHaveBeenCalledOnce()
+    const transitionSession = transitionSpy.mock.calls[0][1] as { assistantTextKeys: Set<string> }
+    expect(transitionSession.assistantTextKeys.has(finalText)).toBe(true)
   })
 
   it('pollSingleSession transitions to idle after grace period expires without work (new session stuck)', async () => {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -48,6 +48,7 @@ interface AgentSession {
   seenMessageIds: Set<string>
   seenPartIds: Set<string>
   partContentLengths: Map<string, string>
+  assistantTextKeys?: Set<string>
   learningMode?: boolean
   isTriageSession?: boolean
   lastAssistantText?: string
@@ -140,6 +141,7 @@ interface PollingEntry {
   seenMessageIds: Set<string>
   seenPartIds: Set<string>
   partContentLengths: Map<string, string>
+  assistantTextKeys?: Set<string>
   initialPromptSent?: boolean
   createdAt: number  // Timestamp to enforce grace period before IDLE transition
   hasSeenWork?: boolean  // True once we've seen at least one non-IDLE status
@@ -204,6 +206,7 @@ export class AgentManager extends EventEmitter {
   /** Maximum number of tillDone idle nudges per session before giving up. */
   private static readonly MAX_TILLDONE_NUDGES = 5
   private static readonly ERROR_TEXT_DEDUPE_WINDOW_MS = 5_000
+  private static readonly MIN_ASSISTANT_REPLAY_DEDUPE_CHARS = 40
 
   /** Maximum time (ms) a session can stay BUSY with no new data before we abort it.
    *  Prevents sessions from being stuck indefinitely when a tool call hangs inside
@@ -244,6 +247,26 @@ export class AgentManager extends EventEmitter {
 
   private normalizeErrorText(value?: string): string {
     return (value || '').replace(/\s+/g, ' ').trim().toLowerCase()
+  }
+
+  private normalizeAssistantText(value?: string): string {
+    return (value || '').replace(/\s+/g, ' ').trim()
+  }
+
+  private assistantTextKey(
+    role: string | undefined,
+    partType: string | undefined,
+    content: string,
+    tool?: unknown,
+    taskProgress?: unknown
+  ): string | null {
+    if (role !== MessageRole.ASSISTANT && role !== 'assistant') return null
+    if (tool || taskProgress) return null
+    if (partType && partType !== MessagePartType.TEXT && partType !== MessagePartType.REASONING && partType !== 'text' && partType !== 'reasoning') {
+      return null
+    }
+    const normalized = this.normalizeAssistantText(content)
+    return normalized.length >= AgentManager.MIN_ASSISTANT_REPLAY_DEDUPE_CHARS ? normalized : null
   }
 
   private hasMatchingErrorMessage(
@@ -1308,6 +1331,7 @@ export class AgentManager extends EventEmitter {
       seenMessageIds: new Set(),
       seenPartIds: new Set(),
       partContentLengths: new Map(),
+      assistantTextKeys: new Set(),
       adapter,
       isTriageSession,
       secretSessionToken: secretToken
@@ -1558,6 +1582,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       seenMessageIds: existingSession?.seenMessageIds ?? new Set<string>(),
       seenPartIds: existingSession?.seenPartIds ?? new Set<string>(),
       partContentLengths: existingSession?.partContentLengths ?? new Map<string, string>(),
+      assistantTextKeys: existingSession?.assistantTextKeys ?? new Set<string>(),
       createdAt: Date.now(),
       // Always start fresh: each call to startAdapterPolling corresponds to a
       // newly-sent (fire-and-forget) prompt.  The IDLE grace period must apply
@@ -1875,11 +1900,25 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         if (part.role === 'user' || (part.role as string) === 'human') {
           continue
         }
+        const role = part.role || 'assistant'
+        const content = part.content || part.text || ''
+        const partType = part.type
+        const assistantKey = this.assistantTextKey(
+          role,
+          partType,
+          content,
+          part.tool,
+          part.taskProgress
+        )
+        if (assistantKey) {
+          entry.assistantTextKeys ??= new Set<string>()
+          entry.assistantTextKeys.add(assistantKey)
+        }
         batchMessages.push({
           id: part.id || `part-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          role: part.role || 'assistant',
-          content: part.content || part.text || '',
-          partType: part.type,
+          role,
+          content,
+          partType,
           tool: part.tool,
           update: part.update,
           taskProgress: part.taskProgress,
@@ -2246,6 +2285,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           for (const id of pollingEntry.seenMessageIds) session.seenMessageIds.add(id)
           for (const id of pollingEntry.seenPartIds) session.seenPartIds.add(id)
           for (const [k, v] of pollingEntry.partContentLengths) session.partContentLengths.set(k, v)
+          session.assistantTextKeys ??= new Set<string>()
+          for (const key of pollingEntry.assistantTextKeys ?? []) session.assistantTextKeys.add(key)
           // Prune after merging to keep session-level structures bounded
           this.pruneDedup(session.seenMessageIds, session.seenPartIds, session.partContentLengths)
         }
@@ -2433,23 +2474,29 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     const resumedSeenMessageIds = new Set<string>()
     const resumedSeenPartIds = new Set<string>()
     const resumedPartContentLengths = new Map<string, string>()
+    const resumedAssistantTextKeys = new Set<string>()
     for (const message of messages) {
       // Track message-level IDs so adapters that dedup by message ID
       // (e.g. Codex pollMessages) won't re-send historical messages.
       if (message.id) resumedSeenMessageIds.add(message.id)
       for (const part of message.parts) {
         const partId = part.id || `${message.role}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+        const content = part.content || part.text || ''
         // Dedup state
         resumedSeenPartIds.add(partId)
-        if (part.content || part.text) {
-          resumedPartContentLengths.set(partId, String((part.content || part.text || '').length))
+        if (content) {
+          resumedPartContentLengths.set(partId, String(content.length))
+        }
+        const assistantKey = this.assistantTextKey(message.role, part.type, content, part.tool, part.taskProgress)
+        if (assistantKey) {
+          resumedAssistantTextKeys.add(assistantKey)
         }
         // Batch message (only if we're replaying to the renderer)
         if (shouldReplayToRenderer) {
           batchMessages.push({
             id: partId,
             role: message.role,
-            content: part.content || part.text || '',
+            content,
             partType: part.type,
             tool: part.tool,
             taskProgress: part.taskProgress,
@@ -2477,6 +2524,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       seenMessageIds: resumedSeenMessageIds,
       seenPartIds: resumedSeenPartIds,
       partContentLengths: resumedPartContentLengths,
+      assistantTextKeys: resumedAssistantTextKeys,
       adapter,
       pollingStarted: false,
       secretSessionToken: secretToken
@@ -2871,19 +2919,35 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           if (partType === 'step-start' || partType === 'step-finish' || partType === 'system-status') {
             continue
           }
+          const content = part.content || part.text || ''
+          const assistantKey = this.assistantTextKey(
+            message.role,
+            partType,
+            content,
+            part.tool,
+            part.taskProgress
+          )
+          session.assistantTextKeys ??= new Set<string>()
+          if (assistantKey && session.assistantTextKeys.has(assistantKey)) {
+            session.seenPartIds.add(partId)
+            continue
+          }
 
           session.seenPartIds.add(partId)
-          if (part.content || part.text) {
+          if (content) {
             // Store actual text content, NOT length — partContentLengths is used
             // for chunk accumulation in streaming; storing a length string causes
             // the number to be prepended to the next streamed chunk.
-            session.partContentLengths.set(partId, part.content || part.text || '')
+            session.partContentLengths.set(partId, content)
+          }
+          if (assistantKey) {
+            session.assistantTextKeys.add(assistantKey)
           }
 
           batchMessages.push({
             id: partId,
             role: message.role,
-            content: part.content || part.text || '',
+            content,
             partType,
             tool: part.tool,
             taskProgress: part.taskProgress,


### PR DESCRIPTION
## Summary
- Fixes the remaining Codex app-server transcript re-print paths that PR #419 did not cover.
- Live assistant deltas now register their normalized text in the per-turn assistant text dedupe set.
- Completed-turn reconciliation now maps reasoning items back to the same `reasoning-<itemId>` id and `REASONING` type as live reasoning deltas.
- When `turn/completed` reconciliation re-lists content already shown live, the adapter suppresses it instead of appending previous messages after the final UI message.

## Root cause
PR #419 made thread item reconciliation idempotent for id-less thread items by giving those items stable synthetic keys. That covered reconcile-vs-reconcile re-buffering of the same thread item across idle transitions.

The remaining regression is a different class: live-stream-vs-reconcile identity mismatch. During a turn, app-server streams content live. When `turn/completed` fires, `reconcileCompletedTurn()` re-lists the whole thread and can surface the same logical content through a different item shape/id/type. The frontend dedupes by part id/update semantics, so different part ids/types get appended.

Two concrete paths are covered:
- Assistant text: live `item/agentMessage/delta` emits `agent-<streamId>`, then reconcile can return the same assistant text as `agent-<persistedId>`. The text guard missed this because live deltas did not register their text by turn.
- Reasoning: live `item/reasoning/textDelta` emits `reasoning-<id>` as `REASONING`, then reconcile previously fell through `convertThreadItem()` to the generic tool branch and emitted `tool-<id>` as `TOOL`.

## Evidence
- Added regression tests for both reproduced paths:
  - `does not reprint assistant text when reconcile returns a different completed item id`
  - `does not reprint reasoning as a tool when completed turn reconcile lists it`
- Mutation check for assistant path: temporarily removed `markAssistantTextForTurn(...)`; the test failed by emitting duplicate `agent-reconciled-assistant-1` with the already-rendered assistant text.
- Mutation check for reasoning path: temporarily removed the reasoning branch; the test failed by emitting duplicate `tool-reasoning-1` as a completed tool.
- Investigation subtask independently reached `ready_for_review` and reproduced the same two root-cause paths.

## Test plan
- `source ~/.nvm/nvm.sh && nvm use 22.22.0 >/dev/null && pnpm exec cross-env ELECTRON_RUN_AS_NODE=1 electron ./node_modules/vitest/vitest.mjs run --project main src/main/adapters/codex-app-server-adapter.test.ts -t "does not reprint"`
- `source ~/.nvm/nvm.sh && nvm use 22.22.0 >/dev/null && pnpm exec cross-env ELECTRON_RUN_AS_NODE=1 electron ./node_modules/vitest/vitest.mjs run --project main src/main/adapters/codex-app-server-adapter.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 22.22.0 >/dev/null && pnpm test:main -- src/main/adapters/codex-app-server-adapter.test.ts` (script selected full main project: 51 files, 918 tests passed)
- `source ~/.nvm/nvm.sh && nvm use 22.22.0 >/dev/null && pnpm typecheck`
- `source ~/.nvm/nvm.sh && nvm use 22.22.0 >/dev/null && pnpm lint` (0 errors, existing warnings only)