### PR TITLE
feat(notion): migrate connector to data source API

### DIFF
--- a/src/main/plugins/notion-client.test.ts
+++ b/src/main/plugins/notion-client.test.ts
@@ -109,6 +109,28 @@ describe('NotionClient', () => {
       })
     })
 
+    it('rejects a repeated search cursor instead of looping forever', async () => {
+      vi.useFakeTimers()
+      const repeatedPage = {
+        results: [],
+        has_more: true,
+        next_cursor: 'repeated-cursor'
+      }
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse(repeatedPage))
+        .mockResolvedValueOnce(jsonResponse(repeatedPage))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const resultPromise = client.searchDataSources()
+      const expectation = expect(resultPromise).rejects.toThrow(
+        'Notion API returned a repeated search cursor'
+      )
+      await vi.runAllTimersAsync()
+
+      await expectation
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
     it('retrieves and queries a selected data source', async () => {
       const schema = { id: 'data-source-1', title: [], properties: {} }
       const fetchMock = vi.fn()

--- a/src/main/plugins/notion-client.test.ts
+++ b/src/main/plugins/notion-client.test.ts
@@ -70,7 +70,7 @@ describe('NotionClient', () => {
   // ── data source API ──────────────────────────────────────
 
   describe('data source API', () => {
-    it('lists every shared data source using cursor pagination', async () => {
+    it('searches shared data sources using cursor pagination', async () => {
       vi.useFakeTimers()
       const fetchMock = vi.fn()
         .mockResolvedValueOnce(jsonResponse({
@@ -129,6 +129,34 @@ describe('NotionClient', () => {
 
       await expectation
       expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('rejects an explicitly incomplete search response', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse({
+        results: [],
+        has_more: false,
+        next_cursor: null,
+        request_status: {
+          type: 'incomplete',
+          incomplete_reason: 'query_result_limit_reached'
+        }
+      })))
+
+      await expect(client.searchDataSources()).rejects.toThrow(
+        'Notion search returned incomplete results: query_result_limit_reached'
+      )
+    })
+
+    it('rejects pagination without a next cursor', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse({
+        results: [],
+        has_more: true,
+        next_cursor: null
+      })))
+
+      await expect(client.searchDataSources()).rejects.toThrow(
+        'Notion API omitted the next search cursor'
+      )
     })
 
     it('retrieves and queries a selected data source', async () => {

--- a/src/main/plugins/notion-client.test.ts
+++ b/src/main/plugins/notion-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { NotionClient, type NotionBlock, type NotionFileObject } from './notion-client'
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -43,6 +43,16 @@ function makeFileBlock(
   })
 }
 
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(JSON.stringify(body))
+  } as unknown as Response
+}
+
 // ── Tests ────────────────────────────────────────────────────
 
 describe('NotionClient', () => {
@@ -50,6 +60,77 @@ describe('NotionClient', () => {
 
   beforeEach(() => {
     client = new NotionClient('test-token')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  // ── data source API ──────────────────────────────────────
+
+  describe('data source API', () => {
+    it('lists every shared data source using cursor pagination', async () => {
+      vi.useFakeTimers()
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse({
+          results: [{ id: 'data-source-1', title: [], properties: {} }],
+          has_more: true,
+          next_cursor: 'cursor-2'
+        }))
+        .mockResolvedValueOnce(jsonResponse({
+          results: [{ id: 'data-source-2', title: [], properties: {} }],
+          has_more: false,
+          next_cursor: null
+        }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const resultPromise = client.searchDataSources()
+      await vi.runAllTimersAsync()
+
+      await expect(resultPromise).resolves.toEqual([
+        { id: 'data-source-1', title: [], properties: {} },
+        { id: 'data-source-2', title: [], properties: {} }
+      ])
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+
+      const [firstUrl, firstInit] = fetchMock.mock.calls[0] as [string, RequestInit]
+      expect(firstUrl).toBe('https://api.notion.com/v1/search')
+      expect(firstInit.headers).toMatchObject({
+        'Authorization': 'Bearer test-token',
+        'Notion-Version': '2026-03-11'
+      })
+      expect(JSON.parse(firstInit.body as string)).toEqual({
+        filter: { property: 'object', value: 'data_source' },
+        page_size: 100
+      })
+      expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toMatchObject({
+        start_cursor: 'cursor-2'
+      })
+    })
+
+    it('retrieves and queries a selected data source', async () => {
+      const schema = { id: 'data-source-1', title: [], properties: {} }
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse(schema))
+        .mockResolvedValueOnce(jsonResponse({
+          results: [],
+          has_more: false,
+          next_cursor: null
+        }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await expect(client.getDataSource('data-source-1')).resolves.toEqual(schema)
+      await expect(client.queryAllPages('data-source-1')).resolves.toEqual([])
+
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://api.notion.com/v1/data_sources/data-source-1'
+      )
+      expect(fetchMock.mock.calls[1][0]).toBe(
+        'https://api.notion.com/v1/data_sources/data-source-1/query'
+      )
+    })
+
   })
 
   // ── blocksToMarkdown ────────────────────────────────────

--- a/src/main/plugins/notion-client.ts
+++ b/src/main/plugins/notion-client.ts
@@ -163,6 +163,7 @@ export class NotionClient {
    */
   async searchDataSources(): Promise<NotionDataSource[]> {
     const results: NotionDataSource[] = []
+    const seenCursors = new Set<string>()
     let startCursor: string | undefined
 
     do {
@@ -179,7 +180,14 @@ export class NotionClient {
       }>('POST', '/v1/search', body)
 
       results.push(...data.results)
-      startCursor = data.has_more && data.next_cursor ? data.next_cursor : undefined
+      const nextCursor = data.has_more && data.next_cursor ? data.next_cursor : undefined
+      if (nextCursor) {
+        if (seenCursors.has(nextCursor)) {
+          throw new Error('Notion API returned a repeated search cursor')
+        }
+        seenCursors.add(nextCursor)
+      }
+      startCursor = nextCursor
 
       if (startCursor) await this.sleep(RATE_LIMIT_DELAY)
     } while (startCursor)

--- a/src/main/plugins/notion-client.ts
+++ b/src/main/plugins/notion-client.ts
@@ -7,10 +7,12 @@
 
 // ── Response types ───────────────────────────────────────────
 
-export interface NotionDatabase {
+export interface NotionDataSource {
   id: string
   title: Array<{ plain_text: string }>
   properties: Record<string, NotionPropertySchema>
+  object?: 'data_source'
+  parent?: { type: string; database_id?: string }
 }
 
 export interface NotionPropertySchema {
@@ -95,7 +97,7 @@ export interface NotionTimestampFilter {
 // ── Client ───────────────────────────────────────────────────
 
 const NOTION_API = 'https://api.notion.com'
-const NOTION_VERSION = '2022-06-28'
+const NOTION_VERSION = '2026-03-11'
 const RATE_LIMIT_DELAY = 350 // ms between paginated requests
 
 export class NotionClient {
@@ -153,21 +155,25 @@ export class NotionClient {
   // ── Public methods ───────────────────────────────────────
 
   /**
-   * List databases accessible to the integration
+   * List data sources accessible to the integration.
+   *
+   * Notion API 2025-09-03 and later split databases (containers) from data
+   * sources (the queryable tables). An omitted query returns every shared data
+   * source visible to the integration, subject to Notion's access rules.
    */
-  async searchDatabases(): Promise<NotionDatabase[]> {
-    const results: NotionDatabase[] = []
+  async searchDataSources(): Promise<NotionDataSource[]> {
+    const results: NotionDataSource[] = []
     let startCursor: string | undefined
 
     do {
       const body: Record<string, unknown> = {
-        filter: { property: 'object', value: 'database' },
+        filter: { property: 'object', value: 'data_source' },
         page_size: 100
       }
       if (startCursor) body.start_cursor = startCursor
 
       const data = await this.request<{
-        results: NotionDatabase[]
+        results: NotionDataSource[]
         has_more: boolean
         next_cursor: string | null
       }>('POST', '/v1/search', body)
@@ -182,17 +188,20 @@ export class NotionClient {
   }
 
   /**
-   * Get a database schema (property definitions)
+   * Get a data source schema (property definitions).
    */
-  async getDatabase(databaseId: string): Promise<NotionDatabase> {
-    return this.request<NotionDatabase>('GET', `/v1/databases/${databaseId}`)
+  async getDataSource(dataSourceId: string): Promise<NotionDataSource> {
+    return this.request<NotionDataSource>(
+      'GET',
+      `/v1/data_sources/${encodeURIComponent(dataSourceId)}`
+    )
   }
 
   /**
-   * Query all pages from a database with optional filters and incremental sync
+   * Query all pages from a data source with optional filters and incremental sync
    */
   async queryAllPages(
-    databaseId: string,
+    dataSourceId: string,
     filter?: NotionFilter,
     lastSyncedAt?: string | null
   ): Promise<NotionPage[]> {
@@ -233,7 +242,7 @@ export class NotionClient {
         results: NotionPage[]
         has_more: boolean
         next_cursor: string | null
-      }>('POST', `/v1/databases/${databaseId}/query`, body)
+      }>('POST', `/v1/data_sources/${encodeURIComponent(dataSourceId)}/query`, body)
 
       pages.push(...data.results)
       startCursor = data.has_more && data.next_cursor ? data.next_cursor : undefined

--- a/src/main/plugins/notion-client.ts
+++ b/src/main/plugins/notion-client.ts
@@ -158,8 +158,9 @@ export class NotionClient {
    * List data sources accessible to the integration.
    *
    * Notion API 2025-09-03 and later split databases (containers) from data
-   * sources (the queryable tables). An omitted query returns every shared data
-   * source visible to the integration, subject to Notion's access rules.
+   * sources (the queryable tables). An omitted query searches across shared
+   * data sources. Search is index-backed, so the UI must offer refresh and an
+   * explicitly incomplete response must not be presented as a complete list.
    */
   async searchDataSources(): Promise<NotionDataSource[]> {
     const results: NotionDataSource[] = []
@@ -177,7 +178,27 @@ export class NotionClient {
         results: NotionDataSource[]
         has_more: boolean
         next_cursor: string | null
+        request_status?: {
+          type?: 'complete' | 'incomplete'
+          incomplete_reason?: string
+        }
       }>('POST', '/v1/search', body)
+
+      if (
+        data.request_status?.type === 'incomplete' ||
+        data.request_status?.incomplete_reason
+      ) {
+        throw new Error(
+          `Notion search returned incomplete results${
+            data.request_status.incomplete_reason
+              ? `: ${data.request_status.incomplete_reason}`
+              : ''
+          }`
+        )
+      }
+      if (data.has_more && !data.next_cursor) {
+        throw new Error('Notion API omitted the next search cursor')
+      }
 
       results.push(...data.results)
       const nextCursor = data.has_more && data.next_cursor ? data.next_cursor : undefined

--- a/src/main/plugins/notion-plugin.test.ts
+++ b/src/main/plugins/notion-plugin.test.ts
@@ -148,6 +148,32 @@ describe('NotionPlugin', () => {
     })
   })
 
+  describe('resolveOptions', () => {
+    it('returns searched data sources', async () => {
+      mockClientInstance.searchDataSources.mockResolvedValue([
+        {
+          id: 'data-source-1',
+          title: [{ plain_text: 'Tasks' }],
+          properties: {}
+        }
+      ])
+
+      await expect(
+        plugin.resolveOptions('data_sources', defaultConfig, makeContext())
+      ).resolves.toEqual([{ value: 'data-source-1', label: 'Tasks' }])
+    })
+
+    it('surfaces data source search failures', async () => {
+      mockClientInstance.searchDataSources.mockRejectedValue(
+        new Error('Notion search returned incomplete results')
+      )
+
+      await expect(
+        plugin.resolveOptions('data_sources', defaultConfig, makeContext())
+      ).rejects.toThrow('Notion search returned incomplete results')
+    })
+  })
+
   // ── importTasks ─────────────────────────────────────────
 
   describe('importTasks', () => {

--- a/src/main/plugins/notion-plugin.test.ts
+++ b/src/main/plugins/notion-plugin.test.ts
@@ -8,7 +8,7 @@ import type { DatabaseManager, TaskRecord } from '../database'
 // ── Shared mock instance (reset per test) ────────────────────
 
 const mockClientInstance = {
-  getDatabase: vi.fn(),
+  getDataSource: vi.fn(),
   queryAllPages: vi.fn(),
   getPageBlocks: vi.fn(),
   blocksToMarkdown: vi.fn(),
@@ -17,7 +17,7 @@ const mockClientInstance = {
   downloadFile: vi.fn(),
   updatePage: vi.fn(),
   getUsers: vi.fn(),
-  searchDatabases: vi.fn()
+  searchDataSources: vi.fn()
 }
 
 vi.mock('./notion-client', () => ({
@@ -72,7 +72,7 @@ function makePage(overrides: Record<string, unknown> = {}) {
 }
 
 const TEST_ATTACHMENTS_DIR = '/tmp/test-notion-attachments'
-const defaultConfig = { api_token: 'ntn_test', database_id: 'db-1' }
+const defaultConfig = { api_token: 'ntn_test', data_source_id: 'db-1' }
 
 // ── Tests ────────────────────────────────────────────────────
 
@@ -87,7 +87,7 @@ describe('NotionPlugin', () => {
     if (!existsSync(TEST_ATTACHMENTS_DIR)) mkdirSync(TEST_ATTACHMENTS_DIR, { recursive: true })
 
     // Default mock returns
-    mockClientInstance.getDatabase.mockResolvedValue(DB_SCHEMA)
+    mockClientInstance.getDataSource.mockResolvedValue(DB_SCHEMA)
     mockClientInstance.queryAllPages.mockResolvedValue([])
     mockClientInstance.getPageBlocks.mockResolvedValue([])
     mockClientInstance.blocksToMarkdown.mockReturnValue('')
@@ -110,11 +110,11 @@ describe('NotionPlugin', () => {
     expect(plugin.requiresMcpServer).toBe(false)
   })
 
-  it('returns config schema with api_token, database_id, and filters', () => {
+  it('returns config schema with api_token, data_source_id, and filters', () => {
     const schema = plugin.getConfigSchema()
     expect(schema).toHaveLength(3)
     expect(schema[0].key).toBe('api_token')
-    expect(schema[1].key).toBe('database_id')
+    expect(schema[1].key).toBe('data_source_id')
     expect(schema[2].key).toBe('filters')
   })
 
@@ -136,15 +136,15 @@ describe('NotionPlugin', () => {
 
   describe('validateConfig', () => {
     it('returns null for valid config', () => {
-      expect(plugin.validateConfig({ api_token: 'ntn_123', database_id: 'db-1' })).toBeNull()
+      expect(plugin.validateConfig({ api_token: 'ntn_123', data_source_id: 'db-1' })).toBeNull()
     })
 
     it('rejects missing api_token', () => {
-      expect(plugin.validateConfig({ database_id: 'db-1' })).toBe('Integration token is required')
+      expect(plugin.validateConfig({ data_source_id: 'db-1' })).toBe('Integration token is required')
     })
 
-    it('rejects missing database_id', () => {
-      expect(plugin.validateConfig({ api_token: 'ntn_123' })).toBe('Database is required')
+    it('rejects missing data_source_id', () => {
+      expect(plugin.validateConfig({ api_token: 'ntn_123' })).toBe('Data source is required')
     })
   })
 

--- a/src/main/plugins/notion-plugin.ts
+++ b/src/main/plugins/notion-plugin.ts
@@ -241,7 +241,7 @@ export class NotionPlugin implements TaskSourcePlugin {
         }))
       } catch (err) {
         console.error('[notion] Failed to fetch data sources:', err)
-        return []
+        throw err
       }
     }
 

--- a/src/main/plugins/notion-plugin.ts
+++ b/src/main/plugins/notion-plugin.ts
@@ -729,7 +729,7 @@ The integration automatically maps Notion properties to task fields:
 
 | Notion Property Type | Task Field | Detected By |
 |---------------------|------------|-------------|
-| Title | Title | (every DB has one) |
+| Title | Title | (every data source has one) |
 | Status / Select named "Status" | Status | Type or name |
 | Select named "Priority" | Priority | Name |
 | People | Assignee | Prefers "Assignee"/"Owner" |
@@ -745,9 +745,9 @@ The integration automatically maps Notion properties to task fields:
 ### "Access forbidden"
 - Open the database in Notion → **...** → **Connections** → ensure your integration is connected
 
-### No databases appear
-- The integration can only see databases explicitly shared with it
-- Share at least one database with your integration
+### No data sources appear
+- The integration can only see data sources explicitly shared with it
+- Share at least one data source with your integration
 
 ### Missing properties in filters
 - Only Status, Select, and Multi-select properties appear as filter options

--- a/src/main/plugins/notion-plugin.ts
+++ b/src/main/plugins/notion-plugin.ts
@@ -18,7 +18,7 @@ import { replaceRemoteImageUrlsInTask } from './replace-image-urls'
 import { normalizeUrlForComparison, buildNormalizedUrlSet } from './url-utils'
 import {
   NotionClient,
-  type NotionDatabase,
+  type NotionDataSource,
   type NotionPage,
   type NotionPropertySchema,
   type NotionPropertyValue,
@@ -190,7 +190,7 @@ const LABELS_HEURISTICS = new Set(['tags', 'labels', 'category'])
 export class NotionPlugin implements TaskSourcePlugin {
   id = 'notion'
   displayName = 'Notion'
-  description = 'Import tasks from a Notion database'
+  description = 'Import tasks from a Notion data source'
   icon = 'BookOpen'
   requiresMcpServer = false
 
@@ -205,10 +205,10 @@ export class NotionPlugin implements TaskSourcePlugin {
         description: 'Internal Integration Token from notion.so/profile/integrations'
       },
       {
-        key: 'database_id',
-        label: 'Database',
+        key: 'data_source_id',
+        label: 'Data source',
         type: 'dynamic-select',
-        optionsResolver: 'databases',
+        optionsResolver: 'data_sources',
         required: true,
         dependsOn: { field: 'api_token', value: '__any__' }
       },
@@ -216,7 +216,7 @@ export class NotionPlugin implements TaskSourcePlugin {
         key: 'filters',
         label: 'Filters',
         type: 'text',
-        dependsOn: { field: 'database_id', value: '__any__' },
+        dependsOn: { field: 'data_source_id', value: '__any__' },
         description: 'Structured filter configuration (managed by custom form)'
       },
     ]
@@ -232,25 +232,25 @@ export class NotionPlugin implements TaskSourcePlugin {
 
     const client = new NotionClient(token)
 
-    if (resolverKey === 'databases') {
+    if (resolverKey === 'data_sources') {
       try {
-        const databases = await client.searchDatabases()
-        return databases.map((db) => ({
-          value: db.id,
-          label: db.title.map((t) => t.plain_text).join('') || 'Untitled'
+        const dataSources = await client.searchDataSources()
+        return dataSources.map((dataSource) => ({
+          value: dataSource.id,
+          label: dataSource.title.map((t) => t.plain_text).join('') || 'Untitled'
         }))
       } catch (err) {
-        console.error('[notion] Failed to fetch databases:', err)
+        console.error('[notion] Failed to fetch data sources:', err)
         return []
       }
     }
 
-    if (resolverKey === 'database_properties') {
-      const databaseId = config.database_id as string
-      if (!databaseId) return []
+    if (resolverKey === 'data_source_properties') {
+      const dataSourceId = config.data_source_id as string
+      if (!dataSourceId) return []
 
       try {
-        const db = await client.getDatabase(databaseId)
+        const db = await client.getDataSource(dataSourceId)
         const result: ConfigFieldOption[] = []
 
         // Pre-fetch users if any people property exists
@@ -295,7 +295,7 @@ export class NotionPlugin implements TaskSourcePlugin {
 
         return result
       } catch (err) {
-        console.error('[notion] Failed to fetch database properties:', err)
+        console.error('[notion] Failed to fetch data source properties:', err)
         return []
       }
     }
@@ -307,8 +307,8 @@ export class NotionPlugin implements TaskSourcePlugin {
     if (!config.api_token || typeof config.api_token !== 'string') {
       return 'Integration token is required'
     }
-    if (!config.database_id || typeof config.database_id !== 'string') {
-      return 'Database is required'
+    if (!config.data_source_id || typeof config.data_source_id !== 'string') {
+      return 'Data source is required'
     }
     return null
   }
@@ -354,13 +354,13 @@ export class NotionPlugin implements TaskSourcePlugin {
   ): Promise<PluginSyncResult> {
     const result: PluginSyncResult = { imported: 0, updated: 0, errors: [] }
     const token = config.api_token as string
-    const databaseId = config.database_id as string
+    const dataSourceId = config.data_source_id as string
 
     const client = new NotionClient(token)
 
     try {
       // Fetch DB schema and build property map
-      const db = await client.getDatabase(databaseId)
+      const db = await client.getDataSource(dataSourceId)
       const propMap = this.buildPropertyMap(db)
 
       // Build filter from config
@@ -374,7 +374,7 @@ export class NotionPlugin implements TaskSourcePlugin {
       const lastSyncedAt = source?.last_synced_at ?? null
 
       // Fetch pages
-      const pages = await client.queryAllPages(databaseId, notionFilter, lastSyncedAt)
+      const pages = await client.queryAllPages(dataSourceId, notionFilter, lastSyncedAt)
 
       for (const page of pages) {
         if (page.archived) continue
@@ -490,11 +490,11 @@ export class NotionPlugin implements TaskSourcePlugin {
     if (!task.external_id) return
 
     const token = config.api_token as string
-    const databaseId = config.database_id as string
+    const dataSourceId = config.data_source_id as string
     const client = new NotionClient(token)
 
     try {
-      const db = await client.getDatabase(databaseId)
+      const db = await client.getDataSource(dataSourceId)
       const propMap = this.buildPropertyMap(db)
       const properties: Record<string, unknown> = {}
 
@@ -565,11 +565,11 @@ export class NotionPlugin implements TaskSourcePlugin {
     }
 
     const token = config.api_token as string
-    const databaseId = config.database_id as string
+    const dataSourceId = config.data_source_id as string
     const client = new NotionClient(token)
 
     try {
-      const db = await client.getDatabase(databaseId)
+      const db = await client.getDataSource(dataSourceId)
       const propMap = this.buildPropertyMap(db)
       const properties: Record<string, unknown> = {}
 
@@ -639,11 +639,11 @@ export class NotionPlugin implements TaskSourcePlugin {
     }
 
     const token = config.api_token as string
-    const databaseId = config.database_id as string
+    const dataSourceId = config.data_source_id as string
     const client = new NotionClient(token)
 
     try {
-      const db = await client.getDatabase(databaseId)
+      const db = await client.getDataSource(dataSourceId)
       const propMap = this.buildPropertyMap(db)
 
       if (!propMap.assignee) {
@@ -667,7 +667,7 @@ export class NotionPlugin implements TaskSourcePlugin {
 
 ## Overview
 
-Import tasks from any Notion database. Supports incremental sync, server-side filtering by database properties, and bidirectional updates.
+Import tasks from any Notion data source. Supports incremental sync, server-side filtering by data source properties, and bidirectional updates.
 
 ## Prerequisites
 
@@ -760,7 +760,7 @@ The integration automatically maps Notion properties to task fields:
    * Auto-detect which Notion properties map to task fields
    */
   private buildPropertyMap(
-    db: NotionDatabase
+    db: NotionDataSource
   ): PropertyMap {
     const props = db.properties
     const map: PropertyMap = { title: '' }

--- a/src/renderer/src/components/plugins/NotionConfigForm.tsx
+++ b/src/renderer/src/components/plugins/NotionConfigForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Loader2, Plus, X, Search, ChevronDown } from 'lucide-react'
+import { Loader2, Plus, X, Search, ChevronDown, RefreshCw } from 'lucide-react'
 import { Input } from '@/components/ui/Input'
 import { Label } from '@/components/ui/Label'
 import { Button } from '@/components/ui/Button'
@@ -48,6 +48,8 @@ export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps)
   const [dbProperties, setDbProperties] = useState<NotionPropertyInfo[]>([])
   const [loadingDataSources, setLoadingDataSources] = useState(false)
   const [loadingProps, setLoadingProps] = useState(false)
+  const [dataSourcesError, setDataSourcesError] = useState<string | null>(null)
+  const [dataSourceRefreshKey, setDataSourceRefreshKey] = useState(0)
 
   const updateField = useCallback(
     (key: string, val: unknown) => onChange({ ...value, [key]: val }),
@@ -59,15 +61,22 @@ export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps)
     const token = value.api_token as string
     if (!token) {
       setDataSources([])
+      setDataSourcesError(null)
       return
     }
     setLoadingDataSources(true)
+    setDataSourcesError(null)
     pluginApi
       .resolveOptions('notion', 'data_sources', value, undefined, sourceId)
       .then(setDataSources)
-      .catch(() => setDataSources([]))
+      .catch((error: unknown) => {
+        setDataSources([])
+        setDataSourcesError(
+          error instanceof Error ? error.message : 'Failed to load data sources'
+        )
+      })
       .finally(() => setLoadingDataSources(false))
-  }, [value.api_token, sourceId])
+  }, [value.api_token, sourceId, dataSourceRefreshKey])
 
   // Fetch properties when the data source changes
   useEffect(() => {
@@ -129,10 +138,28 @@ export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps)
       {/* Data source */}
       {hasToken && (
         <div className="space-y-1.5">
-          <Label>Data source</Label>
+          <div className="flex items-center justify-between">
+            <Label>Data source *</Label>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={() => setDataSourceRefreshKey((current) => current + 1)}
+              disabled={loadingDataSources}
+            >
+              <RefreshCw className="mr-1 h-3 w-3" />
+              Refresh
+            </Button>
+          </div>
           {loadingDataSources ? (
             <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
               <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading data sources...
+            </div>
+          ) : dataSourcesError ? (
+            <div className="text-xs text-destructive py-2">
+              Could not load data sources. Refresh, or check the Notion token and
+              sharing permissions.
             </div>
           ) : (
             <SearchableSelect

--- a/src/renderer/src/components/plugins/NotionConfigForm.tsx
+++ b/src/renderer/src/components/plugins/NotionConfigForm.tsx
@@ -44,9 +44,9 @@ interface NotionFilterRow {
 // ── Main Form ────────────────────────────────────────────────
 
 export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps) {
-  const [databases, setDatabases] = useState<ConfigFieldOption[]>([])
+  const [dataSources, setDataSources] = useState<ConfigFieldOption[]>([])
   const [dbProperties, setDbProperties] = useState<NotionPropertyInfo[]>([])
-  const [loadingDbs, setLoadingDbs] = useState(false)
+  const [loadingDataSources, setLoadingDataSources] = useState(false)
   const [loadingProps, setLoadingProps] = useState(false)
 
   const updateField = useCallback(
@@ -54,37 +54,37 @@ export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps)
     [value, onChange]
   )
 
-  // Fetch databases when token is present
+  // Fetch data sources when token is present
   useEffect(() => {
     const token = value.api_token as string
     if (!token) {
-      setDatabases([])
+      setDataSources([])
       return
     }
-    setLoadingDbs(true)
+    setLoadingDataSources(true)
     pluginApi
-      .resolveOptions('notion', 'databases', value, undefined, sourceId)
-      .then(setDatabases)
-      .catch(() => setDatabases([]))
-      .finally(() => setLoadingDbs(false))
+      .resolveOptions('notion', 'data_sources', value, undefined, sourceId)
+      .then(setDataSources)
+      .catch(() => setDataSources([]))
+      .finally(() => setLoadingDataSources(false))
   }, [value.api_token, sourceId])
 
-  // Fetch properties when database changes
+  // Fetch properties when the data source changes
   useEffect(() => {
-    const dbId = value.database_id as string
-    if (!dbId || !value.api_token) {
+    const dataSourceId = value.data_source_id as string
+    if (!dataSourceId || !value.api_token) {
       setDbProperties([])
       return
     }
     setLoadingProps(true)
     pluginApi
-      .resolveOptions('notion', 'database_properties', value, undefined, sourceId)
+      .resolveOptions('notion', 'data_source_properties', value, undefined, sourceId)
       .then((opts) => {
         setDbProperties(opts.map((o) => JSON.parse(o.value) as NotionPropertyInfo))
       })
       .catch(() => setDbProperties([]))
       .finally(() => setLoadingProps(false))
-  }, [value.database_id, value.api_token, sourceId])
+  }, [value.data_source_id, value.api_token, sourceId])
 
   const filters = (value.filters as NotionFilterRow[]) ?? []
 
@@ -107,7 +107,7 @@ export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps)
   }
 
   const hasToken = !!(value.api_token as string)
-  const hasDatabase = !!(value.database_id as string)
+  const hasDataSource = !!(value.data_source_id as string)
 
   return (
     <div className="space-y-3">
@@ -126,27 +126,27 @@ export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps)
         />
       </div>
 
-      {/* Database */}
+      {/* Data source */}
       {hasToken && (
         <div className="space-y-1.5">
-          <Label>Database</Label>
-          {loadingDbs ? (
+          <Label>Data source</Label>
+          {loadingDataSources ? (
             <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading databases...
+              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading data sources...
             </div>
           ) : (
             <SearchableSelect
-              options={databases}
-              value={(value.database_id as string) ?? ''}
-              onChange={(v) => onChange({ ...value, database_id: v, filters: [] })}
-              placeholder="Select database..."
+              options={dataSources}
+              value={(value.data_source_id as string) ?? ''}
+              onChange={(v) => onChange({ ...value, data_source_id: v, filters: [] })}
+              placeholder="Select data source..."
             />
           )}
         </div>
       )}
 
       {/* Filters */}
-      {hasDatabase && (
+      {hasDataSource && (
         <div className="space-y-1.5">
           <div className="flex items-center justify-between">
             <Label>Filters</Label>


### PR DESCRIPTION
## Summary
- replace legacy database discovery with paginated Notion data-source search
- migrate schema and row queries to `/v1/data_sources` on API version `2026-03-11`
- rename connector config to `data_source_id` and update the UI labels/resolvers

## Breaking change
Existing Notion task-source configs using `database_id` must be reconfigured. No legacy alias or database-ID fallback is included.

## Validation
- `pnpm test:run --project main src/main/plugins/notion-client.test.ts src/main/plugins/notion-plugin.test.ts` (69 tests)
- `pnpm typecheck`