### PR TITLE
Make task dispatch atomic and idempotent

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -121,6 +121,7 @@ function createMockDb(agentConfig: Record<string, unknown> = {}) {
     getSetting: vi.fn(() => null),
     getWorkspaceDir: vi.fn(() => '/tmp/test-workspace'),
     updateTask: vi.fn(),
+    upsertTranscriptParts: vi.fn(() => ({ maxRev: 1, changedPartIds: [] })),
   } as unknown as ConstructorParameters<typeof AgentManager>[0]
 }
 
@@ -289,7 +290,7 @@ describe('AgentManager skill file paths', () => {
   })
 
   describe('writeAgentsDocumentation', () => {
-    it('writes AGENTS.md and CLAUDE.md to workspace root, not .agents/', async () => {
+    it('writes only CLAUDE.md for Claude Code', async () => {
       const mockDb = createMockDb({ coding_agent: 'claude-code' })
       manager = new AgentManager(mockDb)
 
@@ -301,15 +302,29 @@ describe('AgentManager skill file paths', () => {
 
       const writeFilePaths = mockedWriteFileAsync.mock.calls.map(c => c[0] as string)
 
-      // Both files should be written to workspace root
-      expect(writeFilePaths).toContain('/tmp/test-workspace/AGENTS.md')
       expect(writeFilePaths).toContain('/tmp/test-workspace/CLAUDE.md')
+      expect(writeFilePaths).not.toContain('/tmp/test-workspace/AGENTS.md')
+
+      const content = mockedWriteFileAsync.mock.calls[0][1] as string
+      expect(content).not.toContain('Session Started:')
 
       // Neither should be written inside .agents/
       const agentsDirWrites = writeFilePaths.filter(
         p => p.includes('.agents/AGENTS.md') || p.includes('.agents/CLAUDE.md')
       )
       expect(agentsDirWrites).toHaveLength(0)
+    })
+
+    it('writes only AGENTS.md for non-Claude agents', async () => {
+      const mockDb = createMockDb({ coding_agent: 'cursor' })
+      manager = new AgentManager(mockDb)
+
+      await (manager as any).writeAgentsDocumentation('/tmp/test-workspace', [], [], 'agent-1')
+
+      const writeFilePaths = mockedWriteFileAsync.mock.calls.map(c => c[0] as string)
+      expect(writeFilePaths).toContain('/tmp/test-workspace/AGENTS.md')
+      expect(writeFilePaths).not.toContain('/tmp/test-workspace/CLAUDE.md')
+      expect(mockedWriteFileAsync.mock.calls[0][1] as string).not.toContain('Generated:')
     })
 
     it('does not create .agents/ directory for documentation files', async () => {
@@ -323,6 +338,74 @@ describe('AgentManager skill file paths', () => {
       const mkdirCalls = mockedMkdirAsync.mock.calls.map(c => c[0] as string)
       const agentsDirCreates = mkdirCalls.filter(p => p.endsWith('.agents'))
       expect(agentsDirCreates).toHaveLength(0)
+    })
+  })
+
+  describe('startSession', () => {
+    it('returns an existing non-error session for the task', async () => {
+      const mockDb = createMockDb({ coding_agent: 'cursor' })
+      manager = new AgentManager(mockDb)
+      ;(manager as any).sessions.set('session-existing', { taskId: 'task-1', status: 'idle' })
+      const getAdapter = vi.spyOn(manager as any, 'getAdapter')
+
+      await expect(manager.startSession('agent-1', 'task-1', '/tmp/ws')).resolves.toBe('session-existing')
+      expect(getAdapter).not.toHaveBeenCalled()
+    })
+
+    it('shares one in-flight start for concurrent calls on the same task', async () => {
+      const mockDb = createMockDb({ coding_agent: 'cursor' })
+      manager = new AgentManager(mockDb)
+      let resolveStart!: (sessionId: string) => void
+      const deferred = new Promise<string>((resolve) => { resolveStart = resolve })
+      vi.spyOn(manager as any, 'getAdapter').mockReturnValue({})
+      const startAdapterSession = vi.spyOn(manager as any, 'startAdapterSession').mockReturnValue(deferred)
+
+      const starts = [
+        manager.startSession('agent-1', 'task-1', '/tmp/ws'),
+        manager.startSession('agent-1', 'task-1', '/tmp/ws'),
+        manager.startSession('agent-1', 'task-1', '/tmp/ws')
+      ]
+      resolveStart('session-1')
+
+      await expect(Promise.all(starts)).resolves.toEqual(['session-1', 'session-1', 'session-1'])
+      expect(startAdapterSession).toHaveBeenCalledOnce()
+    })
+
+    it('clears a failed in-flight start so it can be retried', async () => {
+      const mockDb = createMockDb({ coding_agent: 'cursor' })
+      manager = new AgentManager(mockDb)
+      vi.spyOn(manager as any, 'getAdapter').mockReturnValue({})
+      const startAdapterSession = vi.spyOn(manager as any, 'startAdapterSession')
+        .mockRejectedValueOnce(new Error('failed'))
+        .mockResolvedValueOnce('session-2')
+
+      await expect(manager.startSession('agent-1', 'task-1', '/tmp/ws')).rejects.toThrow('failed')
+      await expect(manager.startSession('agent-1', 'task-1', '/tmp/ws')).resolves.toBe('session-2')
+      expect(startAdapterSession).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('initial prompt', () => {
+    it('starts a heartbeat-enabled task without a scope error', async () => {
+      const mockDb = createMockDb({ coding_agent: 'cursor' }) as any
+      mockDb.getTask = vi.fn(() => ({
+        id: 'task-1', title: 'Monitor task', description: 'Check production',
+        status: TaskStatus.NotStarted, agent_id: 'agent-1', parent_task_id: null,
+        heartbeat_enabled: true, attachments: [], output_fields: []
+      }))
+      manager = new AgentManager(mockDb)
+      vi.spyOn(manager as any, 'writeSkillFiles').mockResolvedValue(undefined)
+      vi.spyOn(manager as any, 'buildMcpServersForAdapter').mockResolvedValue([])
+      vi.spyOn(manager as any, 'startAdapterPolling').mockImplementation(() => undefined)
+      const adapter = {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        createSession: vi.fn().mockResolvedValue('session-1'),
+        sendPrompt: vi.fn().mockResolvedValue(undefined)
+      }
+
+      await expect((manager as any).startAdapterSession(adapter, 'agent-1', 'task-1', '/tmp/ws')).resolves.toBe('session-1')
+      expect(adapter.sendPrompt).toHaveBeenCalledOnce()
+      expect(adapter.sendPrompt.mock.calls[0][1][0].text).toContain('## Heartbeat Monitoring')
     })
   })
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -188,6 +188,7 @@ interface MessageAttachmentRef {
 
 export class AgentManager extends EventEmitter {
   private sessions: Map<string, AgentSession> = new Map()
+  private startingSessionsByTask: Map<string, Promise<string>> = new Map()
   /** Maps old (temp) session IDs to their re-keyed (real) IDs so that
    *  stale IDs from the renderer still resolve after pollSingleSession re-keys. */
   private sessionIdRedirects: Map<string, string> = new Map()
@@ -1121,7 +1122,7 @@ export class AgentManager extends EventEmitter {
         console.log(`[AgentManager] Wrote ${skills.length} SKILL.md file(s) to ${skillsDir}`)
       }
 
-      // Generate AGENTS.md and CLAUDE.md with skill directory
+      // Generate the documentation file consumed by this coding agent.
       await this.writeAgentsDocumentation(workspaceDir, skills, task?.repos || [], agentId)
     } catch (error) {
       console.error('[AgentManager] Error writing skill files:', error)
@@ -1129,8 +1130,7 @@ export class AgentManager extends EventEmitter {
   }
 
   /**
-   * Generates AGENTS.md and CLAUDE.md with skill directory and metadata.
-   * Both files are written to the workspace root directory.
+   * Generates the documentation file consumed by the selected coding agent.
    */
   private async writeAgentsDocumentation(
     workspaceDir: string,
@@ -1142,15 +1142,15 @@ export class AgentManager extends EventEmitter {
       // Sort skills by confidence (high to low)
       const sortedSkills = [...skills].sort((a, b) => b.confidence - a.confidence)
 
-      // Generate AGENTS.md — write to workspace root (async to avoid blocking)
-      const agentsMd = this.generateAgentsMd(sortedSkills, repos, workspaceDir, agentId)
-      await writeFile(join(workspaceDir, 'AGENTS.md'), agentsMd, 'utf-8')
+      const agent = agentId ? this.db.getAgent(agentId) : undefined
+      const isClaudeCode = agent?.config?.coding_agent === CodingAgentType.CLAUDE_CODE
+      const filename = isClaudeCode ? 'CLAUDE.md' : 'AGENTS.md'
+      const content = isClaudeCode
+        ? this.generateClaudeMd(sortedSkills, repos, workspaceDir, agentId)
+        : this.generateAgentsMd(sortedSkills, repos, workspaceDir, agentId)
+      await writeFile(join(workspaceDir, filename), content, 'utf-8')
 
-      // Generate CLAUDE.md — write to workspace root
-      const claudeMd = this.generateClaudeMd(sortedSkills, repos, workspaceDir, agentId)
-      await writeFile(join(workspaceDir, 'CLAUDE.md'), claudeMd, 'utf-8')
-
-      console.log('[AgentManager] Generated AGENTS.md and CLAUDE.md in workspace root')
+      console.log(`[AgentManager] Generated ${filename} in workspace root`)
     } catch (error) {
       console.error('[AgentManager] Error writing agent documentation:', error)
     }
@@ -1160,11 +1160,7 @@ export class AgentManager extends EventEmitter {
    * Generates AGENTS.md content with skill directory.
    */
   private generateAgentsMd(skills: SkillRecord[], repos: string[], workspaceDir: string, agentId?: string): string {
-    const now = new Date().toISOString()
-
     let md = `# Agent Session Configuration\n\n`
-    md += `**Generated:** ${now}\n`
-    md += `---\n\n`
 
     // Add MCP Servers section
     if (agentId) {
@@ -1279,11 +1275,7 @@ export class AgentManager extends EventEmitter {
    * Generates CLAUDE.md content with skill directory.
    */
   private generateClaudeMd(skills: SkillRecord[], repos: string[], workspaceDir: string, agentId?: string): string {
-    const now = new Date().toISOString()
-
     let md = `# Claude Code Configuration\n\n`
-    md += `**Session Started:** ${now}\n`
-    md += `---\n\n`
 
     // Add MCP Servers section
     if (agentId) {
@@ -1640,12 +1632,11 @@ export class AgentManager extends EventEmitter {
             }
             promptText += '\n\nThis task has subtasks. Each subtask has its own agent. Focus on coordination and any work not covered by subtasks.'
             promptText += '\nUse `list_subtasks` or `get_task` via MCP tools to check live subtask status and outputs.'
+            promptText += '\n\nYou can use the `task-management` MCP server to orchestrate execution instead of doing everything yourself.'
+            promptText += '\n- Use `create_subtask` to break work down.'
+            promptText += '\n- Use `start_task` to triage+start an unassigned task, start an assigned task, or start a specific subtask by ID.'
+            promptText += '\n- Use `wait_for_subtasks` to block until subtasks reach `ready_for_review` or `completed` before continuing coordination.'
           }
-
-          promptText += '\n\nYou can use the `task-management` MCP server to orchestrate execution instead of doing everything yourself.'
-          promptText += '\n- Use `create_subtask` to break work down.'
-          promptText += '\n- Use `start_task` to triage+start an unassigned task, start an assigned task, or start a specific subtask by ID.'
-          promptText += '\n- Use `wait_for_subtasks` to block until subtasks reach `ready_for_review` or `completed` before continuing coordination.'
         }
 
         // Append output field instructions
@@ -1660,8 +1651,9 @@ export class AgentManager extends EventEmitter {
         }
       }
 
-      // Append heartbeat monitoring instructions
-      promptText += `\n\n## Heartbeat Monitoring (Optional)
+      // Append heartbeat instructions only for tasks that opted into monitoring.
+      if (task?.heartbeat_enabled) {
+        promptText += `\n\n## Heartbeat Monitoring
 
 If this task involves something that should be monitored after your work is done (e.g., a PR awaiting review, a deployment to verify, an issue to track), create a \`heartbeat.md\` file in the working directory.
 
@@ -1673,7 +1665,8 @@ Example heartbeat.md:
 - [ ] Check if linked issue #456 has new updates
 \`\`\`
 
-Only create this file when there's genuinely useful monitoring to do. Do not create it for tasks that are fully self-contained.`
+Keep this file current while monitoring is useful.`
+      }
 
       // Append memory file read instruction to user message
       // (user messages are more reliably followed than system prompt instructions)
@@ -2866,21 +2859,30 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
    * Uses promptAsync to send the initial prompt without blocking.
    */
   async startSession(agentId: string, taskId: string, workspaceDir?: string, skipInitialPrompt?: boolean): Promise<string> {
-    const agent = this.db.getAgent(agentId)
-    if (!agent) {
-      throw new Error(`Agent not found: ${agentId}`)
-    }
+    const existing = this.findSessionByTaskId(taskId)
+    if (existing && existing.session.status !== 'error') return existing.sessionId
 
-    // Auto-setup worktrees if caller didn't provide a workspaceDir
-    if (!workspaceDir) {
-      workspaceDir = await this.setupWorktreeIfNeeded(taskId)
-    }
+    const pending = this.startingSessionsByTask.get(taskId)
+    if (pending) return pending
 
-    const adapter = this.getAdapter(agentId)
-    if (!adapter) {
-      throw new Error(`No adapter available for agent ${agentId}`)
+    const start = (async () => {
+      const agent = this.db.getAgent(agentId)
+      if (!agent) throw new Error(`Agent not found: ${agentId}`)
+
+      const resolvedWorkspaceDir = workspaceDir ?? await this.setupWorktreeIfNeeded(taskId)
+      const adapter = this.getAdapter(agentId)
+      if (!adapter) throw new Error(`No adapter available for agent ${agentId}`)
+      return this.startAdapterSession(adapter, agentId, taskId, resolvedWorkspaceDir, skipInitialPrompt)
+    })()
+
+    this.startingSessionsByTask.set(taskId, start)
+    try {
+      return await start
+    } finally {
+      if (this.startingSessionsByTask.get(taskId) === start) {
+        this.startingSessionsByTask.delete(taskId)
+      }
     }
-    return this.startAdapterSession(adapter, agentId, taskId, workspaceDir, skipInitialPrompt)
   }
 
   async startTask(taskId: string, opts?: { preferSubtasks?: boolean; allowTriage?: boolean }): Promise<{

--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -21,6 +21,16 @@ describe('Task CRUD', () => {
     expect(fetched).toEqual(task)
   })
 
+  it('creates a task with its agent and skills atomically', () => {
+    const agent = db.createAgent(makeAgent({ name: 'Watchtower' }))!
+    const skill = db.createSkill(makeSkill({ name: 'alerts-prod-monitor' }))!
+
+    const task = db.createTask(makeTask({ agent_id: agent.id, skill_ids: [skill.id] }))!
+
+    expect(task.agent_id).toBe(agent.id)
+    expect(task.skill_ids).toEqual([skill.id])
+  })
+
   it('returns all tasks', () => {
     db.createTask(makeTask({ title: 'Task 1' }))
     db.createTask(makeTask({ title: 'Task 2' }))

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -393,6 +393,8 @@ export interface CreateTaskData {
   attachments?: FileAttachmentRecord[]
   repos?: string[]
   output_fields?: OutputFieldRecord[]
+  agent_id?: string | null
+  skill_ids?: string[] | null
   external_id?: string
   source_id?: string
   source?: string
@@ -2274,13 +2276,13 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
     this.db.prepare(`
       INSERT INTO tasks (
         id, title, description, type, priority, status, assignee, due_date,
-        labels, attachments, repos, output_fields, external_id, source_id, source,
+        labels, attachments, repos, output_fields, agent_id, skill_ids, external_id, source_id, source,
         is_recurring, recurrence_pattern, recurrence_parent_id,
         auto_start_agent, auto_complete_without_review,
         parent_task_id, sort_order,
         created_at, updated_at
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       data.title,
@@ -2294,6 +2296,8 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
       JSON.stringify(data.attachments ?? []),
       JSON.stringify(data.repos ?? []),
       JSON.stringify(data.output_fields ?? []),
+      data.agent_id ?? null,
+      data.skill_ids === undefined ? null : JSON.stringify(data.skill_ids),
       data.external_id ?? null,
       data.source_id ?? null,
       data.source ?? 'local',

--- a/src/renderer/src/hooks/use-agent-auto-start.test.tsx
+++ b/src/renderer/src/hooks/use-agent-auto-start.test.tsx
@@ -179,12 +179,13 @@ describe('useAgentAutoStart', () => {
     expect(mockElectronAPI.agentSession.start).not.toHaveBeenCalled()
   })
 
-  it('still triages recurring instances (tasks with recurrence_parent_id)', async () => {
+  it('triages recurring instances when their template enables auto-start', async () => {
     const instanceTask = makeTask({
       id: 'instance-1',
       title: 'Daily standup - 2026-04-09',
       is_recurring: false,
-      recurrence_parent_id: 'template-1'
+      recurrence_parent_id: 'template-1',
+      auto_start_agent: true
     })
     const triageAgent = makeAgent({ id: 'agent-triage', is_default: true })
 
@@ -205,6 +206,38 @@ describe('useAgentAutoStart', () => {
     // Should triage the instance normally
     expect(mockElectronAPI.db.updateTask).toHaveBeenCalledWith(instanceTask.id, { status: TaskStatus.Triaging })
     expect(mockElectronAPI.agentSession.start).toHaveBeenCalledWith(triageAgent.id, instanceTask.id, undefined, undefined)
+  })
+
+  it('does not triage or start recurring instances when auto-start is disabled', async () => {
+    const triageInstance = makeTask({
+      id: 'instance-unassigned',
+      recurrence_parent_id: 'template-1',
+      auto_start_agent: false
+    })
+    const assignedInstance = makeTask({
+      id: 'instance-assigned',
+      recurrence_parent_id: 'template-1',
+      auto_start_agent: false,
+      agent_id: 'agent-1'
+    })
+    const agent = makeAgent({ id: 'agent-1', is_default: true })
+
+    renderHook(() =>
+      useAgentAutoStart({
+        tasks: [triageInstance, assignedInstance],
+        agents: [agent],
+        sessions: new Map(),
+        showToast: vi.fn()
+      })
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(350)
+      await Promise.resolve()
+    })
+
+    expect(mockElectronAPI.db.updateTask).not.toHaveBeenCalled()
+    expect(mockElectronAPI.agentSession.start).not.toHaveBeenCalled()
   })
 
   it('starts assigned agent immediately after successful triage completion', async () => {

--- a/src/renderer/src/hooks/use-agent-auto-start.ts
+++ b/src/renderer/src/hooks/use-agent-auto-start.ts
@@ -172,6 +172,7 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
         .filter((task) => {
           // Skip recurring parent template tasks — they are templates, not actionable tasks
           if (isRecurringTemplate(task)) return false
+          if (task.recurrence_parent_id && !task.auto_start_agent) return false
 
           // Skip subtasks — they are managed by sequential subtask orchestration
           if (task.parent_task_id) return false
@@ -245,6 +246,7 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
       allTasks.forEach((task) => {
         // Skip recurring parent template tasks — they are templates, not actionable tasks
         if (isRecurringTemplate(task)) return
+        if (task.recurrence_parent_id && !task.auto_start_agent) return
 
         // Skip parent tasks that have subtasks — subtasks will run sequentially instead
         const hasChildren = allTasks.some((t) => t.parent_task_id === task.id)

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -337,6 +337,8 @@ export interface CreateTaskDTO {
   attachments?: FileAttachment[]
   repos?: string[]
   output_fields?: OutputField[]
+  agent_id?: string | null
+  skill_ids?: string[] | null
   is_recurring?: boolean
   recurrence_pattern?: RecurrencePattern | null
   recurrence_parent_id?: string | null


### PR DESCRIPTION
External task producers can now assign and start a task without racing renderer triage or launching duplicate agent sessions. Agent startup context is also reduced to instructions relevant to the selected backend and task.

- Persist agent_id and skill_ids atomically during task creation
- Share one in-flight session start per task and reuse an existing healthy session
- Respect disabled auto-start on recurring task instances
- Generate only AGENTS.md or CLAUDE.md for the selected backend and remove volatile timestamps
- Add heartbeat and task-orchestration instructions only when the task requires them
- Add regression coverage for atomic assignment, duplicate starts, recurrence opt-out, and prompt generation

Validation:
- 149 test files passed; 2,271 tests passed and 2 skipped
- pnpm typecheck passed
- pnpm build passed
- pnpm lint passed with zero errors; existing warnings remain

Risk/rollback:
- Changes task creation and session-start behavior for all callers. Reverting this commit restores the previous renderer-driven assignment and startup flow.