### PR TITLE
fix(voice): tie speech to a session, and stop repeating sent words

### DIFF
--- a/src/main/voice/voice-speech-service.ts
+++ b/src/main/voice/voice-speech-service.ts
@@ -380,6 +380,14 @@ export class VoiceSpeechService {
   }
 
   /**
+   * DEPRECATED — no caller arms this any more, and none should.
+   *
+   * It matched the first answer from ANY task, so speaking to the Mastermind
+   * drawer made 20x read out whatever the open task wrote next. Speech in and
+   * speech out are tied to one session: the drawer names the Mastermind
+   * session, a task names itself. Kept only so an older renderer cannot crash
+   * main by calling it.
+   *
    * The user spoke a sentence and it was sent, but the sender did not name a
    * task — the Mastermind drawer sends on its own behalf.
    *

--- a/src/renderer/src/components/voice/VoiceOverlay.test.tsx
+++ b/src/renderer/src/components/voice/VoiceOverlay.test.tsx
@@ -62,6 +62,16 @@ describe('VoiceOverlay', () => {
     expect(screen.queryByText(/run the tests again/)).not.toBeInTheDocument()
   })
 
+  it('shows nothing once the sentence has been sent', () => {
+    // The words are in the transcript now. Leaving them in the bubble shows
+    // the user something they have already sent, as though it were still
+    // being heard.
+    reset({ state: 'listening', turnId: 'turn-1', mode: 'conversation', partial: '' })
+    render(<VoiceOverlay />)
+
+    expect(screen.getByTestId('voice-transcript')).toHaveTextContent('Speak now')
+  })
+
   it('brightens and swells with the voice, visibly', () => {
     reset({ state: 'listening', turnId: 'turn-1', level: 0 })
     const { rerender } = render(<VoiceOverlay />)

--- a/src/renderer/src/hooks/use-voice-control.ts
+++ b/src/renderer/src/hooks/use-voice-control.ts
@@ -106,7 +106,11 @@ export function useVoiceControl(): void {
       const sent = insertAndSubmit(text)
       if (sent) {
         useVoiceStore.setState((state) => ({
-          sentSentences: [...state.sentSentences, text].slice(-5)
+          sentSentences: [...state.sentSentences, text].slice(-5),
+          // The sentence has gone. Leaving it in the bubble shows the user
+          // words they have already sent, as though 20x were still hearing
+          // them.
+          partial: ''
         }))
         // The sentence has gone to an agent, so the answer that comes back is
         // the reply to it and may be read aloud. Without this the loop stops

--- a/src/renderer/src/lib/voice-dictation-target.ts
+++ b/src/renderer/src/lib/voice-dictation-target.ts
@@ -33,8 +33,26 @@ export const DASHBOARD_COMPOSER_KEY = 'dashboard-command'
  * a spoken sentence was sent to. The two composers above belong to no task and
  * send on their own behalf.
  */
+/**
+ * The Mastermind session's own id.
+ *
+ * It is a session like any other, so it can name itself. It used to name
+ * nothing, and main then armed an expectation that matched the first answer
+ * from ANY task — so speaking to the drawer made 20x read out whatever the
+ * open task happened to write next.
+ */
+export const MASTERMIND_SESSION_ID = 'mastermind-session'
+
+/**
+ * Which session a composer speaks to.
+ *
+ * Both the drawer and the dashboard command box send to Mastermind, so both
+ * name the Mastermind session. Everything else is a task, and its key is the
+ * task id. Speech in and speech out are tied to one session either way.
+ */
 export function taskIdOfComposer(key: string | null): string | undefined {
-  if (!key || key === MASTERMIND_COMPOSER_KEY || key === DASHBOARD_COMPOSER_KEY) return undefined
+  if (!key) return undefined
+  if (key === MASTERMIND_COMPOSER_KEY || key === DASHBOARD_COMPOSER_KEY) return MASTERMIND_SESSION_ID
   return key
 }
 


### PR DESCRIPTION
Follow-up to #454, from live testing.

## 1. Speaking to Mastermind read out the open task's messages

The drawer named no task, so main armed an expectation matching the **first answer from any task** for 90 seconds. The open task's agent took it.

The drawer is a session and can name itself — `mastermind-session`. Speech in and speech out are now tied to one session, as they should have been.

## 2. The listening bubble showed words already sent

A sent sentence is in the transcript above. Repeating it in the bubble reads as though 20x were still hearing it.

## Known, not fixed here

`insertAndSubmit()` drops words into `testTranscript` when no composer can submit — visible only in Settings, no error. Likely behind the "captured but not sent" report. Needs a visible failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)