### PR TITLE
perf(canvas/terminal): secondary perf cleanups

### DIFF
--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -94,12 +94,14 @@ export function BrowserPanelContent({
 
     setConnectedTaskName(computeConnectedTask())
 
-    // Only re-compute when edges change, not on every panel position change
-    const unsub = useCanvasStore.subscribe((state, prevState) => {
-      if (state.edges !== prevState.edges) {
+    // Only re-compute when edges change, not on every panel position change.
+    // subscribeWithSelector fires the listener only when `edges` identity changes.
+    const unsub = useCanvasStore.subscribe(
+      (state) => state.edges,
+      () => {
         setConnectedTaskName(computeConnectedTask())
       }
-    })
+    )
     return unsub
   }, [panelId])
 

--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -301,11 +301,14 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   // Sync local state when store clears connectingFromId (Escape, background click, or edge completed)
   useEffect(() => {
     if (!isConnectingLocal) return
-    const unsub = useCanvasStore.subscribe((s) => {
-      if (s.connectingFromId !== panel.id) {
-        setIsConnectingLocal(false)
+    const unsub = useCanvasStore.subscribe(
+      (s) => s.connectingFromId,
+      (connectingFromId) => {
+        if (connectingFromId !== panel.id) {
+          setIsConnectingLocal(false)
+        }
       }
-    })
+    )
     return unsub
   }, [isConnectingLocal, panel.id])
 
@@ -383,15 +386,16 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
   // ── Proximity glow — this panel is a target of auto-connect proximity ──
   const [isProximityTarget, setIsProximityTarget] = useState(false)
   useEffect(() => {
-    const unsub = useCanvasStore.subscribe((s, prev) => {
-      if (s.proximityEdge !== prev.proximityEdge) {
-        const isTarget = s.proximityEdge
-          ? (s.proximityEdge.fromId === panel.id || s.proximityEdge.toId === panel.id) &&
-            s.draggingPanelId !== panel.id
+    const unsub = useCanvasStore.subscribe(
+      (s) => s.proximityEdge,
+      (proximityEdge) => {
+        const isTarget = proximityEdge
+          ? (proximityEdge.fromId === panel.id || proximityEdge.toId === panel.id) &&
+            useCanvasStore.getState().draggingPanelId !== panel.id
           : false
         setIsProximityTarget(isTarget)
       }
-    })
+    )
     return unsub
   }, [panel.id])
 
@@ -610,7 +614,6 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
             taskLayout={taskLayout}
             browserSessionId={panel.browserSessionId}
             streamPort={panel.streamPort}
-            zoom={zoom}
           />
         </div>
       )}
@@ -709,10 +712,9 @@ interface PanelContentProps {
   taskLayout?: TaskWorkspaceLayout
   browserSessionId?: string
   streamPort?: number
-  zoom: number
 }
 
-const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, title, taskLayout, browserSessionId, streamPort, zoom }: PanelContentProps) {
+const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, title, taskLayout, browserSessionId, streamPort }: PanelContentProps) {
   if (type === 'task' && refId) {
     return <TaskPanelContent panelId={id} taskId={refId} panelLayout={taskLayout} />
   }
@@ -726,7 +728,7 @@ const MemoizedPanelContent = memo(function PanelContent({ type, id, refId, url, 
     return <WebPagePanelContent panelId={id} url={url} title={title} />
   }
   if (type === 'terminal') {
-    return <TerminalPanelContent terminalId={id} cwd={url} canvasZoom={zoom} />
+    return <TerminalPanelContent terminalId={id} cwd={url} />
   }
   if (type === 'browser') {
     return <BrowserPanelContent panelId={id} url={url} sessionName={browserSessionId} streamPort={streamPort} />

--- a/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.test.tsx
@@ -48,6 +48,7 @@ vi.mock('@xterm/addon-web-links', () => ({
 }))
 
 import { TerminalPanelContent } from './TerminalPanelContent'
+import { useCanvasStore } from '@/stores/canvas-store'
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -62,6 +63,7 @@ function deferred<T>() {
 describe('TerminalPanelContent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    useCanvasStore.setState({ viewport: { x: 0, y: 0, zoom: 1 } })
     terminalWrite.mockResolvedValue(undefined)
     terminalResize.mockResolvedValue(undefined)
     terminalKill.mockResolvedValue(undefined)
@@ -190,8 +192,11 @@ describe('TerminalPanelContent', () => {
     terminalCreate.mockResolvedValue({ pid: 333 })
     terminalGetCwd.mockResolvedValue({ cwd: null })
 
+    // Committed canvas zoom is now read from the store, not a prop.
+    useCanvasStore.setState({ viewport: { x: 0, y: 0, zoom: 0.5 } })
+
     const { container } = render(
-      <TerminalPanelContent terminalId="panel-1" cwd="/tmp" canvasZoom={0.5} />
+      <TerminalPanelContent terminalId="panel-1" cwd="/tmp" />
     )
 
     const terminal = container.querySelector('.xterm-container') as HTMLElement

--- a/src/renderer/src/components/canvas/TerminalPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TerminalPanelContent.tsx
@@ -6,12 +6,20 @@ import { useCanvasStore } from '@/stores/canvas-store'
 import { subscribe } from '@/lib/shared-ipc-listeners'
 import '@xterm/xterm/css/xterm.css'
 
+// Verbose terminal lifecycle logs are off by default (they fire on every
+// init/focus/click). Opt in at runtime with:
+//   localStorage.setItem('debug:terminal', '1')
+const TERMINAL_DEBUG =
+  typeof localStorage !== 'undefined' && localStorage.getItem('debug:terminal') === '1'
+
+function tlog(...args: unknown[]): void {
+  if (TERMINAL_DEBUG) console.log(...args)
+}
+
 interface TerminalPanelContentProps {
   terminalId: string
   /** Initial working directory — restored from persisted panel state */
   cwd?: string
-  /** Current canvas zoom. xterm pointer math must compensate for canvas transforms. */
-  canvasZoom?: number
 }
 
 /**
@@ -27,7 +35,12 @@ interface TerminalPanelContentProps {
  *      sees truly-zero values even during layout shifts.
  *   3. Every fit() call is wrapped in try-catch.
  */
-export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: TerminalPanelContentProps) {
+export function TerminalPanelContent({ terminalId, cwd }: TerminalPanelContentProps) {
+  // Read the committed canvas zoom directly from the store. This subscription
+  // only re-renders THIS terminal when zoom is committed (mouseup / wheel-idle),
+  // instead of the old `zoom` prop that was threaded through MemoizedPanelContent
+  // and broke memoization for every non-terminal panel on each committed zoom.
+  const canvasZoom = useCanvasStore((s) => s.viewport.zoom)
   const containerRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<XTerm | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
@@ -41,11 +54,16 @@ export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: Termin
 
   // Store cwd in a ref — only used at init time, never triggers re-init
   const cwdRef = useRef(cwd)
+  // Last cwd we wrote to the store — lets us skip redundant panel writes when
+  // the 30s poll (or unmount capture) reports an unchanged directory.
+  const lastWrittenCwdRef = useRef(cwd)
+  // Trailing-debounce timer for fit()/resize on rapid container size changes.
+  const resizeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const adjustedMouseEventsRef = useRef<WeakSet<MouseEvent>>(new WeakSet())
   const activeMouseAdjustmentRef = useRef<{ left: number; top: number; zoom: number } | null>(null)
 
   const initTerminal = useCallback(async () => {
-    console.log(`[Terminal:${terminalId}] initTerminal called`, {
+    tlog(`[Terminal:${terminalId}] initTerminal called`, {
       hasContainer: !!containerRef.current,
       hasXterm: !!xtermRef.current,
       initCalled: initCalledRef.current,
@@ -56,7 +74,7 @@ export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: Termin
     // During canvas viewport changes or panel open animations the container
     // may still be 0×0 when this runs.
     const rect = containerRef.current.getBoundingClientRect()
-    console.log(`[Terminal:${terminalId}] container rect`, { w: rect.width, h: rect.height })
+    tlog(`[Terminal:${terminalId}] container rect`, { w: rect.width, h: rect.height })
     if (rect.width < 10 || rect.height < 10) return
 
     initCalledRef.current = true
@@ -130,7 +148,7 @@ export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: Termin
 
       activePidRef.current = pid
 
-      console.log(`[Terminal:${terminalId}] PTY created, setting up listeners`)
+      tlog(`[Terminal:${terminalId}] PTY created, setting up listeners`)
 
       const inputDispose = term.onData((data) => {
         window.electronAPI.terminal.write(terminalId, data)
@@ -187,11 +205,11 @@ export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: Termin
       ]
 
       // Focus the terminal so it can receive keyboard input
-      console.log(`[Terminal:${terminalId}] calling term.focus(), textarea exists:`, !!term.textarea)
+      tlog(`[Terminal:${terminalId}] calling term.focus(), textarea exists:`, !!term.textarea)
       term.focus()
       // Verify focus actually took
       setTimeout(() => {
-        console.log(`[Terminal:${terminalId}] after focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
+        tlog(`[Terminal:${terminalId}] after focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
       }, 100)
 
       isReadyRef.current = true
@@ -221,21 +239,29 @@ export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: Termin
         return
       }
 
-      // ── Subsequent resizes: refit ──
+      // ── Subsequent resizes: refit (trailing-debounced) ──
+      // A single drag/zoom fires dozens of ResizeObserver callbacks; running
+      // fitAddon.fit() + the resize IPC on each one thrashes the PTY. Coalesce
+      // to one fit+resize ~80ms after the size settles.
       if (!xtermRef.current || !fitAddonRef.current) return
       if (width < 10 || height < 10) return // still too small — skip
-      try {
-        fitAddonRef.current.fit()
-        if (xtermRef.current && isReadyRef.current) {
-          window.electronAPI.terminal.resize(
-            terminalId,
-            xtermRef.current.cols,
-            xtermRef.current.rows
-          ).catch(() => {})
+      if (resizeDebounceRef.current) clearTimeout(resizeDebounceRef.current)
+      resizeDebounceRef.current = setTimeout(() => {
+        resizeDebounceRef.current = null
+        if (!xtermRef.current || !fitAddonRef.current) return
+        try {
+          fitAddonRef.current.fit()
+          if (xtermRef.current && isReadyRef.current) {
+            window.electronAPI.terminal.resize(
+              terminalId,
+              xtermRef.current.cols,
+              xtermRef.current.rows
+            ).catch(() => {})
+          }
+        } catch {
+          // ignore fit errors during transitions
         }
-      } catch {
-        // ignore fit errors during transitions
-      }
+      }, 80)
     })
 
     observer.observe(containerRef.current)
@@ -246,6 +272,10 @@ export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: Termin
 
     return () => {
       observer.disconnect()
+      if (resizeDebounceRef.current) {
+        clearTimeout(resizeDebounceRef.current)
+        resizeDebounceRef.current = null
+      }
       const expectedPid = activePidRef.current ?? undefined
       isMountedRef.current = false
 
@@ -253,7 +283,8 @@ export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: Termin
         // Capture cwd before killing the terminal — persists across restarts.
         // Skip ID-only cleanup when this instance never acquired a PTY pid.
         window.electronAPI.terminal.getCwd(terminalId, expectedPid).then(({ cwd: currentCwd }) => {
-          if (currentCwd) {
+          if (currentCwd && currentCwd !== lastWrittenCwdRef.current) {
+            lastWrittenCwdRef.current = currentCwd
             useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
           }
         }).catch(() => {}).finally(() => {
@@ -284,7 +315,10 @@ export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: Termin
       try {
         const expectedPid = activePidRef.current ?? undefined
         const { cwd: currentCwd } = await window.electronAPI.terminal.getCwd(terminalId, expectedPid)
-        if (currentCwd) {
+        // Skip the store write (and the re-render/persist it triggers) when the
+        // directory hasn't changed since the last write.
+        if (currentCwd && currentCwd !== lastWrittenCwdRef.current) {
+          lastWrittenCwdRef.current = currentCwd
           useCanvasStore.getState().updatePanel(terminalId, { url: currentCwd })
         }
       } catch { /* ignore */ }
@@ -375,10 +409,10 @@ export function TerminalPanelContent({ terminalId, cwd, canvasZoom = 1 }: Termin
 
   // Focus the terminal when the container is clicked
   const handleClick = useCallback(() => {
-    console.log(`[Terminal:${terminalId}] container clicked, focusing. hasXterm:`, !!xtermRef.current, 'textarea:', !!xtermRef.current?.textarea)
+    tlog(`[Terminal:${terminalId}] container clicked, focusing. hasXterm:`, !!xtermRef.current, 'textarea:', !!xtermRef.current?.textarea)
     xtermRef.current?.focus()
     setTimeout(() => {
-      console.log(`[Terminal:${terminalId}] after click-focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
+      tlog(`[Terminal:${terminalId}] after click-focus, activeElement:`, document.activeElement?.tagName, document.activeElement?.className)
     }, 50)
   }, [terminalId])
 

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -1,10 +1,21 @@
 import { create } from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 import { settingsApi } from '@/lib/ipc-client'
 
 const CANVAS_STORAGE_KEY = 'canvas_state'
 const CDP_PORT = 19222
 let saveTimer: ReturnType<typeof setTimeout> | null = null
 const SAVE_DEBOUNCE_MS = 1000
+
+// Verbose browser/terminal edge-wiring logs are off by default (they trace a
+// multi-step async connection flow). Opt in at runtime with:
+//   localStorage.setItem('debug:canvas', '1')
+const CANVAS_DEBUG =
+  typeof localStorage !== 'undefined' && localStorage.getItem('debug:canvas') === '1'
+
+function clog(...args: unknown[]): void {
+  if (CANVAS_DEBUG) console.log(...args)
+}
 
 // ── Panel types ────────────────────────────────────────────
 
@@ -211,7 +222,7 @@ function scheduleSave() {
   }, SAVE_DEBOUNCE_MS)
 }
 
-export const useCanvasStore = create<CanvasState>((set, get) => ({
+export const useCanvasStore = create<CanvasState>()(subscribeWithSelector((set, get) => ({
   viewport: { x: 0, y: 0, zoom: 1 },
   panels: [],
   edges: [],
@@ -472,7 +483,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     set({ edges: [] })
     scheduleSave()
   }
-}))
+})))
 
 // ── Snapping utility ──────────────────────────────────────
 
@@ -638,7 +649,7 @@ function notifyAgentOfBrowserConnection(
     ? useCanvasStore.getState().panels.find((p) => p.id === browserPanel.id) || browserPanel
     : browserPanel
 
-  console.log('[BrowserEdge] notifyAgentOfBrowserConnection called', {
+  clog('[BrowserEdge] notifyAgentOfBrowserConnection called', {
     fromPanelId, toPanelId,
     fromType: fromPanel?.type, toType: toPanel?.type,
     taskRefId: taskPanel?.refId, browserPanelId: freshBrowserPanel?.id,
@@ -648,7 +659,7 @@ function notifyAgentOfBrowserConnection(
   })
 
   if (!taskPanel?.refId || !browserPanel) {
-    console.log('[BrowserEdge] BAIL: no taskPanel.refId or no browserPanel')
+    clog('[BrowserEdge] BAIL: no taskPanel.refId or no browserPanel')
     return
   }
 
@@ -661,14 +672,14 @@ function notifyAgentOfBrowserConnection(
 
     const taskId = taskPanel.refId!
     let session = useAgentStore.getState().getSession(taskId)
-    console.log('[BrowserEdge] session state', { taskId, sessionId: session?.sessionId, agentId: session?.agentId })
+    clog('[BrowserEdge] session state', { taskId, sessionId: session?.sessionId, agentId: session?.agentId })
 
     // If no active session, auto-start or resume the task
     if (!session?.sessionId) {
       const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
-      console.log('[BrowserEdge] no session, looking up task', { taskId, agentId: task?.agent_id, sessionId: task?.session_id })
+      clog('[BrowserEdge] no session, looking up task', { taskId, agentId: task?.agent_id, sessionId: task?.session_id })
       if (!task?.agent_id) {
-        console.log('[BrowserEdge] BAIL: no agent_id on task')
+        clog('[BrowserEdge] BAIL: no agent_id on task')
         return
       }
 
@@ -692,7 +703,7 @@ function notifyAgentOfBrowserConnection(
           initSession(taskId, sessionId, task.agent_id)
         }
         session = useAgentStore.getState().getSession(taskId)
-        console.log('[BrowserEdge] session after auto-start', { sessionId: session?.sessionId })
+        clog('[BrowserEdge] session after auto-start', { sessionId: session?.sessionId })
       } catch (err) {
         console.error('[BrowserEdge] Failed to auto-start/resume task:', err)
         return
@@ -700,7 +711,7 @@ function notifyAgentOfBrowserConnection(
     }
 
     if (!session?.sessionId) {
-      console.log('[BrowserEdge] BAIL: still no sessionId after auto-start attempt')
+      clog('[BrowserEdge] BAIL: still no sessionId after auto-start attempt')
       return
     }
 
@@ -715,7 +726,7 @@ function notifyAgentOfBrowserConnection(
     const resolveTab = async (attempt: number): Promise<string | null> => {
       const allTargets = await window.electronAPI.browser.getCdpTargets()
       const webviews = allTargets.filter((t) => t.type === 'webview')
-      console.log(`[BrowserEdge] resolveTab attempt=${attempt}`, {
+      clog(`[BrowserEdge] resolveTab attempt=${attempt}`, {
         allTargets: allTargets.map((t) => ({ tabId: t.tabId, type: t.type, url: t.url?.slice(0, 60) })),
         webviewsCount: webviews.length,
         browserUrl,
@@ -731,7 +742,7 @@ function notifyAgentOfBrowserConnection(
           const result = await window.electronAPI.browser.getTargetId(bp.webContentsId)
           if (result.targetId) {
             match = allTargets.find((t) => t.id === result.targetId) || null
-            if (match) console.log('[BrowserEdge] matched by webContentsId→getTargetId', match.tabId)
+            if (match) clog('[BrowserEdge] matched by webContentsId→getTargetId', match.tabId)
           }
         } catch { /* debugger API failed */ }
       }
@@ -740,13 +751,13 @@ function notifyAgentOfBrowserConnection(
       if (!match && browserUrl) {
         const urlBase = browserUrl.split('?')[0].split('#')[0]
         match = webviews.find((t) => t.url.startsWith(urlBase)) || null
-        if (match) console.log('[BrowserEdge] matched by URL', { tabId: match.tabId, matchUrl: match.url?.slice(0, 60) })
+        if (match) clog('[BrowserEdge] matched by URL', { tabId: match.tabId, matchUrl: match.url?.slice(0, 60) })
       }
 
       // 3. Last resort — first available webview
       if (!match) {
         match = webviews[0] || null
-        if (match) console.log('[BrowserEdge] fallback to first webview', match.tabId)
+        if (match) clog('[BrowserEdge] fallback to first webview', match.tabId)
       }
 
       return match?.tabId || null
@@ -756,14 +767,14 @@ function notifyAgentOfBrowserConnection(
       for (let attempt = 0; attempt < 3; attempt++) {
         tabId = await resolveTab(attempt)
         if (tabId) break
-        console.log(`[BrowserEdge] no tab found, retrying in 1s (attempt ${attempt + 1}/3)`)
+        clog(`[BrowserEdge] no tab found, retrying in 1s (attempt ${attempt + 1}/3)`)
         await new Promise((r) => setTimeout(r, 1000))
       }
     } catch (err) {
       console.error('[BrowserEdge] resolveTab error:', err)
     }
 
-    console.log('[BrowserEdge] final result', { tabId, browserTitle, browserUrl })
+    clog('[BrowserEdge] final result', { tabId, browserTitle, browserUrl })
 
     if (!tabId) {
       agentSessionApi.send(

--- a/src/renderer/src/stores/dashboard-store.ts
+++ b/src/renderer/src/stores/dashboard-store.ts
@@ -407,6 +407,9 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     // Idempotent — don't start multiple timers
     if (_refreshTimerRef) return
     _refreshTimerRef = setInterval(() => {
+      // Skip background refresh while the window is hidden/backgrounded — there's
+      // no visible dashboard to update, and the next tick refetches once visible.
+      if (typeof document !== 'undefined' && document.hidden) return
       // Only refresh if authenticated
       const isAuth = useEnterpriseStore.getState().isAuthenticated
       if (isAuth) {


### PR DESCRIPTION
## Summary

Six low-risk canvas/terminal renderer perf cleanups (re-scoped subtask under the UI-performance parent). Each item was re-verified against current `main` (which already contains the #434 imperative-viewport work via `getLiveViewport()`).

1. **Zoom prop threading** — dropped the `zoom` prop from `MemoizedPanelContent`. It broke `React.memo` for **every** non-terminal panel (task/transcript/browser/webpage) on each committed zoom change, even though only the terminal used it. `TerminalPanelContent` now reads committed zoom itself via `useCanvasStore((s) => s.viewport.zoom)`, so only the terminal panel re-renders on a committed zoom.
2. **Terminal resize thrash** — trailing-debounce (~80ms) `fitAddon.fit()` + `terminal.resize` IPC inside the `ResizeObserver`, so a drag/zoom no longer thrashes the PTY on every observer callback. Timer cleared on unmount.
3. **Selector-less store subscribes** — added `subscribeWithSelector` middleware to `canvas-store` and converted the whole-store `subscribe()` calls in `CanvasPanel` (`connectingFromId`, `proximityEdge`) and `BrowserPanelContent` (`edges`) to selector-based subscriptions, so those listeners fire only when the selected slice changes rather than on every store mutation (e.g. every panel move / viewport commit).
4. **Terminal cwd poll** — skip the panel store write (and the re-render/persist it triggers) when the 30s `getCwd` poll (and the unmount capture) reports an unchanged directory.
5. **Dashboard refresh not visibility-gated** — skip the periodic interval refetch while `document.hidden` in `dashboard-store`.
6. **Hot-path console logs** — gated verbose `TerminalPanelContent` lifecycle logs and `canvas-store` `[BrowserEdge]` logs behind opt-in localStorage debug flags (`debug:terminal` / `debug:canvas`), off by default. `console.error` paths left intact.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors / 122 warnings (matches baseline)
- [x] `pnpm test:run` — 100 files / 1599 tests pass (includes updated terminal test that now sets committed zoom via the store instead of the removed prop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)