### PR TITLE
perf: reduce memory retained by off-screen canvas tasks

### DIFF
--- a/src/renderer/src/components/canvas/CanvasPanel.tsx
+++ b/src/renderer/src/components/canvas/CanvasPanel.tsx
@@ -21,7 +21,7 @@ import { BrowserPanelContent } from './BrowserPanelContent'
 import { getCanvasTaskStatusStyle, shouldPulseCanvasTaskStatusTransition } from './canvas-status-style'
 
 /**
- * Off-viewport ("frozen") panel content.
+ * Off-viewport ("frozen") resource panel content.
  *
  * CSS containment stops a hidden panel's internal churn (streaming transcripts,
  * terminal output) from invalidating canvas-level layout and paint, which keeps
@@ -494,6 +494,12 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
     minHeight: isCollapsed ? undefined : (panel.minHeight ?? 150),
     '--canvas-status-rgb': pulseStyle?.rgb ?? '59,130,246',
   } as CSSProperties
+  // Task/transcript trees are cheap to reconstruct from the durable projection
+  // and can contain thousands of DOM nodes each. Unmount them when off-screen,
+  // mirroring a routed chat UI where only the active conversation is mounted.
+  // Browser and terminal panels stay mounted because unmounting would destroy
+  // their live webContents/PTY sessions.
+  const suspendHeavyContent = frozen && (panel.type === 'task' || panel.type === 'transcript')
 
   return (
     <div
@@ -602,19 +608,22 @@ export const CanvasPanel = memo(function CanvasPanel({ panel, zoom, frozen = fal
       {/* Content area */}
       {!isCollapsed && (
         <div
+          data-canvas-content-mounted={suspendHeavyContent ? 'false' : 'true'}
           className={`flex-1 overflow-hidden min-h-0 ${panel.type === 'task' || panel.type === 'transcript' || panel.type === 'webpage' || panel.type === 'terminal' || panel.type === 'browser' || (panel.type === 'app' && panel.refId) ? '' : 'p-3 overflow-auto'}`}
           style={frozen ? FROZEN_CONTENT_STYLE : undefined}
         >
-          <MemoizedPanelContent
-            type={panel.type}
-            id={panel.id}
-            refId={panel.refId}
-            url={panel.url}
-            title={panel.title}
-            taskLayout={taskLayout}
-            browserSessionId={panel.browserSessionId}
-            streamPort={panel.streamPort}
-          />
+          {!suspendHeavyContent && (
+            <MemoizedPanelContent
+              type={panel.type}
+              id={panel.id}
+              refId={panel.refId}
+              url={panel.url}
+              title={panel.title}
+              taskLayout={taskLayout}
+              browserSessionId={panel.browserSessionId}
+              streamPort={panel.streamPort}
+            />
+          )}
         </div>
       )}
 

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -79,6 +79,13 @@ vi.mock('@/stores/ui-store', () => ({
 
 describe('InfiniteCanvas', () => {
   beforeEach(() => {
+    const api = window.electronAPI as typeof window.electronAPI & {
+      onHeartbeatAlert?: typeof window.electronAPI.onHeartbeatAlert
+      onHeartbeatDisabled?: typeof window.electronAPI.onHeartbeatDisabled
+    }
+    if (!api.onHeartbeatAlert) api.onHeartbeatAlert = vi.fn(() => vi.fn())
+    if (!api.onHeartbeatDisabled) api.onHeartbeatDisabled = vi.fn(() => vi.fn())
+
     useCanvasStore.setState({
       viewport: { x: 0, y: 0, zoom: 1 },
       panels: [],
@@ -126,6 +133,42 @@ describe('InfiniteCanvas', () => {
     render(<InfiniteCanvas />)
     expect(screen.getByText('My Task Panel')).toBeTruthy()
     expect(screen.getByText('Task')).toBeTruthy()
+  })
+
+  it('unmounts off-screen task content while keeping the lightweight panel shell', async () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+    globalThis.ResizeObserver = class {
+      private callback: ResizeObserverCallback
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback
+      }
+      observe() {
+        this.callback([{ contentRect: { width: 800, height: 600 } } as ResizeObserverEntry], this as ResizeObserver)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+
+    try {
+      useCanvasStore.getState().addPanel({
+        type: 'task',
+        title: 'Far Away Task',
+        refId: 'task-123',
+        x: 5000,
+        y: 5000,
+        width: 400,
+        height: 300,
+      })
+
+      const { container } = render(<InfiniteCanvas />)
+      expect(screen.getByText('Far Away Task')).toBeTruthy()
+      await waitFor(() => {
+        expect(container.querySelector('[data-canvas-content-mounted="false"]')).toBeTruthy()
+      })
+      expect(screen.queryByText('Task not found or deleted')).toBeNull()
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver
+    }
   })
 
   it('uses task status color coding for task panels and minimap rectangles', () => {

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -30,7 +30,10 @@ function isPanelVisible(
   containerWidth: number,
   containerHeight: number
 ): boolean {
-  if (!containerWidth || !containerHeight) return true // assume visible if unknown
+  // Keep only lightweight shells mounted until the first measurement. Assuming
+  // everything is visible here briefly mounted and hydrated every transcript
+  // during startup, which is exactly the high-water memory spike we avoid.
+  if (!containerWidth || !containerHeight) return false
 
   // Visible region in canvas coordinates
   const margin = 200 // generous margin to avoid flickering at edges
@@ -253,7 +256,10 @@ export function InfiniteCanvas() {
 
   // Track container size for viewport visibility culling
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 })
-  useEffect(() => {
+  // Measure before child passive effects run. This prevents the initial
+  // zero-size fallback from hydrating every canvas transcript for one frame
+  // before off-screen culling becomes active.
+  useLayoutEffect(() => {
     const el = containerRef.current
     if (!el) return
     const observer = new ResizeObserver((entries) => {

--- a/src/renderer/src/hooks/use-agent-session.ts
+++ b/src/renderer/src/hooks/use-agent-session.ts
@@ -37,16 +37,18 @@ export function useAgentSession(taskId: string | undefined) {
   const session = useAgentStore((s) => (taskId ? s.sessions.get(taskId) : undefined))
   const initSession = useAgentStore((s) => s.initSession)
   const endSession = useAgentStore((s) => s.endSession)
-  const hydrateTranscript = useAgentStore((s) => s.hydrateTranscript)
+  const bindTranscript = useAgentStore((s) => s.bindTranscript)
 
   // Hydrate from the durable transcript projection when a task view binds.
   // The store renders state, not history-of-pushes: output produced while
   // this window wasn't open (background wake-ups, app restarts, resumed
   // sessions) appears immediately without needing a live session.
   useEffect(() => {
-    // Guard for partial store mocks / older bridges without the snapshot API
-    if (taskId && typeof hydrateTranscript === 'function') void hydrateTranscript(taskId)
-  }, [taskId, hydrateTranscript])
+    // Guard for partial store mocks. Releasing the binding drops the renderer
+    // projection while leaving the durable transcript and agent runtime intact.
+    if (taskId && typeof bindTranscript === 'function') return bindTranscript(taskId)
+    return undefined
+  }, [taskId, bindTranscript])
 
   // Project the store session into a stable value. Keyed on individual fields so
   // the returned object keeps identity across unrelated store deltas (e.g. a new

--- a/src/renderer/src/stores/agent-store.test.ts
+++ b/src/renderer/src/stores/agent-store.test.ts
@@ -241,6 +241,56 @@ describe('useAgentStore', () => {
       fireDelta('task-1', [part({ partId: 'p2', content: 'two', createdAt: 200, rev: 2 })])
       expect(useAgentStore.getState().sessions.get('task-1')!.messages.map((m) => m.id)).toEqual(['p1', 'p2'])
     })
+
+    it('releases an unmounted transcript and ignores background deltas until rebound', async () => {
+      getSnapshotMock.mockResolvedValue([part({ partId: 'p1', content: 'large history', rev: 1 })])
+      const release = useAgentStore.getState().bindTranscript('task-1')
+      await vi.waitFor(() => {
+        expect(useAgentStore.getState().sessions.get('task-1')?.messages).toHaveLength(1)
+      })
+
+      release()
+      expect(useAgentStore.getState().sessions.get('task-1')?.messages).toEqual([])
+
+      fireDelta('task-1', [part({ partId: 'p2', content: 'background output', rev: 2 })])
+      expect(useAgentStore.getState().sessions.get('task-1')?.messages).toEqual([])
+    })
+
+    it('keeps the projection until the final mounted consumer releases it', async () => {
+      getSnapshotMock.mockResolvedValue([part({ partId: 'p1', content: 'shared history' })])
+      const releaseFirst = useAgentStore.getState().bindTranscript('task-1')
+      const releaseSecond = useAgentStore.getState().bindTranscript('task-1')
+      await vi.waitFor(() => {
+        expect(useAgentStore.getState().sessions.get('task-1')?.messages).toHaveLength(1)
+      })
+
+      releaseFirst()
+      expect(useAgentStore.getState().sessions.get('task-1')?.messages).toHaveLength(1)
+      releaseSecond()
+      expect(useAgentStore.getState().sessions.get('task-1')?.messages).toEqual([])
+    })
+
+    it('rehydrates the authoritative transcript when a released view mounts again', async () => {
+      getSnapshotMock.mockResolvedValueOnce([part({ partId: 'p1', content: 'first view', rev: 1 })])
+      const release = useAgentStore.getState().bindTranscript('task-1')
+      await vi.waitFor(() => {
+        expect(useAgentStore.getState().sessions.get('task-1')?.messages).toHaveLength(1)
+      })
+      release()
+
+      getSnapshotMock.mockResolvedValueOnce([
+        part({ partId: 'p1', content: 'first view', rev: 1 }),
+        part({ partId: 'p2', content: 'background output', rev: 2 })
+      ])
+      const releaseAgain = useAgentStore.getState().bindTranscript('task-1')
+      await vi.waitFor(() => {
+        expect(useAgentStore.getState().sessions.get('task-1')?.messages.map((message) => message.id)).toEqual([
+          'p1',
+          'p2'
+        ])
+      })
+      releaseAgain()
+    })
   })
 
   describe('Session status via onAgentStatus (state only, not messages)', () => {

--- a/src/renderer/src/stores/agent-store.ts
+++ b/src/renderer/src/stores/agent-store.ts
@@ -96,6 +96,11 @@ interface ProjectionCache {
 }
 
 const projections = new Map<string, ProjectionCache>()
+// Number of mounted transcript views per task. Canvas panels can be kept in the
+// workspace indefinitely, but their full transcript only belongs in renderer
+// memory while at least one view is actually mounted. The durable DB projection
+// is re-hydrated when a view comes back.
+const projectionBindings = new Map<string, number>()
 const bindingTasks = new Set<string>()
 const outputAnalyticsByTask = new Map<string, { messageCount: number; toolNames: Set<string> }>()
 
@@ -112,6 +117,7 @@ function resetProjection(taskId: string): void {
 /** Test-only: clear all projection caches between tests. */
 export function __clearProjectionsForTest(): void {
   projections.clear()
+  projectionBindings.clear()
   bindingTasks.clear()
   outputAnalyticsByTask.clear()
 }
@@ -176,6 +182,8 @@ interface AgentState {
    *  snapshot into the cache and render it. Idempotent; subsequent updates
    *  arrive as `transcript:changed` deltas. */
   hydrateTranscript: (taskId: string) => Promise<void>
+  /** Retain a task's transcript while a view is mounted. Returns its cleanup. */
+  bindTranscript: (taskId: string) => () => void
   endSession: (taskId: string) => void
   removeSession: (taskId: string) => void
   clearMessageDedup: (taskId: string) => void
@@ -232,12 +240,16 @@ export const useAgentStore = create<AgentState>((set, get) => {
     })
   }
 
-  const hydrateTranscript = async (taskId: string): Promise<void> => {
+  const hydrateTranscript = async (taskId: string, requireBinding = false): Promise<void> => {
     if (!taskId || bindingTasks.has(taskId)) return
+    if (requireBinding && !projectionBindings.has(taskId)) return
     if (typeof window.electronAPI?.agentSession?.getTranscriptSnapshot !== 'function') return
     bindingTasks.add(taskId)
     try {
       const snapshot = await agentSessionApi.getTranscriptSnapshot(taskId)
+      // The panel may have gone off-screen while the snapshot IPC was in
+      // flight. Do not repopulate the cache after its final consumer left.
+      if (requireBinding && !projectionBindings.has(taskId)) return
       if (snapshot.length === 0) return
       const maxRev = snapshot.reduce((m, p) => Math.max(m, p.rev || 0), 0)
       // Snapshot is the authoritative full state — replace the cache.
@@ -255,6 +267,7 @@ export const useAgentStore = create<AgentState>((set, get) => {
   // the renderer may have missed (dropped IPC event).
   const reconcileDelta = async (taskId: string): Promise<void> => {
     if (typeof window.electronAPI?.agentSession?.getTranscriptDelta !== 'function') return
+    if (!projections.has(taskId)) return
     try {
       const sinceRev = getProjection(taskId).rev
       const { parts, maxRev } = await agentSessionApi.getTranscriptDelta(taskId, sinceRev)
@@ -270,7 +283,13 @@ export const useAgentStore = create<AgentState>((set, get) => {
   // Transcript content: the ONLY writer of messages. Idempotent delta apply.
   onTranscriptChanged((event: TranscriptChangedEvent) => {
     if (!event?.taskId) return
-    applyParts(event.taskId, event.parts || [], event.maxRev)
+    // Background agents continue writing to the durable projection, but an
+    // unmounted task has no renderer consumer. Ignoring its payload here avoids
+    // rebuilding every off-screen transcript in memory; bindTranscript() loads
+    // the authoritative snapshot when the task becomes visible again.
+    if (projections.has(event.taskId)) {
+      applyParts(event.taskId, event.parts || [], event.maxRev)
+    }
     accumulateOutputAnalytics(event.taskId, event.parts || [])
   })
 
@@ -287,7 +306,9 @@ export const useAgentStore = create<AgentState>((set, get) => {
             agentId: event.agentId || '',
             taskId: event.taskId,
             status: event.status,
-            messages: deriveMessages(getProjection(event.taskId)),
+            messages: projections.has(event.taskId)
+              ? deriveMessages(projections.get(event.taskId)!)
+              : [],
             pendingApproval: null
           })
         })
@@ -299,10 +320,6 @@ export const useAgentStore = create<AgentState>((set, get) => {
           next_status: event.status,
           source: 'backend'
         })
-      } else if (event.taskId && event.status === SessionStatus.IDLE) {
-        // A session this window never observed just went idle — bind so its
-        // output is rendered from the projection.
-        void hydrateTranscript(event.taskId)
       }
       return
     }
@@ -430,7 +447,38 @@ export const useAgentStore = create<AgentState>((set, get) => {
       }
     },
 
-    hydrateTranscript,
+    hydrateTranscript: (taskId) => hydrateTranscript(taskId),
+
+    bindTranscript: (taskId) => {
+      const previousCount = projectionBindings.get(taskId) ?? 0
+      projectionBindings.set(taskId, previousCount + 1)
+      if (previousCount === 0) void hydrateTranscript(taskId, true)
+
+      let released = false
+      return () => {
+        if (released) return
+        released = true
+
+        const nextCount = (projectionBindings.get(taskId) ?? 1) - 1
+        if (nextCount > 0) {
+          projectionBindings.set(taskId, nextCount)
+          return
+        }
+
+        projectionBindings.delete(taskId)
+        resetProjection(taskId)
+        set((state) => {
+          const session = state.sessions.get(taskId)
+          if (!session || session.messages.length === 0) return state
+          return {
+            sessions: new Map(state.sessions).set(taskId, {
+              ...session,
+              messages: []
+            })
+          }
+        })
+      }
+    },
 
     initSession: (taskId, sessionId, agentId) => {
       set((state) => {


### PR DESCRIPTION
## Summary

- unmount reconstructible task/transcript content outside the canvas viewport while preserving lightweight panel shells
- reference-count mounted transcript consumers and release renderer projections when the final view unmounts
- rehydrate the authoritative durable transcript when a panel returns, while ignoring background deltas for views with no consumer
- keep browser and terminal panels mounted so live webContents and PTY sessions are preserved

## Root cause

The installed v0.0.124 workspace retained all 29 canvas workspaces even though 26 were off-screen. This produced 21,578 DOM elements, about 19,000 of them inside hidden panels, and retained every transcript projection in the renderer. The main renderer consumed about 2.095 GB RSS; the complete Electron process tree consumed 2.416 GB. `vmmap` attributed most of the renderer footprint to Chromium PartitionAlloc rather than the V8 heap.

## Measurement

Measured against a safely isolated copy of the same 178 MB production-sized local database and the same 29-panel canvas:

| Metric | Before | After |
| --- | ---: | ---: |
| Total Electron process-tree RSS | 2.416 GB | 0.594 GB |
| Renderer V8 heap used after forced GC | ~320 MB | ~38 MB |
| DOM elements | 21,578 | 4,399 |
| Mounted / suspended canvas contents | 29 / 0 | 6 / 23 |

This is a 75.4% reduction in steady-state process-tree RSS. Chromium GC was explicitly triggered for the heap/steady-state comparison; process RSS was measured five seconds later.

## Validation

- `pnpm typecheck`
- focused ESLint on all changed files
- `pnpm build`
- agent store: 34/34 passing
- agent session hook: 15/15 passing (existing React `act(...)` warnings remain)
- infinite canvas: 20/20 passing
- mutation check: both new behavior suites fail when transcript release / content suspension is disabled

