### PR TITLE
Keep task completion and status controls accessible

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -591,6 +591,10 @@ export function registerIpcHandlers(
     return await worktreeManager.getTaskChanges(taskId, repos)
   })
 
+  ipcMain.handle('worktree:files', async (_, taskId: string, repos: { fullName: string }[]) => {
+    return await worktreeManager.getTaskFiles(taskId, repos)
+  })
+
   ipcMain.handle('worktree:readFile', (_, taskId: string, repoFullName: string | null, filePath: string) => {
     return worktreeManager.readTaskFile(taskId, repoFullName, filePath)
   })

--- a/src/main/worktree-manager.test.ts
+++ b/src/main/worktree-manager.test.ts
@@ -209,6 +209,27 @@ describe('WorktreeManager', () => {
     expect(workspace?.allFiles?.some((filePath) => filePath.startsWith('.opencode/')) ?? false).toBe(false)
   })
 
+  it('returns the workspace and repository inventory without computing a diff', async () => {
+    const workspacePath = path.join('/tmp/20x-user-data', 'workspaces', 'task-fast-files')
+    const repoPath = path.join(workspacePath, '20x')
+    existsSyncMock.mockImplementation((candidate: string) => candidate === workspacePath || candidate === repoPath)
+    readdirMock.mockImplementation(async (candidate: string) => candidate === workspacePath
+      ? [{ name: 'AGENTS.md', isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false }]
+      : [])
+    execFileMock.mockImplementation((_file: string, args: string[], _options: unknown, callback: (error: Error | null, stdout?: string, stderr?: string) => void) => {
+      if (args.includes('ls-files')) callback(null, 'README.md\0src/index.ts\0', '')
+      else callback(new Error(`Unexpected command: ${args.join(' ')}`))
+    })
+
+    const result = await new WorktreeManager().getTaskFiles('task-fast-files', [{ fullName: 'peakflo/20x' }])
+
+    expect(result).toEqual([
+      { repo: 'Task workspace', allFiles: ['AGENTS.md'], workspace: true },
+      { repo: 'peakflo/20x', allFiles: ['README.md', 'src/index.ts'] }
+    ])
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+  })
+
   it('reads selected files lazily and rejects paths resolving outside the task workspace', () => {
     const workspacePath = path.join('/tmp/20x-user-data', 'workspaces', 'task-5')
     const repoPath = path.join(workspacePath, '20x')

--- a/src/main/worktree-manager.ts
+++ b/src/main/worktree-manager.ts
@@ -34,6 +34,15 @@ export interface TaskChangesResult {
   ciStatus?: 'passing' | 'failing' | 'pending' | 'none'
 }
 
+export interface TaskFileInventoryResult {
+  repo: string
+  allFiles: string[]
+  workspace?: boolean
+  error?: string
+  noWorktree?: boolean
+  path?: string
+}
+
 export interface TaskFileContent {
   content: string
   size: number
@@ -352,14 +361,7 @@ export class WorktreeManager {
       try {
         // Complete browsable worktree inventory: tracked + untracked files,
         // while respecting .gitignore and never traversing .git internals.
-        let allFiles: string[] = []
-        try {
-          const { stdout } = await execFileAsync(
-            'git', ['-c', 'core.quotepath=false', 'ls-files', '--cached', '--others', '--exclude-standard', '-z'],
-            { cwd: wtPath, ...gitOpts }
-          )
-          allFiles = [...new Set(stdout.split('\0').filter(Boolean))].sort((left, right) => left.localeCompare(right))
-        } catch { /* keep diff available if inventory fails */ }
+        const allFiles = await this.listRepositoryFiles(wtPath, gitOpts)
 
         // Agents auto-commit, so "uncommitted only" (git diff HEAD) is usually
         // empty. We want the task's whole diff: base branch → current work
@@ -512,6 +514,42 @@ export class WorktreeManager {
 
     const workspaceFiles = await this.listNonRepositoryWorkspaceFiles(taskId, repos)
     return [{ repo: 'Task workspace', diff: '', allFiles: workspaceFiles, workspace: true }, ...results]
+  }
+
+  /** Fast inventory used to render All files before the more expensive diff,
+   * branch, pull-request, and CI discovery completes. */
+  async getTaskFiles(taskId: string, repos: { fullName: string }[]): Promise<TaskFileInventoryResult[]> {
+    const results: TaskFileInventoryResult[] = []
+    const gitOpts = { maxBuffer: 64 * 1024 * 1024 }
+
+    for (const repo of repos) {
+      const repoName = repo.fullName.split('/').pop() || repo.fullName
+      const wtPath = this.worktreePath(taskId, repoName)
+      if (!existsSync(wtPath)) {
+        results.push({ repo: repo.fullName, allFiles: [], noWorktree: true, path: wtPath })
+        continue
+      }
+      try {
+        results.push({ repo: repo.fullName, allFiles: await this.listRepositoryFiles(wtPath, gitOpts) })
+      } catch (error) {
+        results.push({ repo: repo.fullName, allFiles: [], error: error instanceof Error ? error.message : String(error) })
+      }
+    }
+
+    const workspaceFiles = await this.listNonRepositoryWorkspaceFiles(taskId, repos)
+    return [{ repo: 'Task workspace', allFiles: workspaceFiles, workspace: true }, ...results]
+  }
+
+  private async listRepositoryFiles(wtPath: string, gitOpts: { maxBuffer: number }): Promise<string[]> {
+    try {
+      const { stdout } = await execFileAsync(
+        'git', ['-c', 'core.quotepath=false', 'ls-files', '--cached', '--others', '--exclude-standard', '-z'],
+        { cwd: wtPath, ...gitOpts }
+      )
+      return [...new Set(stdout.split('\0').filter(Boolean))].sort((left, right) => left.localeCompare(right))
+    } catch {
+      return []
+    }
   }
 
   private async listNonRepositoryWorkspaceFiles(taskId: string, repos: { fullName: string }[]): Promise<string[]> {

--- a/src/mobile/components/CollapsibleDescription.tsx
+++ b/src/mobile/components/CollapsibleDescription.tsx
@@ -1,9 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { Markdown } from '@/components/ui/Markdown'
 
-const COLLAPSED_LINE_COUNT = 5
 const LINE_HEIGHT_PX = 20
-const COLLAPSED_MAX_HEIGHT = COLLAPSED_LINE_COUNT * LINE_HEIGHT_PX
 const STORAGE_KEY_PREFIX = '20x-desc-expanded-'
 
 interface CollapsibleDescriptionProps {
@@ -19,6 +17,7 @@ interface CollapsibleDescriptionProps {
   onSave?: (description: string) => void | Promise<void>
   /** Placeholder shown when description is empty and `onSave` is provided. */
   placeholder?: string
+  collapsedLines?: number
 }
 
 export function CollapsibleDescription({
@@ -27,7 +26,8 @@ export function CollapsibleDescription({
   size = 'sm',
   className,
   onSave,
-  placeholder = 'Add description...'
+  placeholder = 'Add description...',
+  collapsedLines = 5
 }: CollapsibleDescriptionProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -44,13 +44,14 @@ export function CollapsibleDescription({
   })
 
   const editable = typeof onSave === 'function'
+  const collapsedMaxHeight = Math.max(1, collapsedLines) * LINE_HEIGHT_PX
 
   const measureContent = useCallback(() => {
     if (contentRef.current) {
       const scrollHeight = contentRef.current.scrollHeight
-      setNeedsCollapse(scrollHeight > COLLAPSED_MAX_HEIGHT + 8)
+      setNeedsCollapse(scrollHeight > collapsedMaxHeight + 8)
     }
-  }, [])
+  }, [collapsedMaxHeight])
 
   useEffect(() => {
     measureContent()
@@ -61,6 +62,13 @@ export function CollapsibleDescription({
     window.addEventListener('resize', measureContent)
     return () => window.removeEventListener('resize', measureContent)
   }, [measureContent])
+
+  useEffect(() => {
+    if (isEditing || !contentRef.current || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measureContent)
+    observer.observe(contentRef.current)
+    return () => observer.disconnect()
+  }, [isEditing, measureContent])
 
   // Keep draft synced with prop when not editing
   useEffect(() => {
@@ -191,7 +199,7 @@ export function CollapsibleDescription({
         <div
           ref={contentRef}
           className={`overflow-hidden transition-all duration-200 ${editable ? 'cursor-text rounded-md active:bg-accent/30' : ''}`}
-          style={isCollapsed ? { maxHeight: `${COLLAPSED_MAX_HEIGHT}px` } : undefined}
+          style={isCollapsed ? { maxHeight: `${collapsedMaxHeight}px` } : undefined}
           onClick={editable ? beginEdit : undefined}
           role={editable ? 'button' : undefined}
           tabIndex={editable ? 0 : undefined}

--- a/src/mobile/pages/ArtifactViewerPage.tsx
+++ b/src/mobile/pages/ArtifactViewerPage.tsx
@@ -116,16 +116,6 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
           <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m15 18-6-6 6-6"/></svg>
         </button>
         <span className="min-w-0 flex-1 truncate text-sm font-medium">{artifact?.title || 'Artifact'}</span>
-        {artifact && (
-          <button
-            type="button"
-            onClick={() => setRefreshTrigger((trigger) => trigger + 1)}
-            className="rounded-md p-1.5 text-muted-foreground active:opacity-60"
-            aria-label={`Refresh ${artifact.title}`}
-          >
-            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 11a8.1 8.1 0 0 0-15.5-2M4 4v5h5"/><path d="M4 13a8.1 8.1 0 0 0 15.5 2M20 20v-5h-5"/></svg>
-          </button>
-        )}
         {artifact?.type === ArtifactType.PR && externalUrl && (
           <a href={externalUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary">Open ↗</a>
         )}

--- a/src/mobile/pages/ArtifactViewerPage.tsx
+++ b/src/mobile/pages/ArtifactViewerPage.tsx
@@ -12,6 +12,8 @@ import { api } from '../api/client'
 import { ArtifactType, useArtifactStore } from '../stores/artifact-store'
 import type { Route } from '../App'
 
+const ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS = 30_000
+
 function hardenHtml(source: string): string {
   const policy = "default-src 'none'; connect-src 'none'; img-src data: blob:; style-src 'unsafe-inline'; script-src 'unsafe-inline'"
   const guard = `<meta http-equiv="Content-Security-Policy" content="${policy}"><base href="about:blank"><script>window.open=function(){return null};</script>`
@@ -47,10 +49,19 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [pullRequest, setPullRequest] = useState<PullRequestDetails | null>(null)
+  const [refreshTrigger, setRefreshTrigger] = useState(0)
 
   useEffect(() => {
     if (!artifact) void hydrate(taskId)
   }, [artifact, hydrate, taskId])
+
+  useEffect(() => {
+    if (!artifact) return
+    const interval = window.setInterval(() => {
+      setRefreshTrigger((trigger) => trigger + 1)
+    }, ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS)
+    return () => window.clearInterval(interval)
+  }, [artifact?.id])
 
   useEffect(() => {
     if (!artifact?.path || artifact.type === ArtifactType.PR) {
@@ -68,7 +79,7 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
       if (!cancelled) setLoading(false)
     })
     return () => { cancelled = true }
-  }, [artifact?.path, artifact?.reloadTrigger, artifact?.type, taskId])
+  }, [artifact?.path, artifact?.reloadTrigger, artifact?.type, refreshTrigger, taskId])
 
   useEffect(() => {
     if (artifact?.type !== ArtifactType.PR || !artifact.url) return
@@ -83,7 +94,7 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
       if (!cancelled) setLoading(false)
     })
     return () => { cancelled = true }
-  }, [artifact?.reloadTrigger, artifact?.type, artifact?.url])
+  }, [artifact?.reloadTrigger, artifact?.type, artifact?.url, refreshTrigger])
 
   const imageUrl = useMemo(() => {
     if (artifact?.type !== ArtifactType.IMAGE) return null
@@ -105,6 +116,16 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
           <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m15 18-6-6 6-6"/></svg>
         </button>
         <span className="min-w-0 flex-1 truncate text-sm font-medium">{artifact?.title || 'Artifact'}</span>
+        {artifact && (
+          <button
+            type="button"
+            onClick={() => setRefreshTrigger((trigger) => trigger + 1)}
+            className="rounded-md p-1.5 text-muted-foreground active:opacity-60"
+            aria-label={`Refresh ${artifact.title}`}
+          >
+            <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 11a8.1 8.1 0 0 0-15.5-2M4 4v5h5"/><path d="M4 13a8.1 8.1 0 0 0 15.5 2M20 20v-5h-5"/></svg>
+          </button>
+        )}
         {artifact?.type === ArtifactType.PR && externalUrl && (
           <a href={externalUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary">Open ↗</a>
         )}
@@ -118,11 +139,11 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
           <div className="mx-auto max-w-3xl p-5"><Markdown size="sm">{content.content}</Markdown></div>
         )}
         {!loading && !error && artifact?.type === ArtifactType.IMAGE && imageUrl && (
-          <div className="flex min-h-full items-center justify-center p-4"><img src={imageUrl} alt={artifact.title} className="max-h-full max-w-full object-contain" /></div>
+          <div className="flex min-h-full items-center justify-center p-4"><img key={`${artifact.reloadTrigger}:${refreshTrigger}`} src={imageUrl} alt={artifact.title} className="max-h-full max-w-full object-contain" /></div>
         )}
         {!loading && !error && artifact?.type === ArtifactType.HTML && content && (
           <iframe
-            key={artifact.reloadTrigger}
+            key={`${artifact.reloadTrigger}:${refreshTrigger}`}
             title={artifact.title}
             srcDoc={hardenHtml(content.content)}
             sandbox="allow-scripts"

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -340,6 +340,7 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
             taskId={task.id}
             description={task.description || ''}
             size="sm"
+            collapsedLines={3}
             onSave={async (description) => {
               await updateTask(task.id, { description })
             }}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -228,6 +228,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('worktree:cleanup', taskId, repos, org, removeTaskDir),
     changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; allFiles?: string[]; workspace?: boolean; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string; prTitle?: string; ciStatus?: 'passing' | 'failing' | 'pending' | 'none' }>> =>
       ipcRenderer.invoke('worktree:changes', taskId, repos),
+    files: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; allFiles: string[]; workspace?: boolean; error?: string; noWorktree?: boolean; path?: string }>> =>
+      ipcRenderer.invoke('worktree:files', taskId, repos),
     readFile: (taskId: string, repoFullName: string | null, filePath: string): Promise<{ content: string; size: number; binary: boolean; truncated: boolean } | null> =>
       ipcRenderer.invoke('worktree:readFile', taskId, repoFullName, filePath),
     runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> =>

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import { ArtifactContentKind, ArtifactType, type Artifact, type ArtifactApi, type ArtifactUIState } from '@shared/artifacts'
 import { PinnedArtifactTabId } from '@/stores/artifact-store'
 import { ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS, ArtifactsPanel } from './ArtifactsPanel'
@@ -48,7 +48,7 @@ describe('ArtifactsPanel', () => {
     expect(screen.queryByText('Loaded changes')).not.toBeInTheDocument()
   })
 
-  it('manually and periodically refreshes only the selected artifact', async () => {
+  it('refreshes on open and periodically only while the artifact is selected', async () => {
     const dynamicArtifactApi: ArtifactApi = {
       scan: vi.fn().mockResolvedValue([]),
       read: vi.fn().mockResolvedValue({ kind: ArtifactContentKind.TEXT, content: '# Current content' })
@@ -87,14 +87,16 @@ describe('ArtifactsPanel', () => {
     await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(1))
     expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Refresh Review notes' }))
-    await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(2))
-
     act(() => intervalCallback?.())
-    await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(3))
+    await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(2))
 
     rerender(<ArtifactsPanel {...props} ui={baseUi} />)
     expect(clearIntervalSpy).toHaveBeenCalledWith(1)
-    expect(screen.queryByRole('button', { name: 'Refresh Review notes' })).not.toBeInTheDocument()
+
+    rerender(<ArtifactsPanel {...props} ui={{ ...baseUi, activeTabId: artifact.id }} />)
+    await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(3))
+
+    rerender(<ArtifactsPanel {...props} artifacts={[{ ...artifact, reloadTrigger: 1 }]} ui={{ ...baseUi, activeTabId: artifact.id }} />)
+    await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(4))
   })
 })

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
-import type { ArtifactApi, ArtifactUIState } from '@shared/artifacts'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ArtifactContentKind, ArtifactType, type Artifact, type ArtifactApi, type ArtifactUIState } from '@shared/artifacts'
 import { PinnedArtifactTabId } from '@/stores/artifact-store'
-import { ArtifactsPanel } from './ArtifactsPanel'
+import { ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS, ArtifactsPanel } from './ArtifactsPanel'
 
 const artifactApi: ArtifactApi = {
   scan: vi.fn().mockResolvedValue([]),
@@ -15,7 +15,10 @@ const baseUi: ArtifactUIState = {
   railExpanded: false
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
 
 describe('ArtifactsPanel', () => {
   it('mounts Changes only while the Changes tab is selected', () => {
@@ -43,5 +46,55 @@ describe('ArtifactsPanel', () => {
 
     rerender(<ArtifactsPanel {...props} ui={baseUi} />)
     expect(screen.queryByText('Loaded changes')).not.toBeInTheDocument()
+  })
+
+  it('manually and periodically refreshes only the selected artifact', async () => {
+    const dynamicArtifactApi: ArtifactApi = {
+      scan: vi.fn().mockResolvedValue([]),
+      read: vi.fn().mockResolvedValue({ kind: ArtifactContentKind.TEXT, content: '# Current content' })
+    }
+    const artifact: Artifact = {
+      id: 'artifact-1',
+      taskId: 'task-1',
+      type: ArtifactType.MARKDOWN,
+      title: 'Review notes',
+      path: 'review.md',
+      updatedAt: 1,
+      reloadTrigger: 0
+    }
+    let intervalCallback: (() => void) | undefined
+    const intervalSpy = vi.spyOn(window, 'setInterval').mockImplementation((callback, timeout) => {
+      if (timeout === ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS) intervalCallback = callback as () => void
+      return 1 as unknown as ReturnType<typeof window.setInterval>
+    })
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval').mockImplementation(() => undefined)
+    const props = {
+      taskId: 'task-1',
+      artifacts: [artifact],
+      artifactApi: dynamicArtifactApi,
+      hasChanges: true,
+      hasOutput: false,
+      onSelectTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onToggleOpen: vi.fn(),
+      onToggleRail: vi.fn(),
+      details: <div>Task details</div>,
+      changes: <div>Loaded changes</div>,
+      output: null
+    }
+    const { rerender } = render(<ArtifactsPanel {...props} ui={{ ...baseUi, activeTabId: artifact.id }} />)
+
+    await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(1))
+    expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh Review notes' }))
+    await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(2))
+
+    act(() => intervalCallback?.())
+    await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(3))
+
+    rerender(<ArtifactsPanel {...props} ui={baseUi} />)
+    expect(clearIntervalSpy).toHaveBeenCalledWith(1)
+    expect(screen.queryByRole('button', { name: 'Refresh Review notes' })).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react'
-import { PanelRightClose, RefreshCw } from 'lucide-react'
+import { PanelRightClose } from 'lucide-react'
 import { ArtifactType, type Artifact, type ArtifactApi, type ArtifactUIState } from '@shared/artifacts'
 import { PinnedArtifactTabId } from '@/stores/artifact-store'
 import { cn } from '@/lib/utils'
@@ -46,18 +46,7 @@ export function ArtifactsPanel({ artifacts, ui, artifactApi, hasChanges, hasOutp
   return (
     <section className={cn('flex h-full min-h-0 min-w-0 flex-col bg-background', className)} data-task-artifacts>
       <div className="relative">
-        <ArtifactTabStrip artifacts={artifacts} activeTabId={active} hasChanges={hasChanges} hasOutput={hasOutput} changesCount={changesCount} onSelectTab={onSelectTab} onCloseTab={onCloseTab} className={activeArtifact ? 'pr-20' : 'pr-11'} />
-        {activeArtifact && (
-          <button
-            type="button"
-            aria-label={`Refresh ${activeArtifact.title}`}
-            title="Refresh artifact"
-            onClick={() => setRefreshTrigger((trigger) => trigger + 1)}
-            className="absolute right-10 top-1.5 grid h-7 w-7 place-items-center rounded-md bg-background text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            <RefreshCw className="h-3.5 w-3.5" />
-          </button>
-        )}
+        <ArtifactTabStrip artifacts={artifacts} activeTabId={active} hasChanges={hasChanges} hasOutput={hasOutput} changesCount={changesCount} onSelectTab={onSelectTab} onCloseTab={onCloseTab} className="pr-11" />
         <button type="button" aria-label="Close artifacts" onClick={onToggleOpen} className="absolute right-2 top-1.5 grid h-7 w-7 place-items-center rounded-md bg-background text-muted-foreground hover:bg-accent hover:text-foreground"><PanelRightClose className="h-3.5 w-3.5" /></button>
       </div>
       <div className="relative min-h-0 flex-1">

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from 'react'
-import { PanelRightClose } from 'lucide-react'
+import { useEffect, useState, type ReactNode } from 'react'
+import { PanelRightClose, RefreshCw } from 'lucide-react'
 import { ArtifactType, type Artifact, type ArtifactApi, type ArtifactUIState } from '@shared/artifacts'
 import { PinnedArtifactTabId } from '@/stores/artifact-store'
 import { cn } from '@/lib/utils'
@@ -9,6 +9,8 @@ import { ImageArtifactView } from './viewers/ImageArtifactView'
 import { HtmlArtifactView } from './viewers/HtmlArtifactView'
 import { PrArtifactView } from './viewers/PrArtifactView'
 import { FileArtifactView } from './viewers/FileArtifactView'
+
+export const ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS = 30_000
 
 export interface ArtifactsPanelProps {
   taskId: string
@@ -30,11 +32,32 @@ export interface ArtifactsPanelProps {
 
 export function ArtifactsPanel({ artifacts, ui, artifactApi, hasChanges, hasOutput, changesCount, onSelectTab, onCloseTab, onToggleOpen, details, changes, output, className }: ArtifactsPanelProps) {
   const active = ui.activeTabId || PinnedArtifactTabId.DETAILS
+  const activeArtifact = artifacts.find((artifact) => artifact.id === active)
+  const [refreshTrigger, setRefreshTrigger] = useState(0)
+
+  useEffect(() => {
+    if (!activeArtifact) return
+    const interval = window.setInterval(() => {
+      setRefreshTrigger((trigger) => trigger + 1)
+    }, ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS)
+    return () => window.clearInterval(interval)
+  }, [activeArtifact?.id])
 
   return (
     <section className={cn('flex h-full min-h-0 min-w-0 flex-col bg-background', className)} data-task-artifacts>
       <div className="relative">
-        <ArtifactTabStrip artifacts={artifacts} activeTabId={active} hasChanges={hasChanges} hasOutput={hasOutput} changesCount={changesCount} onSelectTab={onSelectTab} onCloseTab={onCloseTab} className="pr-11" />
+        <ArtifactTabStrip artifacts={artifacts} activeTabId={active} hasChanges={hasChanges} hasOutput={hasOutput} changesCount={changesCount} onSelectTab={onSelectTab} onCloseTab={onCloseTab} className={activeArtifact ? 'pr-20' : 'pr-11'} />
+        {activeArtifact && (
+          <button
+            type="button"
+            aria-label={`Refresh ${activeArtifact.title}`}
+            title="Refresh artifact"
+            onClick={() => setRefreshTrigger((trigger) => trigger + 1)}
+            className="absolute right-10 top-1.5 grid h-7 w-7 place-items-center rounded-md bg-background text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </button>
+        )}
         <button type="button" aria-label="Close artifacts" onClick={onToggleOpen} className="absolute right-2 top-1.5 grid h-7 w-7 place-items-center rounded-md bg-background text-muted-foreground hover:bg-accent hover:text-foreground"><PanelRightClose className="h-3.5 w-3.5" /></button>
       </div>
       <div className="relative min-h-0 flex-1">
@@ -43,7 +66,7 @@ export function ArtifactsPanel({ artifacts, ui, artifactApi, hasChanges, hasOutp
         {hasOutput && <div className={active === PinnedArtifactTabId.OUTPUT ? 'h-full overflow-y-auto p-4' : 'hidden'}>{output}</div>}
         {artifacts.map((artifact) => (
           <div key={artifact.id} className={active === artifact.id ? 'h-full' : 'hidden'}>
-            {active === artifact.id ? <ArtifactViewer artifact={artifact} artifactApi={artifactApi} /> : null}
+            {active === artifact.id ? <ArtifactViewer artifact={{ ...artifact, reloadTrigger: artifact.reloadTrigger + refreshTrigger }} artifactApi={artifactApi} /> : null}
           </div>
         ))}
       </div>

--- a/src/renderer/src/components/artifacts/viewers/ImageArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/ImageArtifactView.tsx
@@ -6,5 +6,5 @@ import { useArtifactContent } from './use-artifact-content'
 export function ImageArtifactView({ artifact, artifactApi }: { artifact: Artifact; artifactApi: ArtifactApi }) {
   const state = useArtifactContent(artifact, artifactApi)
   const source = artifact.url || (state.content?.kind === ArtifactContentKind.DATA_URL ? state.content.content : null)
-  return <ArtifactViewState loading={state.loading} error={state.error} missing={!source}><div className="flex h-full items-center justify-center overflow-auto bg-muted/30 p-4"><img src={source || ''} alt={artifact.title} className="max-h-full max-w-full object-contain" /></div></ArtifactViewState>
+  return <ArtifactViewState loading={state.loading} error={state.error} missing={!source}><div className="flex h-full items-center justify-center overflow-auto bg-muted/30 p-4"><img key={artifact.reloadTrigger} src={source || ''} alt={artifact.title} className="max-h-full max-w-full object-contain" /></div></ArtifactViewState>
 }

--- a/src/renderer/src/components/tasks/ChangesPanel.test.tsx
+++ b/src/renderer/src/components/tasks/ChangesPanel.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
-const { changes, readFile } = vi.hoisted(() => ({ changes: vi.fn(), readFile: vi.fn() }))
-vi.mock('@/lib/ipc-client', () => ({ worktreeApi: { changes, readFile } }))
+const { changes, files, readFile } = vi.hoisted(() => ({ changes: vi.fn(), files: vi.fn(), readFile: vi.fn() }))
+vi.mock('@/lib/ipc-client', () => ({ worktreeApi: { changes, files, readFile } }))
 
 import { ChangesPanel } from './ChangesPanel'
 
@@ -35,15 +35,21 @@ new file mode 100644
 
 beforeEach(() => {
   persisted.clear()
-  changes.mockReset().mockResolvedValue([{
+  const inventory = [{
     repo: 'Task workspace',
-    diff: '',
     allFiles: ['.agents/skills/ui/SKILL.md', 'AGENTS.md', 'attachments/spec.pdf'],
     workspace: true
   }, {
     repo: 'peakflo/20x',
+    allFiles: ['README.md', 'package.json', 'src/components/Button.tsx', 'src/new.ts', 'src/unchanged.ts']
+  }]
+  files.mockReset().mockResolvedValue(inventory)
+  changes.mockReset().mockResolvedValue([{
+    ...inventory[0],
+    diff: ''
+  }, {
+    ...inventory[1],
     diff,
-    allFiles: ['README.md', 'package.json', 'src/components/Button.tsx', 'src/new.ts', 'src/unchanged.ts'],
     branch: 'feature/changes',
     pushed: true
   }])
@@ -56,6 +62,20 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe('ChangesPanel', () => {
+  it('shows All files before the diff calculation finishes', async () => {
+    let resolveChanges: (value: unknown) => void = () => undefined
+    changes.mockReturnValueOnce(new Promise((resolve) => { resolveChanges = resolve }))
+
+    render(<ChangesPanel taskId="task-1" repos={['peakflo/20x']} />)
+
+    expect(await screen.findByText('AGENTS.md')).toBeInTheDocument()
+    expect(screen.getByText('package.json')).toBeInTheDocument()
+    expect(screen.getByTitle('Refresh')).toBeDisabled()
+
+    resolveChanges([])
+    await waitFor(() => expect(screen.getByTitle('Refresh')).not.toBeDisabled())
+  })
+
   it('shows the repository inventory in All files and preserves the tree in Diff', async () => {
     render(<ChangesPanel taskId="task-1" repos={['peakflo/20x']} />)
 

--- a/src/renderer/src/components/tasks/ChangesPanel.tsx
+++ b/src/renderer/src/components/tasks/ChangesPanel.tsx
@@ -503,6 +503,13 @@ export function ChangesPanel({ taskId, repos, className, onSummary, onPullReques
     const list = reposKey ? reposKey.split('|') : []
     setLoading(true)
     try {
+      const inventory = await worktreeApi.files(taskId, list.map((fullName) => ({ fullName })))
+      setData(inventory.map((entry) => ({ ...entry, files: [] })))
+    } catch {
+      // Fall through to the complete changes request. Older preload bridges can
+      // still render once that request returns.
+    }
+    try {
       const res = await worktreeApi.changes(taskId, list.map((fullName) => ({ fullName })))
       const parsed = res.map((r) => {
         const files = r.diff ? parseUnifiedDiff(r.diff) : []

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -469,6 +469,7 @@ function TaskDetailViewComponent({ task, agents, onEdit, onDelete, onUpdateAttac
                 size="sm"
                 className="mt-3 text-muted-foreground"
                 onSave={onUpdateDescription}
+                collapsedLines={displayMode === 'panel' ? 3 : 5}
               />
             )}
           </div>

--- a/src/renderer/src/components/tasks/TaskHeaderBar.test.tsx
+++ b/src/renderer/src/components/tasks/TaskHeaderBar.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TaskStatus } from '@/types'
+import type { WorkfloTask } from '@/types'
+import { TaskHeaderBar, TaskPrimaryAction } from './TaskHeaderBar'
+
+function makeTask(status = TaskStatus.NotStarted): WorkfloTask {
+  return {
+    id: 'task-1',
+    title: 'Review the redesign',
+    description: '',
+    type: 'general',
+    priority: 'medium',
+    status,
+    assignee: '',
+    due_date: null,
+    labels: [],
+    attachments: [],
+    repos: [],
+    output_fields: [],
+    agent_id: null,
+    session_id: null,
+    external_id: null,
+    source_id: null,
+    source: 'manual',
+    skill_ids: null,
+    snoozed_until: null,
+    resolution: null,
+    feedback_rating: null,
+    feedback_comment: null,
+    is_recurring: false,
+    recurrence_pattern: null,
+    recurrence_parent_id: null,
+    last_occurrence_at: null,
+    next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
+    parent_task_id: null,
+    sort_order: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z'
+  }
+}
+
+const requiredProps = {
+  onRename: vi.fn(),
+  detailsOpen: false,
+  showDetailsToggle: false,
+  onToggleDetails: vi.fn(),
+  onEdit: vi.fn(),
+  onDelete: vi.fn()
+}
+
+afterEach(cleanup)
+
+describe('TaskHeaderBar', () => {
+  it('keeps Complete visible alongside the current agent action', () => {
+    const onComplete = vi.fn()
+    render(
+      <TaskHeaderBar
+        {...requiredProps}
+        task={makeTask()}
+        action={TaskPrimaryAction.START}
+        onAction={vi.fn()}
+        onComplete={onComplete}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('header-cta-complete'))
+    expect(onComplete).toHaveBeenCalledOnce()
+  })
+
+  it('does not duplicate Complete when it is already the primary action', () => {
+    render(
+      <TaskHeaderBar
+        {...requiredProps}
+        task={makeTask(TaskStatus.ReadyForReview)}
+        action={TaskPrimaryAction.COMPLETE}
+        onAction={vi.fn()}
+        onComplete={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByTestId('header-cta-complete')).toHaveLength(1)
+  })
+
+  it('changes status from the status badge menu', () => {
+    const onStatusChange = vi.fn()
+    render(
+      <TaskHeaderBar
+        {...requiredProps}
+        task={makeTask()}
+        onStatusChange={onStatusChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change task status' }))
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Ready for Review' }))
+
+    expect(onStatusChange).toHaveBeenCalledWith(TaskStatus.ReadyForReview)
+  })
+
+  it('hides Complete after the task is completed', () => {
+    render(
+      <TaskHeaderBar
+        {...requiredProps}
+        task={makeTask(TaskStatus.Completed)}
+        onComplete={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('header-cta-complete')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/tasks/TaskHeaderBar.tsx
+++ b/src/renderer/src/components/tasks/TaskHeaderBar.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Bot, Check, ChevronDown, ExternalLink, FolderOpen, Layers, M
 import { Button } from '@/components/ui/Button'
 import { TaskPriorityBadge } from './TaskPriorityBadge'
 import { TaskStatusBadge } from './TaskStatusBadge'
+import { TASK_STATUSES, TaskStatus } from '@/types'
 import type { Agent, WorkfloTask } from '@/types'
 
 export enum TaskPrimaryAction {
@@ -26,6 +27,8 @@ interface TaskHeaderBarProps {
   agent?: Agent | null
   action?: TaskPrimaryAction | null
   onAction?: () => void
+  onComplete?: () => void
+  onStatusChange?: (status: TaskStatus) => void | Promise<void>
   onBack?: () => void
   onRename: (title: string) => void | Promise<void>
   detailsOpen: boolean
@@ -44,6 +47,8 @@ export function TaskHeaderBar({
   agent,
   action,
   onAction,
+  onComplete,
+  onStatusChange,
   onBack,
   onRename,
   detailsOpen,
@@ -59,7 +64,9 @@ export function TaskHeaderBar({
   const [editing, setEditing] = useState(false)
   const [title, setTitle] = useState(task.title)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [statusMenuOpen, setStatusMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+  const statusMenuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => setTitle(task.title), [task.title])
   useEffect(() => {
@@ -70,6 +77,14 @@ export function TaskHeaderBar({
     window.addEventListener('pointerdown', close)
     return () => window.removeEventListener('pointerdown', close)
   }, [menuOpen])
+  useEffect(() => {
+    if (!statusMenuOpen) return
+    const close = (event: PointerEvent) => {
+      if (!statusMenuRef.current?.contains(event.target as Node)) setStatusMenuOpen(false)
+    }
+    window.addEventListener('pointerdown', close)
+    return () => window.removeEventListener('pointerdown', close)
+  }, [statusMenuOpen])
 
   const commitTitle = async () => {
     const next = title.trim()
@@ -83,6 +98,9 @@ export function TaskHeaderBar({
 
   const actionMeta = action ? ACTION_META[action] : null
   const ActionIcon = actionMeta?.icon
+  const showStandaloneComplete = task.status !== TaskStatus.Completed
+    && !!onComplete
+    && (action !== TaskPrimaryAction.COMPLETE || !onAction)
 
   return (
     <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border/50 bg-background px-3">
@@ -112,8 +130,40 @@ export function TaskHeaderBar({
           </button>
         )}
       </div>
+      <div ref={statusMenuRef} className="relative shrink-0">
+        <button
+          type="button"
+          onClick={() => setStatusMenuOpen((open) => !open)}
+          className="group inline-flex items-center gap-0.5 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+          aria-label="Change task status"
+          aria-haspopup="menu"
+          aria-expanded={statusMenuOpen}
+        >
+          <TaskStatusBadge status={task.status} />
+          <ChevronDown className="h-3 w-3 text-muted-foreground transition-colors group-hover:text-foreground" />
+        </button>
+        {statusMenuOpen && (
+          <div role="menu" aria-label="Task status" className="absolute right-0 top-7 z-50 w-48 overflow-hidden rounded-lg border border-border/50 bg-popover p-1 shadow-xl">
+            {TASK_STATUSES.map((status) => (
+              <button
+                key={status.value}
+                type="button"
+                role="menuitemradio"
+                aria-checked={task.status === status.value}
+                onClick={() => {
+                  setStatusMenuOpen(false)
+                  if (task.status !== status.value) void onStatusChange?.(status.value)
+                }}
+                className="flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-xs text-foreground hover:bg-accent"
+              >
+                <span>{status.label}</span>
+                {task.status === status.value && <Check className="h-3.5 w-3.5 text-primary" />}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
       <div className="hidden items-center gap-1.5 lg:flex">
-        <TaskStatusBadge status={task.status} />
         <TaskPriorityBadge priority={task.priority} />
         <span className="inline-flex max-w-36 items-center gap-1.5 rounded-full border border-border/50 bg-card px-2 py-1 text-[11px] text-muted-foreground">
           <Bot className="h-3 w-3" />
@@ -124,6 +174,18 @@ export function TaskHeaderBar({
         <Button size="sm" onClick={onAction} className="h-8 gap-1.5 px-3" data-testid={`header-cta-${action}`}>
           {ActionIcon && <ActionIcon className="h-3.5 w-3.5" />}
           {actionMeta.label}
+        </Button>
+      )}
+      {showStandaloneComplete && (
+        <Button
+          variant={actionMeta && onAction ? 'outline' : 'default'}
+          size="sm"
+          onClick={onComplete}
+          className="h-8 gap-1.5 px-3"
+          data-testid="header-cta-complete"
+        >
+          <Check className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">Complete</span>
         </Button>
       )}
       {showDetailsToggle && (

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -762,6 +762,21 @@ Update existing skills that were helpful or create new ones for patterns worth r
     }
   }, [onUpdateTask, task?.id, updateTaskInStore])
 
+  const handleStatusChange = useCallback(async (status: TaskStatus) => {
+    if (!task?.id || status === task.status) return
+    // Completing a task has feedback and external-source side effects, so keep
+    // it on the same path as the persistent Complete action.
+    if (status === TaskStatus.Completed) {
+      await handleCompleteTask()
+      return
+    }
+    if (onUpdateTask) await onUpdateTask(task.id, { status })
+    else {
+      await taskApi.update(task.id, { status })
+      updateTaskInStore(task.id, { status })
+    }
+  }, [handleCompleteTask, onUpdateTask, task?.id, task?.status, updateTaskInStore])
+
   const handleOpenFolder = useCallback(async () => {
     if (!task?.id) return
     const workspaceDir = await window.electronAPI.tasks.getWorkspaceDir(task.id)
@@ -917,6 +932,8 @@ Update existing skills that were helpful or create new ones for patterns worth r
           agent={assignedAgent}
           action={primaryAction}
           onAction={handlePrimaryAction}
+          onComplete={() => void handleCompleteTask()}
+          onStatusChange={handleStatusChange}
           onBack={onBack}
           onRename={handleRename}
           detailsOpen={artifactUI.open && artifactUI.activeTabId === PinnedArtifactTabId.DETAILS}

--- a/src/renderer/src/components/ui/CollapsibleDescription.test.tsx
+++ b/src/renderer/src/components/ui/CollapsibleDescription.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, fireEvent, cleanup, screen, waitFor } from '@testing-library/react'
+import { act, render, fireEvent, cleanup, screen, waitFor } from '@testing-library/react'
 import { CollapsibleDescription } from './CollapsibleDescription'
 
 // Mock Markdown to render plain text, making it easy to measure
@@ -51,6 +51,7 @@ describe('CollapsibleDescription', () => {
   afterEach(() => {
     cleanup()
     restoreScrollHeight()
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -121,6 +122,31 @@ describe('CollapsibleDescription', () => {
     // Expand - maxHeight should be removed
     fireEvent.click(getByText('Show more'))
     expect((contentDiv as HTMLElement).style.maxHeight).toBe('')
+  })
+
+  it('uses a compact line limit and remeasures when its pane width changes', () => {
+    let height = 40
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() { return height }
+    })
+    let resizeCallback: (() => void) | undefined
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(callback: () => void) { resizeCallback = callback }
+      observe() {}
+      disconnect() {}
+    })
+
+    const { container } = render(
+      <CollapsibleDescription taskId="task-compact" description={LONG_DESCRIPTION} collapsedLines={3} />
+    )
+    expect(screen.queryByText('Show more')).toBeNull()
+
+    height = 180
+    act(() => resizeCallback?.())
+
+    expect(screen.getByText('Show more')).toBeTruthy()
+    expect((container.querySelector('.overflow-hidden') as HTMLElement).style.maxHeight).toBe('60px')
   })
 
   describe('inline editing', () => {

--- a/src/renderer/src/components/ui/CollapsibleDescription.tsx
+++ b/src/renderer/src/components/ui/CollapsibleDescription.tsx
@@ -2,9 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 import { ChevronDown, ChevronUp, Pencil, Plus } from 'lucide-react'
 import { Markdown } from './Markdown'
 
-const COLLAPSED_LINE_COUNT = 5
 const LINE_HEIGHT_PX = 20 // approximate line height for sm markdown text
-const COLLAPSED_MAX_HEIGHT = COLLAPSED_LINE_COUNT * LINE_HEIGHT_PX
 const STORAGE_KEY_PREFIX = '20x-desc-expanded-'
 
 interface CollapsibleDescriptionProps {
@@ -20,6 +18,8 @@ interface CollapsibleDescriptionProps {
   onSave?: (description: string) => void | Promise<void>
   /** Placeholder shown when description is empty and `onSave` is provided. */
   placeholder?: string
+  /** Maximum preview lines before showing the expand control. */
+  collapsedLines?: number
 }
 
 export function CollapsibleDescription({
@@ -28,7 +28,8 @@ export function CollapsibleDescription({
   size = 'sm',
   className,
   onSave,
-  placeholder = 'Add description...'
+  placeholder = 'Add description...',
+  collapsedLines = 5
 }: CollapsibleDescriptionProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -45,13 +46,14 @@ export function CollapsibleDescription({
   })
 
   const editable = typeof onSave === 'function'
+  const collapsedMaxHeight = Math.max(1, collapsedLines) * LINE_HEIGHT_PX
 
   const measureContent = useCallback(() => {
     if (contentRef.current) {
       const scrollHeight = contentRef.current.scrollHeight
-      setNeedsCollapse(scrollHeight > COLLAPSED_MAX_HEIGHT + 8) // 8px tolerance
+      setNeedsCollapse(scrollHeight > collapsedMaxHeight + 8) // 8px tolerance
     }
-  }, [])
+  }, [collapsedMaxHeight])
 
   useEffect(() => {
     measureContent()
@@ -63,6 +65,16 @@ export function CollapsibleDescription({
     window.addEventListener('resize', measureContent)
     return () => window.removeEventListener('resize', measureContent)
   }, [measureContent])
+
+  // The artifact split can resize without a browser-window resize. Observe the
+  // content itself so newly wrapped lines immediately gain a Show less/more
+  // control as the Details pane narrows.
+  useEffect(() => {
+    if (isEditing || !contentRef.current || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measureContent)
+    observer.observe(contentRef.current)
+    return () => observer.disconnect()
+  }, [isEditing, measureContent])
 
   // Keep draft in sync with prop when not editing (e.g., external updates)
   useEffect(() => {
@@ -193,7 +205,7 @@ export function CollapsibleDescription({
         <div
           ref={contentRef}
           className={`overflow-hidden transition-all duration-200 ${editable ? 'cursor-text rounded-md hover:bg-accent/30 -mx-2 px-2 py-1' : ''}`}
-          style={isCollapsed ? { maxHeight: `${COLLAPSED_MAX_HEIGHT}px` } : undefined}
+          style={isCollapsed ? { maxHeight: `${collapsedMaxHeight}px` } : undefined}
           onClick={editable ? beginEdit : undefined}
           role={editable ? 'button' : undefined}
           tabIndex={editable ? 0 : undefined}

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -546,6 +546,9 @@ export const worktreeApi = {
   changes: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; diff: string; allFiles?: string[]; workspace?: boolean; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string; prTitle?: string; ciStatus?: 'passing' | 'failing' | 'pending' | 'none' }>> => {
     return window.electronAPI.worktree.changes(taskId, repos)
   },
+  files: (taskId: string, repos: { fullName: string }[]): Promise<Array<{ repo: string; allFiles: string[]; workspace?: boolean; error?: string; noWorktree?: boolean; path?: string }>> => {
+    return window.electronAPI.worktree.files(taskId, repos)
+  },
   readFile: (taskId: string, repoFullName: string | null, filePath: string): Promise<{ content: string; size: number; binary: boolean; truncated: boolean } | null> => {
     const readFile = window.electronAPI.worktree.readFile
     if (typeof readFile !== 'function') {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -292,6 +292,7 @@ interface ElectronAPI {
     setup: (taskId: string, repos: { fullName: string; defaultBranch: string }[], org: string, provider: 'github' | 'gitlab') => Promise<string>
     cleanup: (taskId: string, repos: { fullName: string }[], org: string, removeTaskDir?: boolean) => Promise<void>
     changes: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; diff: string; allFiles?: string[]; workspace?: boolean; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string; prTitle?: string; ciStatus?: 'passing' | 'failing' | 'pending' | 'none' }>>
+    files: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; allFiles: string[]; workspace?: boolean; error?: string; noWorktree?: boolean; path?: string }>>
     readFile: (taskId: string, repoFullName: string | null, filePath: string) => Promise<{ content: string; size: number; binary: boolean; truncated: boolean } | null>
     runCleanupNow: () => Promise<{ cleaned: number; errors: string[] }>
   }


### PR DESCRIPTION
## Summary
- keep Complete visible in the task header for every non-completed task, alongside Start/Resume/Restart/Triage when applicable
- make the task status badge clickable with an enum-backed status menu
- route status-menu completion through the existing feedback and external-source completion flow
- silently refresh the currently open artifact or pull request on open, every 30 seconds, and whenever agent output invalidates it
- preserve the rendered preview during background refresh and avoid polling-driven iframe/image remounts
- stop artifact polling as soon as its tab is hidden; no manual refresh control
- render the Changes All files inventory first, then enrich it with git diff, branch, PR, and CI data in the background
- keep task descriptions compact in Details/mobile and remeasure collapse when the artifact pane is resized
- add focused regression tests for task actions, silent artifact refresh, files-first Changes loading, and responsive description collapse

## Verification
- targeted renderer tests for TaskHeaderBar, TaskWorkspace, TaskDetailView, CollapsibleDescription, ArtifactsPanel, artifact viewers, and ChangesPanel
- main-process WorktreeManager tests
- `pnpm typecheck`
- targeted ESLint checks
- `git diff --check`