### PR TITLE
fix: stop codex app-server transcript re-printing streamed reasoning/messages on idle

### DIFF
--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -344,6 +344,87 @@ describe('CodexAppServerAdapter', () => {
     expect(session.bufferedThreadItemIds.size).toBeGreaterThan(0)
   })
 
+  it('reconciles a reasoning item as a REASONING part, not a duplicate tool part', () => {
+    // Regression: reasoning is streamed live via item/reasoning/textDelta as
+    // `reasoning-<id>` (REASONING). reconcileCompletedTurn() re-lists the thread and
+    // re-emits the same reasoning item as item/completed. convertThreadItem() had no
+    // reasoning branch, so the reconcile copy fell through to the tool branch and was
+    // emitted as `tool-<id>` (TOOL) — a distinct part the renderer appended below the
+    // final message. The reconcile copy must reuse `reasoning-<id>` so it collapses.
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+
+    const live = adapter.convertEventToMessageParts({
+      method: 'item/reasoning/textDelta',
+      params: { itemId: 'rs_1', delta: 'Thinking about it', threadId: 'thread-1', turnId: 'turn-1' }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(live[0]).toMatchObject({ id: 'reasoning-rs_1', type: MessagePartType.REASONING })
+
+    const reconciled = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        itemId: 'rs_1',
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: { id: 'rs_1', type: 'reasoning', text: 'Thinking about it, done.' }
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(reconciled).toHaveLength(1)
+    expect(reconciled[0]).toMatchObject({
+      id: 'reasoning-rs_1',
+      type: MessagePartType.REASONING,
+      role: MessageRole.ASSISTANT,
+      update: true
+    })
+    // Must NOT be re-emitted as a separate tool part with a different id.
+    expect(reconciled[0].id).not.toBe('tool-rs_1')
+    expect(reconciled[0].type).not.toBe(MessagePartType.TOOL)
+  })
+
+  it('does not re-print a streamed assistant message when reconcile re-lists it under a different item id', () => {
+    // Regression: the live agent-message stream and the persisted thread item can
+    // carry DIFFERENT ids (`agent-<streamId>` vs `agent-<persistedId>`), both with
+    // update:false, so the renderer appends the final message twice. The turn text
+    // dedup guard only fired on convertThreadItem's item/completed branch, so a
+    // streamed message was never registered and the reconcile copy slipped through.
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+    const seenMessageIds = new Set<string>()
+    const seenPartIds = new Set<string>()
+    const lengths = new Map<string, string>()
+    const finalText = 'Here is the app: https://3050-example.runworkflo.com/?exec=abc'
+
+    const streamed = adapter.convertEventToMessageParts({
+      method: 'item/agentMessage/delta',
+      params: { itemId: 'msg_stream_1', delta: finalText, threadId: 'thread-1', turnId: 'turn-1' }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(streamed[0]).toMatchObject({ id: 'agent-msg_stream_1', text: finalText })
+
+    // Reconcile re-lists the SAME logical message under a different persisted id.
+    const reconciled = adapter.convertEventToMessageParts({
+      method: 'item/completed',
+      params: {
+        itemId: 'item_persisted_1',
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'item_persisted_1',
+          type: 'agent_message',
+          role: 'assistant',
+          content: finalText
+        }
+      }
+    }, seenMessageIds, seenPartIds, lengths, session)
+
+    expect(reconciled).toHaveLength(0)
+  })
+
   it('keeps the session busy when a completed turn is followed by an active thread status', async () => {
     const adapterInstance = new CodexAppServerAdapter()
     const adapter = adapterPrivate(adapterInstance)

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -1215,6 +1215,13 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       seenPartIds.add(partId)
       session.streamedTextByItemId.set(itemId, next)
       partContentLengths.set(partId, String(next.length))
+      // Register the streamed text against the turn so a later reconcile pass that
+      // re-lists this assistant message under a DIFFERENT persisted item id does not
+      // re-emit it as a brand-new part below the final message. Streaming deltas
+      // never reach convertThreadItem()'s item/completed branch (which is the only
+      // other place that marks turn text), so without this the live-vs-reconcile
+      // copies could not be collapsed and the transcript repeated older messages.
+      this.markAssistantTextForTurn(session, params, item ?? {}, next)
       return [{
         id: partId,
         type: MessagePartType.TEXT,
@@ -1326,6 +1333,29 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     const type = asString(item.type) || ''
     const role = extractRole(item)
     const text = extractText(item)
+
+    // Reasoning items are streamed live via item/reasoning/textDelta as a REASONING
+    // part with id `reasoning-<itemId>`. reconcileCompletedTurn() re-lists the whole
+    // thread and re-emits the same reasoning item as an item/completed. Without this
+    // branch it fell through to the tool branch below and was emitted as a distinct
+    // `tool-<itemId>` TOOL part, so the renderer could not collapse it against the
+    // live `reasoning-<itemId>` part and the reasoning was repeated after each turn.
+    // Emit it with the SAME part id/type as the live stream so the two collapse.
+    if (type.includes('reasoning')) {
+      const partId = `reasoning-${itemId}`
+      const alreadySeen = seenPartIds.has(partId)
+      if (alreadySeen && method !== 'item/completed') return []
+      seenPartIds.add(partId)
+      const reasoningText = text || session.streamedTextByItemId.get(itemId) || ''
+      partContentLengths.set(partId, String(reasoningText.length))
+      return [{
+        id: partId,
+        type: MessagePartType.REASONING,
+        text: reasoningText,
+        role: MessageRole.ASSISTANT,
+        update: alreadySeen
+      }]
+    }
 
     if (role === 'user' || type.includes('user') || type === 'user_message') {
       const partId = `user-${itemId}`


### PR DESCRIPTION
## Problem

Codex is **still re-printing previous messages after the last message** in the agent transcript, even after PR #419.

## Root cause (incomplete fix, not a regression)

PR #419 made `reconcileCompletedTurn()` idempotent for the **reconcile-vs-reconcile** path (`bufferedThreadItemIds` + `computeThreadItemKey`) — it stops the *same* item being re-buffered across idles. But it never covered the **live-stream-vs-reconcile** path: on every `turn/completed` the adapter re-lists the whole thread and re-emits items that were already delivered live during the turn. When the reconcile emission lands under a **different part id/type** than the live emission, the renderer cannot collapse the two and appends a duplicate below the final message.

The only commit touching this file since #419 is #423 (git metadata roots), which is unrelated to reconcile/buffering — so this is an incomplete fix, not a regression. #419's logic and its regression test still pass.

Two concrete, reproduced paths (investigation subtask confirmed both):

1. **Reasoning items** — streamed live via `item/reasoning/textDelta` as part id `reasoning-<id>` (REASONING). `convertThreadItem()` had **no reasoning branch**, so on reconcile the same item routed into the **tool** branch and was emitted as `tool-<id>` (TOOL, name `reasoning`). Different part id *and* type → the renderer appends a duplicate.
2. **Assistant final message** when the persisted thread-item id differs from the streaming `itemId` — live delta emits `agent-<streamId>`, reconcile emits `agent-<persistedId>`, both `update:false` → appended twice. The `hasSeenAssistantTextForTurn` guard missed it because streaming deltas never call `markAssistantTextForTurn()` (only `convertThreadItem`'s `item/completed` branch did), so the text wasn't registered for the turn when reconcile ran.

## Fix

Make the reconcile emission reuse the **same part identity as the live path**:

1. Add a **reasoning branch** to `convertThreadItem()` that emits `reasoning-<itemId>` (REASONING, `role: assistant`), updating in place when the part was already streamed — so it collapses against the live reasoning part instead of appearing as a separate tool call.
2. **Register streamed assistant text** for the turn via `markAssistantTextForTurn()` inside the `item/agentMessage/delta` handler, so a later reconcile `item/completed` for the same message (under a different persisted id) is recognized as already-shown and dropped.

Both changes are additive and scoped to the transcript emission path.

## Tests

- Added `reconciles a reasoning item as a REASONING part, not a duplicate tool part`
- Added `does not re-print a streamed assistant message when reconcile re-lists it under a different item id`

Both new tests fail on `main` (reproduce the bug) and pass with the fix.

- ✅ `pnpm typecheck`
- ✅ `eslint` on changed files
- ✅ Full main project suite: **918 tests passed** (24 in the codex adapter, incl. the 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)