### PR TITLE
perf: stabilize TaskWorkspace prop identities

### DIFF
--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo, lazy, Suspense } from 'react'
+import { useEffect, useState, useCallback, useMemo, useRef, lazy, Suspense } from 'react'
 import { Sidebar } from './Sidebar'
 import { TaskWorkspace } from '@/components/tasks/TaskWorkspace'
 import { InfiniteCanvas } from '@/components/canvas/InfiniteCanvas'
@@ -18,6 +18,7 @@ const OrchestratorPanel = lazy(() => import('@/components/orchestrator/Orchestra
 import { useTasks } from '@/hooks/use-tasks'
 import { useUIStore } from '@/stores/ui-store'
 import { useAgentStore } from '@/stores/agent-store'
+import { useTaskStore } from '@/stores/task-store'
 import { useAgentAutoStart } from '@/hooks/use-agent-auto-start'
 import { useOverdueNotifications } from '@/hooks/use-overdue-notifications'
 import { attachmentApi, worktreeApi, settingsApi, updaterApi } from '@/lib/ipc-client'
@@ -25,7 +26,7 @@ import { useTaskSourceStore } from '@/stores/task-source-store'
 import { isOverdue, isSnoozed } from '@/lib/utils'
 import { captureAnalyticsEvent, capturePageView } from '@/lib/analytics'
 import { TaskStatus, PluginActionId } from '@/types'
-import type { FileAttachment } from '@/types'
+import type { FileAttachment, OutputField, UpdateTaskDTO } from '@/types'
 import { MessageSquare, ExternalLink, LayoutDashboard, CheckSquare, Zap, Settings, Layers, PanelLeftClose, PanelLeftOpen, Search } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { ThemeToggle } from './ThemeToggle'
@@ -127,12 +128,118 @@ export function AppLayout() {
     () => dashboardPreviewTaskId ? allTasks.find((t) => t.id === dashboardPreviewTaskId) : undefined,
     [dashboardPreviewTaskId, allTasks]
   )
+  const filteredTasksRef = useRef(tasks)
+  filteredTasksRef.current = tasks
 
   const handleGoToFullView = useCallback((taskId: string) => {
     closeDashboardPreview()
     selectTask(taskId)
     setSidebarView('tasks')
   }, [closeDashboardPreview, selectTask, setSidebarView])
+
+  const [toast, setToast] = useState<{ message: string; isError?: boolean } | null>(null)
+  const showToast = useCallback((message: string, isError?: boolean) => {
+    setToast({ message, isError })
+    setTimeout(() => setToast(null), isError ? 5000 : 3000)
+  }, [])
+
+  const getLatestTask = useCallback(
+    (taskId: string | null | undefined) => (
+      taskId ? useTaskStore.getState().tasks.find((t) => t.id === taskId) : undefined
+    ),
+    []
+  )
+
+  const completeTask = useCallback(
+    async (taskId: string, options?: { selectNextTask?: boolean }) => {
+      const task = getLatestTask(taskId)
+      if (!task) return
+      const taskTitle = task.title
+      try {
+        if (task.source_id) {
+          const actionField = task.output_fields.find((f) => f.id === 'action')
+          const actionValue = actionField?.value ? String(actionField.value) : PluginActionId.Complete
+          const result = await executeAction(actionValue, task.id, task.source_id)
+          if (!result.success) {
+            showToast(result.error || 'Failed to complete task', true)
+            return
+          }
+        }
+        await updateTask(task.id, { status: TaskStatus.Completed })
+      } catch (err) {
+        console.error('Failed to complete task:', err)
+        showToast('Failed to complete task', true)
+        return
+      }
+
+      if (options?.selectNextTask) {
+        const activeTasks = filteredTasksRef.current.filter((t) => t.id !== task.id && t.status !== TaskStatus.Completed)
+        selectTask(activeTasks.length > 0 ? activeTasks[0].id : null)
+      }
+      showToast(`"${taskTitle}" completed`)
+    },
+    [executeAction, getLatestTask, selectTask, showToast, updateTask]
+  )
+
+  const selectedTaskId = selectedTask?.id
+  const handleEditSelectedTask = useCallback(() => {
+    if (selectedTaskId) openEditModal(selectedTaskId)
+  }, [openEditModal, selectedTaskId])
+  const handleDeleteSelectedTask = useCallback(() => {
+    if (selectedTaskId) openDeleteModal(selectedTaskId)
+  }, [openDeleteModal, selectedTaskId])
+  const handleUpdateSelectedAttachments = useCallback(
+    async (attachments: FileAttachment[]) => {
+      if (selectedTaskId) await updateTask(selectedTaskId, { attachments })
+    },
+    [selectedTaskId, updateTask]
+  )
+  const handleUpdateSelectedOutputFields = useCallback(
+    async (output_fields: OutputField[]) => {
+      if (selectedTaskId) await updateTask(selectedTaskId, { output_fields })
+    },
+    [selectedTaskId, updateTask]
+  )
+  const handleCompleteSelectedTask = useCallback(async () => {
+    if (selectedTaskId) await completeTask(selectedTaskId, { selectNextTask: true })
+  }, [completeTask, selectedTaskId])
+
+  const handleAssignAgent = useCallback(async (taskId: string, agentId: string | null) => {
+    await updateTask(taskId, { agent_id: agentId })
+  }, [updateTask])
+  const handleUpdateTask = useCallback(async (taskId: string, data: Record<string, unknown>) => {
+    await updateTask(taskId, data as UpdateTaskDTO)
+  }, [updateTask])
+  const handleNavigateToTask = useCallback((taskId: string) => selectTask(taskId), [selectTask])
+
+  const handleEditDashboardPreviewTask = useCallback(() => {
+    if (dashboardPreviewTaskId) openEditModal(dashboardPreviewTaskId)
+  }, [dashboardPreviewTaskId, openEditModal])
+  const handleDeleteDashboardPreviewTask = useCallback(() => {
+    if (dashboardPreviewTaskId) openDeleteModal(dashboardPreviewTaskId)
+  }, [dashboardPreviewTaskId, openDeleteModal])
+  const handleUpdateDashboardPreviewAttachments = useCallback(
+    async (attachments: FileAttachment[]) => {
+      if (dashboardPreviewTaskId) await updateTask(dashboardPreviewTaskId, { attachments })
+    },
+    [dashboardPreviewTaskId, updateTask]
+  )
+  const handleUpdateDashboardPreviewOutputFields = useCallback(
+    async (output_fields: OutputField[]) => {
+      if (dashboardPreviewTaskId) await updateTask(dashboardPreviewTaskId, { output_fields })
+    },
+    [dashboardPreviewTaskId, updateTask]
+  )
+  const handleCompleteDashboardPreviewTask = useCallback(async () => {
+    if (dashboardPreviewTaskId) await completeTask(dashboardPreviewTaskId)
+  }, [completeTask, dashboardPreviewTaskId])
+  const handleNavigateFromDashboardPreview = useCallback(
+    (taskId: string) => {
+      closeDashboardPreview()
+      handleGoToFullView(taskId)
+    },
+    [closeDashboardPreview, handleGoToFullView]
+  )
 
   const overdueCount = useMemo(
     () => tasks.filter(
@@ -142,12 +249,6 @@ export function AppLayout() {
   )
 
   useOverdueNotifications(tasks)
-
-  const [toast, setToast] = useState<{ message: string; isError?: boolean } | null>(null)
-  const showToast = useCallback((message: string, isError?: boolean) => {
-    setToast({ message, isError })
-    setTimeout(() => setToast(null), isError ? 5000 : 3000)
-  }, [])
 
   const [onboardingOpen, setOnboardingOpen] = useState(false)
 
@@ -390,53 +491,14 @@ export function AppLayout() {
               <TaskWorkspace
               task={selectedTask}
               agents={agents}
-              onEdit={() => {
-                if (selectedTask) openEditModal(selectedTask.id)
-              }}
-              onDelete={() => {
-                if (selectedTask) openDeleteModal(selectedTask.id)
-              }}
-              onUpdateAttachments={async (attachments: FileAttachment[]) => {
-                if (selectedTask) {
-                  await updateTask(selectedTask.id, { attachments })
-                }
-              }}
-              onUpdateOutputFields={async (output_fields) => {
-                if (selectedTask) {
-                  await updateTask(selectedTask.id, { output_fields })
-                }
-              }}
-              onCompleteTask={async () => {
-                if (!selectedTask) return
-                const taskTitle = selectedTask.title
-                try {
-                  if (selectedTask.source_id) {
-                    const actionField = selectedTask.output_fields.find((f) => f.id === 'action')
-                    const actionValue = actionField?.value ? String(actionField.value) : PluginActionId.Complete
-                    const result = await executeAction(actionValue, selectedTask.id, selectedTask.source_id)
-                    if (!result.success) {
-                      showToast(result.error || 'Failed to complete task', true)
-                      return
-                    }
-                  }
-                  await updateTask(selectedTask.id, { status: TaskStatus.Completed })
-                } catch (err) {
-                  console.error('Failed to complete task:', err)
-                  showToast('Failed to complete task', true)
-                  return
-                }
-                // Select next active task
-                const activeTasks = tasks.filter((t) => t.id !== selectedTask.id && t.status !== TaskStatus.Completed)
-                selectTask(activeTasks.length > 0 ? activeTasks[0].id : null)
-                showToast(`"${taskTitle}" completed`)
-              }}
-              onAssignAgent={async (taskId, agentId) => {
-                await updateTask(taskId, { agent_id: agentId })
-              }}
-              onUpdateTask={async (taskId, data) => {
-                await updateTask(taskId, data)
-              }}
-              onNavigateToTask={(taskId) => selectTask(taskId)}
+              onEdit={handleEditSelectedTask}
+              onDelete={handleDeleteSelectedTask}
+              onUpdateAttachments={handleUpdateSelectedAttachments}
+              onUpdateOutputFields={handleUpdateSelectedOutputFields}
+              onCompleteTask={handleCompleteSelectedTask}
+              onAssignAgent={handleAssignAgent}
+              onUpdateTask={handleUpdateTask}
+              onNavigateToTask={handleNavigateToTask}
             />
           ) : null}
           </div>
@@ -588,48 +650,14 @@ export function AppLayout() {
               <TaskWorkspace
                 task={dashboardPreviewTask}
                 agents={agents}
-                onEdit={() => {
-                  if (dashboardPreviewTask) openEditModal(dashboardPreviewTask.id)
-                }}
-                onDelete={() => {
-                  if (dashboardPreviewTask) openDeleteModal(dashboardPreviewTask.id)
-                }}
-                onUpdateAttachments={async (attachments: FileAttachment[]) => {
-                  await updateTask(dashboardPreviewTask.id, { attachments })
-                }}
-                onUpdateOutputFields={async (output_fields) => {
-                  await updateTask(dashboardPreviewTask.id, { output_fields })
-                }}
-                onCompleteTask={async () => {
-                  const taskTitle = dashboardPreviewTask.title
-                  try {
-                    if (dashboardPreviewTask.source_id) {
-                      const actionField = dashboardPreviewTask.output_fields.find((f) => f.id === 'action')
-                      const actionValue = actionField?.value ? String(actionField.value) : PluginActionId.Complete
-                      const result = await executeAction(actionValue, dashboardPreviewTask.id, dashboardPreviewTask.source_id)
-                      if (!result.success) {
-                        showToast(result.error || 'Failed to complete task', true)
-                        return
-                      }
-                    }
-                    await updateTask(dashboardPreviewTask.id, { status: TaskStatus.Completed })
-                  } catch (err) {
-                    console.error('Failed to complete task:', err)
-                    showToast('Failed to complete task', true)
-                    return
-                  }
-                  showToast(`"${taskTitle}" completed`)
-                }}
-                onAssignAgent={async (taskId, agentId) => {
-                  await updateTask(taskId, { agent_id: agentId })
-                }}
-                onUpdateTask={async (taskId, data) => {
-                  await updateTask(taskId, data)
-                }}
-                onNavigateToTask={(taskId) => {
-                  closeDashboardPreview()
-                  handleGoToFullView(taskId)
-                }}
+                onEdit={handleEditDashboardPreviewTask}
+                onDelete={handleDeleteDashboardPreviewTask}
+                onUpdateAttachments={handleUpdateDashboardPreviewAttachments}
+                onUpdateOutputFields={handleUpdateDashboardPreviewOutputFields}
+                onCompleteTask={handleCompleteDashboardPreviewTask}
+                onAssignAgent={handleAssignAgent}
+                onUpdateTask={handleUpdateTask}
+                onNavigateToTask={handleNavigateFromDashboardPreview}
               />
             )}
           </div>

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -389,7 +389,7 @@ interface TaskDetailViewProps {
   onReorderSubtasks?: (orderedIds: string[]) => void
 }
 
-export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onAddSkills, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage, onEditAgent, onUpdateDescription, onUpdateAutoFlags, subtasks, parentTask, onNavigateToTask, onOpenSubtaskInWindow, onAddSubtask, onReorderSubtasks }: TaskDetailViewProps) {
+function TaskDetailViewComponent({ task, agents, onEdit, onDelete, onUpdateAttachments, onUpdateOutputFields, onCompleteTask, onAssignAgent, onUpdateRepos, onAddRepos, onUpdateSkillIds, onAddSkills, onStartAgent, canStartAgent, onResumeAgent, canResumeAgent, onRestartAgent, canRestartAgent, onSnooze, onUnsnooze, onReassign, onTriage, canTriage, onEditAgent, onUpdateDescription, onUpdateAutoFlags, subtasks, parentTask, onNavigateToTask, onOpenSubtaskInWindow, onAddSubtask, onReorderSubtasks }: TaskDetailViewProps) {
   // Per-field selectors — a selector-less useSkillStore() re-renders this
   // large view on every skill-store mutation.
   const skills = useSkillStore((s) => s.skills)
@@ -856,3 +856,5 @@ export function TaskDetailView({ task, agents, onEdit, onDelete, onUpdateAttachm
     </div>
   )
 }
+
+export const TaskDetailView = React.memo(TaskDetailViewComponent)

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -19,7 +19,7 @@ import { useSettingsStore, type GitProvider } from '@/stores/settings-store'
 import { useTaskStore } from '@/stores/task-store'
 import { taskApi, worktreeApi, taskSourceApi, onAgentIncompatibleSession, onWorktreeProgress, attachmentApi } from '@/lib/ipc-client'
 import { subscribe } from '@/lib/shared-ipc-listeners'
-import { useEffect, useCallback, useRef, useState, useMemo } from 'react'
+import { memo, useEffect, useCallback, useRef, useState, useMemo } from 'react'
 import { TaskStatus } from '@/types'
 import type { WorkfloTask, FileAttachment, OutputField, Agent, UpdateAgentDTO, CreateAgentDTO } from '@/types'
 import type { GitHubRepo } from '@/types/electron'
@@ -37,7 +37,7 @@ interface TaskWorkspaceProps {
   onUpdateOutputFields: (fields: OutputField[]) => void
   onCompleteTask: () => void
   onAssignAgent: (taskId: string, agentId: string | null) => void
-  onUpdateTask?: (taskId: string, data: Partial<WorkfloTask>) => Promise<void>
+  onUpdateTask?: (taskId: string, data: Record<string, unknown>) => Promise<void>
   onNavigateToTask?: (taskId: string) => void
   /** When provided, each subtask shows an action to open it as a separate canvas window/panel. */
   onOpenSubtaskInWindow?: (taskId: string) => void
@@ -45,7 +45,7 @@ interface TaskWorkspaceProps {
   panelLayout?: TaskWorkspaceLayout
 }
 
-export function TaskWorkspace({
+function TaskWorkspaceComponent({
   task,
   agents,
   onEdit,
@@ -640,6 +640,37 @@ Update existing skills that were helpful or create new ones for patterns worth r
     }
   }, [task?.agent_id, task?.id, session.sessionId, start, stop, removeSession, onUpdateTask])
 
+  const handleEditAgent = useCallback((agentId: string) => setEditingAgentId(agentId), [])
+  const handleSaveAgent = useCallback(async (data: CreateAgentDTO | UpdateAgentDTO) => {
+    if (!editingAgentId) return
+    await updateAgent(editingAgentId, data as UpdateAgentDTO)
+    setEditingAgentId(null)
+  }, [editingAgentId, updateAgent])
+
+  const handleUpdateSkillIds = useCallback(async (skillIds: string[] | null) => {
+    if (task?.id && onUpdateTask) await onUpdateTask(task.id, { skill_ids: skillIds })
+  }, [onUpdateTask, task?.id])
+  const handleUpdateDescription = useCallback(async (description: string) => {
+    if (!task?.id) return
+    if (onUpdateTask) {
+      await onUpdateTask(task.id, { description })
+    } else {
+      await taskApi.update(task.id, { description })
+      updateTaskInStore(task.id, { description })
+    }
+  }, [onUpdateTask, task?.id, updateTaskInStore])
+  const handleShowSkillSelector = useCallback(() => setShowSkillSelector(true), [])
+  const handleShowSnooze = useCallback(() => setShowSnooze(true), [])
+  const handleUpdateAutoFlags = useCallback(async (updates: Record<string, unknown>) => {
+    if (!task?.id) return
+    if (onUpdateTask) {
+      await onUpdateTask(task.id, updates)
+    } else {
+      await taskApi.update(task.id, updates)
+      updateTaskInStore(task.id, updates)
+    }
+  }, [onUpdateTask, task?.id, updateTaskInStore])
+
   if (!task) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -666,12 +697,6 @@ Update existing skills that were helpful or create new ones for patterns worth r
   const canTriage = !task.agent_id && agents.length > 0 && triageAgentConfigured && session.status === SessionStatus.IDLE
     && task.status !== TaskStatus.Completed && task.status !== TaskStatus.Triaging
 
-  const handleEditAgent = (agentId: string) => setEditingAgentId(agentId)
-  const handleSaveAgent = async (data: CreateAgentDTO | UpdateAgentDTO) => {
-    if (!editingAgentId) return
-    await updateAgent(editingAgentId, data as UpdateAgentDTO)
-    setEditingAgentId(null)
-  }
   const editingAgent = editingAgentId ? agents.find((a) => a.id === editingAgentId) : undefined
 
   return (
@@ -696,39 +721,22 @@ Update existing skills that were helpful or create new ones for patterns worth r
             onAssignAgent={handleAssignAgent}
             onUpdateRepos={handleUpdateRepos}
             onAddRepos={handleAddRepos}
-            onUpdateSkillIds={async (skillIds) => {
-              if (onUpdateTask) await onUpdateTask(task.id, { skill_ids: skillIds })
-            }}
-            onUpdateDescription={onUpdateTask
-              ? async (description) => {
-                await onUpdateTask(task.id, { description })
-              }
-              : async (description) => {
-                await taskApi.update(task.id, { description })
-                updateTaskInStore(task.id, { description })
-              }
-            }
-            onAddSkills={() => setShowSkillSelector(true)}
+            onUpdateSkillIds={handleUpdateSkillIds}
+            onUpdateDescription={handleUpdateDescription}
+            onAddSkills={handleShowSkillSelector}
             onStartAgent={handleStartSession}
             canStartAgent={!!canStart}
             onResumeAgent={handleResumeSession}
             canResumeAgent={!!canResume}
             onRestartAgent={handleStartFreshSession}
             canRestartAgent={!!canRestart}
-            onSnooze={() => setShowSnooze(true)}
+            onSnooze={handleShowSnooze}
             onUnsnooze={handleUnsnooze}
             onReassign={handleReassign}
             onTriage={handleTriage}
             canTriage={!!canTriage}
             onEditAgent={handleEditAgent}
-            onUpdateAutoFlags={async (updates) => {
-              if (onUpdateTask) {
-                await onUpdateTask(task.id, updates)
-              } else {
-                await taskApi.update(task.id, updates)
-                updateTaskInStore(task.id, updates)
-              }
-            }}
+            onUpdateAutoFlags={handleUpdateAutoFlags}
             subtasks={subtasks}
             parentTask={parentTask}
             onNavigateToTask={onNavigateToTask}
@@ -850,3 +858,5 @@ Update existing skills that were helpful or create new ones for patterns worth r
     </>
   )
 }
+
+export const TaskWorkspace = memo(TaskWorkspaceComponent)

--- a/src/renderer/src/hooks/use-agent-session.ts
+++ b/src/renderer/src/hooks/use-agent-session.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { agentSessionApi } from '@/lib/ipc-client'
 import { useAgentStore, SessionStatus } from '@/stores/agent-store'
 import { captureAnalyticsEvent } from '@/lib/analytics'
@@ -48,16 +48,31 @@ export function useAgentSession(taskId: string | undefined) {
     if (taskId && typeof hydrateTranscript === 'function') void hydrateTranscript(taskId)
   }, [taskId, hydrateTranscript])
 
-  const sessionState: AgentSessionState = session
-    ? {
-        sessionId: session.sessionId,
-        status: session.status,
-        messages: session.messages,
-        pendingApproval: session.pendingApproval,
-        systemStatus: session.systemStatus,
-        pendingSend: session.pendingSend
-      }
-    : EMPTY_SESSION
+  // Project the store session into a stable value. Keyed on individual fields so
+  // the returned object keeps identity across unrelated store deltas (e.g. a new
+  // session Map identity that leaves these fields referentially equal). This lets
+  // downstream React.memo boundaries actually bail out.
+  const sessionState: AgentSessionState = useMemo(
+    () =>
+      session
+        ? {
+            sessionId: session.sessionId,
+            status: session.status,
+            messages: session.messages,
+            pendingApproval: session.pendingApproval,
+            systemStatus: session.systemStatus,
+            pendingSend: session.pendingSend
+          }
+        : EMPTY_SESSION,
+    [
+      session?.sessionId,
+      session?.status,
+      session?.messages,
+      session?.pendingApproval,
+      session?.systemStatus,
+      session?.pendingSend
+    ]
+  )
 
   const start = useCallback(
     async (agentId: string, tId: string, workspaceDir?: string, skipInitialPrompt?: boolean) => {
@@ -212,5 +227,11 @@ export function useAgentSession(taskId: string | undefined) {
     [taskId]
   )
 
-  return { session: sessionState, start, resume, abort, stop, sendMessage, approve }
+  // Memoize the returned hook object so consumers that spread/destructure it (and
+  // any effect/memo keyed on the whole object) see a stable identity when nothing
+  // meaningful changed. All callbacks below are already useCallback-stable.
+  return useMemo(
+    () => ({ session: sessionState, start, resume, abort, stop, sendMessage, approve }),
+    [sessionState, start, resume, abort, stop, sendMessage, approve]
+  )
 }


### PR DESCRIPTION
## Summary
- Hoist AppLayout -> TaskWorkspace handlers into stable useCallback props for both the main task view and dashboard preview.
- Memoize TaskWorkspace and TaskDetailView, and replace TaskWorkspace -> TaskDetailView inline handlers with stable callbacks.
- Memoize the useAgentSession session projection and returned hook object so consumers keep stable identities across unrelated store churn.

## Test plan
- [x] pnpm typecheck
- [x] pnpm lint (0 errors / 122 warnings)
- [x] pnpm test:run src/renderer/src/components/tasks/TaskWorkspace.test.tsx (6 tests)
- [ ] pnpm test:run full suite locally is blocked by better-sqlite3 native binding under Node 26.4.0 after install script failure; non-SQLite suites ran and the final result was 95 files / 1429 tests passed, 5 SQLite-backed files / 158 tests failed with missing better_sqlite3.node.

Generated with Codex