### PR TITLE
fix: coalesce transcript changed emissions

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -2878,7 +2878,10 @@ describe('AgentManager durable transcript write-through', () => {
     const mockDb = createMockDb({})
     const upserted: Array<{ taskId: string; parts: Array<{ id: string; role?: string; content?: string; partType?: string }> }> = []
     Object.assign(mockDb as any, {
-      upsertTranscriptParts: vi.fn((taskId: string, parts: never[]) => { upserted.push({ taskId, parts }) }),
+      upsertTranscriptParts: vi.fn((taskId: string, parts: never[]) => {
+        upserted.push({ taskId, parts })
+        return { maxRev: upserted.length, changedPartIds: [] }
+      }),
       hasTranscriptParts: vi.fn(() => false),
       getTranscriptParts: vi.fn(() => [])
     })
@@ -2942,6 +2945,49 @@ describe('AgentManager durable transcript write-through', () => {
 
     await expect(mgr.getTranscriptSnapshot('task-1')).resolves.toEqual(rows)
     expect((mockDb as any).getTranscriptParts).toHaveBeenCalledWith('task-1', undefined)
+  })
+
+  it('coalesces transcript:changed emissions per task behind one trailing delta read', () => {
+    vi.useFakeTimers()
+    try {
+      const mockDb = createMockDb({})
+      const sent: Array<{ channel: string; data: unknown }> = []
+      let rev = 0
+      Object.assign(mockDb as any, {
+        upsertTranscriptParts: vi.fn((_taskId: string, parts: Array<{ id: string }>) => {
+          rev += parts.length
+          return { maxRev: rev, changedPartIds: parts.map((p) => p.id) }
+        }),
+        getTranscriptDelta: vi.fn((taskId: string, sinceRev: number) => ({
+          maxRev: rev,
+          parts: [
+            { taskId, partId: 'p1', seq: 1, role: 'assistant', content: 'one', createdAt: 1, updatedAt: 1, rev: 1 },
+            { taskId, partId: 'p2', seq: 2, role: 'assistant', content: 'two', createdAt: 2, updatedAt: 2, rev: 2 },
+            { taskId, partId: 'p3', seq: 3, role: 'assistant', content: 'three', createdAt: 3, updatedAt: 3, rev: 3 }
+          ].filter((p) => p.rev > sinceRev)
+        }))
+      })
+      const mgr = new AgentManager(mockDb)
+      mgr.addExternalListener((channel, data) => sent.push({ channel, data }))
+
+      ;(mgr as any).sendToRenderer('agent:output', { taskId: 'task-1', data: { id: 'p1', role: 'assistant', content: 'one', partType: 'text' } })
+      ;(mgr as any).sendToRenderer('agent:output', { taskId: 'task-1', data: { id: 'p2', role: 'assistant', content: 'two', partType: 'text' } })
+      ;(mgr as any).sendToRenderer('agent:output', { taskId: 'task-1', data: { id: 'p3', role: 'assistant', content: 'three', partType: 'text' } })
+
+      expect((mockDb as any).getTranscriptDelta).not.toHaveBeenCalled()
+      expect(sent.filter((e) => e.channel === 'transcript:changed')).toHaveLength(0)
+
+      vi.advanceTimersByTime(125)
+
+      expect((mockDb as any).getTranscriptDelta).toHaveBeenCalledOnce()
+      expect((mockDb as any).getTranscriptDelta).toHaveBeenCalledWith('task-1', 0)
+      const transcriptEvents = sent.filter((e) => e.channel === 'transcript:changed')
+      expect(transcriptEvents).toHaveLength(1)
+      expect(transcriptEvents[0].data).toMatchObject({ taskId: 'task-1', maxRev: 3 })
+      expect((transcriptEvents[0].data as { parts: Array<{ partId: string }> }).parts.map((p) => p.partId)).toEqual(['p1', 'p2', 'p3'])
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -259,6 +259,9 @@ export class AgentManager extends EventEmitter {
   // the data to the UI within ~50ms instead of waiting up to 2 seconds.
   private nudgeTimer: ReturnType<typeof setTimeout> | null = null
   private static readonly NUDGE_DELAY_MS = 50
+  private transcriptChangedTimer: ReturnType<typeof setTimeout> | null = null
+  private pendingTranscriptChanged = new Map<string, { sinceRev: number; maxRev: number }>()
+  private static readonly TRANSCRIPT_CHANGED_FLUSH_MS = 125
   private pollingInProgress = false  // Prevents overlapping tick() calls
   private pollTickFn: (() => Promise<void>) | null = null  // Reference to the tick function
 
@@ -4868,14 +4871,15 @@ Important:
       }))
 
     if (parts.length > 0) {
-      const { maxRev, changedPartIds } = this.db.upsertTranscriptParts(taskId, parts)
+      const result = this.db.upsertTranscriptParts(taskId, parts)
+      if (!result) return
+      const { maxRev, changedPartIds } = result
       // Event-sourced push: notify clients of the delta (the parts just written),
       // applied idempotently by part id on the client. This is BOTH the durable
       // update and the low-latency streaming path — a single authoritative source.
       if (changedPartIds.length > 0) {
         const prevRev = maxRev - changedPartIds.length
-        const { parts: deltaParts } = this.db.getTranscriptDelta(taskId, prevRev)
-        this.emitTranscriptChanged(taskId, deltaParts, maxRev)
+        this.emitTranscriptChanged(taskId, prevRev, maxRev)
       }
     }
   }
@@ -4886,7 +4890,32 @@ Important:
    * these parts into their projection cache by id; order/dedup are guaranteed by
    * the cache being keyed on part id and sorted by created_at.
    */
-  private emitTranscriptChanged(taskId: string, parts: ReturnType<DatabaseManager['getTranscriptParts']>, maxRev: number): void {
+  private emitTranscriptChanged(taskId: string, sinceRev: number, maxRev: number): void {
+    const pending = this.pendingTranscriptChanged.get(taskId)
+    this.pendingTranscriptChanged.set(taskId, {
+      sinceRev: pending ? Math.min(pending.sinceRev, sinceRev) : sinceRev,
+      maxRev: pending ? Math.max(pending.maxRev, maxRev) : maxRev
+    })
+
+    if (this.transcriptChangedTimer) return
+    this.transcriptChangedTimer = setTimeout(() => {
+      this.transcriptChangedTimer = null
+      this.flushTranscriptChanged()
+    }, AgentManager.TRANSCRIPT_CHANGED_FLUSH_MS)
+  }
+
+  private flushTranscriptChanged(): void {
+    const pending = this.pendingTranscriptChanged
+    this.pendingTranscriptChanged = new Map()
+    for (const [taskId, { sinceRev, maxRev: queuedMaxRev }] of pending) {
+      const { parts, maxRev } = this.db.getTranscriptDelta(taskId, sinceRev)
+      const effectiveMaxRev = Math.max(maxRev, queuedMaxRev)
+      if (parts.length === 0 && effectiveMaxRev <= sinceRev) continue
+      this.sendTranscriptChangedNow(taskId, parts, effectiveMaxRev)
+    }
+  }
+
+  private sendTranscriptChangedNow(taskId: string, parts: ReturnType<DatabaseManager['getTranscriptParts']>, maxRev: number): void {
     const payload = { taskId, parts, maxRev }
     if (this.mainWindow && !this.mainWindow.isDestroyed()) {
       this.mainWindow.webContents.send('transcript:changed', payload)

--- a/src/mobile/stores/agent-store.test.ts
+++ b/src/mobile/stores/agent-store.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Mock } from 'vitest'
+import { captureAnalyticsEvent } from '@/lib/analytics'
 import { onEvent } from '../api/websocket'
 import { useAgentStore, SessionStatus, __clearProjectionsForTest } from './agent-store'
 import { api, type TranscriptPartRecord } from '../api/client'
+
+vi.mock('@/lib/analytics', () => ({
+  captureAnalyticsEvent: vi.fn()
+}))
 
 // Capture the onEvent callbacks registered at store init time
 const eventHandlers = new Map<string, (payload: unknown) => void>()
@@ -113,6 +118,40 @@ describe('useAgentStore (projection model)', () => {
     it('ignores deltas with no taskId', () => {
       transcriptHandler({ parts: [part('a')], maxRev: 1 })
       expect(useAgentStore.getState().sessions.size).toBe(0)
+    })
+
+    it('batches output analytics until the task goes idle', () => {
+      setSession('task-1', SessionStatus.WORKING)
+
+      transcriptHandler({
+        taskId: 'task-1',
+        parts: [
+          part('p1', { content: 'one', rev: 1 }),
+          part('t1', { partType: 'tool', content: '', tool: { name: 'Bash', status: 'success' } as never, rev: 2 })
+        ],
+        maxRev: 2
+      })
+      transcriptHandler({
+        taskId: 'task-1',
+        parts: [part('t2', { partType: 'tool', content: '', tool: { name: 'Read', status: 'success' } as never, rev: 3 })],
+        maxRev: 3
+      })
+
+      expect(captureAnalyticsEvent).not.toHaveBeenCalledWith('agent_output_batch_received', expect.anything())
+
+      statusHandler({ sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: SessionStatus.IDLE })
+
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith('agent_output_batch_received', {
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        session_id: 'sess-1',
+        message_count: 3,
+        tool_names: ['Bash', 'Read']
+      })
+      expect(captureAnalyticsEvent).toHaveBeenCalledTimes(2)
+
+      statusHandler({ sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: SessionStatus.IDLE })
+      expect(captureAnalyticsEvent).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/mobile/stores/agent-store.ts
+++ b/src/mobile/stores/agent-store.ts
@@ -104,11 +104,13 @@ interface ProjectionCache {
 
 const projections = new Map<string, ProjectionCache>()
 const bindingTasks = new Set<string>()
+const outputAnalyticsByTask = new Map<string, { messageCount: number; toolNames: Set<string> }>()
 
 /** Test-only: reset the module-level projection cache between tests. */
 export function __clearProjectionsForTest(): void {
   projections.clear()
   bindingTasks.clear()
+  outputAnalyticsByTask.clear()
 }
 
 function getProjection(taskId: string): ProjectionCache {
@@ -185,6 +187,30 @@ export const useAgentStore = create<AgentState>((set, get) => {
     commitMessages(taskId)
   }
 
+  const accumulateOutputAnalytics = (taskId: string, parts: TranscriptPartRecord[]): void => {
+    if (parts.length === 0) return
+    const aggregate = outputAnalyticsByTask.get(taskId) || { messageCount: 0, toolNames: new Set<string>() }
+    aggregate.messageCount += parts.length
+    for (const part of parts) {
+      const toolName = (part.tool as { name?: string } | undefined)?.name
+      if (toolName) aggregate.toolNames.add(toolName)
+    }
+    outputAnalyticsByTask.set(taskId, aggregate)
+  }
+
+  const flushOutputAnalytics = (taskId: string, session: TaskSession | undefined): void => {
+    const aggregate = outputAnalyticsByTask.get(taskId)
+    if (!aggregate) return
+    outputAnalyticsByTask.delete(taskId)
+    captureAnalyticsEvent('agent_output_batch_received', {
+      task_id: taskId,
+      agent_id: session?.agentId,
+      session_id: session?.sessionId,
+      message_count: aggregate.messageCount,
+      tool_names: Array.from(aggregate.toolNames).sort()
+    })
+  }
+
   const bindTranscript = async (taskId: string): Promise<void> => {
     if (!taskId || bindingTasks.has(taskId)) return
     bindingTasks.add(taskId)
@@ -219,20 +245,7 @@ export const useAgentStore = create<AgentState>((set, get) => {
     const event = payload as { taskId?: string; parts?: TranscriptPartRecord[]; maxRev?: number }
     if (!event?.taskId) return
     applyParts(event.taskId, event.parts || [], event.maxRev)
-    const parts = event.parts || []
-    if (parts.length > 0) {
-      const s = get().sessions.get(event.taskId)
-      const toolNames = Array.from(
-        new Set(parts.map((p) => (p.tool as { name?: string } | undefined)?.name).filter(Boolean) as string[])
-      ).sort()
-      captureAnalyticsEvent('agent_output_batch_received', {
-        task_id: event.taskId,
-        agent_id: s?.agentId,
-        session_id: s?.sessionId,
-        message_count: parts.length,
-        tool_names: toolNames
-      })
-    }
+    accumulateOutputAnalytics(event.taskId, event.parts || [])
   })
 
   // Session state only (status / sessionId) — never messages.
@@ -263,6 +276,9 @@ export const useAgentStore = create<AgentState>((set, get) => {
     // "starting". Interim `idle` events during resume must NOT clear it.
     if (event.status !== SessionStatus.IDLE) updated.pendingSend = false
     set({ sessions: new Map(state.sessions).set(session.taskId, updated) })
+    if (previousStatus !== SessionStatus.IDLE && event.status === SessionStatus.IDLE) {
+      flushOutputAnalytics(session.taskId, updated)
+    }
     if (previousStatus !== event.status) {
       captureAnalyticsEvent('agent_session_status_changed', {
         task_id: session.taskId,

--- a/src/renderer/src/stores/agent-store.test.ts
+++ b/src/renderer/src/stores/agent-store.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Mock } from 'vitest'
+import { captureAnalyticsEvent } from '@/lib/analytics'
 import { useAgentStore, SessionStatus, __clearProjectionsForTest } from './agent-store'
 import type { Agent, CreateAgentDTO, UpdateAgentDTO } from '@/types'
 import type { AgentStatusEvent, TranscriptPartRecord, TranscriptChangedEvent } from '@/types/electron'
+
+vi.mock('@/lib/analytics', () => ({
+  captureAnalyticsEvent: vi.fn()
+}))
 
 const mockElectronAPI = window.electronAPI
 
@@ -182,6 +187,34 @@ describe('useAgentStore', () => {
       const msgs = useAgentStore.getState().sessions.get('task-1')!.messages
       expect(msgs.find((m) => m.id === 't1')!.tool?.name).toBe('Bash')
       expect(msgs.find((m) => m.id === 'tp1')!.taskProgress?.status).toBe('running')
+    })
+
+    it('batches output analytics until the task goes idle', () => {
+      useAgentStore.getState().initSession('task-1', 'sess-1', 'agent-1')
+
+      fireDelta('task-1', [
+        part({ partId: 'p1', content: 'one', rev: 1 }),
+        part({ partId: 't1', partType: 'tool', content: '', tool: { name: 'Bash', status: 'success' } as never, rev: 2 })
+      ], 2)
+      fireDelta('task-1', [
+        part({ partId: 't2', partType: 'tool', content: '', tool: { name: 'Read', status: 'success' } as never, rev: 3 })
+      ], 3)
+
+      expect(captureAnalyticsEvent).not.toHaveBeenCalledWith('agent_output_batch_received', expect.anything())
+
+      statusCallback!({ sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: SessionStatus.IDLE })
+
+      expect(captureAnalyticsEvent).toHaveBeenCalledWith('agent_output_batch_received', {
+        task_id: 'task-1',
+        agent_id: 'agent-1',
+        session_id: 'sess-1',
+        message_count: 3,
+        tool_names: ['Bash', 'Read']
+      })
+      expect(captureAnalyticsEvent).toHaveBeenCalledTimes(2)
+
+      statusCallback!({ sessionId: 'sess-1', agentId: 'agent-1', taskId: 'task-1', status: SessionStatus.IDLE })
+      expect(captureAnalyticsEvent).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/renderer/src/stores/agent-store.ts
+++ b/src/renderer/src/stores/agent-store.ts
@@ -97,6 +97,7 @@ interface ProjectionCache {
 
 const projections = new Map<string, ProjectionCache>()
 const bindingTasks = new Set<string>()
+const outputAnalyticsByTask = new Map<string, { messageCount: number; toolNames: Set<string> }>()
 
 function getProjection(taskId: string): ProjectionCache {
   let p = projections.get(taskId)
@@ -112,6 +113,7 @@ function resetProjection(taskId: string): void {
 export function __clearProjectionsForTest(): void {
   projections.clear()
   bindingTasks.clear()
+  outputAnalyticsByTask.clear()
 }
 
 function toAgentMessage(p: TranscriptPartRecord): AgentMessage {
@@ -195,6 +197,30 @@ export const useAgentStore = create<AgentState>((set, get) => {
     commitMessages(taskId)
   }
 
+  const accumulateOutputAnalytics = (taskId: string, parts: TranscriptPartRecord[]): void => {
+    if (parts.length === 0) return
+    const aggregate = outputAnalyticsByTask.get(taskId) || { messageCount: 0, toolNames: new Set<string>() }
+    aggregate.messageCount += parts.length
+    for (const part of parts) {
+      const toolName = (part.tool as { name?: string } | undefined)?.name
+      if (toolName) aggregate.toolNames.add(toolName)
+    }
+    outputAnalyticsByTask.set(taskId, aggregate)
+  }
+
+  const flushOutputAnalytics = (taskId: string, session: TaskSession | undefined): void => {
+    const aggregate = outputAnalyticsByTask.get(taskId)
+    if (!aggregate) return
+    outputAnalyticsByTask.delete(taskId)
+    captureAnalyticsEvent('agent_output_batch_received', {
+      task_id: taskId,
+      agent_id: session?.agentId,
+      session_id: session?.sessionId,
+      message_count: aggregate.messageCount,
+      tool_names: Array.from(aggregate.toolNames).sort()
+    })
+  }
+
   const hydrateTranscript = async (taskId: string): Promise<void> => {
     if (!taskId || bindingTasks.has(taskId)) return
     if (typeof window.electronAPI?.agentSession?.getTranscriptSnapshot !== 'function') return
@@ -234,20 +260,7 @@ export const useAgentStore = create<AgentState>((set, get) => {
   onTranscriptChanged((event: TranscriptChangedEvent) => {
     if (!event?.taskId) return
     applyParts(event.taskId, event.parts || [], event.maxRev)
-    const parts = event.parts || []
-    if (parts.length > 0) {
-      const s = get().sessions.get(event.taskId)
-      const toolNames = Array.from(
-        new Set(parts.map((p) => (p.tool as { name?: string } | undefined)?.name).filter(Boolean) as string[])
-      ).sort()
-      captureAnalyticsEvent('agent_output_batch_received', {
-        task_id: event.taskId,
-        agent_id: s?.agentId,
-        session_id: s?.sessionId,
-        message_count: parts.length,
-        tool_names: toolNames
-      })
-    }
+    accumulateOutputAnalytics(event.taskId, event.parts || [])
   })
 
   // Session state only (status / pendingApproval / sessionId) — never messages.
@@ -291,6 +304,9 @@ export const useAgentStore = create<AgentState>((set, get) => {
     // "starting". Interim `idle` events during resume must NOT clear it.
     if (event.status !== SessionStatus.IDLE) updated.pendingSend = false
     set({ sessions: new Map(state.sessions).set(session.taskId, updated) })
+    if (previousStatus !== SessionStatus.IDLE && event.status === SessionStatus.IDLE) {
+      flushOutputAnalytics(session.taskId, updated)
+    }
     if (previousStatus !== event.status) {
       captureAnalyticsEvent('agent_session_status_changed', {
         task_id: session.taskId,


### PR DESCRIPTION
## Summary
- Coalesce durable transcript change notifications per task behind a 125ms trailing timer so rapid persisted chunks produce one delta read and one `transcript:changed` delivery per tick.
- Defer desktop and mobile `agent_output_batch_received` analytics aggregation until the task transitions idle, avoiding Set/sort work on every streamed delta.
- Add regression coverage for main-process transcript coalescing and desktop/mobile analytics batching.

## Test plan
- `pnpm test -- run src/main/agent-manager.test.ts src/renderer/src/stores/agent-store.test.ts src/mobile/stores/agent-store.test.ts`
- `pnpm typecheck`
- `pnpm lint -- src/main/agent-manager.ts src/main/agent-manager.test.ts src/renderer/src/stores/agent-store.ts src/renderer/src/stores/agent-store.test.ts src/mobile/stores/agent-store.ts src/mobile/stores/agent-store.test.ts` (0 errors; existing repo warnings)
- `pnpm test -- run` attempted; blocked by local `better-sqlite3` native binding missing after Node 26 compile failure

Generated with Codex