### PR TITLE
feat: make agent model picker searchable

### DIFF
--- a/scripts/rebuild-native.mjs
+++ b/scripts/rebuild-native.mjs
@@ -15,16 +15,43 @@ const require = createRequire(import.meta.url)
 
 const electronVersion = require('electron/package.json').version
 
+// Apple clang on recent macOS/CLT often fails to find libc++ headers
+// (`climits` not found) unless the SDK sysroot is explicit.
+function macSdkEnv() {
+  if (process.platform !== 'darwin') return process.env
+  try {
+    const sdkRoot = execSync('xcrun --sdk macosx --show-sdk-path', { encoding: 'utf8' }).trim()
+    if (!sdkRoot) return process.env
+    const cxxInc = `${sdkRoot}/usr/include/c++/v1`
+    return {
+      ...process.env,
+      SDKROOT: process.env.SDKROOT || sdkRoot,
+      CFLAGS: `${process.env.CFLAGS || ''} -isysroot ${sdkRoot}`.trim(),
+      CXXFLAGS: `${process.env.CXXFLAGS || ''} -isysroot ${sdkRoot} -I${cxxInc}`.trim(),
+      CPPFLAGS: `${process.env.CPPFLAGS || ''} -isysroot ${sdkRoot} -I${cxxInc}`.trim(),
+      LDFLAGS: `${process.env.LDFLAGS || ''} -isysroot ${sdkRoot}`.trim()
+    }
+  } catch {
+    return process.env
+  }
+}
+
+const rebuildEnv = macSdkEnv()
+
+function rebuildForElectron(cwd) {
+  execSync(
+    `npx node-gyp rebuild --runtime=electron --target=${electronVersion} --dist-url=https://electronjs.org/headers`,
+    { cwd, stdio: 'inherit', env: rebuildEnv }
+  )
+}
+
 // ── better-sqlite3 ─────────────────────────────────────────────
 const sqlitePath = dirname(require.resolve('better-sqlite3/package.json'))
 
 console.log(`Rebuilding better-sqlite3 for Electron ${electronVersion}`)
 console.log(`Package path: ${sqlitePath}`)
 
-execSync(
-  `npx node-gyp rebuild --runtime=electron --target=${electronVersion} --dist-url=https://electronjs.org/headers`,
-  { cwd: sqlitePath, stdio: 'inherit' }
-)
+rebuildForElectron(sqlitePath)
 
 console.log('better-sqlite3 done')
 
@@ -35,10 +62,7 @@ try {
   console.log(`\nRebuilding node-pty for Electron ${electronVersion}`)
   console.log(`Package path: ${ptyPath}`)
 
-  execSync(
-    `npx node-gyp rebuild --runtime=electron --target=${electronVersion} --dist-url=https://electronjs.org/headers`,
-    { cwd: ptyPath, stdio: 'inherit' }
-  )
+  rebuildForElectron(ptyPath)
 
   console.log('node-pty done')
 } catch (err) {

--- a/src/renderer/src/components/agents/AgentForm.tsx
+++ b/src/renderer/src/components/agents/AgentForm.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/Input'
 import { Textarea } from '@/components/ui/Textarea'
 import { Label } from '@/components/ui/Label'
 import { Checkbox } from '@/components/ui/Checkbox'
+import { SearchableSelect } from '@/components/ui/SearchableSelect'
 import { agentConfigApi } from '@/lib/ipc-client'
 import { useMcpStore } from '@/stores/mcp-store'
 import { useSkillStore } from '@/stores/skill-store'
@@ -425,17 +426,13 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
                 </Button>
               </div>
             ) : availableModels.length > 0 ? (
-              <select
+              <SearchableSelect
                 id="agent-model"
                 value={model}
-                onChange={(e) => setModel(e.target.value)}
-                className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm cursor-pointer"
-              >
-                <option value="">Select a model...</option>
-                {availableModels.map((m) => (
-                  <option key={m.id} value={m.id}>{m.name}</option>
-                ))}
-              </select>
+                onChange={setModel}
+                placeholder="Select a model..."
+                options={availableModels.map((m) => ({ value: m.id, label: m.name }))}
+              />
             ) : (
               <div className="space-y-2">
                 <Input

--- a/src/renderer/src/components/plugins/NotionConfigForm.tsx
+++ b/src/renderer/src/components/plugins/NotionConfigForm.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
-import { Loader2, Plus, X, Search, ChevronDown, RefreshCw } from 'lucide-react'
+import { useState, useEffect, useCallback } from 'react'
+import { Loader2, Plus, X, Search, RefreshCw } from 'lucide-react'
 import { Input } from '@/components/ui/Input'
 import { Label } from '@/components/ui/Label'
 import { Button } from '@/components/ui/Button'
+import { SearchableSelect } from '@/components/ui/SearchableSelect'
 import { pluginApi } from '@/lib/ipc-client'
 import type { ConfigFieldOption } from '@/types'
 import type { PluginFormProps } from './PluginFormProps'
@@ -368,96 +369,6 @@ function MultiSelectValues({
           <p className="text-xs text-muted-foreground px-2 py-1">No matching values</p>
         )}
       </div>
-    </div>
-  )
-}
-
-// ── Searchable Select ────────────────────────────────────────
-
-function SearchableSelect({
-  options,
-  value,
-  onChange,
-  placeholder
-}: {
-  options: { value: string; label: string }[]
-  value: string
-  onChange: (value: string) => void
-  placeholder?: string
-}) {
-  const [open, setOpen] = useState(false)
-  const [search, setSearch] = useState('')
-  const containerRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [])
-
-  const filtered = search
-    ? options.filter((o) => o.label.toLowerCase().includes(search.toLowerCase()))
-    : options
-
-  const selectedLabel = options.find((o) => o.value === value)?.label
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        onClick={() => {
-          setOpen(!open)
-          if (!open) setTimeout(() => inputRef.current?.focus(), 0)
-        }}
-        className="w-full flex items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm"
-      >
-        <span className={selectedLabel ? '' : 'text-muted-foreground'}>
-          {selectedLabel || placeholder || 'Select...'}
-        </span>
-        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-      </button>
-
-      {open && (
-        <div className="absolute z-50 mt-1 w-full rounded-md border border-input bg-popover shadow-md">
-          <div className="relative border-b border-input">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-            <input
-              ref={inputRef}
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search..."
-              className="w-full bg-transparent pl-8 pr-3 py-2 text-sm outline-none"
-            />
-          </div>
-          <div className="max-h-48 overflow-y-auto p-1">
-            {filtered.map((opt) => (
-              <button
-                key={opt.value}
-                type="button"
-                onClick={() => {
-                  onChange(opt.value)
-                  setOpen(false)
-                  setSearch('')
-                }}
-                className={`w-full text-left rounded px-2 py-1.5 text-sm hover:bg-accent ${
-                  opt.value === value ? 'bg-accent' : ''
-                }`}
-              >
-                {opt.label}
-              </button>
-            ))}
-            {filtered.length === 0 && (
-              <p className="px-2 py-1.5 text-xs text-muted-foreground">No results</p>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/renderer/src/components/ui/SearchableSelect.test.tsx
+++ b/src/renderer/src/components/ui/SearchableSelect.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { SearchableSelect } from './SearchableSelect'
 
 const OPTIONS = [
@@ -9,6 +9,10 @@ const OPTIONS = [
 ]
 
 describe('SearchableSelect', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   it('filters options by label and value', () => {
     const onChange = vi.fn()
 

--- a/src/renderer/src/components/ui/SearchableSelect.test.tsx
+++ b/src/renderer/src/components/ui/SearchableSelect.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { SearchableSelect } from './SearchableSelect'
+
+const OPTIONS = [
+  { value: 'anthropic/claude-sonnet-4', label: 'Anthropic - Claude Sonnet 4' },
+  { value: 'openai/gpt-5', label: 'OpenAI - GPT-5' },
+  { value: 'google/gemini-2.5-pro', label: 'Google - Gemini 2.5 Pro' }
+]
+
+describe('SearchableSelect', () => {
+  it('filters options by label and value', () => {
+    const onChange = vi.fn()
+
+    render(
+      <SearchableSelect
+        options={OPTIONS}
+        value=""
+        onChange={onChange}
+        placeholder="Select a model..."
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /select a model/i }))
+    expect(screen.getAllByRole('option')).toHaveLength(3)
+
+    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'sonnet' } })
+    expect(screen.getAllByRole('option')).toHaveLength(1)
+    expect(screen.getByRole('option', { name: /Claude Sonnet 4/i })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'gemini-2.5' } })
+    expect(screen.getAllByRole('option')).toHaveLength(1)
+    expect(screen.getByRole('option', { name: /Gemini 2.5 Pro/i })).toBeInTheDocument()
+  })
+
+  it('calls onChange and closes when an option is selected', () => {
+    const onChange = vi.fn()
+
+    render(
+      <SearchableSelect
+        options={OPTIONS}
+        value=""
+        onChange={onChange}
+        placeholder="Select a model..."
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /select a model/i }))
+    fireEvent.click(screen.getByRole('option', { name: /GPT-5/i }))
+
+    expect(onChange).toHaveBeenCalledWith('openai/gpt-5')
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/ui/SearchableSelect.tsx
+++ b/src/renderer/src/components/ui/SearchableSelect.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react'
+import { ChevronDown, Search } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export interface SearchableSelectOption {
+  value: string
+  label: string
+}
+
+interface SearchableSelectProps {
+  options: SearchableSelectOption[]
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  id?: string
+  className?: string
+}
+
+export function SearchableSelect({
+  options,
+  value,
+  onChange,
+  placeholder,
+  id,
+  className
+}: SearchableSelectProps) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+        setSearch('')
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  const q = search.trim().toLowerCase()
+  const filtered = q
+    ? options.filter(
+        (o) => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q)
+      )
+    : options
+
+  const selectedLabel = options.find((o) => o.value === value)?.label ?? (value || undefined)
+
+  const close = () => {
+    setOpen(false)
+    setSearch('')
+  }
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <button
+        type="button"
+        id={id}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => {
+          if (open) {
+            close()
+          } else {
+            setOpen(true)
+            setTimeout(() => inputRef.current?.focus(), 0)
+          }
+        }}
+        className="w-full flex items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm cursor-pointer"
+      >
+        <span className={cn('truncate text-left', selectedLabel ? '' : 'text-muted-foreground')}>
+          {selectedLabel || placeholder || 'Select...'}
+        </span>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border border-input bg-popover shadow-md">
+          <div className="relative border-b border-input">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.preventDefault()
+                  close()
+                }
+              }}
+              placeholder="Search..."
+              className="w-full bg-transparent pl-8 pr-3 py-2 text-sm outline-none"
+            />
+          </div>
+          <div className="max-h-48 overflow-y-auto p-1" role="listbox">
+            {filtered.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                role="option"
+                aria-selected={opt.value === value}
+                onClick={() => {
+                  onChange(opt.value)
+                  close()
+                }}
+                className={cn(
+                  'w-full text-left rounded px-2 py-1.5 text-sm hover:bg-accent cursor-pointer',
+                  opt.value === value && 'bg-accent'
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+            {filtered.length === 0 && (
+              <p className="px-2 py-1.5 text-xs text-muted-foreground">No results</p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Replace the plain Model `<select>` in Settings → Agents with a searchable dropdown so long provider/model lists are filterable by name or ID
- Extract a shared `SearchableSelect` UI component (also used by Notion config) plus a focused unit test
- Harden `scripts/rebuild-native.mjs` so `better-sqlite3` / `node-pty` rebuilds work on recent macOS CLT (missing `climits` / SDK sysroot)

<img width="352" height="249" alt="image" src="https://github.com/user-attachments/assets/8cc33cc4-83e1-44ae-a91f-38d6d6ded27a" />
