### PR TITLE
fix: Ctrl+/Ctrl-/Ctrl+0 zoom shortcuts not working on Windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -180,6 +180,26 @@ function createWindow(): void {
     mainWindow?.webContents.setZoomLevel(0)
   })
 
+  // On Windows, `titleBarStyle: 'hidden'` + `titleBarOverlay` (Window Controls
+  // Overlay) removes the native frame that would normally host the menu bar's
+  // accelerator table — Menu.setApplicationMenu()'s Ctrl+/Ctrl-/Ctrl+0 roles
+  // don't reliably fire in that mode. Handle the zoom shortcuts directly so
+  // they work regardless of the (invisible) native menu.
+  if (!isMac) {
+    mainWindow.webContents.on('before-input-event', (_event, input) => {
+      if (input.type !== 'keyDown' || !input.control || input.meta || input.alt || input.shift) return
+      const wc = mainWindow?.webContents
+      if (!wc) return
+      if (input.key === '=' || input.key === '+') {
+        wc.setZoomLevel(Math.min(wc.getZoomLevel() + 0.5, 9))
+      } else if (input.key === '-') {
+        wc.setZoomLevel(Math.max(wc.getZoomLevel() - 0.5, -8))
+      } else if (input.key === '0') {
+        wc.setZoomLevel(0)
+      }
+    })
+  }
+
   // Auto-reload on renderer crash (blank screen recovery)
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
     console.error(`[Main] Renderer crashed: reason=${details.reason}, exitCode=${details.exitCode}`)


### PR DESCRIPTION
## Summary
- `Ctrl +` / `Ctrl -` / `Ctrl 0` zoom shortcuts didn't work on Windows, and clicking the native View menu's Zoom In/Out (when revealed via Alt) didn't work either.
- Root cause: `titleBarStyle: 'hidden'` + `titleBarOverlay` (Window Controls Overlay mode) removes the native frame that would normally host the menu bar's accelerator table, so `Menu.setApplicationMenu()`'s `resetZoom`/`zoomIn`/`zoomOut` roles don't reliably fire via keyboard on Windows even though the menu items exist.
- Fix: handle the zoom shortcuts directly via `before-input-event` on the main window's webContents (Windows/Linux only — macOS keeps its native menu bar and isn't affected), independent of the native menu's accelerator resolution.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] Manual verification on Windows: `Ctrl +`/`Ctrl -`/`Ctrl 0` now zoom the main window in/out/reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)