### PR TITLE
fix: guard every child-process pipe against EPIPE crashes

### DIFF
--- a/src/main/adapters/acp-adapter.ts
+++ b/src/main/adapters/acp-adapter.ts
@@ -8,6 +8,7 @@
 
 import { spawn, execFile, ChildProcess } from 'child_process'
 import { randomUUID } from 'crypto'
+import { guardChildStreams } from '../child-stream-guards'
 import { mkdtempSync } from 'fs'
 import { homedir, tmpdir } from 'os'
 import { dirname, join } from 'path'
@@ -436,6 +437,11 @@ export class AcpAdapter implements CodingAgentAdapter {
       }
     )
 
+    // Every pipe needs an error listener before the first write. The agent can
+    // exit at any moment, and an unhandled EPIPE on its stdin takes the whole
+    // main process down with a crash dialog.
+    guardChildStreams(acpProcess, `AcpAdapter/${this.agentType}`)
+
     const session: AcpSession = {
       sessionId,
       acpSessionId: null,
@@ -605,6 +611,11 @@ export class AcpAdapter implements CodingAgentAdapter {
         ...(needsShell ? { shell: true } : {})
       }
     )
+
+    // Every pipe needs an error listener before the first write. The agent can
+    // exit at any moment, and an unhandled EPIPE on its stdin takes the whole
+    // main process down with a crash dialog.
+    guardChildStreams(acpProcess, `AcpAdapter/${this.agentType}`)
 
     const session: AcpSession = {
       sessionId,

--- a/src/main/adapters/codex-adapter.ts
+++ b/src/main/adapters/codex-adapter.ts
@@ -11,6 +11,7 @@
 
 import { spawn, type ChildProcess } from 'child_process'
 import { existsSync } from 'fs'
+import { guardChildStreams } from '../child-stream-guards'
 import type {
   CodingAgentAdapter,
   SessionConfig,
@@ -209,6 +210,11 @@ export class CodexAdapter implements CodingAgentAdapter {
       }
     )
 
+    // Every pipe needs an error listener before the first write. Codex can exit
+    // at any moment, and an unhandled EPIPE on its stdin crashes the main
+    // process.
+    guardChildStreams(codexProcess, 'CodexAdapter')
+
     // Create session state
     const session: CodexSession = {
       sessionId: '', // Will be set to threadId after thread.create
@@ -297,6 +303,11 @@ export class CodexAdapter implements CodingAgentAdapter {
         ...(needsShellResume ? { shell: true } : {}),
       }
     )
+
+    // Every pipe needs an error listener before the first write. Codex can exit
+    // at any moment, and an unhandled EPIPE on its stdin crashes the main
+    // process.
+    guardChildStreams(codexProcess, 'CodexAdapter')
 
     // Create session state
     const session: CodexSession = {

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -738,8 +738,11 @@ describe('CodexAppServerAdapter', () => {
 
     await adapterInstance.respondToApproval('thread-1', true)
 
+    // The second argument is the guard callback that keeps a dead pipe from
+    // crashing the main process (see child-stream-guards.ts).
     expect(session.process.stdin.write).toHaveBeenCalledWith(
-      `${JSON.stringify({ jsonrpc: '2.0', id: 7, result: { decision: 'accept' } })}\n`
+      `${JSON.stringify({ jsonrpc: '2.0', id: 7, result: { decision: 'accept' } })}\n`,
+      expect.any(Function)
     )
     expect(session.pendingApproval).toBeNull()
   })
@@ -788,7 +791,8 @@ describe('CodexAppServerAdapter', () => {
     })
 
     expect(session.process.stdin.write).toHaveBeenCalledWith(
-      `${JSON.stringify({ jsonrpc: '2.0', id: 9, result: { action: 'accept', content: {} } })}\n`
+      `${JSON.stringify({ jsonrpc: '2.0', id: 9, result: { action: 'accept', content: {} } })}\n`,
+      expect.any(Function)
     )
   })
 

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -8,6 +8,7 @@
 
 import { spawn, type ChildProcess } from 'child_process'
 import { existsSync, mkdtempSync, readFileSync } from 'fs'
+import { guardChildStreams, writeToChildStdin } from '../child-stream-guards'
 import { homedir, tmpdir } from 'os'
 import { basename, isAbsolute, join, relative, resolve } from 'path'
 import { promisify } from 'util'
@@ -611,6 +612,11 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       stdio: ['pipe', 'pipe', 'pipe'],
       ...(needsShell ? { shell: true } : {})
     })
+
+    // Every pipe needs an error listener before the first write. The app server
+    // can exit at any moment, and an unhandled EPIPE on its stdin crashes the
+    // main process.
+    guardChildStreams(child, 'CodexAppServerAdapter')
 
     const session: AppServerSession = {
       sessionId,
@@ -1497,7 +1503,8 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
   }
 
   private writeJson(session: AppServerSession, payload: unknown): void {
-    session.process.stdin?.write(`${JSON.stringify(payload)}\n`)
+    // A dead app server must not take the application with it.
+    writeToChildStdin(session.process, `${JSON.stringify(payload)}\n`, 'CodexAppServerAdapter')
   }
 
   private requireSession(sessionId: string): AppServerSession {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -17,6 +17,7 @@ import { CodexAppServerAdapter } from './adapters/codex-app-server-adapter'
 import type { CodingAgentAdapter, SessionConfig, MessagePart, SessionMessage, McpServerConfig } from './adapters/coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './adapters/coding-agent-adapter'
 import { getTaskApiPort, waitForTaskApiServer } from './task-api-server'
+import { guardChildStreams, writeToChildStdin } from './child-stream-guards'
 import { randomUUID } from 'crypto'
 import { registerSecretSession, unregisterSecretSession, getSecretBrokerPort, writeSecretShellWrapper } from './secret-broker'
 import { registerMcpProxyTarget, getMcpAuthProxyPort } from './mcp-auth-proxy'
@@ -4335,6 +4336,10 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         env: { ...process.env, npm_config_yes: 'true', ...(serverData.environment || {}), ...extraEnv }
       })
 
+      // Every pipe needs an error listener before the first write. A server that
+      // exits mid-probe must not crash the main process with EPIPE.
+      guardChildStreams(proc, 'mcp-probe')
+
       let buffer = ''
       let stderrBuf = ''
       let phase: 'init' | 'tools' = 'init'
@@ -4352,8 +4357,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         if (phase === 'init' && msg.id === 1 && msg.result) {
           phase = 'tools'
           // Send initialized notification + tools/list request
-          proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n')
-          proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }) + '\n')
+          writeToChildStdin(proc, JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n', 'mcp-probe')
+          writeToChildStdin(proc, JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }) + '\n', 'mcp-probe')
         } else if (phase === 'tools' && msg.id === 2 && msg.result) {
           const rawTools = Array.isArray(msg.result.tools) ? msg.result.tools : []
           const tools = rawTools.map((t) => ({ name: t.name || '', description: t.description || '' }))
@@ -4395,7 +4400,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       })
 
       // Send initialize
-      proc.stdin.write(JSON.stringify({
+      writeToChildStdin(proc, JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
         method: 'initialize',
@@ -4404,7 +4409,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           capabilities: {},
           clientInfo: { name: 'pf-desktop', version: '1.0.0' }
         }
-      }) + '\n')
+      }) + '\n', 'mcp-probe')
     })
   }
 

--- a/src/main/child-stream-guards.test.ts
+++ b/src/main/child-stream-guards.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PassThrough, Writable } from 'stream'
+import type { ChildProcess } from 'child_process'
+import {
+  guardChildStreams,
+  guardStream,
+  isBenignStreamError,
+  writeToChildStdin
+} from './child-stream-guards'
+
+function errnoError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`write ${code}`), { code })
+}
+
+/** A stdin whose async write always fails, like a pipe whose child has exited. */
+function deadPipe(): Writable {
+  return new Writable({
+    write(_chunk, _enc, cb) {
+      cb(errnoError('EPIPE'))
+    }
+  })
+}
+
+function fakeChild(stdin: Writable | null): ChildProcess {
+  return { stdin, stdout: null, stderr: null } as unknown as ChildProcess
+}
+
+describe('isBenignStreamError', () => {
+  it.each(['EPIPE', 'EIO', 'ECONNRESET', 'ERR_STREAM_DESTROYED', 'ERR_STREAM_WRITE_AFTER_END'])(
+    'treats %s as benign',
+    (code) => {
+      expect(isBenignStreamError(errnoError(code))).toBe(true)
+    }
+  )
+
+  it.each([
+    ['a real fault', errnoError('EACCES')],
+    ['an error without a code', new Error('boom')],
+    ['null', null],
+    ['undefined', undefined]
+  ])('does not treat %s as benign', (_label, value) => {
+    expect(isBenignStreamError(value)).toBe(false)
+  })
+})
+
+describe('guardStream', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('swallows a benign error that would otherwise be unhandled', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const stream = new PassThrough()
+
+    guardStream(stream, 'test')
+
+    expect(() => stream.emit('error', errnoError('EPIPE'))).not.toThrow()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('logs a real fault instead of hiding it', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const stream = new PassThrough()
+
+    guardStream(stream, 'test')
+    stream.emit('error', errnoError('EACCES'))
+
+    expect(warnSpy).toHaveBeenCalledWith('[test] stream error:', 'write EACCES')
+  })
+
+  it('is idempotent, so repeated calls do not stack listeners', () => {
+    const stream = new PassThrough()
+
+    guardStream(stream, 'test')
+    guardStream(stream, 'test')
+
+    expect(stream.listenerCount('error')).toBe(1)
+  })
+
+  it('does nothing when the stream is absent', () => {
+    expect(() => guardStream(null, 'test')).not.toThrow()
+    expect(() => guardStream(undefined, 'test')).not.toThrow()
+  })
+
+  /**
+   * The invariant this whole module exists for. Without a guard an `error`
+   * event on a stream is re-thrown by EventEmitter, which in the Electron main
+   * process is an uncaught exception, a crash dialog, and a restart.
+   */
+  it('proves the invariant: an unguarded stream throws on the same error', () => {
+    const unguarded = new PassThrough()
+
+    expect(() => unguarded.emit('error', errnoError('EPIPE'))).toThrow(/EPIPE/)
+  })
+})
+
+describe('guardChildStreams', () => {
+  it('guards stdin, stdout and stderr', () => {
+    const stdin = new PassThrough()
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    const child = { stdin, stdout, stderr } as unknown as ChildProcess
+
+    guardChildStreams(child, 'test')
+
+    for (const stream of [stdin, stdout, stderr]) {
+      expect(stream.listenerCount('error')).toBe(1)
+      expect(() => stream.emit('error', errnoError('EPIPE'))).not.toThrow()
+    }
+  })
+
+  it('tolerates a child with no pipes and a missing child', () => {
+    expect(() => guardChildStreams(fakeChild(null), 'test')).not.toThrow()
+    expect(() => guardChildStreams(null, 'test')).not.toThrow()
+  })
+})
+
+describe('writeToChildStdin', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not crash when the pipe fails asynchronously with EPIPE', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const stdin = deadPipe()
+
+    expect(writeToChildStdin(fakeChild(stdin), 'payload\n', 'test')).toBe(true)
+
+    // The failure arrives after write() returns, on a later tick.
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('reports a genuine write fault without throwing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const stdin = new Writable({
+      write(_chunk, _enc, cb) {
+        cb(errnoError('EACCES'))
+      }
+    })
+    guardStream(stdin, 'test/stdin')
+
+    writeToChildStdin(fakeChild(stdin), 'payload\n', 'test')
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(warnSpy).toHaveBeenCalledWith('[test] stdin write failed:', 'write EACCES')
+  })
+
+  it('returns false and writes nothing when the child has gone', () => {
+    const stdin = new PassThrough()
+    stdin.destroy()
+
+    expect(writeToChildStdin(fakeChild(stdin), 'payload\n', 'test')).toBe(false)
+    expect(writeToChildStdin(fakeChild(null), 'payload\n', 'test')).toBe(false)
+    expect(writeToChildStdin(null, 'payload\n', 'test')).toBe(false)
+  })
+
+  it('returns false when the write throws synchronously', () => {
+    const stdin = {
+      destroyed: false,
+      writable: true,
+      on: () => stdin,
+      write: () => {
+        throw errnoError('ERR_STREAM_DESTROYED')
+      }
+    }
+
+    expect(
+      writeToChildStdin(fakeChild(stdin as unknown as Writable), 'payload\n', 'test')
+    ).toBe(false)
+  })
+})

--- a/src/main/child-stream-guards.ts
+++ b/src/main/child-stream-guards.ts
@@ -1,0 +1,111 @@
+import type { ChildProcess } from 'child_process'
+import type { Writable } from 'stream'
+
+/**
+ * Pipe failures that are the normal consequence of the peer going away.
+ *
+ * A child process can exit at any moment. Anything already in flight towards
+ * its stdin — or a socket the client has already closed — fails with one of
+ * these codes. None of them mean the application is broken.
+ */
+const BENIGN_STREAM_ERROR_CODES = new Set([
+  'EPIPE',
+  'EIO',
+  'ECONNRESET',
+  'ERR_STREAM_DESTROYED',
+  'ERR_STREAM_WRITE_AFTER_END'
+])
+
+/** Marks a stream that already carries a guard, so guards are not stacked. */
+const GUARDED = Symbol.for('20x.streamErrorGuardInstalled')
+
+type Guardable = (NodeJS.WritableStream | NodeJS.ReadableStream) & {
+  on?: (event: string, listener: (err: NodeJS.ErrnoException) => void) => unknown
+  [GUARDED]?: boolean
+}
+
+/**
+ * True when the error is a routine pipe or socket teardown rather than a fault.
+ */
+export function isBenignStreamError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null | undefined)?.code
+  return typeof code === 'string' && BENIGN_STREAM_ERROR_CODES.has(code)
+}
+
+/**
+ * Attaches an `error` listener to one stream.
+ *
+ * A Node stream with no `error` listener does not stay quiet: it re-throws on
+ * the event loop, and in the Electron main process that is an uncaught
+ * exception, a crash dialog, and a restart. Writing to a pipe whose child has
+ * just exited is routine, so the error must land somewhere harmless.
+ *
+ * Note that a write callback does NOT replace this listener. Node calls the
+ * callback AND emits `error` on the stream, so the callback alone still lets
+ * the process fall over.
+ */
+export function guardStream(stream: Guardable | null | undefined, label: string): void {
+  if (!stream || typeof stream.on !== 'function') return
+  if (stream[GUARDED]) return
+
+  try {
+    Object.defineProperty(stream, GUARDED, { value: true, enumerable: false })
+  } catch {
+    // A frozen or proxied stream still gets its listener; only the marker fails.
+  }
+
+  stream.on('error', (err: NodeJS.ErrnoException) => {
+    if (isBenignStreamError(err)) return
+    try {
+      console.warn(`[${label}] stream error:`, err?.message ?? err)
+    } catch {
+      // Error handlers must never throw. The console can be gone too.
+    }
+  })
+}
+
+/**
+ * Attaches error listeners to every pipe of a spawned child process.
+ *
+ * Call this immediately after `spawn`/`fork`, before the first write. Note that
+ * `child.on('error')` does NOT cover this: that event reports a failure to
+ * spawn, never a failure to write to a pipe after the child has gone.
+ */
+export function guardChildStreams(child: ChildProcess | null | undefined, label: string): void {
+  if (!child) return
+  guardStream(child.stdin as Guardable | null, `${label}/stdin`)
+  guardStream(child.stdout as Guardable | null, `${label}/stdout`)
+  guardStream(child.stderr as Guardable | null, `${label}/stderr`)
+}
+
+/**
+ * Writes to a child's stdin and never throws.
+ *
+ * Returns true when the data was handed to the pipe. A false result means the
+ * child had already gone; that is an expected outcome, not a fault.
+ */
+export function writeToChildStdin(
+  child: ChildProcess | null | undefined,
+  data: string | Uint8Array,
+  label: string
+): boolean {
+  const stdin = child?.stdin as Writable | null | undefined
+  if (!stdin || stdin.destroyed || stdin.writable === false) return false
+
+  guardStream(stdin as unknown as Guardable, `${label}/stdin`)
+
+  try {
+    stdin.write(data, (err) => {
+      if (!err || isBenignStreamError(err)) return
+      try {
+        console.warn(`[${label}] stdin write failed:`, err.message)
+      } catch {
+        // Nothing else can be reported safely.
+      }
+    })
+    return true
+  } catch {
+    // The child went away between the writable check and the write itself.
+    return false
+  }
+}

--- a/src/main/crash-logger.test.ts
+++ b/src/main/crash-logger.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const tempUserData = mkdtempSync(join(tmpdir(), '20x-crash-logger-'))
+const showErrorBox = vi.fn()
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => tempUserData,
+    getVersion: () => '0.0.0-test',
+    on: vi.fn()
+  },
+  dialog: { showErrorBox }
+}))
+
+/**
+ * The crash dialog is the user-visible symptom of the EPIPE bug: the pipe
+ * failure is harmless, the application keeps running, but the user is told to
+ * restart it. Benign stream errors must be logged and nothing more.
+ */
+describe('initCrashLogger uncaughtException handling', () => {
+  let handlers: Array<(error: Error) => void>
+  let originalOn: typeof process.on
+
+  beforeEach(async () => {
+    handlers = []
+    showErrorBox.mockClear()
+    originalOn = process.on.bind(process)
+    vi.spyOn(process, 'on').mockImplementation(((event: string, listener: never) => {
+      if (event === 'uncaughtException') handlers.push(listener as (error: Error) => void)
+      return process
+    }) as typeof process.on)
+
+    const { initCrashLogger } = await import('./crash-logger')
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    initCrashLogger()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    process.on = originalOn
+  })
+
+  it('does not show a crash dialog for a pipe teardown', () => {
+    const epipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+
+    for (const handler of handlers) handler(epipe)
+
+    expect(showErrorBox).not.toHaveBeenCalled()
+  })
+
+  it('still records the pipe teardown in the crash log', () => {
+    const epipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })
+
+    for (const handler of handlers) handler(epipe)
+
+    const log = readFileSync(join(tempUserData, 'logs', 'crash.log'), 'utf-8')
+    expect(log).toContain('non-fatal stream error')
+    expect(log).toContain('write EPIPE')
+  })
+
+  it('still shows a crash dialog for a genuine fault', () => {
+    for (const handler of handlers) handler(new Error('genuine failure'))
+
+    expect(showErrorBox).toHaveBeenCalledTimes(1)
+    expect(showErrorBox.mock.calls[0][1]).toContain('genuine failure')
+  })
+})

--- a/src/main/crash-logger.ts
+++ b/src/main/crash-logger.ts
@@ -1,6 +1,7 @@
 import { app, dialog } from 'electron'
 import { appendFileSync, mkdirSync, existsSync } from 'fs'
 import { join } from 'path'
+import { isBenignStreamError } from './child-stream-guards'
 
 let logPath: string
 
@@ -54,6 +55,21 @@ export function initCrashLogger(): void {
 
   // Uncaught exceptions in main process
   process.on('uncaughtException', (error) => {
+    // Last line of defence for pipe teardown. Every pipe should carry its own
+    // error listener (see child-stream-guards.ts), but one missed listener must
+    // not put a crash dialog in front of the user: the application keeps
+    // running, so the report is only noise. The event is still logged, so a
+    // missing guard stays visible in the crash log.
+    if (isBenignStreamError(error)) {
+      logCrash(
+        Object.assign(new Error(`[non-fatal stream error] ${error.message}`), {
+          name: error.name,
+          stack: error.stack
+        })
+      )
+      return
+    }
+
     logCrash(error)
 
     // Show a user-friendly dialog

--- a/src/main/github-manager.ts
+++ b/src/main/github-manager.ts
@@ -1,6 +1,7 @@
 import { execFile, spawn, type ChildProcess } from 'child_process'
 import { promisify } from 'util'
 import { shell } from 'electron'
+import { guardChildStreams, writeToChildStdin } from './child-stream-guards'
 import {
   PullRequestCheckState,
   PullRequestReviewDecision,
@@ -180,6 +181,10 @@ export class GitHubManager {
         { stdio: ['pipe', 'pipe', 'pipe'] }
       )
 
+      // Every pipe needs an error listener before the first write; a CLI that
+      // exits early must not crash the main process with EPIPE.
+      guardChildStreams(this.authProcess, 'GitHubManager')
+
       let completed = false
       let browserOpened = false
       let codeEmitted = false
@@ -229,8 +234,9 @@ export class GitHubManager {
         reject(err)
       })
 
-      // Write newline for any potential "Press Enter" prompts
-      this.authProcess.stdin?.write('\n')
+      // Write newline for any potential "Press Enter" prompts. `gh` may have
+      // already exited, so the write must never throw.
+      writeToChildStdin(this.authProcess, '\n', 'GitHubManager')
     })
   }
 

--- a/src/main/gitlab-manager.ts
+++ b/src/main/gitlab-manager.ts
@@ -2,6 +2,7 @@ import { execFile, spawn, type ChildProcess } from 'child_process'
 import { promisify } from 'util'
 import { shell } from 'electron'
 import type { GitHubRepo } from './github-manager'
+import { guardChildStreams, writeToChildStdin } from './child-stream-guards'
 
 const execFileAsync = promisify(execFile)
 
@@ -100,6 +101,10 @@ export class GitLabManager {
         { stdio: ['pipe', 'pipe', 'pipe'] }
       )
 
+      // Every pipe needs an error listener before the first write; a CLI that
+      // exits early must not crash the main process with EPIPE.
+      guardChildStreams(this.authProcess, 'GitLabManager')
+
       let completed = false
       let browserOpened = false
       let output = ''
@@ -148,8 +153,9 @@ export class GitLabManager {
         reject(err)
       })
 
-      // Write newline for any potential prompts
-      this.authProcess.stdin?.write('\n')
+      // Write newline for any potential prompts. `glab` may have already
+      // exited, so the write must never throw.
+      writeToChildStdin(this.authProcess, '\n', 'GitLabManager')
     })
   }
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -39,6 +39,7 @@ import type { EnterpriseHeartbeat } from './enterprise-heartbeat'
 import type { EnterpriseStateSync } from './enterprise-state-sync'
 import { analytics } from './analytics-service'
 import { listTaskArtifactEntries, readTaskArtifact } from './artifacts'
+import { guardChildStreams, writeToChildStdin } from './child-stream-guards'
 
 const MIME_MAP: Record<string, string> = {
   '.pdf': 'application/pdf',
@@ -1739,7 +1740,11 @@ export function registerIpcHandlers(
 
     return {
       write: (data: string) => {
-        ptyProcess.write(data)
+        // node-pty throws once the pty is gone. Losing keystrokes to a dead
+        // terminal is acceptable; crashing the application is not.
+        try {
+          ptyProcess.write(data)
+        } catch { /* the pty went away */ }
       },
       resize: (cols: number, rows: number) => {
         ptyProcess.resize(cols, rows)
@@ -1851,6 +1856,11 @@ else:
       env: { ...process.env } as Record<string, string>,
     })
 
+    // Every pipe needs an error listener before the first write. The shell can
+    // exit at any moment, and an unhandled EPIPE on its stdin crashes the main
+    // process.
+    guardChildStreams(child, 'Terminal')
+
     const outputBuffer: string[] = []
 
     /** Append raw PTY output to the line buffer, stripping ANSI escape codes */
@@ -1900,7 +1910,9 @@ else:
 
     return {
       write: (data: string) => {
-        if (child.stdin?.writable) child.stdin.write(data)
+        // A `writable` check alone races the child's exit; the write itself
+        // must not throw either.
+        writeToChildStdin(child, data, 'Terminal')
       },
       kill: () => {
         try { child.kill('SIGTERM') } catch { /* ignore */ }

--- a/src/main/mcp-tool-caller.js
+++ b/src/main/mcp-tool-caller.js
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process'
+import { guardChildStreams, writeToChildStdin } from './child-stream-guards'
 import { getTaskApiPort } from './task-api-server'
 
 /**
@@ -102,6 +103,10 @@ export class McpToolCaller {
       }
     })
 
+    // Every pipe needs an error listener before the first write. An MCP server
+    // that exits mid-handshake must not crash the main process with EPIPE.
+    guardChildStreams(proc, 'mcp')
+
     /** @type {LocalMcpSession} */
     const session = {
       proc,
@@ -150,7 +155,7 @@ export class McpToolCaller {
         resolve: (result) => {
           clearTimeout(timer)
           if (result.success) {
-            proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n')
+            writeToChildStdin(proc, JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n', 'mcp')
             resolve(true)
           } else {
             resolve(false)
@@ -159,7 +164,7 @@ export class McpToolCaller {
         timer
       })
 
-      proc.stdin.write(JSON.stringify({
+      writeToChildStdin(proc, JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
         method: 'initialize',
@@ -168,7 +173,7 @@ export class McpToolCaller {
           capabilities: {},
           clientInfo: { name: 'pf-desktop', version: '1.0.0' }
         }
-      }) + '\n')
+      }) + '\n', 'mcp')
     })
 
     if (!initResult) {
@@ -192,12 +197,12 @@ export class McpToolCaller {
 
       session.pending.set(id, { resolve, timer })
 
-      session.proc.stdin.write(JSON.stringify({
+      writeToChildStdin(session.proc, JSON.stringify({
         jsonrpc: '2.0',
         id,
         method: 'tools/call',
         params: { name: toolName, arguments: toolArgs }
-      }) + '\n')
+      }) + '\n', 'mcp')
     })
   }
 

--- a/src/main/mcp-tool-caller.ts
+++ b/src/main/mcp-tool-caller.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process'
+import { guardChildStreams, writeToChildStdin } from './child-stream-guards'
 import type { McpServerRecord } from './database'
 import { getTaskApiPort } from './task-api-server'
 
@@ -107,6 +108,10 @@ export class McpToolCaller {
       }
     })
 
+    // Every pipe needs an error listener before the first write. An MCP server
+    // that exits mid-handshake must not crash the main process with EPIPE.
+    guardChildStreams(proc, 'mcp')
+
     const session: LocalMcpSession = {
       proc,
       alive: true,
@@ -154,7 +159,7 @@ export class McpToolCaller {
         resolve: (result) => {
           clearTimeout(timer)
           if (result.success) {
-            proc.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n')
+            writeToChildStdin(proc, JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n', 'mcp')
             resolve(true)
           } else {
             resolve(false)
@@ -163,7 +168,7 @@ export class McpToolCaller {
         timer
       })
 
-      proc.stdin.write(JSON.stringify({
+      writeToChildStdin(proc, JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
         method: 'initialize',
@@ -172,7 +177,7 @@ export class McpToolCaller {
           capabilities: {},
           clientInfo: { name: 'pf-desktop', version: '1.0.0' }
         }
-      }) + '\n')
+      }) + '\n', 'mcp')
     })
 
     if (!initResult) {
@@ -200,12 +205,12 @@ export class McpToolCaller {
 
       session.pending.set(id, { resolve, timer })
 
-      session.proc.stdin!.write(JSON.stringify({
+      writeToChildStdin(session.proc, JSON.stringify({
         jsonrpc: '2.0',
         id,
         method: 'tools/call',
         params: { name: toolName, arguments: toolArgs }
-      }) + '\n')
+      }) + '\n', 'mcp')
     })
   }
 

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -19,6 +19,7 @@ import type { PluginRegistry } from './plugins/registry'
 import { listTaskArtifactEntries, readTaskArtifact } from './artifacts'
 import type { Artifact, ArtifactFileEntry } from '../shared/artifacts'
 import { MOBILE_VOICE_CAPABILITIES } from '../shared/voice'
+import { guardStream } from './child-stream-guards'
 
 // ── State ────────────────────────────────────────────────────
 let server: HttpServer | null = null
@@ -89,7 +90,12 @@ export function startMobileApiServer(
       const url = new URL(req.url || '/', `http://localhost`)
       const token = url.searchParams.get('token')
       if (!validateSession(token)) {
-        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+        // A client that has already hung up turns this write into an
+        // unhandled ECONNRESET/EPIPE, which would crash the main process.
+        guardStream(socket, 'MobileAPI/upgrade')
+        try {
+          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+        } catch { /* the client went away */ }
         socket.destroy()
         return
       }

--- a/src/main/process-stream-errors.ts
+++ b/src/main/process-stream-errors.ts
@@ -1,10 +1,12 @@
-const IGNORED_PROCESS_STREAM_ERROR_CODES = new Set(['EPIPE', 'EIO'])
+import { isBenignStreamError } from './child-stream-guards'
 
 export function handleProcessStreamError(
   streamName: 'stdout' | 'stderr',
   err: NodeJS.ErrnoException
 ): void {
-  if (err.code && IGNORED_PROCESS_STREAM_ERROR_CODES.has(err.code)) {
+  // One shared list of benign codes, so this handler and the child-process
+  // pipe guards can never disagree about what counts as a crash.
+  if (isBenignStreamError(err)) {
     return
   }
 


### PR DESCRIPTION
## Problem

The app crashed again with the dialog:

```
An unexpected error occurred. The app may need to be restarted.
Error: write EPIPE
```

`~/Library/Application Support/20x/logs/crash.log` records two of these — `2026-08-09T23:40:10Z` (v0.0.127) and `2026-08-12T14:08:36Z` (v0.0.129):

```
Error: write EPIPE
Stack: Error: write EPIPE
    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:95:16)
```

## Root cause

The stack has no application frames. That is the signature of an **unhandled `error` event on a Node stream**, not of a fault in our own code.

PR #266 hardened the main process's **own** `process.stdout` / `process.stderr`. Those handlers are installed and still work — but they cover only two streams. Every **child-process pipe** was left unguarded. `grep` over `src/main` found exactly one `stdin.on('error')` in the whole main process, in `voice/voice-worker-client.ts`, added by the separate voice fix.

Two facts make this a crash rather than a logged warning:

- **`child.on('error')` does not help.** That event reports a failure to *spawn*, never a failure to *write* to a pipe after the child has gone. Most sites had it and were still exposed.
- **A write callback does not help either.** On failure Node calls the callback **and** emits `error` on the stream (`onwriteError` → `errorOrDestroy`). With no `error` listener, EventEmitter re-throws, and in the main process that is an uncaught exception, a crash dialog, and a restart.

So the prior fix was **active but insufficient in scope**, not regressed.

Any coding agent, MCP server, terminal shell, or `gh`/`glab` CLI that exits while data is in flight towards its stdin reproduces this.

## Fix

New `src/main/child-stream-guards.ts` holds one shared list of benign codes (`EPIPE`, `EIO`, `ECONNRESET`, `ERR_STREAM_DESTROYED`, `ERR_STREAM_WRITE_AFTER_END`) and three helpers:

| Helper | Purpose |
| --- | --- |
| `isBenignStreamError(err)` | one predicate, shared by all callers |
| `guardStream(stream, label)` | idempotent `error` listener on one stream |
| `guardChildStreams(child, label)` | guards `stdin`, `stdout` and `stderr` after spawn |
| `writeToChildStdin(child, data, label)` | guarded write that never throws |

Applied at every site that writes to a child pipe:

| Site | Change |
| --- | --- |
| `adapters/acp-adapter.ts` | guard both spawn paths (covers Cursor, Gemini, Codex-ACP) |
| `adapters/codex-adapter.ts` | guard both spawn paths |
| `adapters/codex-app-server-adapter.ts` | guard spawn; `writeJson` had **no** callback and no listener |
| `mcp-tool-caller.ts` **and** `.js` | guard spawn + all three writes (`index.ts` imports the `.js` twin, so both need it) |
| `agent-manager.ts` | guard the MCP probe spawn + its three writes |
| `ipc-handlers.ts` | guard the Python PTY; the `stdin?.writable` check raced the child's exit. `try/catch` round the node-pty write, which throws synchronously |
| `github-manager.ts`, `gitlab-manager.ts` | guard the `gh`/`glab` auth children |
| `mobile-api-server.ts` | guard the 401 upgrade socket write |
| `process-stream-errors.ts` | reuse the shared predicate, so the two lists cannot drift |

**Last line of defence:** `crash-logger.ts` now treats a benign stream error as non-fatal. It is still written to `crash.log` (tagged `[non-fatal stream error]`, so a missing guard stays visible), but it no longer puts a "the app may need to be restarted" dialog in front of the user. The app was never actually broken by it.

## Verification

- `src/main/child-stream-guards.test.ts` — 20 tests. Includes an invariant test proving an **unguarded** stream *does* throw on the same error, so the guard tests are not vacuous.
- `src/main/crash-logger.test.ts` — 3 tests: no dialog for `EPIPE`, still logged, still a dialog for a genuine fault.
- **Non-vacuity checked:** with the `crash-logger.ts` change reverted, 2 of those 3 tests fail; both pass with it.
- `pnpm test:run --project main` — **1432 passed, 74 files, 0 failed**.
- `pnpm typecheck` — clean. `pnpm lint` — 0 errors (122 pre-existing warnings, none from the new files).
- `pnpm exec electron-vite build` — succeeds; the guards are confirmed present in `out/main/index.js`.

Two assertions in `codex-app-server-adapter.test.ts` now expect the guard callback as the second `write` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)