### PR TITLE
Refresh artifact previews without flicker

### DIFF
--- a/src/mobile/pages/ArtifactViewerPage.tsx
+++ b/src/mobile/pages/ArtifactViewerPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Markdown } from '@/components/ui/Markdown'
 import {
   ArtifactContentKind,
@@ -50,6 +50,7 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
   const [error, setError] = useState<string | null>(null)
   const [pullRequest, setPullRequest] = useState<PullRequestDetails | null>(null)
   const [refreshTrigger, setRefreshTrigger] = useState(0)
+  const settledArtifactRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!artifact) void hydrate(taskId)
@@ -65,18 +66,30 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
 
   useEffect(() => {
     if (!artifact?.path || artifact.type === ArtifactType.PR) {
-      setLoading(false)
+      if (artifact && artifact.type !== ArtifactType.PR) {
+        settledArtifactRef.current = artifact.id
+        setLoading(false)
+      }
       return
     }
     let cancelled = false
-    setLoading(true)
-    setError(null)
+    const initialLoad = settledArtifactRef.current !== artifact.id
+    if (initialLoad) {
+      setLoading(true)
+      setError(null)
+    }
     void api.artifacts.content(taskId, artifact.path).then((result) => {
-      if (!cancelled) setContent(result)
+      if (!cancelled) {
+        setContent(result)
+        setError(null)
+      }
     }).catch((reason: unknown) => {
-      if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason))
+      if (!cancelled && initialLoad) setError(reason instanceof Error ? reason.message : String(reason))
     }).finally(() => {
-      if (!cancelled) setLoading(false)
+      if (!cancelled) {
+        settledArtifactRef.current = artifact.id
+        if (initialLoad) setLoading(false)
+      }
     })
     return () => { cancelled = true }
   }, [artifact?.path, artifact?.reloadTrigger, artifact?.type, refreshTrigger, taskId])
@@ -84,14 +97,23 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
   useEffect(() => {
     if (artifact?.type !== ArtifactType.PR || !artifact.url) return
     let cancelled = false
-    setLoading(true)
-    setError(null)
+    const initialLoad = settledArtifactRef.current !== artifact.id
+    if (initialLoad) {
+      setLoading(true)
+      setError(null)
+    }
     void api.github.pullRequest(artifact.url).then((result) => {
-      if (!cancelled) setPullRequest(result)
+      if (!cancelled) {
+        setPullRequest(result)
+        setError(null)
+      }
     }).catch((reason: unknown) => {
-      if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason))
+      if (!cancelled && initialLoad) setError(reason instanceof Error ? reason.message : String(reason))
     }).finally(() => {
-      if (!cancelled) setLoading(false)
+      if (!cancelled) {
+        settledArtifactRef.current = artifact.id
+        if (initialLoad) setLoading(false)
+      }
     })
     return () => { cancelled = true }
   }, [artifact?.reloadTrigger, artifact?.type, artifact?.url, refreshTrigger])
@@ -129,11 +151,11 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
           <div className="mx-auto max-w-3xl p-5"><Markdown size="sm">{content.content}</Markdown></div>
         )}
         {!loading && !error && artifact?.type === ArtifactType.IMAGE && imageUrl && (
-          <div className="flex min-h-full items-center justify-center p-4"><img key={`${artifact.reloadTrigger}:${refreshTrigger}`} src={imageUrl} alt={artifact.title} className="max-h-full max-w-full object-contain" /></div>
+          <div className="flex min-h-full items-center justify-center p-4"><img key={artifact.reloadTrigger} src={imageUrl} alt={artifact.title} className="max-h-full max-w-full object-contain" /></div>
         )}
         {!loading && !error && artifact?.type === ArtifactType.HTML && content && (
           <iframe
-            key={`${artifact.reloadTrigger}:${refreshTrigger}`}
+            key={artifact.reloadTrigger}
             title={artifact.title}
             srcDoc={hardenHtml(content.content)}
             sandbox="allow-scripts"

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
@@ -55,7 +55,7 @@ export function ArtifactsPanel({ artifacts, ui, artifactApi, hasChanges, hasOutp
         {hasOutput && <div className={active === PinnedArtifactTabId.OUTPUT ? 'h-full overflow-y-auto p-4' : 'hidden'}>{output}</div>}
         {artifacts.map((artifact) => (
           <div key={artifact.id} className={active === artifact.id ? 'h-full' : 'hidden'}>
-            {active === artifact.id ? <ArtifactViewer artifact={{ ...artifact, reloadTrigger: artifact.reloadTrigger + refreshTrigger }} artifactApi={artifactApi} /> : null}
+            {active === artifact.id ? <ArtifactViewer artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} /> : null}
           </div>
         ))}
       </div>
@@ -63,12 +63,12 @@ export function ArtifactsPanel({ artifacts, ui, artifactApi, hasChanges, hasOutp
   )
 }
 
-function ArtifactViewer({ artifact, artifactApi }: { artifact: Artifact; artifactApi: ArtifactApi }) {
+function ArtifactViewer({ artifact, artifactApi, refreshTrigger }: { artifact: Artifact; artifactApi: ArtifactApi; refreshTrigger: number }) {
   switch (artifact.type) {
-    case ArtifactType.MARKDOWN: return <MarkdownArtifactView artifact={artifact} artifactApi={artifactApi} />
-    case ArtifactType.IMAGE: return <ImageArtifactView artifact={artifact} artifactApi={artifactApi} />
-    case ArtifactType.HTML: return <HtmlArtifactView artifact={artifact} artifactApi={artifactApi} />
-    case ArtifactType.PR: return <PrArtifactView artifact={artifact} />
-    default: return <FileArtifactView artifact={artifact} artifactApi={artifactApi} />
+    case ArtifactType.MARKDOWN: return <MarkdownArtifactView artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
+    case ArtifactType.IMAGE: return <ImageArtifactView artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
+    case ArtifactType.HTML: return <HtmlArtifactView artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
+    case ArtifactType.PR: return <PrArtifactView artifact={artifact} refreshTrigger={refreshTrigger} />
+    default: return <FileArtifactView artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
   }
 }

--- a/src/renderer/src/components/artifacts/viewers/FileArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/FileArtifactView.tsx
@@ -3,8 +3,8 @@ import { ArtifactContentKind } from '@shared/artifacts'
 import { ArtifactViewState } from './ArtifactViewState'
 import { useArtifactContent } from './use-artifact-content'
 
-export function FileArtifactView({ artifact, artifactApi }: { artifact: Artifact; artifactApi: ArtifactApi }) {
-  const state = useArtifactContent(artifact, artifactApi)
+export function FileArtifactView({ artifact, artifactApi, refreshTrigger = 0 }: { artifact: Artifact; artifactApi: ArtifactApi; refreshTrigger?: number }) {
+  const state = useArtifactContent(artifact, artifactApi, refreshTrigger)
   const text = state.content?.kind === ArtifactContentKind.TEXT ? state.content.content : null
   return <ArtifactViewState loading={state.loading} error={state.error} missing={text === null}><pre className="h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs text-foreground/80">{text}</pre></ArtifactViewState>
 }

--- a/src/renderer/src/components/artifacts/viewers/HtmlArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/HtmlArtifactView.tsx
@@ -6,8 +6,8 @@ import { useArtifactContent } from './use-artifact-content'
 
 const HARDENING = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data: blob:; media-src data: blob:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; font-src data:"><script>window.open=function(){return null};</script>`
 
-export function HtmlArtifactView({ artifact, artifactApi, onMessage }: { artifact: Artifact; artifactApi: ArtifactApi; onMessage?: (data: unknown) => void }) {
-  const state = useArtifactContent(artifact, artifactApi)
+export function HtmlArtifactView({ artifact, artifactApi, onMessage, refreshTrigger = 0 }: { artifact: Artifact; artifactApi: ArtifactApi; onMessage?: (data: unknown) => void; refreshTrigger?: number }) {
+  const state = useArtifactContent(artifact, artifactApi, refreshTrigger)
   const html = state.content?.kind === ArtifactContentKind.TEXT ? state.content.content : null
   const srcDoc = useMemo(() => html === null ? '' : `${HARDENING}${html}`, [html])
 

--- a/src/renderer/src/components/artifacts/viewers/ImageArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/ImageArtifactView.tsx
@@ -3,8 +3,8 @@ import { ArtifactContentKind } from '@shared/artifacts'
 import { ArtifactViewState } from './ArtifactViewState'
 import { useArtifactContent } from './use-artifact-content'
 
-export function ImageArtifactView({ artifact, artifactApi }: { artifact: Artifact; artifactApi: ArtifactApi }) {
-  const state = useArtifactContent(artifact, artifactApi)
+export function ImageArtifactView({ artifact, artifactApi, refreshTrigger = 0 }: { artifact: Artifact; artifactApi: ArtifactApi; refreshTrigger?: number }) {
+  const state = useArtifactContent(artifact, artifactApi, refreshTrigger)
   const source = artifact.url || (state.content?.kind === ArtifactContentKind.DATA_URL ? state.content.content : null)
   return <ArtifactViewState loading={state.loading} error={state.error} missing={!source}><div className="flex h-full items-center justify-center overflow-auto bg-muted/30 p-4"><img key={artifact.reloadTrigger} src={source || ''} alt={artifact.title} className="max-h-full max-w-full object-contain" /></div></ArtifactViewState>
 }

--- a/src/renderer/src/components/artifacts/viewers/MarkdownArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/MarkdownArtifactView.tsx
@@ -4,8 +4,8 @@ import { ArtifactContentKind } from '@shared/artifacts'
 import { ArtifactViewState } from './ArtifactViewState'
 import { useArtifactContent } from './use-artifact-content'
 
-export function MarkdownArtifactView({ artifact, artifactApi }: { artifact: Artifact; artifactApi: ArtifactApi }) {
-  const state = useArtifactContent(artifact, artifactApi)
+export function MarkdownArtifactView({ artifact, artifactApi, refreshTrigger = 0 }: { artifact: Artifact; artifactApi: ArtifactApi; refreshTrigger?: number }) {
+  const state = useArtifactContent(artifact, artifactApi, refreshTrigger)
   const text = state.content?.kind === ArtifactContentKind.TEXT ? state.content.content : null
   return <ArtifactViewState loading={state.loading} error={state.error} missing={text === null}><div className="h-full overflow-y-auto px-6 py-5"><Markdown size="sm">{text || ''}</Markdown></div></ArtifactViewState>
 }

--- a/src/renderer/src/components/artifacts/viewers/PrArtifactView.test.tsx
+++ b/src/renderer/src/components/artifacts/viewers/PrArtifactView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
 import {
   ArtifactType,
   PullRequestCheckState,
@@ -73,5 +73,21 @@ describe('PrArtifactView', () => {
     expect(screen.getByText('verify')).toBeInTheDocument()
     expect(screen.getByText('1 passed')).toBeInTheDocument()
     expect(screen.getByText('1 pending')).toBeInTheDocument()
+  })
+
+  it('keeps the current PR visible during a background refresh', async () => {
+    const fetchDetails = window.electronAPI.github.fetchPullRequestDetails as ReturnType<typeof vi.fn>
+    const { rerender } = render(<PrArtifactView artifact={artifact} refreshTrigger={0} />)
+    expect(await screen.findByText('Task artifacts')).toBeInTheDocument()
+
+    let resolveRefresh: (value: PullRequestDetails) => void = () => undefined
+    fetchDetails.mockReturnValueOnce(new Promise((resolve) => { resolveRefresh = resolve }))
+    rerender(<PrArtifactView artifact={artifact} refreshTrigger={1} />)
+
+    expect(screen.getByText('Task artifacts')).toBeInTheDocument()
+    expect(screen.queryByText('Loading pull request…')).not.toBeInTheDocument()
+
+    act(() => resolveRefresh({ ...details, title: 'Updated task artifacts', commentsCount: 4 }))
+    expect(await screen.findByText('Updated task artifacts')).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/artifacts/viewers/PrArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/PrArtifactView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   AlertTriangle,
   ArrowRight,
@@ -48,15 +48,17 @@ function CheckIcon({ state }: { state: PullRequestCheckState }) {
   return <Loader2 className="h-3.5 w-3.5 animate-spin text-amber-500" />
 }
 
-export function PrArtifactView({ artifact }: { artifact: Artifact }) {
+export function PrArtifactView({ artifact, refreshTrigger = 0 }: { artifact: Artifact; refreshTrigger?: number }) {
   const [details, setDetails] = useState<PullRequestDetails | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
+  const settledUrlRef = useRef<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     if (!artifact.url) {
+      settledUrlRef.current = null
       setLoading(false)
       setError('Pull request URL is unavailable.')
       return
@@ -67,17 +69,26 @@ export function PrArtifactView({ artifact }: { artifact: Artifact }) {
       setError('Restart 20x to load the updated pull request integration.')
       return
     }
-    setLoading(true)
-    setError(null)
+    const initialLoad = settledUrlRef.current !== artifact.url
+    if (initialLoad) {
+      setLoading(true)
+      setError(null)
+    }
     void fetchPullRequestDetails(artifact.url).then((result) => {
-      if (!cancelled) setDetails(result)
+      if (!cancelled) {
+        setDetails(result)
+        setError(null)
+      }
     }).catch((reason: unknown) => {
-      if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason))
+      if (!cancelled && initialLoad) setError(reason instanceof Error ? reason.message : String(reason))
     }).finally(() => {
-      if (!cancelled) setLoading(false)
+      if (!cancelled) {
+        settledUrlRef.current = artifact.url!
+        if (initialLoad) setLoading(false)
+      }
     })
     return () => { cancelled = true }
-  }, [artifact.url, artifact.reloadTrigger, refreshKey])
+  }, [artifact.url, artifact.reloadTrigger, refreshKey, refreshTrigger])
 
   const checkSummary = useMemo(() => {
     const checks = details?.checks || []

--- a/src/renderer/src/components/artifacts/viewers/use-artifact-content.ts
+++ b/src/renderer/src/components/artifacts/viewers/use-artifact-content.ts
@@ -1,30 +1,43 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { Artifact, ArtifactApi, ArtifactContent } from '@shared/artifacts'
 
-export function useArtifactContent(artifact: Artifact, artifactApi: ArtifactApi) {
+export function useArtifactContent(artifact: Artifact, artifactApi: ArtifactApi, refreshTrigger = 0) {
   const [content, setContent] = useState<ArtifactContent | null>(null)
   const [loading, setLoading] = useState(!!artifact.path)
   const [error, setError] = useState<string | null>(null)
+  const settledIdentityRef = useRef<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     if (!artifact.path) {
+      settledIdentityRef.current = null
       setContent(null)
       setLoading(false)
       setError(null)
       return
     }
-    setLoading(true)
-    setError(null)
+    const identity = `${artifact.taskId}:${artifact.path}`
+    const initialLoad = settledIdentityRef.current !== identity
+    if (initialLoad) {
+      setContent(null)
+      setLoading(true)
+      setError(null)
+    }
     artifactApi.read(artifact.taskId, artifact.path).then((next) => {
-      if (!cancelled) setContent(next)
+      if (!cancelled) {
+        setContent(next)
+        setError(null)
+      }
     }).catch((reason: unknown) => {
-      if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason))
+      if (!cancelled && initialLoad) setError(reason instanceof Error ? reason.message : String(reason))
     }).finally(() => {
-      if (!cancelled) setLoading(false)
+      if (!cancelled) {
+        settledIdentityRef.current = identity
+        if (initialLoad) setLoading(false)
+      }
     })
     return () => { cancelled = true }
-  }, [artifact.taskId, artifact.path, artifact.reloadTrigger, artifactApi])
+  }, [artifact.taskId, artifact.path, artifact.reloadTrigger, artifactApi, refreshTrigger])
 
   return { content, loading, error }
 }


### PR DESCRIPTION
## Summary
- keep the current artifact or pull-request preview mounted during periodic background refresh
- show loading UI only for the initial fetch
- separate polling refreshes from agent-driven artifact invalidation
- avoid polling-driven iframe and image remounts on desktop and mobile

## Verification
- `pnpm test:run --project renderer src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx src/renderer/src/components/artifacts/viewers/PrArtifactView.test.tsx src/renderer/src/components/artifacts/viewers/HtmlArtifactView.test.tsx`
- `pnpm typecheck`
- targeted ESLint checks
- `git diff --check`