### PR TITLE
perf(canvas): imperative gesture transforms — zero React work per pan/zoom/drag frame

### DIFF
--- a/src/renderer/src/components/canvas/CanvasConnections.tsx
+++ b/src/renderer/src/components/canvas/CanvasConnections.tsx
@@ -16,12 +16,20 @@ export function CanvasConnections({
   const connectingFromId = useCanvasStore((s) => s.connectingFromId)
   const proximityEdge = useCanvasStore((s) => s.proximityEdge)
   const removeEdge = useCanvasStore((s) => s.removeEdge)
+  // A dragged panel doesn't write x/y to `panels` until mouseup (see
+  // CanvasPanel) — it publishes its live position here instead. This is the
+  // only component that re-renders per drag frame, and its cost is O(edges).
+  const liveDrag = useCanvasStore((s) => s.liveDrag)
 
   const panelMap = useMemo(() => {
     const map = new Map<string, CanvasPanelData>()
     for (const p of panels) map.set(p.id, p)
+    if (liveDrag) {
+      const dragged = map.get(liveDrag.id)
+      if (dragged) map.set(dragged.id, { ...dragged, x: liveDrag.x, y: liveDrag.y })
+    }
     return map
-  }, [panels])
+  }, [panels, liveDrag])
 
   /**
    * Find the best connection anchor point on a panel edge

--- a/src/renderer/src/components/canvas/CanvasMinimap.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useRef, useState, useMemo } from 'react'
+import { useCallback, useRef, useState, useMemo, useEffect } from 'react'
 import { useCanvasStore, type CanvasPanelData, MIN_ZOOM, MAX_ZOOM } from '@/stores/canvas-store'
+import { getLiveViewport, subscribeLiveViewport } from '@/stores/canvas-live-viewport'
 import { useTaskStore } from '@/stores/task-store'
 import { Minus, Plus, Maximize2, ChevronDown, ChevronUp } from 'lucide-react'
 import { getCanvasTaskStatusStyle } from './canvas-status-style'
@@ -113,10 +114,12 @@ export function CanvasMinimap({
       const canvasX = (mx - MINIMAP_PAD) / scale + bounds.minX
       const canvasY = (my - MINIMAP_PAD) / scale + bounds.minY
 
-      // Center the viewport on this point
-      const newVpX = -(canvasX * viewport.zoom - containerWidth / 2)
-      const newVpY = -(canvasY * viewport.zoom - containerHeight / 2)
-      setViewport({ x: newVpX, y: newVpY })
+      // Center the viewport on this point (live zoom — a wheel gesture may
+      // still be in flight and not yet committed to the store)
+      const liveZoom = getLiveViewport().zoom || viewport.zoom
+      const newVpX = -(canvasX * liveZoom - containerWidth / 2)
+      const newVpY = -(canvasY * liveZoom - containerHeight / 2)
+      setViewport({ x: newVpX, y: newVpY, zoom: liveZoom })
     },
     [scale, bounds, viewport.zoom, containerWidth, containerHeight, setViewport]
   )
@@ -158,6 +161,39 @@ export function CanvasMinimap({
 
   const zoomPercent = Math.round(viewport.zoom * 100)
 
+  // ── Follow the viewport during a gesture, imperatively ──
+  // The canvas doesn't write the viewport to the store while the user is
+  // panning/zooming (see InfiniteCanvas), so the minimap can't re-render its
+  // way there. Track the live viewport and patch the rect/readouts in place —
+  // no React render, and the minimap still moves at native refresh rate.
+  const vpRectRef = useRef<SVGRectElement>(null)
+  const zoomLabelRef = useRef<HTMLSpanElement>(null)
+  const zoomSliderRef = useRef<HTMLInputElement>(null)
+  // Projection captured during render; only re-derived when the store commits.
+  const projectionRef = useRef({ minX: bounds.minX, minY: bounds.minY, scale })
+  projectionRef.current = { minX: bounds.minX, minY: bounds.minY, scale }
+
+  useEffect(() => {
+    const applyLiveViewport = (vp: { x: number; y: number; zoom: number }) => {
+      const { minX, minY, scale: s } = projectionRef.current
+      const rectEl = vpRectRef.current
+      if (rectEl && s > 0 && vp.zoom > 0) {
+        const left = -vp.x / vp.zoom
+        const top = -vp.y / vp.zoom
+        rectEl.setAttribute('x', String(MINIMAP_PAD + (left - minX) * s))
+        rectEl.setAttribute('y', String(MINIMAP_PAD + (top - minY) * s))
+        rectEl.setAttribute('width', String(Math.max(4, (containerWidth / vp.zoom) * s)))
+        rectEl.setAttribute('height', String(Math.max(3, (containerHeight / vp.zoom) * s)))
+      }
+      const label = zoomLabelRef.current
+      if (label) label.textContent = `${Math.round(vp.zoom * 100)}%`
+      const slider = zoomSliderRef.current
+      if (slider) slider.value = String(vp.zoom * 100)
+    }
+    applyLiveViewport(getLiveViewport())
+    return subscribeLiveViewport(applyLiveViewport)
+  }, [containerWidth, containerHeight, collapsed])
+
   if (panels.length === 0) return null
 
   return (
@@ -175,7 +211,7 @@ export function CanvasMinimap({
           Map
         </span>
         <div className="flex items-center gap-1">
-          <span className="text-[10px] text-muted-foreground/40 tabular-nums">
+          <span ref={zoomLabelRef} className="text-[10px] text-muted-foreground/40 tabular-nums">
             {zoomPercent}%
           </span>
           {collapsed ? (
@@ -249,6 +285,7 @@ export function CanvasMinimap({
 
             {/* Viewport rectangle */}
             <rect
+              ref={vpRectRef}
               x={vpRect.x}
               y={vpRect.y}
               width={Math.max(4, vpRect.w)}
@@ -273,6 +310,7 @@ export function CanvasMinimap({
 
             {/* Zoom slider */}
             <input
+              ref={zoomSliderRef}
               type="range"
               min={MIN_ZOOM * 100}
               max={MAX_ZOOM * 100}

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_PANEL_HEIGHT,
   type CanvasPanelData,
 } from '@/stores/canvas-store'
+import { getLiveViewport } from '@/stores/canvas-live-viewport'
 import { X, Focus, Maximize2, Minimize2, PanelLeft, PanelRight, Columns2, Globe } from 'lucide-react'
 import type { TaskWorkspaceLayout } from '@/components/tasks/TaskWorkspace'
 import { useTaskStore } from '@/stores/task-store'
@@ -18,6 +19,19 @@ import { WebPagePanelContent } from './WebPagePanelContent'
 import { TerminalPanelContent } from './TerminalPanelContent'
 import { BrowserPanelContent } from './BrowserPanelContent'
 import { getCanvasTaskStatusStyle, shouldPulseCanvasTaskStatusTransition } from './canvas-status-style'
+
+/**
+ * Off-viewport ("frozen") panel content.
+ *
+ * CSS containment stops a hidden panel's internal churn (streaming transcripts,
+ * terminal output) from invalidating canvas-level layout and paint, which keeps
+ * gesture rasterisation cheap no matter how many background panels are open.
+ *
+ * Deliberately only applied while frozen: containment makes the element a
+ * containing block for fixed-position descendants, and visible task panels
+ * render full-screen dialogs (TaskWorkspace) that must escape the panel.
+ */
+const FROZEN_CONTENT_STYLE: CSSProperties = { visibility: 'hidden', contain: 'layout paint' }
 
 interface CanvasPanelProps {
   panel: CanvasPanelData
@@ -44,6 +58,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   const focusPanel = useCanvasStore((s) => s.focusPanel)
   const setDraggingPanelId = useCanvasStore((s) => s.setDraggingPanelId)
   const setSnapGuides = useCanvasStore((s) => s.setSnapGuides)
+  const setLiveDrag = useCanvasStore((s) => s.setLiveDrag)
   // Read connectingFromId imperatively to avoid re-rendering ALL panels when it changes.
   // Only the connect button click handlers need it — not the render path.
   const setConnectingFromId = useCanvasStore((s) => s.setConnectingFromId)
@@ -57,6 +72,11 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   const [statusPulse, setStatusPulse] = useState<{ status: TaskStatus; key: number } | null>(null)
   const dragStart = useRef({ x: 0, y: 0, panelX: 0, panelY: 0 })
   const resizeStart = useRef({ x: 0, y: 0, w: 0, h: 0 })
+  // Latest imperative geometry, committed to the store on mouseup. Held in
+  // refs (not effect-local vars) so an effect re-run mid-gesture — a zoom
+  // commit changes the `zoom` prop — can't lose the in-progress position.
+  const dragCommit = useRef({ x: 0, y: 0 })
+  const resizeCommit = useRef({ w: 0, h: 0 })
   const previousTaskStatusRef = useRef<TaskStatus | undefined>(undefined)
 
   // ── Drag handling ─────────────────────────────────────────
@@ -74,6 +94,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         panelX: panel.x,
         panelY: panel.y,
       }
+      dragCommit.current = { x: panel.x, y: panel.y }
     },
     [bringToFront, panel.id, panel.x, panel.y, setDraggingPanelId]
   )
@@ -81,9 +102,17 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   useEffect(() => {
     if (!isDragging) return
 
-    // rAF-coalesce: mousemove fires at 60–120 Hz and each store write commits
-    // the whole canvas subtree. Process at most one move per frame, dropping
-    // intermediate events.
+    // Imperative drag: the panel is moved with a CSS transform inside a single
+    // rAF and the position is committed to the store ONCE, on mouseup. Writing
+    // x/y per frame (even rAF-coalesced) re-committed the entire canvas subtree
+    // — every panel wrapper, the connections layer and the minimap — 60–120
+    // times a second. Now a drag frame costs one style write.
+    const el = panelRef.current
+    const baseX = dragStart.current.panelX
+    const baseY = dragStart.current.panelY
+
+    if (el) el.style.willChange = 'transform'
+
     let rafId: number | null = null
     let lastEvent: MouseEvent | null = null
     let hadGuides = false
@@ -92,8 +121,11 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       rafId = null
       const e = lastEvent
       if (!e) return
-      const dx = (e.clientX - dragStart.current.x) / zoom
-      const dy = (e.clientY - dragStart.current.y) / zoom
+      // Read the zoom from the live viewport — during a simultaneous pinch-zoom
+      // the store value lags until the gesture commits.
+      const liveZoom = getLiveViewport().zoom || zoom || 1
+      const dx = (e.clientX - dragStart.current.x) / liveZoom
+      const dy = (e.clientY - dragStart.current.y) / liveZoom
       const newX = dragStart.current.panelX + dx
       const newY = dragStart.current.panelY + dy
 
@@ -105,10 +137,16 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         otherPanels
       )
 
-      updatePanel(panel.id, { x: snappedX, y: snappedY })
-      // Skip the write when guides stay empty — calculateSnap returns a fresh
-      // array every call, and an unconditional write re-renders the canvas
-      // even when nothing snapped.
+      dragCommit.current = { x: snappedX, y: snappedY }
+      // Move the panel on the compositor. `left`/`top` stay at the store
+      // position for the whole drag, so this delta is always well-defined.
+      if (el) el.style.transform = `translate(${snappedX - baseX}px, ${snappedY - baseY}px)`
+      // Publish the live position for the (few) consumers that must follow the
+      // panel mid-drag — currently just the connection curves.
+      setLiveDrag({ id: panel.id, x: snappedX, y: snappedY })
+
+      // Both setters bail out when nothing actually changed, so a drag that
+      // stays snapped (or never snaps) performs no store write at all.
       if (guides.length > 0 || hadGuides) setSnapGuides(guides)
       hadGuides = guides.length > 0
 
@@ -129,6 +167,24 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         cancelAnimationFrame(rafId)
         processMove()
       }
+
+      // Hand the final position back to React in a single paint: drop the
+      // transform and write left/top imperatively *now*, then commit the same
+      // values to the store (whose re-render writes identical left/top).
+      const { x: finalX, y: finalY } = dragCommit.current
+      if (el) {
+        el.style.transform = ''
+        el.style.willChange = ''
+        el.style.left = `${finalX}px`
+        el.style.top = `${finalY}px`
+      }
+      // A click on the title bar that never moved must not re-commit the
+      // canvas — only write when the panel actually went somewhere.
+      if (finalX !== baseX || finalY !== baseY) {
+        updatePanel(panel.id, { x: finalX, y: finalY })
+      }
+      setLiveDrag(null)
+
       // If there's a proximity edge, auto-connect on drop
       const prox = useCanvasStore.getState().proximityEdge
       if (prox) {
@@ -159,10 +215,11 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     window.addEventListener('mouseup', handleUp)
     return () => {
       if (rafId != null) cancelAnimationFrame(rafId)
+      if (el) el.style.willChange = ''
       window.removeEventListener('mousemove', handleMove)
       window.removeEventListener('mouseup', handleUp)
     }
-  }, [isDragging, panel.id, panel.width, panel.height, zoom, updatePanel, setDraggingPanelId, setSnapGuides])
+  }, [isDragging, panel.id, panel.width, panel.height, zoom, updatePanel, setDraggingPanelId, setSnapGuides, setLiveDrag])
 
   // ── Resize handling ───────────────────────────────────────
   const handleResizeStart = useCallback(
@@ -177,6 +234,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
         w: panel.width,
         h: panel.height,
       }
+      resizeCommit.current = { w: panel.width, h: panel.height }
     },
     [bringToFront, panel.id, panel.width, panel.height]
   )
@@ -184,8 +242,11 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   useEffect(() => {
     if (!isResizing) return
 
-    // rAF-coalesced like drag: one store write (and one full canvas commit,
-    // plus terminal/webview reflows) per frame instead of per mousemove.
+    // Imperative like drag: size the element directly inside a rAF and commit
+    // the final size to the store once, on mouseup. The panel's own content
+    // still reflows (plain CSS layout) — but React never re-renders the canvas.
+    const el = panelRef.current
+
     let rafId: number | null = null
     let lastEvent: MouseEvent | null = null
 
@@ -193,14 +254,18 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       rafId = null
       const e = lastEvent
       if (!e) return
-      const dx = (e.clientX - resizeStart.current.x) / zoom
-      const dy = (e.clientY - resizeStart.current.y) / zoom
+      const liveZoom = getLiveViewport().zoom || zoom || 1
+      const dx = (e.clientX - resizeStart.current.x) / liveZoom
+      const dy = (e.clientY - resizeStart.current.y) / liveZoom
       const minW = panel.minWidth ?? 200
       const minH = panel.minHeight ?? 150
-      updatePanel(panel.id, {
-        width: Math.max(minW, resizeStart.current.w + dx),
-        height: Math.max(minH, resizeStart.current.h + dy),
-      })
+      const nextW = Math.max(minW, resizeStart.current.w + dx)
+      const nextH = Math.max(minH, resizeStart.current.h + dy)
+      resizeCommit.current = { w: nextW, h: nextH }
+      if (el) {
+        el.style.width = `${nextW}px`
+        el.style.height = `${nextH}px`
+      }
     }
 
     const handleMove = (e: MouseEvent) => {
@@ -212,6 +277,10 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       if (rafId != null) {
         cancelAnimationFrame(rafId)
         processMove()
+      }
+      const { w: finalW, h: finalH } = resizeCommit.current
+      if (finalW !== resizeStart.current.w || finalH !== resizeStart.current.h) {
+        updatePanel(panel.id, { width: finalW, height: finalH })
       }
       setIsResizing(false)
     }
@@ -530,7 +599,7 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       {!isCollapsed && (
         <div
           className={`flex-1 overflow-hidden min-h-0 ${panel.type === 'task' || panel.type === 'transcript' || panel.type === 'webpage' || panel.type === 'terminal' || panel.type === 'browser' || (panel.type === 'app' && panel.refId) ? '' : 'p-3 overflow-auto'}`}
-          style={frozen ? { visibility: 'hidden' } : undefined}
+          style={frozen ? FROZEN_CONTENT_STYLE : undefined}
         >
           <MemoizedPanelContent
             type={panel.type}

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react'
 import { InfiniteCanvas } from './InfiniteCanvas'
 import { useCanvasStore } from '@/stores/canvas-store'
 import { TaskStatus } from '@/types'
@@ -87,6 +87,8 @@ describe('InfiniteCanvas', () => {
       draggingPanelId: null,
       snapGuides: [],
       connectingFromId: null,
+      proximityEdge: null,
+      liveDrag: null,
       isLoaded: true, // Skip async load in tests
     })
     taskStoreState.tasks = []
@@ -322,6 +324,101 @@ describe('InfiniteCanvas', () => {
     expect(screen.getByTitle('Focus panel (zoom to fit)')).toBeTruthy()
     expect(screen.getByTitle('Collapse')).toBeTruthy()
     expect(screen.getByTitle('Close panel')).toBeTruthy()
+  })
+
+  // ── Imperative gesture transforms ────────────────────────
+  // During a pan/zoom/drag gesture the canvas must do ZERO React work: the
+  // DOM is transformed directly and the store is written exactly once, when
+  // the gesture ends.
+
+  describe('imperative gesture transforms', () => {
+    const flushFrames = async () => {
+      // rAF + the queued microtasks React uses to commit
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+    }
+
+    it('pans the layer imperatively and commits the viewport once the wheel goes idle', async () => {
+      const { container } = render(<InfiniteCanvas />)
+      const layer = container.querySelector('[data-canvas-transform-layer="true"]') as HTMLElement
+      const canvas = layer.parentElement as HTMLElement
+
+      fireEvent.wheel(canvas, { deltaX: 30, deltaY: 40 })
+      await flushFrames()
+
+      // DOM moved…
+      expect(layer.style.transform).toBe('translate(-30px, -40px) scale(1)')
+      expect(layer.style.willChange).toBe('transform')
+      // …but the store was NOT written during the gesture.
+      expect(useCanvasStore.getState().viewport).toEqual({ x: 0, y: 0, zoom: 1 })
+
+      // Wheel idle → single commit.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200))
+      })
+      expect(useCanvasStore.getState().viewport).toEqual({ x: -30, y: -40, zoom: 1 })
+      expect(layer.style.willChange).toBe('')
+    })
+
+    it('commits the viewport on mouseup after a drag-pan', async () => {
+      const { container } = render(<InfiniteCanvas />)
+      const layer = container.querySelector('[data-canvas-transform-layer="true"]') as HTMLElement
+      const canvas = layer.parentElement as HTMLElement
+
+      fireEvent.mouseDown(canvas, { button: 1, clientX: 100, clientY: 100 })
+      fireEvent.mouseMove(canvas, { clientX: 150, clientY: 130 })
+      await flushFrames()
+
+      expect(layer.style.transform).toBe('translate(50px, 30px) scale(1)')
+      expect(useCanvasStore.getState().viewport).toEqual({ x: 0, y: 0, zoom: 1 })
+
+      fireEvent.mouseUp(canvas)
+      expect(useCanvasStore.getState().viewport).toEqual({ x: 50, y: 30, zoom: 1 })
+    })
+
+    it('keeps the DOM transform in sync with programmatic viewport changes', async () => {
+      const { container } = render(<InfiniteCanvas />)
+      const layer = container.querySelector('[data-canvas-transform-layer="true"]') as HTMLElement
+
+      await act(async () => {
+        useCanvasStore.getState().setViewport({ x: 12, y: 34, zoom: 2 })
+      })
+
+      expect(layer.style.transform).toBe('translate(12px, 34px) scale(2)')
+    })
+
+    it('moves a dragged panel with a transform and writes x/y only on mouseup', async () => {
+      useCanvasStore.getState().addPanel({
+        type: 'task',
+        title: 'Draggable',
+        x: 100,
+        y: 100,
+        width: 400,
+        height: 300,
+      })
+      const { container } = render(<InfiniteCanvas />)
+      const panelEl = container.querySelector('[data-canvas-panel="true"]') as HTMLElement
+      const titleBar = panelEl.querySelector('.cursor-grab') as HTMLElement
+
+      fireEvent.mouseDown(titleBar, { button: 0, clientX: 200, clientY: 200 })
+      fireEvent.mouseMove(window, { clientX: 260, clientY: 250 })
+      await flushFrames()
+
+      // Moved on the compositor, store untouched (left/top still the origin).
+      expect(panelEl.style.transform).toBe('translate(60px, 50px)')
+      expect(panelEl.style.willChange).toBe('transform')
+      expect(useCanvasStore.getState().panels[0]).toMatchObject({ x: 100, y: 100 })
+
+      await act(async () => {
+        fireEvent.mouseUp(window)
+      })
+
+      expect(useCanvasStore.getState().panels[0]).toMatchObject({ x: 160, y: 150 })
+      expect(panelEl.style.transform).toBe('')
+      expect(panelEl.style.willChange).toBe('')
+    })
   })
 
   it('keeps canvas content selectable inside panels', () => {

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -1,6 +1,13 @@
-import { useCallback, useRef, useState, useEffect, useMemo, type CSSProperties } from 'react'
-import { useCanvasStore, DEFAULT_PANEL_WIDTH, DEFAULT_PANEL_HEIGHT } from '@/stores/canvas-store'
-import type { SnapGuide, CanvasPanelData, Viewport } from '@/stores/canvas-store'
+import { useCallback, useRef, useState, useEffect, useLayoutEffect, useMemo, type CSSProperties } from 'react'
+import {
+  useCanvasStore,
+  DEFAULT_PANEL_WIDTH,
+  DEFAULT_PANEL_HEIGHT,
+  panViewport,
+  zoomViewportAtPoint,
+} from '@/stores/canvas-store'
+import type { CanvasPanelData, Viewport } from '@/stores/canvas-store'
+import { getLiveViewport, setLiveViewport } from '@/stores/canvas-live-viewport'
 import { useUIStore } from '@/stores/ui-store'
 import { useTaskStore } from '@/stores/task-store'
 import { CanvasPanel } from './CanvasPanel'
@@ -46,12 +53,47 @@ function isPanelVisible(
 
 // Grid dot spacing in canvas-space pixels
 const GRID_SIZE = 40
+/**
+ * Wheel/trackpad gestures have no "end" event. Commit the viewport to the
+ * store this long after the last wheel event.
+ */
+const WHEEL_IDLE_MS = 150
 const STATUS_HIGHLIGHT_MS = 5_000
 const STATUS_POPUP_EDGE_PAD = 28
 const STATUS_POPUP_TOP_SAFE = 70
 const STATUS_POPUP_BOTTOM_SAFE = 150
 const STATUS_POPUP_LEFT_SAFE = 170
 const STATUS_POPUP_RIGHT_SAFE = 220
+
+/**
+ * Dot-grid background painted on the STATIC container instead of inside the
+ * transformed layer: panning/zooming becomes two background-* property writes
+ * (compositor work) instead of repositioning and re-rasterising a DOM node
+ * that lives under the canvas transform.
+ */
+function gridBackgroundStyle(viewport: Viewport): {
+  backgroundImage: string
+  backgroundSize: string
+  backgroundPosition: string
+} {
+  const size = GRID_SIZE * viewport.zoom
+  // Screen-space dot radius. Matches the previous canvas-space formula
+  // `max(1, min(2, 1.5 / zoom))` rendered under a `scale(zoom)` transform.
+  const dot = Math.max(viewport.zoom, Math.min(2 * viewport.zoom, 1.5))
+  return {
+    backgroundImage: `radial-gradient(circle, var(--canvas-dot) ${dot}px, transparent ${dot}px)`,
+    backgroundSize: `${size}px ${size}px`,
+    backgroundPosition: `${viewport.x + size / 2}px ${viewport.y + size / 2}px`,
+  }
+}
+
+function formatViewportCoords(viewport: Viewport): string {
+  return `${Math.round(-viewport.x / viewport.zoom)}, ${Math.round(-viewport.y / viewport.zoom)}`
+}
+
+function viewportTransform(viewport: Viewport): string {
+  return `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`
+}
 
 interface StatusHighlight {
   id: string
@@ -165,10 +207,7 @@ export function InfiniteCanvas() {
   const previousTaskStatusRef = useRef(new Map<string, TaskStatus>())
   const viewport = useCanvasStore((s) => s.viewport)
   const panels = useCanvasStore((s) => s.panels)
-  const snapGuides = useCanvasStore((s) => s.snapGuides)
   const isLoaded = useCanvasStore((s) => s.isLoaded)
-  const panBy = useCanvasStore((s) => s.panBy)
-  const zoomAtPoint = useCanvasStore((s) => s.zoomAtPoint)
   const zoomTo = useCanvasStore((s) => s.zoomTo)
   const resetViewport = useCanvasStore((s) => s.resetViewport)
   const fitToContent = useCanvasStore((s) => s.fitToContent)
@@ -353,27 +392,119 @@ export function InfiniteCanvas() {
     })
   }, [canvasPendingApp])
 
-  // ── rAF-coalesced viewport updates ───────────────────────
-  // Trackpad wheel and mousemove events fire at 60–120 Hz (uncoalesced by
-  // React); writing to the store per event commits the whole canvas subtree
-  // per event. Accumulate deltas and flush at most one store write per frame.
+  // ── Imperative gesture transforms ─────────────────────────
+  // During a pan/zoom gesture React does ZERO work: the accumulated deltas are
+  // applied straight to the transformed layer's `style.transform` (and to the
+  // grid background) inside a single rAF, and the resulting viewport is
+  // committed to the zustand store exactly once, when the gesture ends.
+  //
+  // Writing the viewport to the store per frame (as before) re-committed the
+  // whole canvas subtree — grid, connection curves, minimap and every panel
+  // wrapper — 60–120 times a second. Now that cost is paid once per gesture
+  // and the frames themselves are compositor-bound.
+  const transformLayerRef = useRef<HTMLDivElement>(null)
+  const gridRef = useRef<HTMLDivElement>(null)
+  const zoomLabelRef = useRef<HTMLSpanElement>(null)
+  const coordsLabelRef = useRef<HTMLSpanElement>(null)
+
+  /** Authoritative viewport while a gesture is in flight. */
+  const liveViewportRef = useRef<Viewport>(viewport)
+  const gestureActiveRef = useRef(false)
+  const viewportDirtyRef = useRef(false)
+  const wheelIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   const pendingPanRef = useRef({ dx: 0, dy: 0 })
   const pendingZoomRef = useRef<{ deltaY: number; clientX: number; clientY: number; rect: DOMRect } | null>(null)
   const viewportRafRef = useRef<number | null>(null)
 
+  const applyViewportToDom = useCallback((vp: Viewport) => {
+    const layer = transformLayerRef.current
+    if (layer) layer.style.transform = viewportTransform(vp)
+
+    const grid = gridRef.current
+    if (grid) {
+      const bg = gridBackgroundStyle(vp)
+      grid.style.backgroundImage = bg.backgroundImage
+      grid.style.backgroundSize = bg.backgroundSize
+      grid.style.backgroundPosition = bg.backgroundPosition
+    }
+
+    // HUD readouts stay live during the gesture without a React render.
+    const zoomLabel = zoomLabelRef.current
+    if (zoomLabel) zoomLabel.textContent = `${Math.round(vp.zoom * 100)}%`
+    const coordsLabel = coordsLabelRef.current
+    if (coordsLabel) coordsLabel.textContent = formatViewportCoords(vp)
+
+    // Notify imperative subscribers (minimap viewport rectangle).
+    setLiveViewport(vp)
+  }, [])
+
+  // Store → live viewport sync. Runs for every *programmatic* viewport change
+  // (keyboard zoom, Ctrl+0, focusPanel, minimap navigation, fitToContent) and
+  // for the single commit at the end of a gesture — a no-op re-apply there.
+  // Single sync point, so the ref can never drift from the store.
+  useEffect(() => {
+    liveViewportRef.current = viewport
+    applyViewportToDom(viewport)
+  }, [viewport, applyViewportToDom])
+
+  // A re-render triggered mid-gesture by something else (a panel updated, a
+  // task status streamed in) repaints the transform from the *store* viewport
+  // via JSX and would snap the canvas back a frame. Re-assert the live value
+  // after every commit while a gesture is running.
+  useLayoutEffect(() => {
+    if (gestureActiveRef.current) applyViewportToDom(liveViewportRef.current)
+  })
+
+  const beginGesture = useCallback(() => {
+    if (gestureActiveRef.current) return
+    gestureActiveRef.current = true
+    // Promote the layer for the duration of the gesture only — a permanent
+    // will-change keeps a dedicated compositor layer (and its memory) alive.
+    const layer = transformLayerRef.current
+    if (layer) layer.style.willChange = 'transform'
+  }, [])
+
   const flushViewportUpdate = useCallback(() => {
     viewportRafRef.current = null
+    let next = liveViewportRef.current
+
     const pan = pendingPanRef.current
     if (pan.dx !== 0 || pan.dy !== 0) {
       pendingPanRef.current = { dx: 0, dy: 0 }
-      panBy(pan.dx, pan.dy)
+      next = panViewport(next, pan.dx, pan.dy)
     }
     const zoom = pendingZoomRef.current
     if (zoom) {
       pendingZoomRef.current = null
-      zoomAtPoint(zoom.deltaY, zoom.clientX, zoom.clientY, zoom.rect)
+      next = zoomViewportAtPoint(next, zoom.deltaY, zoom.clientX, zoom.clientY, zoom.rect)
     }
-  }, [panBy, zoomAtPoint])
+
+    if (next === liveViewportRef.current) return
+    liveViewportRef.current = next
+    viewportDirtyRef.current = true
+    applyViewportToDom(next)
+  }, [applyViewportToDom])
+
+  /** End the gesture and commit the live viewport to the store (once). */
+  const commitViewport = useCallback(() => {
+    if (wheelIdleTimerRef.current != null) {
+      clearTimeout(wheelIdleTimerRef.current)
+      wheelIdleTimerRef.current = null
+    }
+    if (viewportRafRef.current != null) {
+      cancelAnimationFrame(viewportRafRef.current)
+      flushViewportUpdate()
+    }
+    gestureActiveRef.current = false
+    const layer = transformLayerRef.current
+    if (layer) layer.style.willChange = ''
+
+    if (!viewportDirtyRef.current) return
+    viewportDirtyRef.current = false
+    // Store remains the source of truth at rest (and scheduleSave persists it).
+    useCanvasStore.getState().setViewport(liveViewportRef.current)
+  }, [flushViewportUpdate])
 
   const scheduleViewportUpdate = useCallback(() => {
     if (viewportRafRef.current != null) return
@@ -401,6 +532,7 @@ export function InfiniteCanvas() {
   useEffect(() => {
     return () => {
       if (viewportRafRef.current != null) cancelAnimationFrame(viewportRafRef.current)
+      if (wheelIdleTimerRef.current != null) clearTimeout(wheelIdleTimerRef.current)
     }
   }, [])
 
@@ -445,6 +577,7 @@ export function InfiniteCanvas() {
       }
 
       e.preventDefault()
+      beginGesture()
 
       if (e.ctrlKey || e.metaKey) {
         const rect = container.getBoundingClientRect()
@@ -452,8 +585,12 @@ export function InfiniteCanvas() {
       } else {
         queuePan(-e.deltaX, -e.deltaY)
       }
+
+      // No "wheel end" event exists — commit once the stream goes quiet.
+      if (wheelIdleTimerRef.current != null) clearTimeout(wheelIdleTimerRef.current)
+      wheelIdleTimerRef.current = setTimeout(commitViewport, WHEEL_IDLE_MS)
     },
-    [queuePan, queueZoom]
+    [queuePan, queueZoom, beginGesture, commitViewport]
   )
 
   useEffect(() => {
@@ -466,6 +603,10 @@ export function InfiniteCanvas() {
   // ── Mouse-drag panning ───────────────────────────────────
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
+      // Flush a still-pending wheel gesture so anything reading the store
+      // viewport below (and on the next interaction) sees the current value.
+      commitViewport()
+
       // Close context menu on any click
       if (contextMenu) {
         setContextMenu(null)
@@ -494,10 +635,11 @@ export function InfiniteCanvas() {
       if (isMiddle || isLeftOnCanvas || isSpacePan) {
         e.preventDefault()
         setIsPanning(true)
+        beginGesture()
         panStartRef.current = { x: e.clientX, y: e.clientY }
       }
     },
-    [spaceHeld, contextMenu]
+    [spaceHeld, contextMenu, commitViewport, beginGesture]
   )
 
   const handleMouseMove = useCallback(
@@ -507,7 +649,7 @@ export function InfiniteCanvas() {
         const container = containerRef.current
         if (container) {
           const rect = container.getBoundingClientRect()
-          const vp = useCanvasStore.getState().viewport
+          const vp = getLiveViewport()
           setMouseCanvasPos({
             x: (e.clientX - rect.left - vp.x) / vp.zoom,
             y: (e.clientY - rect.top - vp.y) / vp.zoom,
@@ -526,7 +668,9 @@ export function InfiniteCanvas() {
 
   const handleMouseUp = useCallback(() => {
     setIsPanning(false)
-  }, [])
+    // Gesture end — this is the single store write for the whole pan.
+    commitViewport()
+  }, [commitViewport])
 
   // ── Context menu ─────────────────────────────────────────
   const handleContextMenu = useCallback(
@@ -534,9 +678,11 @@ export function InfiniteCanvas() {
       e.preventDefault()
       const container = containerRef.current
       if (!container) return
+      commitViewport()
       const rect = container.getBoundingClientRect()
-      const canvasX = (e.clientX - rect.left - viewport.x) / viewport.zoom
-      const canvasY = (e.clientY - rect.top - viewport.y) / viewport.zoom
+      const vp = getLiveViewport()
+      const canvasX = (e.clientX - rect.left - vp.x) / vp.zoom
+      const canvasY = (e.clientY - rect.top - vp.y) / vp.zoom
       setContextMenu({
         clientX: e.clientX,
         clientY: e.clientY,
@@ -544,7 +690,7 @@ export function InfiniteCanvas() {
         canvasY,
       })
     },
-    [viewport]
+    [commitViewport]
   )
 
   // ── Focused panel tracking (for Tab cycling) ─────────────
@@ -574,16 +720,22 @@ export function InfiniteCanvas() {
       if (e.code === 'Space' && !e.repeat && !isInputFocused) {
         setSpaceHeld(true)
       }
+      // Keyboard/programmatic viewport changes keep going through the store —
+      // it stays the source of truth at rest. Commit any in-flight gesture
+      // first so we zoom from the value the user is actually looking at.
       if (e.code === 'Equal' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
-        zoomTo(viewport.zoom * 1.2)
+        commitViewport()
+        zoomTo(liveViewportRef.current.zoom * 1.2)
       }
       if (e.code === 'Minus' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
-        zoomTo(viewport.zoom / 1.2)
+        commitViewport()
+        zoomTo(liveViewportRef.current.zoom / 1.2)
       }
       if (e.code === 'Digit0' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
+        commitViewport()
         resetViewport()
       }
 
@@ -597,6 +749,7 @@ export function InfiniteCanvas() {
             e.preventDefault()
             const container = containerRef.current
             if (container) {
+              commitViewport()
               const rect = container.getBoundingClientRect()
               useCanvasStore.getState().focusPanel(currentPanels[idx].id, rect.width, rect.height)
               setFocusedPanelIndex(idx)
@@ -618,6 +771,7 @@ export function InfiniteCanvas() {
         setFocusedPanelIndex(next)
         const container = containerRef.current
         if (container) {
+          commitViewport()
           const rect = container.getBoundingClientRect()
           useCanvasStore.getState().focusPanel(currentPanels[next].id, rect.width, rect.height)
         }
@@ -654,7 +808,7 @@ export function InfiniteCanvas() {
       window.removeEventListener('keyup', handleKeyUp)
       window.removeEventListener('blur', handleBlur)
     }
-  }, [viewport.zoom, zoomTo, resetViewport, focusedPanelIndex])
+  }, [zoomTo, resetViewport, focusedPanelIndex, commitViewport, setConnectingFromId])
 
   const zoomPercent = Math.round(viewport.zoom * 100)
 
@@ -675,10 +829,22 @@ export function InfiniteCanvas() {
         onMouseLeave={handleMouseUp}
         onContextMenu={handleContextMenu}
       >
+        {/* Background grid dots — painted on the static container so panning
+            and zooming only move a background image (no DOM under the canvas
+            transform, no React work per frame). */}
+        <div
+          ref={gridRef}
+          aria-hidden="true"
+          className="absolute inset-0"
+          style={{ ...gridBackgroundStyle(viewport), pointerEvents: 'none' }}
+        />
+
         {/* Transformed layer */}
         <div
+          ref={transformLayerRef}
+          data-canvas-transform-layer="true"
           style={{
-            transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+            transform: viewportTransform(viewport),
             transformOrigin: '0 0',
             position: 'absolute',
             top: 0,
@@ -687,22 +853,8 @@ export function InfiniteCanvas() {
             height: 0,
           }}
         >
-          {/* Background grid dots */}
-          <CanvasGrid
-            zoom={viewport.zoom}
-            viewportX={viewport.x}
-            viewportY={viewport.y}
-            containerWidth={containerSize.width}
-            containerHeight={containerSize.height}
-          />
-
           {/* Snap guides */}
-          <SnapGuides
-            guides={snapGuides}
-            containerWidth={containerSize.width}
-            containerHeight={containerSize.height}
-            viewport={viewport}
-          />
+          <SnapGuides />
 
           {/* Connection lines */}
           <CanvasConnections mouseCanvasPos={mouseCanvasPos} />
@@ -778,7 +930,7 @@ export function InfiniteCanvas() {
         >
           <ZoomOut className="h-3.5 w-3.5" />
         </Button>
-        <span className="text-xs text-muted-foreground w-10 text-center tabular-nums">
+        <span ref={zoomLabelRef} className="text-xs text-muted-foreground w-10 text-center tabular-nums">
           {zoomPercent}%
         </span>
         <Button
@@ -811,11 +963,13 @@ export function InfiniteCanvas() {
             const btn = e.currentTarget.getBoundingClientRect()
             const rect = containerRef.current?.getBoundingClientRect()
             if (!rect) return
+            commitViewport()
+            const vp = getLiveViewport()
             setContextMenu({
               clientX: btn.left,
               clientY: btn.bottom + 4,
-              canvasX: (btn.left - rect.left - viewport.x) / viewport.zoom,
-              canvasY: (btn.bottom + 4 - rect.top - viewport.y) / viewport.zoom,
+              canvasX: (btn.left - rect.left - vp.x) / vp.zoom,
+              canvasY: (btn.bottom + 4 - rect.top - vp.y) / vp.zoom,
             })
           }}
           title="Add to canvas"
@@ -828,9 +982,8 @@ export function InfiniteCanvas() {
       {/* ── HUD: Viewport info (top-right) ── */}
       <div className="absolute top-3 right-3 flex items-center gap-2 text-[10px] text-muted-foreground/40 z-10 select-none">
         <Move className="h-3 w-3" />
-        <span className="tabular-nums">
-          {Math.round(-viewport.x / viewport.zoom)},{' '}
-          {Math.round(-viewport.y / viewport.zoom)}
+        <span ref={coordsLabelRef} className="tabular-nums">
+          {formatViewportCoords(viewport)}
         </span>
       </div>
 
@@ -866,76 +1019,21 @@ export function InfiniteCanvas() {
   )
 }
 
-// ── Grid dots background ───────────────────────────────────
-
-function CanvasGrid({
-  zoom,
-  viewportX,
-  viewportY,
-  containerWidth,
-  containerHeight,
-}: {
-  zoom: number
-  viewportX: number
-  viewportY: number
-  containerWidth: number
-  containerHeight: number
-}) {
-  // Container size comes from the ResizeObserver-tracked state — calling
-  // getBoundingClientRect() here (in the render phase) forced a synchronous
-  // style+layout flush on every pan/zoom frame.
-  // Guard against zero-size container (during window move/minimize transitions)
-  if (!containerWidth || !containerHeight || !zoom) return null
-
-  const visibleLeft = -viewportX / zoom
-  const visibleTop = -viewportY / zoom
-  const visibleWidth = containerWidth / zoom
-  const visibleHeight = containerHeight / zoom
-
-  const gridLeft = Math.floor(visibleLeft / GRID_SIZE) * GRID_SIZE - GRID_SIZE
-  const gridTop = Math.floor(visibleTop / GRID_SIZE) * GRID_SIZE - GRID_SIZE
-  const gridWidth = visibleWidth + GRID_SIZE * 3
-  const gridHeight = visibleHeight + GRID_SIZE * 3
-
-  const dotSize = Math.max(1, Math.min(2, 1.5 / zoom))
-
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        left: gridLeft,
-        top: gridTop,
-        width: gridWidth,
-        height: gridHeight,
-        backgroundImage: `radial-gradient(circle, var(--canvas-dot) ${dotSize}px, transparent ${dotSize}px)`,
-        backgroundSize: `${GRID_SIZE}px ${GRID_SIZE}px`,
-        backgroundPosition: `${GRID_SIZE / 2}px ${GRID_SIZE / 2}px`,
-        pointerEvents: 'none',
-      }}
-    />
-  )
-}
-
 // ── Snap guide lines ───────────────────────────────────────
 
-function SnapGuides({
-  guides,
-  containerWidth,
-  containerHeight,
-  viewport,
-}: {
-  guides: SnapGuide[]
-  containerWidth: number
-  containerHeight: number
-  viewport: { x: number; y: number; zoom: number }
-}) {
-  if (guides.length === 0) return null
-  if (!containerWidth || !containerHeight || !viewport.zoom) return null
+/** Canvas-space half-length of a guide line — long enough to always span the
+ *  viewport at any zoom, so the guides don't depend on the viewport at all. */
+const GUIDE_EXTENT = 50_000
 
-  const visibleLeft = -viewport.x / viewport.zoom
-  const visibleTop = -viewport.y / viewport.zoom
-  const visibleWidth = containerWidth / viewport.zoom
-  const visibleHeight = containerHeight / viewport.zoom
+/**
+ * Subscribes to `snapGuides` itself rather than taking them as a prop: guides
+ * appear/disappear mid-drag, and a prop would force InfiniteCanvas (and with
+ * it every panel) to re-render. The store bails out on structurally equal
+ * guide arrays, so a drag that stays snapped writes nothing at all.
+ */
+function SnapGuides() {
+  const guides = useCanvasStore((s) => s.snapGuides)
+  if (guides.length === 0) return null
 
   return (
     <>
@@ -947,15 +1045,15 @@ function SnapGuides({
             guide.axis === 'x'
               ? {
                   left: guide.position,
-                  top: visibleTop - 1000,
+                  top: -GUIDE_EXTENT,
                   width: 1,
-                  height: visibleHeight + 2000,
+                  height: GUIDE_EXTENT * 2,
                   background: 'rgba(30,150,235,0.25)',
                 }
               : {
-                  left: visibleLeft - 1000,
+                  left: -GUIDE_EXTENT,
                   top: guide.position,
-                  width: visibleWidth + 2000,
+                  width: GUIDE_EXTENT * 2,
                   height: 1,
                   background: 'rgba(30,150,235,0.25)',
                 }

--- a/src/renderer/src/stores/canvas-live-viewport.ts
+++ b/src/renderer/src/stores/canvas-live-viewport.ts
@@ -1,0 +1,39 @@
+import type { Viewport } from './canvas-store'
+
+/**
+ * Live canvas viewport — the *authoritative value during a gesture*.
+ *
+ * While the user pans/zooms, InfiniteCanvas transforms the canvas layer
+ * imperatively and does NOT write to the zustand store (a store write commits
+ * the whole canvas subtree — grid, connections, minimap and every panel
+ * wrapper — on every frame). The store is only updated once, when the gesture
+ * ends, so it remains the source of truth at rest.
+ *
+ * Consumers that must follow the viewport *during* a gesture (the minimap
+ * rectangle, the zoom/coordinate readouts) subscribe here and update the DOM
+ * imperatively — no React render involved.
+ *
+ * Invariant: at rest `getLiveViewport()` deep-equals `useCanvasStore.getState().viewport`.
+ * InfiniteCanvas re-publishes on every store viewport change to keep that true
+ * for programmatic changes (keyboard zoom, focusPanel, minimap navigation…).
+ */
+let liveViewport: Viewport = { x: 0, y: 0, zoom: 1 }
+
+type LiveViewportListener = (viewport: Viewport) => void
+const listeners = new Set<LiveViewportListener>()
+
+export function getLiveViewport(): Viewport {
+  return liveViewport
+}
+
+export function setLiveViewport(viewport: Viewport): void {
+  liveViewport = viewport
+  for (const listener of listeners) listener(viewport)
+}
+
+export function subscribeLiveViewport(listener: LiveViewportListener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}

--- a/src/renderer/src/stores/canvas-store.test.ts
+++ b/src/renderer/src/stores/canvas-store.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { useCanvasStore, MIN_ZOOM, MAX_ZOOM, calculateSnap, SNAP_GAP } from './canvas-store'
+import {
+  useCanvasStore,
+  MIN_ZOOM,
+  MAX_ZOOM,
+  calculateSnap,
+  SNAP_GAP,
+  panViewport,
+  clampZoom,
+  zoomViewportAtPoint,
+  snapGuidesEqual,
+} from './canvas-store'
 import type { CanvasPanelData } from './canvas-store'
 
 // Mock settingsApi to prevent actual IPC calls during tests
@@ -22,6 +32,8 @@ describe('canvas-store', () => {
       draggingPanelId: null,
       snapGuides: [],
       connectingFromId: null,
+      proximityEdge: null,
+      liveDrag: null,
     })
   })
 
@@ -266,6 +278,97 @@ describe('canvas-store', () => {
       useCanvasStore.getState().setConnectingFromId('panel-1')
       useCanvasStore.getState().setConnectingFromId(null)
       expect(useCanvasStore.getState().connectingFromId).toBeNull()
+    })
+  })
+
+  // ── Pure viewport math (shared with the imperative gesture path) ──
+
+  describe('viewport math helpers', () => {
+    it('pans without mutating the input viewport', () => {
+      const vp = { x: 10, y: 20, zoom: 2 }
+      const next = panViewport(vp, 5, -5)
+      expect(next).toEqual({ x: 15, y: 15, zoom: 2 })
+      expect(vp).toEqual({ x: 10, y: 20, zoom: 2 })
+    })
+
+    it('clamps zoom to the supported range', () => {
+      expect(clampZoom(100)).toBe(MAX_ZOOM)
+      expect(clampZoom(0)).toBe(MIN_ZOOM)
+      expect(clampZoom(1.5)).toBe(1.5)
+    })
+
+    it('produces the same result as the zoomAtPoint store action', () => {
+      const rect = { left: 0, top: 0 } as DOMRect
+      const expected = zoomViewportAtPoint({ x: 0, y: 0, zoom: 1 }, -120, 400, 300, rect)
+
+      useCanvasStore.getState().zoomAtPoint(-120, 400, 300, rect)
+
+      expect(useCanvasStore.getState().viewport).toEqual(expected)
+    })
+
+    it('keeps the zoom anchor point fixed on screen', () => {
+      const rect = { left: 0, top: 0 } as DOMRect
+      const start = { x: 0, y: 0, zoom: 1 }
+      const anchorX = 400
+      const anchorY = 300
+      const canvasX = (anchorX - start.x) / start.zoom
+      const canvasY = (anchorY - start.y) / start.zoom
+
+      const next = zoomViewportAtPoint(start, -120, anchorX, anchorY, rect)
+
+      expect(canvasX * next.zoom + next.x).toBeCloseTo(anchorX, 6)
+      expect(canvasY * next.zoom + next.y).toBeCloseTo(anchorY, 6)
+    })
+
+    it('compares snap guides structurally', () => {
+      expect(snapGuidesEqual([], [])).toBe(true)
+      expect(
+        snapGuidesEqual([{ axis: 'x', position: 10 }], [{ axis: 'x', position: 10 }])
+      ).toBe(true)
+      expect(
+        snapGuidesEqual([{ axis: 'x', position: 10 }], [{ axis: 'y', position: 10 }])
+      ).toBe(false)
+      expect(snapGuidesEqual([{ axis: 'x', position: 10 }], [])).toBe(false)
+    })
+  })
+
+  // ── Transient drag state: no-op writes must not change identity ──
+
+  describe('transient drag state bail-outs', () => {
+    it('keeps snapGuides identity when the guides are unchanged', () => {
+      useCanvasStore.getState().setSnapGuides([{ axis: 'x', position: 40 }])
+      const first = useCanvasStore.getState().snapGuides
+
+      useCanvasStore.getState().setSnapGuides([{ axis: 'x', position: 40 }])
+      expect(useCanvasStore.getState().snapGuides).toBe(first)
+
+      useCanvasStore.getState().setSnapGuides([{ axis: 'x', position: 41 }])
+      expect(useCanvasStore.getState().snapGuides).not.toBe(first)
+    })
+
+    it('keeps proximityEdge identity when the same pair is re-detected', () => {
+      useCanvasStore.getState().setProximityEdge({ fromId: 'a', toId: 'b' })
+      const first = useCanvasStore.getState().proximityEdge
+
+      useCanvasStore.getState().setProximityEdge({ fromId: 'a', toId: 'b' })
+      expect(useCanvasStore.getState().proximityEdge).toBe(first)
+
+      useCanvasStore.getState().setProximityEdge(null)
+      expect(useCanvasStore.getState().proximityEdge).toBeNull()
+    })
+
+    it('keeps liveDrag identity when the panel has not moved', () => {
+      useCanvasStore.getState().setLiveDrag({ id: 'p1', x: 10, y: 20 })
+      const first = useCanvasStore.getState().liveDrag
+
+      useCanvasStore.getState().setLiveDrag({ id: 'p1', x: 10, y: 20 })
+      expect(useCanvasStore.getState().liveDrag).toBe(first)
+
+      useCanvasStore.getState().setLiveDrag({ id: 'p1', x: 11, y: 20 })
+      expect(useCanvasStore.getState().liveDrag).not.toBe(first)
+
+      useCanvasStore.getState().setLiveDrag(null)
+      expect(useCanvasStore.getState().liveDrag).toBeNull()
     })
   })
 

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -70,6 +70,59 @@ export const MAX_ZOOM = 3
 export const DEFAULT_PANEL_WIDTH = 1020
 export const DEFAULT_PANEL_HEIGHT = 780
 
+// ── Pure viewport math ─────────────────────────────────────
+// Shared by the store actions *and* by the imperative gesture path in
+// InfiniteCanvas (which transforms the DOM directly during a pan/zoom and
+// only commits to the store once, on gesture end). Keeping the math in one
+// place guarantees the imperative path and the store can never diverge.
+
+/** Translate a viewport by a screen-space delta. */
+export function panViewport(viewport: Viewport, dx: number, dy: number): Viewport {
+  return { ...viewport, x: viewport.x + dx, y: viewport.y + dy }
+}
+
+/** Clamp a zoom level to the supported range. */
+export function clampZoom(zoom: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom))
+}
+
+/**
+ * Zoom around a screen point (wheel / pinch). `delta` is the raw wheel deltaY.
+ * Scales the zoom factor by delta magnitude for smooth trackpad pinch-to-zoom:
+ * Mac trackpads send small deltas (~2-4px) per event; mice send larger (~100px).
+ * The intensity is clamped so a single event never exceeds a ~15% step.
+ */
+export function zoomViewportAtPoint(
+  viewport: Viewport,
+  delta: number,
+  clientX: number,
+  clientY: number,
+  containerRect: { left: number; top: number }
+): Viewport {
+  const intensity = Math.min(Math.abs(delta) / 100, 0.15)
+  const factor = delta > 0 ? 1 - intensity : 1 + intensity
+  const newZoom = clampZoom(viewport.zoom * factor)
+
+  const pointX = (clientX - containerRect.left - viewport.x) / viewport.zoom
+  const pointY = (clientY - containerRect.top - viewport.y) / viewport.zoom
+
+  return {
+    x: clientX - containerRect.left - pointX * newZoom,
+    y: clientY - containerRect.top - pointY * newZoom,
+    zoom: newZoom,
+  }
+}
+
+/** Structural equality for snap guide lists — avoids no-op store writes. */
+export function snapGuidesEqual(a: SnapGuide[], b: SnapGuide[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].axis !== b[i].axis || a[i].position !== b[i].position) return false
+  }
+  return true
+}
+
 // ── Store ──────────────────────────────────────────────────
 
 // ── Persistence shape ─────────────────────────────────────
@@ -96,6 +149,18 @@ interface CanvasState {
 
   // Auto-connect proximity state (transient, shown during drag)
   proximityEdge: { fromId: string; toId: string } | null
+
+  /**
+   * Live position of the panel currently being dragged (transient).
+   *
+   * Panel drags move the panel imperatively (CSS transform) and do NOT write
+   * x/y to `panels` until mouseup — that would re-commit the whole canvas
+   * subtree per frame. This tiny slice lets the few consumers that must track
+   * the panel live (connection curves) follow it without dragging the rest of
+   * the canvas into the render.
+   */
+  liveDrag: { id: string; x: number; y: number } | null
+  setLiveDrag: (drag: { id: string; x: number; y: number } | null) => void
 
   // Persistence
   isLoaded: boolean
@@ -155,6 +220,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   snapGuides: [],
   connectingFromId: null,
   proximityEdge: null,
+  liveDrag: null,
   isLoaded: false,
 
   loadCanvas: async () => {
@@ -193,14 +259,12 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   },
 
   panBy: (dx, dy) => {
-    set((s) => ({
-      viewport: { ...s.viewport, x: s.viewport.x + dx, y: s.viewport.y + dy }
-    }))
+    set((s) => ({ viewport: panViewport(s.viewport, dx, dy) }))
     scheduleSave()
   },
 
   zoomTo: (zoom, centerX, centerY) => {
-    const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom))
+    const clamped = clampZoom(zoom)
     set((s) => {
       if (centerX !== undefined && centerY !== undefined) {
         const ratio = clamped / s.viewport.zoom
@@ -214,21 +278,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   },
 
   zoomAtPoint: (delta, clientX, clientY, containerRect) => {
-    const { viewport } = get()
-    // Scale zoom factor by delta magnitude for smooth trackpad pinch-to-zoom.
-    // Mac trackpads send small deltas (~2-4px) per event; mice send larger (~100px).
-    // Clamp the intensity so it never exceeds a ~15% step per event.
-    const intensity = Math.min(Math.abs(delta) / 100, 0.15)
-    const factor = delta > 0 ? 1 - intensity : 1 + intensity
-    const newZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, viewport.zoom * factor))
-
-    const pointX = (clientX - containerRect.left - viewport.x) / viewport.zoom
-    const pointY = (clientY - containerRect.top - viewport.y) / viewport.zoom
-
-    const newX = clientX - containerRect.left - pointX * newZoom
-    const newY = clientY - containerRect.top - pointY * newZoom
-
-    set({ viewport: { x: newX, y: newY, zoom: newZoom } })
+    set({ viewport: zoomViewportAtPoint(get().viewport, delta, clientX, clientY, containerRect) })
     scheduleSave()
   },
 
@@ -354,7 +404,19 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 
   // Drag
   setDraggingPanelId: (id) => set({ draggingPanelId: id }),
-  setSnapGuides: (guides) => set({ snapGuides: guides }),
+  // Bail out when the guides are structurally unchanged — calculateSnap()
+  // allocates a fresh array every frame, and an unconditional write would
+  // re-render the guide layer on every frame of a snapped drag.
+  setSnapGuides: (guides) => {
+    if (snapGuidesEqual(get().snapGuides, guides)) return
+    set({ snapGuides: guides })
+  },
+  setLiveDrag: (drag) => {
+    const prev = get().liveDrag
+    if (prev === drag) return
+    if (prev && drag && prev.id === drag.id && prev.x === drag.x && prev.y === drag.y) return
+    set({ liveDrag: drag })
+  },
 
   // Edges
   addEdge: (fromPanelId, toPanelId, edgeType) => {
@@ -397,7 +459,14 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
   },
 
   setConnectingFromId: (id) => set({ connectingFromId: id }),
-  setProximityEdge: (edge) => set({ proximityEdge: edge }),
+  // Proximity detection runs every drag frame and returns a fresh object —
+  // bail out when it names the same pair so subscribers stay put.
+  setProximityEdge: (edge) => {
+    const prev = get().proximityEdge
+    if (prev === edge) return
+    if (prev && edge && prev.fromId === edge.fromId && prev.toId === edge.toId) return
+    set({ proximityEdge: edge })
+  },
 
   clearEdges: () => {
     set({ edges: [] })


### PR DESCRIPTION
Stacked on **#434** (`perf/ui-performance-fixes`), which added the rAF plumbing this builds on. Merge #434 first; this PR will retarget to `main` automatically.

## Problem

#434 coalesced canvas gesture writes to one store write per frame. But *one store write per frame* still means a full React commit of the entire `InfiniteCanvas` subtree per frame — grid, connection curves, minimap, and every panel's wrapper div. Cost grows with panel count, so pan/zoom gets worse the more you have open.

Figma/tldraw-class canvases do the opposite: **React does zero work during a gesture; the compositor does everything**, and the store is written once when the gesture ends.

## What changed

### Viewport — `InfiniteCanvas.tsx`
- During a pan/zoom, accumulated deltas are applied straight to the transformed layer's `style.transform` inside the existing rAF flush. The live viewport lives in a ref and is committed to the store **exactly once**: on `mouseup`, or 150 ms after the last wheel event (wheel gestures have no end event).
- Viewport math (`panViewport` / `zoomViewportAtPoint` / `clampZoom`) extracted into pure exported helpers in `canvas-store` and used by **both** the store actions and the imperative path, so the two can't diverge.
- **One** store→ref/DOM sync effect. Programmatic changes (keyboard zoom, Ctrl+0, `focusPanel`, Ctrl+1-9, Ctrl+Tab, minimap navigation, `fitToContent`) keep going through the store, which stays the source of truth at rest.
- A re-render triggered mid-gesture by unrelated state (a streaming task status) would repaint the transform from the stale store value — a layout effect re-asserts the live transform after every commit while a gesture is active.
- `will-change: transform` added on gesture start, removed on end (no permanent layer memory).
- **Dot grid removed from the transformed DOM entirely**: it's now a `background-image` on the static container, so panning moves `background-position` instead of repositioning and re-rasterising a node under the canvas transform. Screen-space dot size matches the old formula exactly.
- HUD zoom % / coordinate readouts and the minimap viewport rect follow the gesture **imperatively** via a small live-viewport pub/sub — they stay live at native refresh rate without a single React render.

### Panels — `CanvasPanel.tsx`
- **Drag** moves the panel via a CSS `transform` delta (`left`/`top` stay at the store position for the whole drag). `x`/`y` is committed once, on mouseup — with the final position written to `left`/`top` imperatively in the same paint so there's no flash, and skipped entirely if the panel never moved.
- **Resize** sizes the element directly per frame and commits `width`/`height` on mouseup.
- Snap calculation and proximity auto-connect still run per frame against store positions. Both `setSnapGuides` and `setProximityEdge` now bail out on structurally-equal values, so a drag that stays snapped performs **no store write at all**.
- Connection curves still follow the dragged panel, via a new transient `liveDrag` store slice. `CanvasConnections` is now the only component that re-renders per drag frame, at O(edges) instead of O(canvas subtree).
- `SnapGuides` subscribes to the store itself instead of taking a prop, so guide changes no longer re-render `InfiniteCanvas` (and with it every panel). Its lines no longer depend on the viewport at all.
- `contain: layout paint` on **frozen** (off-viewport) panel content — background transcript/terminal churn stops invalidating canvas-level layout and paint. Deliberately *not* applied to visible panels: containment makes the element a containing block for fixed-position descendants, and `TaskWorkspace` renders full-screen dialogs inline that must escape the panel.

### Derived per-frame consumers
- `visiblePanelIds` culling now recomputes at commit time (the existing 200 px margin makes the mid-gesture staleness invisible).
- Minimap viewport rect / zoom readout / zoom slider: imperative.

## Result

Per gesture frame, React work drops from O(canvas subtree) to **zero**. Pan/zoom/drag stay at native refresh rate regardless of how many panels, transcripts or terminals are open. Mid-pinch the browser reuses the cached raster (slightly soft) and re-rasterises once on commit — the standard tradeoff.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — **0 errors, 122 warnings** (matches baseline exactly)
- `pnpm test:run` — **100 files, 1596 tests pass** (baseline 1584 + 12 new)

New tests:
- `canvas-store.test.ts` — pure viewport helpers (incl. "the zoom anchor point stays fixed on screen" and "helper result == `zoomAtPoint` action result"), plus identity-preservation for the `snapGuides` / `proximityEdge` / `liveDrag` bail-outs.
- `InfiniteCanvas.test.tsx` — wheel pan moves the layer transform while the store stays untouched, then commits once on wheel-idle; drag-pan commits on mouseup; programmatic `setViewport` still drives the DOM; a dragged panel moves by transform with the store untouched until mouseup.

Manually verified paths unchanged: snap guides, proximity auto-connect on drop, minimap click/drag navigation, `focusPanel` + Ctrl+Tab cycling, Ctrl+1-9, Ctrl+0/±, context menu canvas coordinates, and store-persisted viewport (`scheduleSave` still fires via `setViewport`).

## Follow-ups (not in scope here)
- Minimap **drag** navigation still writes the viewport per mousemove; it could route through the same imperative path.
- Item 8 of the design (webContents/background throttling for offscreen browser webviews) is left out deliberately — it's a main-process change with its own risk profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)