### PR TITLE
fix: run heartbeat LLM check when instructions aren't GitHub-only

### DIFF
--- a/src/main/heartbeat-scheduler.test.ts
+++ b/src/main/heartbeat-scheduler.test.ts
@@ -1,4 +1,34 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Stub `gh` so pre-flight tests never touch the network. The scheduler calls
+// promisify(execFile), so the stub exposes the promisify custom symbol.
+const ghStub = vi.hoisted(() => {
+  const calls: string[][] = []
+  let respond: (argv: string[]) => string = () => '0'
+  return {
+    calls,
+    reset: (responder?: (argv: string[]) => string) => {
+      calls.length = 0
+      respond = responder ?? (() => '0')
+    },
+    invoke: (argv: string[]) => {
+      calls.push(argv)
+      return respond(argv)
+    },
+  }
+})
+
+vi.mock('child_process', () => {
+  const execFile = () => {
+    throw new Error('callback-style execFile is not used by HeartbeatScheduler')
+  }
+  Object.defineProperty(execFile, Symbol.for('nodejs.util.promisify.custom'), {
+    value: (_command: string, argv: string[]) =>
+      Promise.resolve({ stdout: ghStub.invoke(argv), stderr: '' }),
+  })
+  return { execFile }
+})
+
 import { HeartbeatScheduler } from './heartbeat-scheduler'
 import { HeartbeatStatus, HEARTBEAT_OK_TOKEN, HEARTBEAT_INFO_TOKEN, HEARTBEAT_DEFAULTS, TaskStatus } from '../shared/constants'
 import type { DatabaseManager, TaskRecord } from './database'
@@ -221,6 +251,163 @@ describe('HeartbeatScheduler', () => {
       expect(requiresLlmCurrentStateChecks('Check whether the PR has conflicts')).toBe(false)
       expect(requiresLlmCurrentStateChecks('Check for new PR comments and reviews')).toBe(false)
       expect(requiresLlmCurrentStateChecks('Verify CI pipeline passed')).toBe(false)
+    })
+  })
+
+  // ── preflightCoversAllChecks ─────────────────────────────
+
+  describe('preflightCoversAllChecks', () => {
+    const coversAllChecks = (content: string) => {
+      const scheduler = new HeartbeatScheduler({} as DatabaseManager, {} as AgentManager)
+      return (scheduler as unknown as {
+        preflightCoversAllChecks: (heartbeatContent: string) => boolean
+      }).preflightCoversAllChecks(content)
+    }
+
+    it('returns true when every check references a GitHub URL', () => {
+      const content = [
+        '# Heartbeat Checks',
+        '- [ ] Check if PR https://github.com/acme/app/pull/42 has new review comments',
+        '- [ ] Verify CI passed on https://github.com/acme/app/pull/42',
+      ].join('\n')
+      expect(coversAllChecks(content)).toBe(true)
+    })
+
+    it('returns false when a check has no GitHub URL', () => {
+      const content = [
+        '# Heartbeat Checks',
+        '- [ ] Check if PR https://github.com/acme/app/pull/42 has new review comments',
+        '- [ ] Monitor if any new transactions appeared in the profiler',
+      ].join('\n')
+      expect(coversAllChecks(content)).toBe(false)
+    })
+
+    it('returns false for free-text-only instructions', () => {
+      const content = '## Periodic checks\nMonitor if any new transactions appeared in the profiler'
+      expect(coversAllChecks(content)).toBe(false)
+    })
+
+    it('ignores informational sections the agent wrote for context', () => {
+      const content = [
+        '# Heartbeat Checks',
+        '- [ ] Check https://github.com/acme/app/pull/42 for new comments',
+        '',
+        '## Current Status',
+        '- 2026-07-28: Production validation confirmed the query performs a COLLSCAN.',
+        '',
+        '## Latest Finding',
+        '- Query Stats recorded 17 executions returning zero documents.',
+      ].join('\n')
+      expect(coversAllChecks(content)).toBe(true)
+    })
+
+    it('still requires an LLM when a non-GitHub check follows an informational section', () => {
+      const content = [
+        '## Current Status',
+        '- 2026-07-28: Opened https://github.com/acme/app/pull/42.',
+        '',
+        '## Periodic checks',
+        'Monitor if any new transactions appeared in the profiler',
+      ].join('\n')
+      expect(coversAllChecks(content)).toBe(false)
+    })
+
+    it('ignores headings, horizontal rules, blockquotes and code fences', () => {
+      const content = [
+        '# Heartbeat Checks',
+        '---',
+        '> Reminder: read-only checks only',
+        '```bash',
+        'gh pr view 42',
+        '```',
+        '- [ ] Check https://github.com/acme/app/pull/42 for new comments',
+      ].join('\n')
+      expect(coversAllChecks(content)).toBe(true)
+    })
+
+    it('returns false when the file has no check lines at all', () => {
+      expect(coversAllChecks('# Heartbeat Checks\n\n## Current Status')).toBe(false)
+    })
+  })
+
+  // ── runPreflightChecks ───────────────────────────────────
+
+  describe('runPreflightChecks', () => {
+    const runPreflight = (scheduler: HeartbeatScheduler, content: string, task: TaskRecord) =>
+      (scheduler as unknown as {
+        runPreflightChecks: (heartbeatContent: string, task: TaskRecord) => Promise<string>
+      }).runPreflightChecks(content, task)
+
+    /** A PR with nothing new: no failed checks, no comments/reviews, no conflicts. */
+    const quietPr = (argv: string[]): string => {
+      const jq = argv[argv.indexOf('--jq') + 1]
+      if (jq === '.head.sha') return 'abc1234'
+      if (jq.startsWith('{ mergeable')) {
+        return JSON.stringify({ mergeable: true, mergeable_state: 'clean', head_sha: 'abc1234' })
+      }
+      return '0'
+    }
+
+    beforeEach(() => ghStub.reset(quietPr))
+    afterEach(() => ghStub.reset())
+
+    it('does not skip the LLM when the heartbeat mixes PR links with free-text checks', async () => {
+      // Regression: a quiet PR used to short-circuit the whole file to
+      // 'no_changes', so the free-text instruction was never actually checked.
+      const content = [
+        '## Periodic checks',
+        'Monitor if any new transactions appeared in the profiler',
+        '',
+        '## Heartbeat Checks',
+        '- [ ] Check https://github.com/acme/app/pull/42 for new review comments',
+      ].join('\n')
+
+      const result = await runPreflight(scheduler, content, makeTask())
+
+      expect(result).toBe('inconclusive')
+      expect(ghStub.calls).toHaveLength(0) // bails out before spending gh calls
+    })
+
+    it('returns inconclusive without any gh calls for free-text-only heartbeats', async () => {
+      const result = await runPreflight(
+        scheduler,
+        '## Periodic checks\nMonitor if any new transactions appeared in the profiler',
+        makeTask()
+      )
+
+      expect(result).toBe('inconclusive')
+      expect(ghStub.calls).toHaveLength(0)
+    })
+
+    it('still skips the LLM when a GitHub-only heartbeat has nothing new', async () => {
+      const content = [
+        '# Heartbeat Checks',
+        '- [ ] Check https://github.com/acme/app/pull/42 for new review comments',
+        '',
+        '## Current Status',
+        '- 2026-07-28: PR opened, all checks green.',
+      ].join('\n')
+
+      const result = await runPreflight(scheduler, content, makeTask())
+
+      expect(result).toBe('no_changes')
+      expect(ghStub.calls.length).toBeGreaterThan(0)
+    })
+
+    it('detects a failed CI run on a GitHub-only heartbeat', async () => {
+      ghStub.reset((argv) => {
+        const jq = argv[argv.indexOf('--jq') + 1]
+        if (jq === '.head.sha') return 'abc1234'
+        return argv[1].endsWith('/check-runs') ? '1' : '0'
+      })
+
+      const result = await runPreflight(
+        scheduler,
+        '# Heartbeat Checks\n- [ ] Verify CI on https://github.com/acme/app/pull/42',
+        makeTask()
+      )
+
+      expect(result).toBe('changes_detected')
     })
   })
 

--- a/src/main/heartbeat-scheduler.ts
+++ b/src/main/heartbeat-scheduler.ts
@@ -11,6 +11,19 @@ import { HeartbeatStatus, HEARTBEAT_OK_TOKEN, HEARTBEAT_INFO_TOKEN, HEARTBEAT_DE
 const execFileAsync = promisify(execFile)
 
 /**
+ * Matches a GitHub PR/issue URL. Non-global so it is safe for repeated `.test()`
+ * calls (a global regex would carry `lastIndex` between calls).
+ */
+const GITHUB_URL_PATTERN = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/(?:pull|issues)\/\d+/
+
+/**
+ * Headings whose body is context the agent wrote for itself (status logs, past
+ * findings, notes) rather than instructions to run. Lines under these headings
+ * are not treated as checks when deciding whether pre-flight covers the file.
+ */
+const INFORMATIONAL_HEADING_PATTERN = /(status|finding|note|context|history|summary|progress|log|result)/i
+
+/**
  * HeartbeatScheduler - Periodic monitoring of tasks in ready_for_review status
  *
  * Inspired by OpenClaw's heartbeat pattern, this scheduler:
@@ -685,6 +698,15 @@ export class HeartbeatScheduler {
       return 'inconclusive' // No URLs to check — need LLM
     }
 
+    // Pre-flight can only clear a heartbeat when EVERY check in the file is a
+    // GitHub check it knows how to verify with `gh api`. A file that mixes PR
+    // links with free-text instructions (e.g. "Monitor if any new transactions
+    // appeared in the profiler") would otherwise be marked 'no_changes' purely
+    // because GitHub was quiet, and the free-text checks would silently never run.
+    if (!this.preflightCoversAllChecks(heartbeatContent)) {
+      return 'inconclusive'
+    }
+
     const lastCheck = task.heartbeat_last_check_at
     if (!lastCheck) {
       return 'inconclusive' // First check — need LLM to establish baseline
@@ -751,6 +773,51 @@ export class HeartbeatScheduler {
 
   private requiresLlmCurrentStateChecks(heartbeatContent: string): boolean {
     return /(requested changes|request changes)/i.test(heartbeatContent)
+  }
+
+  /**
+   * Whether every check in heartbeat.md is a GitHub check that pre-flight can
+   * verify on its own. Only then may pre-flight report 'no_changes' and skip the
+   * LLM entirely.
+   *
+   * A "check line" is any non-empty line that is not a heading, horizontal rule,
+   * blockquote, or fenced code — minus the bodies of purely informational
+   * sections (`## Current Status`, `## Latest Finding`, …), which agents use to
+   * record context rather than instructions.
+   *
+   * Returns false when there are no check lines at all: an instruction-free file
+   * gives pre-flight nothing to reason about, so the LLM should look at it.
+   */
+  private preflightCoversAllChecks(heartbeatContent: string): boolean {
+    let inCodeFence = false
+    let inInformationalSection = false
+    let checkLines = 0
+
+    for (const rawLine of heartbeatContent.split('\n')) {
+      const line = rawLine.trim()
+      if (!line) continue
+
+      if (/^(```|~~~)/.test(line)) {
+        inCodeFence = !inCodeFence
+        continue
+      }
+      if (inCodeFence) continue
+
+      // Horizontal rules — `---`/`***`/`___` only, never a `- [ ]` list item
+      if (/^(-{3,}|\*{3,}|_{3,})$/.test(line)) continue
+      if (line.startsWith('>')) continue
+
+      if (line.startsWith('#')) {
+        inInformationalSection = INFORMATIONAL_HEADING_PATTERN.test(line)
+        continue
+      }
+      if (inInformationalSection) continue
+
+      checkLines++
+      if (!GITHUB_URL_PATTERN.test(line)) return false
+    }
+
+    return checkLines > 0
   }
 
   private hasMergeConflicts(prState: { mergeable: boolean | null; mergeable_state?: string | null }): boolean {


### PR DESCRIPTION
## Problem

A heartbeat whose instructions are free text never got checked by the LLM — because one unrelated PR link elsewhere in the same file silenced the whole file.

`runPreflightChecks()` treats the presence of **any** GitHub URL in `heartbeat.md` as authority over the entire file. If `gh api` reports no new comments / reviews / CI failures / conflicts on that PR, it returns `no_changes`, and `runHeartbeat()` takes that as "nothing to do" and skips the LLM session entirely. Every non-GitHub instruction in the file is then silently never evaluated.

The reported task's `heartbeat.md` is 5.4 KB, and contains exactly **one** GitHub URL — buried in a findings note, not even a check:

```
## Latest Findings
- The PO matching aggregation wrapped `_id`, `issuerId`, ... Fix: https://github.com/peakflo/upload-functions/pull/9685.

## Heartbeat Checks
- [ ] Create `issuerId_1_scheduledDate_1` on `billing.bills`, then verify ...
- [ ] Recheck the next hourly Query Stats window ...
- [ ] Rewrite and test the AIExtractor company-alias aggregation ...
- [ ] Replace the repeated tax-embedding anti-join ...
```

None of the actual checks are GitHub checks. All of them were being skipped. Running the real file through the current code confirms it:

```
GITHUB_URLS_FOUND        = [{"owner":"peakflo","repo":"upload-functions","type":"pull","number":9685}]
OLD_CODE_TAKES_FAST_PATH = true
NEW_CODE_TAKES_FAST_PATH = false
```

`heartbeat_logs` for that task shows the fast path swallowing 8 consecutive runs over ~8 hours:

```
2026-07-31T02:04:14Z | ok | Pre-flight: no changes detected (LLM skipped)
2026-07-31T00:03:39Z | ok | Pre-flight: no changes detected (LLM skipped)
2026-07-30T22:02:44Z | ok | Pre-flight: no changes detected (LLM skipped)
...
```

(That log line is emitted only on `no_changes`, which is unreachable when zero URLs are extracted — so this is proof the file had the link, not an inference.)

The single escape hatch, `requiresLlmCurrentStateChecks()`, only matches `/requested changes/`, so it does not help.

Note: a heartbeat containing *no* GitHub URL at all already works correctly — pre-flight returns `inconclusive` and the LLM runs. The bug needs a URL to be present somewhere in the file.

## Fix

Pre-flight may short-circuit only when **every check line carries a GitHub URL** it can verify with `gh api` (`preflightCoversAllChecks`). Anything else returns `inconclusive`, which routes to the LLM exactly as before.

To keep the cost optimisation for genuinely GitHub-only heartbeats, bodies of purely informational sections (`## Latest Findings`, `## Current Status`, `## Notes`, …) are not treated as checks — agents write those to record context, not instructions. That is also why the incidental PR link above no longer counts as coverage. Headings, horizontal rules, blockquotes and fenced code are skipped too.

The guard runs before any `gh` call, so mixed files no longer pay for API round-trips whose result would be discarded.

## Test plan

- [x] Regression test reproduces the production shape (quiet PR link + free-text check) — returned `no_changes` before, `inconclusive` now; verified failing against the unfixed code with `expected 'no_changes' to be 'inconclusive'`
- [x] Verified against the actual 5.4 KB production `heartbeat.md` (see output above)
- [x] Control tests confirm the fast path survives — a GitHub-only heartbeat with a quiet PR still returns `no_changes`, and a failed check-run still returns `changes_detected`
- [x] `gh` is stubbed in tests, so pre-flight no longer hits the network
- [x] `pnpm test:main` — 978 passed / 51 files
- [x] `pnpm typecheck` clean; `eslint` clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)