### PR TITLE
feat: ask how to complete a task that came from a task source

### DIFF
--- a/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { TaskPanelContent } from './TaskPanelContent'
 
 const {
@@ -9,6 +9,7 @@ const {
   addPanelMock,
   addEdgeMock,
   bringToFrontMock,
+  executeActionMock,
   canvasState,
   taskList,
 } = vi.hoisted(() => ({
@@ -18,6 +19,7 @@ const {
   addPanelMock: vi.fn(() => 'panel-new'),
   addEdgeMock: vi.fn(),
   bringToFrontMock: vi.fn(),
+  executeActionMock: vi.fn(async () => ({ success: true })),
   canvasState: {
     panels: [
       { id: 'panel-1', type: 'task', refId: 'task-1', x: 100, y: 200, width: 1020, height: 780 },
@@ -29,7 +31,7 @@ const {
       title: 'Current Task',
       parent_task_id: null,
       output_fields: [],
-      source_id: null,
+      source_id: null as string | null,
       repos: [],
       priority: 'medium',
       type: 'general',
@@ -40,7 +42,7 @@ const {
       title: 'Child Task',
       parent_task_id: 'task-1',
       output_fields: [],
-      source_id: null,
+      source_id: null as string | null,
       repos: [],
       priority: 'medium',
       type: 'general',
@@ -53,9 +55,11 @@ vi.mock('@/components/tasks/TaskWorkspace', () => ({
   TaskWorkspace: ({
     onNavigateToTask,
     onOpenSubtaskInWindow,
+    onCompleteTask,
   }: {
     onNavigateToTask?: (taskId: string) => void
     onOpenSubtaskInWindow?: (taskId: string) => void
+    onCompleteTask?: () => void
   }) => (
     <>
       <button type="button" onClick={() => onNavigateToTask?.('child-1')}>
@@ -63,6 +67,9 @@ vi.mock('@/components/tasks/TaskWorkspace', () => ({
       </button>
       <button type="button" onClick={() => onOpenSubtaskInWindow?.('child-1')}>
         Open child in window
+      </button>
+      <button type="button" onClick={() => onCompleteTask?.()}>
+        Complete task
       </button>
     </>
   ),
@@ -110,11 +117,12 @@ vi.mock('@/stores/ui-store', () => ({
   }),
 }))
 
-vi.mock('@/stores/task-source-store', () => ({
-  useTaskSourceStore: () => ({
-    executeAction: vi.fn(),
-  }),
-}))
+vi.mock('@/stores/task-source-store', () => {
+  const state = { sources: [], executeAction: executeActionMock }
+  const useTaskSourceStore = (selector: (value: typeof state) => unknown) => selector(state)
+  useTaskSourceStore.getState = () => state
+  return { useTaskSourceStore }
+})
 
 describe('TaskPanelContent', () => {
   afterEach(() => {
@@ -123,6 +131,7 @@ describe('TaskPanelContent', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    taskList[0].source_id = null
     canvasState.panels = [
       { id: 'panel-1', type: 'task', refId: 'task-1', x: 100, y: 200, width: 1020, height: 780 },
     ]
@@ -172,5 +181,27 @@ describe('TaskPanelContent', () => {
     expect(bringToFrontMock).toHaveBeenCalledWith('panel-2')
     expect(addPanelMock).not.toHaveBeenCalled()
     expect(addEdgeMock).not.toHaveBeenCalled()
+  })
+
+  it('completes a task with no source directly from the canvas panel', async () => {
+    render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
+
+    fireEvent.click(screen.getByText('Complete task'))
+
+    await waitFor(() =>
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: 'completed' })
+    )
+    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
+  })
+
+  it('asks how to complete a source-backed task from the canvas panel', async () => {
+    taskList[0].source_id = 'src-1'
+    render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
+
+    fireEvent.click(screen.getByText('Complete task'))
+
+    expect(await screen.findByTestId('complete-at-source-dialog')).toBeTruthy()
+    expect(updateTaskMock).not.toHaveBeenCalled()
+    expect(executeActionMock).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/canvas/TaskPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.tsx
@@ -4,8 +4,7 @@ import { useCanvasStore, DEFAULT_PANEL_WIDTH, DEFAULT_PANEL_HEIGHT } from '@/sto
 import { useTaskStore } from '@/stores/task-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useUIStore } from '@/stores/ui-store'
-import { useTaskSourceStore } from '@/stores/task-source-store'
-import { TaskStatus, PluginActionId } from '@/types'
+import { useTaskCompletion } from '@/hooks/use-task-completion'
 import type { FileAttachment } from '@/types'
 
 interface TaskPanelContentProps {
@@ -30,9 +29,10 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
   // Per-action selectors: a selector-less useStore() subscribes to the whole
   // store, so every ui-store change (modals, filters, sidebar) would re-render
   // every canvas task panel's entire TaskWorkspace tree.
-  const executeAction = useTaskSourceStore((s) => s.executeAction)
   const openEditModal = useUIStore((s) => s.openEditModal)
   const openDeleteModal = useUIStore((s) => s.openDeleteModal)
+  // Source-backed tasks ask whether to close the task in the source system.
+  const { requestComplete, completionDialog } = useTaskCompletion()
 
   const handleEdit = useCallback(() => {
     if (task) openEditModal(task.id)
@@ -57,19 +57,8 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
   )
 
   const handleCompleteTask = useCallback(async () => {
-    if (!task) return
-    try {
-      if (task.source_id) {
-        const actionField = task.output_fields.find((f) => f.id === 'action')
-        const actionValue = actionField?.value ? String(actionField.value) : PluginActionId.Complete
-        const result = await executeAction(actionValue, task.id, task.source_id)
-        if (!result.success) return
-      }
-      await updateTask(task.id, { status: TaskStatus.Completed })
-    } catch (err) {
-      console.error('Failed to complete task:', err)
-    }
-  }, [task, updateTask, executeAction])
+    if (task) await requestComplete(task.id)
+  }, [task, requestComplete])
 
   const handleAssignAgent = useCallback(
     async (tid: string, agentId: string | null) => {
@@ -160,6 +149,7 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
         onOpenSubtaskInWindow={handleOpenSubtaskInWindow}
         panelLayout={panelLayout}
       />
+      {completionDialog}
     </div>
   )
 }

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -23,14 +23,13 @@ const OrchestratorPanel = lazy(() => import('@/components/orchestrator/Orchestra
 import { useTasks } from '@/hooks/use-tasks'
 import { useUIStore } from '@/stores/ui-store'
 import { useAgentStore } from '@/stores/agent-store'
-import { useTaskStore } from '@/stores/task-store'
 import { useAgentAutoStart } from '@/hooks/use-agent-auto-start'
 import { useOverdueNotifications } from '@/hooks/use-overdue-notifications'
+import { useTaskCompletion } from '@/hooks/use-task-completion'
 import { attachmentApi, worktreeApi, settingsApi, updaterApi } from '@/lib/ipc-client'
-import { useTaskSourceStore } from '@/stores/task-source-store'
 import { isOverdue, isSnoozed } from '@/lib/utils'
 import { captureAnalyticsEvent, capturePageView } from '@/lib/analytics'
-import { TaskStatus, PluginActionId } from '@/types'
+import { TaskStatus } from '@/types'
 import type { FileAttachment, OutputField, UpdateTaskDTO } from '@/types'
 import { MessageSquare, LayoutDashboard, CheckSquare, Zap, Settings, Layers, PanelLeftClose, PanelLeftOpen, Search } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
@@ -58,7 +57,6 @@ export function AppLayout() {
   const agents = useAgentStore((s) => s.agents)
   const fetchAgents = useAgentStore((s) => s.fetchAgents)
   const stopAndRemoveSessionForTask = useAgentStore((s) => s.stopAndRemoveSessionForTask)
-  const executeAction = useTaskSourceStore((s) => s.executeAction)
   // Use individual selectors for UI store to prevent full-tree re-renders
   const sidebarView = useUIStore((s) => s.sidebarView)
   const setSidebarView = useUIStore((s) => s.setSidebarView)
@@ -148,42 +146,29 @@ export function AppLayout() {
     setTimeout(() => setToast(null), isError ? 5000 : 3000)
   }, [])
 
-  const getLatestTask = useCallback(
-    (taskId: string | null | undefined) => (
-      taskId ? useTaskStore.getState().tasks.find((t) => t.id === taskId) : undefined
-    ),
-    []
+  // Source-backed tasks ask the user whether to close the task in the source
+  // system or only in 20x. `completionDialog` renders that question.
+  const { requestComplete, completionDialog } = useTaskCompletion({ onToast: showToast })
+
+  const selectNextActiveTask = useCallback(
+    (completedTaskId: string) => {
+      const activeTasks = filteredTasksRef.current.filter(
+        (t) => t.id !== completedTaskId && t.status !== TaskStatus.Completed
+      )
+      selectTask(activeTasks.length > 0 ? activeTasks[0].id : null)
+    },
+    [selectTask]
   )
 
   const completeTask = useCallback(
     async (taskId: string, options?: { selectNextTask?: boolean }) => {
-      const task = getLatestTask(taskId)
-      if (!task) return
-      const taskTitle = task.title
-      try {
-        if (task.source_id) {
-          const actionField = task.output_fields.find((f) => f.id === 'action')
-          const actionValue = actionField?.value ? String(actionField.value) : PluginActionId.Complete
-          const result = await executeAction(actionValue, task.id, task.source_id)
-          if (!result.success) {
-            showToast(result.error || 'Failed to complete task', true)
-            return
-          }
-        }
-        await updateTask(task.id, { status: TaskStatus.Completed })
-      } catch (err) {
-        console.error('Failed to complete task:', err)
-        showToast('Failed to complete task', true)
-        return
-      }
-
-      if (options?.selectNextTask) {
-        const activeTasks = filteredTasksRef.current.filter((t) => t.id !== task.id && t.status !== TaskStatus.Completed)
-        selectTask(activeTasks.length > 0 ? activeTasks[0].id : null)
-      }
-      showToast(`"${taskTitle}" completed`)
+      await requestComplete(taskId, {
+        onCompleted: options?.selectNextTask
+          ? (task) => selectNextActiveTask(task.id)
+          : undefined
+      })
     },
-    [executeAction, getLatestTask, selectTask, showToast, updateTask]
+    [requestComplete, selectNextActiveTask]
   )
 
   const selectedTaskId = selectedTask?.id
@@ -599,6 +584,9 @@ export function AppLayout() {
           </DialogBody>
         </DialogContent>
       </Dialog>
+
+      {/* Complete at source or manually */}
+      {completionDialog}
 
       {/* Delete Confirmation */}
       <DeleteConfirmDialog

--- a/src/renderer/src/components/tasks/CompleteAtSourceDialog.tsx
+++ b/src/renderer/src/components/tasks/CompleteAtSourceDialog.tsx
@@ -1,0 +1,73 @@
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel
+} from '@/components/ui/AlertDialog'
+import { Button } from '@/components/ui/Button'
+
+export interface CompleteAtSourceDialogProps {
+  isOpen: boolean
+  /** Title of the task being completed. */
+  taskTitle: string
+  /** Display name of the task source, e.g. "Linear — Engineering". */
+  sourceName: string
+  /** True while one of the two completion paths runs. */
+  isBusy?: boolean
+  /** Complete the task in the external source, then locally. */
+  onCompleteAtSource: () => void
+  /** Complete the task locally only — the user updates the source. */
+  onCompleteManually: () => void
+  onCancel: () => void
+}
+
+/**
+ * Asks the user how a task that came from an external source must be completed:
+ * in the source system, or locally only.
+ */
+export function CompleteAtSourceDialog({
+  isOpen,
+  taskTitle,
+  sourceName,
+  isBusy = false,
+  onCompleteAtSource,
+  onCompleteManually,
+  onCancel
+}: CompleteAtSourceDialogProps) {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={(open) => !open && !isBusy && onCancel()}>
+      <AlertDialogContent data-testid="complete-at-source-dialog">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Complete in {sourceName}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            "{taskTitle}" came from {sourceName}. 20x can close it there for you, or you can
+            mark it complete here only and update {sourceName} yourself.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-col-reverse sm:flex-row sm:justify-end">
+          <AlertDialogCancel disabled={isBusy} onClick={onCancel}>
+            Cancel
+          </AlertDialogCancel>
+          <Button
+            variant="outline"
+            disabled={isBusy}
+            onClick={onCompleteManually}
+            data-testid="complete-manually"
+          >
+            I'll do it manually
+          </Button>
+          <Button
+            disabled={isBusy}
+            onClick={onCompleteAtSource}
+            data-testid="complete-at-source"
+          >
+            Complete at source
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/src/hooks/use-task-completion.test.tsx
+++ b/src/renderer/src/hooks/use-task-completion.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { useTaskCompletion } from './use-task-completion'
+import { TaskStatus, PluginActionId } from '@/types'
+import type { WorkfloTask } from '@/types'
+
+const { updateTaskMock, executeActionMock, storeState } = vi.hoisted(() => ({
+  updateTaskMock: vi.fn(async () => undefined),
+  executeActionMock: vi.fn<() => Promise<{ success: boolean; error?: string }>>(async () => ({
+    success: true
+  })),
+  storeState: {
+    tasks: [] as unknown[],
+    sources: [] as unknown[]
+  }
+}))
+
+vi.mock('@/stores/task-store', () => {
+  const getState = () => ({ tasks: storeState.tasks, updateTask: updateTaskMock })
+  const useTaskStore = (selector: (s: ReturnType<typeof getState>) => unknown) => selector(getState())
+  useTaskStore.getState = getState
+  return { useTaskStore }
+})
+
+vi.mock('@/stores/task-source-store', () => {
+  const getState = () => ({ sources: storeState.sources, executeAction: executeActionMock })
+  const useTaskSourceStore = (selector: (s: ReturnType<typeof getState>) => unknown) =>
+    selector(getState())
+  useTaskSourceStore.getState = getState
+  return { useTaskSourceStore }
+})
+
+function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
+  return {
+    id: 'task-1',
+    title: 'Fix the login bug',
+    description: '',
+    type: 'general',
+    priority: 'medium',
+    status: TaskStatus.ReadyForReview,
+    assignee: '',
+    due_date: null,
+    labels: [],
+    attachments: [],
+    repos: [],
+    output_fields: [],
+    agent_id: null,
+    session_id: null,
+    external_id: null,
+    source_id: null,
+    source: 'manual',
+    skill_ids: null,
+    snoozed_until: null,
+    resolution: null,
+    feedback_rating: null,
+    feedback_comment: null,
+    is_recurring: false,
+    recurrence_pattern: null,
+    recurrence_parent_id: null,
+    last_occurrence_at: null,
+    next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
+    parent_task_id: null,
+    sort_order: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides
+  } as WorkfloTask
+}
+
+const onToast = vi.fn()
+const onCompleted = vi.fn()
+
+function Harness({ taskId = 'task-1' }: { taskId?: string }) {
+  const { requestComplete, completionDialog } = useTaskCompletion({ onToast })
+  return (
+    <>
+      <button type="button" onClick={() => void requestComplete(taskId, { onCompleted })}>
+        Complete
+      </button>
+      {completionDialog}
+    </>
+  )
+}
+
+describe('useTaskCompletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    executeActionMock.mockResolvedValue({ success: true })
+    storeState.tasks = []
+    storeState.sources = []
+  })
+
+  afterEach(cleanup)
+
+  it('completes a task with no source immediately, without asking', async () => {
+    storeState.tasks = [makeTask({ source_id: null })]
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+
+    await waitFor(() =>
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+    )
+    expect(executeActionMock).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
+    expect(onCompleted).toHaveBeenCalled()
+  })
+
+  it('asks before completing a task that came from a source', async () => {
+    storeState.tasks = [makeTask({ source_id: 'src-1' })]
+    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+
+    expect(await screen.findByTestId('complete-at-source-dialog')).toBeTruthy()
+    // Nothing happens until the user answers.
+    expect(executeActionMock).not.toHaveBeenCalled()
+    expect(updateTaskMock).not.toHaveBeenCalled()
+    expect(screen.getByText('Complete in Linear?')).toBeTruthy()
+  })
+
+  it('pushes the completion to the source when the user picks "complete at source"', async () => {
+    storeState.tasks = [makeTask({ source_id: 'src-1' })]
+    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+    fireEvent.click(await screen.findByTestId('complete-at-source'))
+
+    await waitFor(() =>
+      expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete, 'task-1', 'src-1')
+    )
+    expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+    await waitFor(() => expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull())
+  })
+
+  it('skips the source call when the user picks "I\'ll do it manually"', async () => {
+    storeState.tasks = [makeTask({ source_id: 'src-1' })]
+    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+    fireEvent.click(await screen.findByTestId('complete-manually'))
+
+    await waitFor(() =>
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+    )
+    expect(executeActionMock).not.toHaveBeenCalled()
+    expect(onToast).toHaveBeenCalledWith('"Fix the login bug" completed in 20x only')
+  })
+
+  it('uses the action output field as the source action id', async () => {
+    storeState.tasks = [
+      makeTask({
+        source_id: 'src-1',
+        output_fields: [{ id: 'action', value: PluginActionId.Approve }] as WorkfloTask['output_fields']
+      })
+    ]
+    storeState.sources = [{ id: 'src-1', name: 'Peakflo' }]
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+    fireEvent.click(await screen.findByTestId('complete-at-source'))
+
+    await waitFor(() =>
+      expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Approve, 'task-1', 'src-1')
+    )
+  })
+
+  it('keeps the task open and reports the error when the source call fails', async () => {
+    storeState.tasks = [makeTask({ source_id: 'src-1' })]
+    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
+    executeActionMock.mockResolvedValue({ success: false, error: 'Linear rejected the update' })
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+    fireEvent.click(await screen.findByTestId('complete-at-source'))
+
+    await waitFor(() =>
+      expect(onToast).toHaveBeenCalledWith('Linear rejected the update', true)
+    )
+    expect(updateTaskMock).not.toHaveBeenCalled()
+    // The dialog stays open so the user can retry or complete manually.
+    expect(screen.getByTestId('complete-at-source-dialog')).toBeTruthy()
+  })
+
+  it('completes nothing when the user cancels', async () => {
+    storeState.tasks = [makeTask({ source_id: 'src-1' })]
+    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+    fireEvent.click(await screen.findByText('Cancel'))
+
+    await waitFor(() => expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull())
+    expect(executeActionMock).not.toHaveBeenCalled()
+    expect(updateTaskMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the task source label when the source record is not loaded', async () => {
+    storeState.tasks = [makeTask({ source_id: 'src-1', source: 'jira' })]
+    storeState.sources = []
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+
+    expect(await screen.findByText('Complete in jira?')).toBeTruthy()
+  })
+})

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useState, type ReactNode } from 'react'
+import { CompleteAtSourceDialog } from '@/components/tasks/CompleteAtSourceDialog'
+import { useTaskSourceStore } from '@/stores/task-source-store'
+import { useTaskStore } from '@/stores/task-store'
+import { TaskStatus, PluginActionId } from '@/types'
+import type { WorkfloTask } from '@/types'
+
+export interface UseTaskCompletionOptions {
+  /** Shows a short message to the user. Optional. */
+  onToast?: (message: string, isError?: boolean) => void
+}
+
+export interface CompleteTaskRequestOptions {
+  /** Runs after the task is completed. */
+  onCompleted?: (task: WorkfloTask) => void
+}
+
+interface PendingCompletion {
+  taskId: string
+  options?: CompleteTaskRequestOptions
+}
+
+/**
+ * Single completion path for tasks.
+ *
+ * A task that came from an external source (Linear, Jira, GitHub, ...) has two
+ * valid completions: close it in the source system, or close it only in 20x
+ * because the user updates the source. This hook asks the user which one to
+ * use, instead of always pushing the completion to the source.
+ *
+ * Tasks without a source complete immediately — there is nothing to ask.
+ */
+export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
+  const updateTask = useTaskStore((s) => s.updateTask)
+  const executeAction = useTaskSourceStore((s) => s.executeAction)
+  const sources = useTaskSourceStore((s) => s.sources)
+
+  const [pending, setPending] = useState<PendingCompletion | null>(null)
+  const [isBusy, setIsBusy] = useState(false)
+
+  // The dialog reads the task through the store, so an import that arrives
+  // while the dialog is open cannot make the prompt act on stale data.
+  const tasks = useTaskStore((s) => s.tasks)
+  const pendingTask = useMemo(
+    () => (pending ? tasks.find((t) => t.id === pending.taskId) : undefined),
+    [pending, tasks]
+  )
+
+  const sourceName = useMemo(() => {
+    if (!pendingTask?.source_id) return 'the task source'
+    const source = sources.find((s) => s.id === pendingTask.source_id)
+    return source?.name || pendingTask.source || 'the task source'
+  }, [pendingTask, sources])
+
+  /**
+   * Applies the completion. When `atSource` is true the plugin action runs
+   * first; a failure leaves the task open so the two systems stay in sync.
+   */
+  const runCompletion = useCallback(
+    async (
+      task: WorkfloTask,
+      options: CompleteTaskRequestOptions | undefined,
+      atSource: boolean
+    ): Promise<boolean> => {
+      try {
+        if (atSource && task.source_id) {
+          const actionField = task.output_fields.find((f) => f.id === 'action')
+          const actionValue = actionField?.value
+            ? String(actionField.value)
+            : PluginActionId.Complete
+          const result = await executeAction(actionValue, task.id, task.source_id)
+          if (!result.success) {
+            onToast?.(result.error || 'Failed to complete task', true)
+            return false
+          }
+        }
+        await updateTask(task.id, { status: TaskStatus.Completed })
+      } catch (err) {
+        console.error('Failed to complete task:', err)
+        onToast?.('Failed to complete task', true)
+        return false
+      }
+
+      options?.onCompleted?.(task)
+      onToast?.(
+        atSource
+          ? `"${task.title}" completed`
+          : `"${task.title}" completed in 20x only`
+      )
+      return true
+    },
+    [executeAction, onToast, updateTask]
+  )
+
+  /**
+   * Entry point for every user-triggered completion. Reads the task from the
+   * store so callers cannot pass a stale copy.
+   */
+  const requestComplete = useCallback(
+    async (taskId: string, options?: CompleteTaskRequestOptions) => {
+      const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
+      if (!task) return
+      if (task.source_id) {
+        setPending({ taskId, options })
+        return
+      }
+      await runCompletion(task, options, false)
+    },
+    [runCompletion]
+  )
+
+  const resolvePending = useCallback(
+    async (atSource: boolean) => {
+      if (!pending || isBusy) return
+      const task = useTaskStore.getState().tasks.find((t) => t.id === pending.taskId)
+      if (!task) {
+        setPending(null)
+        return
+      }
+      setIsBusy(true)
+      try {
+        const done = await runCompletion(task, pending.options, atSource)
+        if (done) setPending(null)
+      } finally {
+        setIsBusy(false)
+      }
+    },
+    [isBusy, pending, runCompletion]
+  )
+
+  const handleCompleteAtSource = useCallback(() => resolvePending(true), [resolvePending])
+  const handleCompleteManually = useCallback(() => resolvePending(false), [resolvePending])
+  const handleCancel = useCallback(() => {
+    if (!isBusy) setPending(null)
+  }, [isBusy])
+
+  const completionDialog: ReactNode = (
+    <CompleteAtSourceDialog
+      isOpen={pending !== null}
+      taskTitle={pendingTask?.title || ''}
+      sourceName={sourceName}
+      isBusy={isBusy}
+      onCompleteAtSource={handleCompleteAtSource}
+      onCompleteManually={handleCompleteManually}
+      onCancel={handleCancel}
+    />
+  )
+
+  return { requestComplete, completionDialog }
+}


### PR DESCRIPTION
## Summary

Completing a task that has a `source_id` always pushed the completion to the external system (Linear, Jira, GitHub, Peakflo, …) through the plugin action. The user had no way to close a task in 20x while updating the source themselves, and no warning before 20x wrote to the source.

Completing a source-backed task now shows a prompt with two completions:

| Choice | Source system | 20x task |
|---|---|---|
| **Complete at source** | Plugin action runs (previous behaviour) | Set to Completed |
| **I'll do it manually** | Untouched | Set to Completed |
| **Cancel** | Untouched | Stays open |

Tasks with no source complete immediately — there is nothing to ask.

## Details

- A failed source call keeps the dialog open and shows the error toast, so the two systems cannot go out of sync silently.
- The dialog names the source (`Complete in Linear?`), falling back to the task's `source` label when the source record is not loaded yet.
- The action id still comes from the `action` output field when present, else `PluginActionId.Complete` — unchanged.
- The dialog reads the task through the store at answer time, so a sync that lands while the dialog is open cannot make the prompt act on stale data.

## Refactor

`AppLayout.completeTask` and `TaskPanelContent.handleCompleteTask` held duplicate copies of the source-completion logic. Both now use the new `useTaskCompletion` hook, which owns the prompt, the plugin call, and the local status update.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors (warnings are pre-existing)
- [x] `pnpm test:run` — 149 files / 2268 tests pass
- [x] 8 new tests in `use-task-completion.test.tsx` cover: no-source fast path, prompt shown, complete-at-source, complete-manually, `action` output field, source failure, cancel, source-name fallback
- [x] 2 new tests in `TaskPanelContent.test.tsx` cover the canvas panel call site
- [x] Non-vacuity verified — restoring the old always-push behaviour fails 7 of the 8 new tests

## Notes

Mobile is unaffected: `src/mobile` never ran the source-completion path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)