### PR TITLE
feat: add latest Anthropic models

### DIFF
--- a/src/renderer/src/components/settings/tabs/AgentsSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/AgentsSettings.tsx
@@ -6,7 +6,7 @@ import { AgentFormDialog } from '../forms/AgentFormDialog'
 import { OpenCodeLogo, AnthropicLogo, OpenAILogo } from '@/components/icons/AgentLogos'
 import { useAgentStore } from '@/stores/agent-store'
 import { agentConfigApi } from '@/lib/ipc-client'
-import { CodingAgentType } from '@/types'
+import { CLAUDE_MODELS, CODEX_MODELS, CodingAgentType } from '@/types'
 import type { Agent, CreateAgentDTO, UpdateAgentDTO } from '@/types'
 
 interface ConnectionInfo {
@@ -45,7 +45,7 @@ export function AgentsSettings() {
       setConnections((prev) => new Map(prev).set(agent.id, {
         status: 'connected',
         providerCount: 1,
-        modelCount: 6,
+        modelCount: CLAUDE_MODELS.length,
         testedAt: new Date()
       }))
       return
@@ -55,7 +55,7 @@ export function AgentsSettings() {
       setConnections((prev) => new Map(prev).set(agent.id, {
         status: 'connected',
         providerCount: 1,
-        modelCount: 4,
+        modelCount: CODEX_MODELS.length,
         testedAt: new Date()
       }))
       return

--- a/src/renderer/src/types/index.test.ts
+++ b/src/renderer/src/types/index.test.ts
@@ -2,25 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { CLAUDE_MODELS, ClaudeModel, CODEX_MODELS, CodexModel } from './index'
 
 describe('CLAUDE_MODELS', () => {
-  it('includes Claude Fable 5', () => {
-    expect(CLAUDE_MODELS).toContainEqual({
-      id: ClaudeModel.FABLE_5,
-      name: 'claude-fable-5'
-    })
-  })
-
-  it('includes Claude Opus 4.8', () => {
-    expect(CLAUDE_MODELS).toContainEqual({
-      id: ClaudeModel.OPUS_4_8,
-      name: 'claude-opus-4-8'
-    })
-  })
-
-  it('includes Claude Opus 4.7', () => {
-    expect(CLAUDE_MODELS).toContainEqual({
-      id: ClaudeModel.OPUS_4_7,
-      name: 'Claude Opus 4.7'
-    })
+  it('lists the latest Claude models first in preferred order', () => {
+    expect(CLAUDE_MODELS.slice(0, 4)).toEqual([
+      { id: ClaudeModel.FABLE_5, name: 'Claude Fable 5' },
+      { id: ClaudeModel.OPUS_5, name: 'Claude Opus 5' },
+      { id: ClaudeModel.SONNET_5, name: 'Claude Sonnet 5' },
+      { id: ClaudeModel.OPUS_4_8, name: 'Claude Opus 4.8' }
+    ])
   })
 })
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -45,6 +45,8 @@ export const CODING_AGENTS: { value: CodingAgentType; label: string }[] = [
 
 export enum ClaudeModel {
   FABLE_5 = 'claude-fable-5',
+  OPUS_5 = 'claude-opus-5',
+  SONNET_5 = 'claude-sonnet-5',
   OPUS_4_8 = 'claude-opus-4-8',
   OPUS_4_7 = 'claude-opus-4-7',
   SONNET_4_6 = 'claude-sonnet-4-6',
@@ -57,8 +59,10 @@ export enum ClaudeModel {
 }
 
 export const CLAUDE_MODELS: { id: ClaudeModel; name: string }[] = [
-  { id: ClaudeModel.FABLE_5, name: 'claude-fable-5' },
-  { id: ClaudeModel.OPUS_4_8, name: 'claude-opus-4-8' },
+  { id: ClaudeModel.FABLE_5, name: 'Claude Fable 5' },
+  { id: ClaudeModel.OPUS_5, name: 'Claude Opus 5' },
+  { id: ClaudeModel.SONNET_5, name: 'Claude Sonnet 5' },
+  { id: ClaudeModel.OPUS_4_8, name: 'Claude Opus 4.8' },
   { id: ClaudeModel.OPUS_4_7, name: 'Claude Opus 4.7' },
   { id: ClaudeModel.SONNET_4_6, name: 'Claude Sonnet 4.6' },
   { id: ClaudeModel.SONNET_4_5, name: 'Claude Sonnet 4.5' },


### PR DESCRIPTION
## Summary
- Add Claude Opus 5 and Claude Sonnet 5 to the Claude Code model roster, ordered after Claude Fable 5 based on Anthropic's latest models comparison.
- Normalize the display labels for the newest Claude entries.
- Derive CLI agent model counts from the exported model arrays instead of stale literals.

## Test plan
- pnpm typecheck
- ./node_modules/.bin/vitest run src/renderer/src/types/index.test.ts

Notes: The normal `pnpm test:run ...` script could not run because Electron's postinstall binary was unavailable after the native install path failed on `better-sqlite3` with Node 26. The direct Vitest command passed for the focused test.

Source: Anthropic Models overview (2026-07-27): https://platform.claude.com/docs/en/about-claude/models/overview