### PR TITLE
fix: ask about source completion on the feedback path too

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1251,6 +1251,73 @@ describe('AgentManager transitionToIdle — enterprise task completion after fee
     expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
   })
 
+  // ── complete_at_source: the user's answer from the feedback dialog ──
+
+  it('skips executeAction when the user chose to update the source themselves', async () => {
+    const mockDb = createEnterpriseTaskDb({ complete_at_source: false })
+    const { mgr, session } = setupManager(mockDb)
+
+    const mockSyncManager = {
+      executeAction: vi.fn().mockResolvedValue({ success: true }),
+    }
+    mgr.setSyncManager(mockSyncManager as any)
+
+    await (mgr as any).transitionToIdle('session-1', session)
+
+    // The user closes it in the source system, so 20x must not.
+    expect(mockSyncManager.executeAction).not.toHaveBeenCalled()
+    // The task still completes locally.
+    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+  })
+
+  it('calls executeAction when the user chose to close it at the source', async () => {
+    const mockDb = createEnterpriseTaskDb({ complete_at_source: true })
+    const { mgr, session } = setupManager(mockDb)
+
+    const mockSyncManager = {
+      executeAction: vi.fn().mockResolvedValue({ success: true }),
+    }
+    mgr.setSyncManager(mockSyncManager as any)
+
+    await (mgr as any).transitionToIdle('session-1', session)
+
+    expect(mockSyncManager.executeAction).toHaveBeenCalled()
+    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+  })
+
+  it('still pushes to the source when nobody was asked (unattended run)', async () => {
+    const mockDb = createEnterpriseTaskDb({ complete_at_source: null })
+    const { mgr, session } = setupManager(mockDb)
+
+    const mockSyncManager = {
+      executeAction: vi.fn().mockResolvedValue({ success: true }),
+    }
+    mgr.setSyncManager(mockSyncManager as any)
+
+    await (mgr as any).transitionToIdle('session-1', session)
+
+    expect(mockSyncManager.executeAction).toHaveBeenCalled()
+  })
+
+  it('tells the renderer when the source refuses the completion', async () => {
+    const mockDb = createEnterpriseTaskDb()
+    const { mgr, session } = setupManager(mockDb)
+
+    const mockSyncManager = {
+      executeAction: vi.fn().mockResolvedValue({ success: false, error: 'API unavailable' }),
+    }
+    mgr.setSyncManager(mockSyncManager as any)
+
+    const sendSpy = vi.spyOn(mgr as any, 'sendToRenderer')
+
+    await (mgr as any).transitionToIdle('session-1', session)
+
+    // Without this event the task silently returns to review.
+    const failureCall = sendSpy.mock.calls.find((call) => call[0] === 'task:source-action-failed')
+    expect(failureCall).toBeDefined()
+    expect(failureCall?.[1]).toMatchObject({ taskId: 'task-1', error: 'API unavailable' })
+  })
+
   it('skips executeAction when syncManager is not set', async () => {
     const mockDb = createEnterpriseTaskDb()
     const { mgr, session } = setupManager(mockDb)

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -3526,7 +3526,17 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     task: TaskRecord
   ): Promise<boolean> {
     const yieldEventLoop = (): Promise<void> => new Promise((r) => setImmediate(r))
-    if (task.source_id && this.syncManager) {
+
+    /**
+     * The user answers this in the feedback dialog before the learning session
+     * starts, and the answer is stored on the task. `false` means the user
+     * closes the task in the source system themselves, so 20x must not do it.
+     * `null` means nobody was asked — an unattended run (auto-complete without
+     * review, a scheduled run, an MCP caller) — which keeps pushing, as before.
+     */
+    const pushToSource = task.complete_at_source !== false
+
+    if (task.source_id && this.syncManager && pushToSource) {
       const actionField = task.output_fields?.find((f: OutputFieldRecord) => f.id === 'action')
       const actionValue = actionField?.value ? String(actionField.value) : PluginActionId.Complete
       console.log(`[AgentManager] Enterprise task — calling executeAction("${actionValue}") for source ${task.source_id}`)
@@ -3545,9 +3555,18 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           taskId: session.taskId,
           updates: { status: TaskStatus.ReadyForReview }
         })
+        // Without this the task silently returns to review and the user is
+        // never told that the source system refused the completion.
+        this.sendToRenderer('task:source-action-failed', {
+          taskId: session.taskId,
+          taskTitle: task.title,
+          error: failure
+        })
         return false
       }
       await yieldEventLoop()
+    } else if (task.source_id && !pushToSource) {
+      console.log(`[AgentManager] Task ${session.taskId} completes locally — the user updates the source`)
     }
 
     this.db.updateTask(session.taskId, { status: TaskStatus.Completed })

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -271,6 +271,7 @@ export interface TaskRow {
   heartbeat_next_check_at: string | null
   auto_start_agent: number
   auto_complete_without_review: number
+  complete_at_source: number | null
   parent_task_id: string | null
   sort_order: number
   created_at: string
@@ -362,6 +363,12 @@ export interface TaskRecord {
   heartbeat_next_check_at: string | null
   auto_start_agent: boolean
   auto_complete_without_review: boolean
+  /**
+   * How the user chose to complete a task that came from an external source.
+   * null = not answered yet, true = close it at the source, false = the user
+   * updates the source themselves.
+   */
+  complete_at_source: boolean | null
   parent_task_id: string | null
   sort_order: number
   created_at: string
@@ -401,6 +408,7 @@ export interface CreateTaskData {
   recurrence_parent_id?: string | null
   auto_start_agent?: boolean
   auto_complete_without_review?: boolean
+  complete_at_source?: boolean | null
   parent_task_id?: string | null
   /** Cron expression — if provided, sets is_recurring=true and stores as recurrence_pattern */
   cron?: string
@@ -435,6 +443,7 @@ export interface UpdateTaskData {
   heartbeat_next_check_at?: string | null
   auto_start_agent?: boolean
   auto_complete_without_review?: boolean
+  complete_at_source?: boolean | null
   parent_task_id?: string | null
   sort_order?: number
 }
@@ -469,6 +478,7 @@ const UPDATABLE_COLUMNS = new Set([
   'heartbeat_next_check_at',
   'auto_start_agent',
   'auto_complete_without_review',
+  'complete_at_source',
   'parent_task_id',
   'sort_order'
 ])
@@ -518,7 +528,8 @@ function deserializeTask(row: TaskRow): TaskRecord {
     heartbeat_last_check_at: row.heartbeat_last_check_at ?? null,
     heartbeat_next_check_at: row.heartbeat_next_check_at ?? null,
     auto_start_agent: (row.auto_start_agent ?? 0) === 1,
-    auto_complete_without_review: (row.auto_complete_without_review ?? 0) === 1
+    auto_complete_without_review: (row.auto_complete_without_review ?? 0) === 1,
+    complete_at_source: row.complete_at_source == null ? null : row.complete_at_source === 1
   }
 }
 
@@ -1038,6 +1049,7 @@ export class DatabaseManager {
         heartbeat_next_check_at TEXT DEFAULT NULL,
         auto_start_agent INTEGER NOT NULL DEFAULT 0,
         auto_complete_without_review INTEGER NOT NULL DEFAULT 0,
+        complete_at_source INTEGER DEFAULT NULL,
         parent_task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
         sort_order INTEGER NOT NULL DEFAULT 0,
         created_at TEXT NOT NULL,
@@ -1274,6 +1286,7 @@ export class DatabaseManager {
         heartbeat_next_check_at TEXT DEFAULT NULL,
         auto_start_agent INTEGER NOT NULL DEFAULT 0,
         auto_complete_without_review INTEGER NOT NULL DEFAULT 0,
+        complete_at_source INTEGER DEFAULT NULL,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       )
@@ -1624,6 +1637,9 @@ export class DatabaseManager {
     // Add auto_start_agent and auto_complete_without_review columns for recurring tasks
     if (!columnNames.has('auto_start_agent')) {
       this.db.exec(`ALTER TABLE tasks ADD COLUMN auto_start_agent INTEGER NOT NULL DEFAULT 0`)
+    }
+    if (!columnNames.has('complete_at_source')) {
+      this.db.exec(`ALTER TABLE tasks ADD COLUMN complete_at_source INTEGER DEFAULT NULL`)
     }
     if (!columnNames.has('auto_complete_without_review')) {
       this.db.exec(`ALTER TABLE tasks ADD COLUMN auto_complete_without_review INTEGER NOT NULL DEFAULT 0`)

--- a/src/main/recurrence-scheduler.ts
+++ b/src/main/recurrence-scheduler.ts
@@ -45,6 +45,7 @@ interface RawTaskRow {
   heartbeat_next_check_at: string | null
   auto_start_agent: number
   auto_complete_without_review: number
+  complete_at_source: number | null
   parent_task_id: string | null
   sort_order: number
   created_at: string
@@ -432,6 +433,8 @@ export class RecurrenceScheduler {
       heartbeat_next_check_at: row.heartbeat_next_check_at ?? null,
       auto_start_agent: (row.auto_start_agent ?? 0) === 1,
       auto_complete_without_review: (row.auto_complete_without_review ?? 0) === 1,
+      // A new occurrence must not inherit the answer given on a past one.
+      complete_at_source: row.complete_at_source == null ? null : row.complete_at_source === 1,
       parent_task_id: row.parent_task_id ?? null,
       sort_order: row.sort_order ?? 0,
     }

--- a/src/mobile/stores/task-store.ts
+++ b/src/mobile/stores/task-store.ts
@@ -49,6 +49,7 @@ export interface Task {
   heartbeat_next_check_at?: string | null
   auto_start_agent: boolean
   auto_complete_without_review: boolean
+  complete_at_source: boolean | null
   parent_task_id: string | null
   sort_order: number
   created_at: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -180,6 +180,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('task:updated', handler)
     return () => ipcRenderer.removeListener('task:updated', handler)
   },
+  onTaskSourceActionFailed: (callback: (event: unknown) => void): (() => void) => {
+    const handler = (_: unknown, data: unknown): void => callback(data)
+    ipcRenderer.on('task:source-action-failed', handler)
+    return () => ipcRenderer.removeListener('task:source-action-failed', handler)
+  },
   onTaskCreated: (callback: (event: unknown) => void): (() => void) => {
     const handler = (_: unknown, data: unknown): void => callback(data)
     ipcRenderer.on('task:created', handler)

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -42,6 +42,7 @@ const makeTask = (overrides: Partial<WorkfloTask> = {}): WorkfloTask => ({
   next_occurrence_at: null,
   auto_start_agent: false,
   auto_complete_without_review: false,
+  complete_at_source: null,
   parent_task_id: null,
   sort_order: 0,
   created_at: '2026-01-01T00:00:00.000Z',

--- a/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardWorkspace.test.tsx
@@ -124,6 +124,7 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     next_occurrence_at: null,
     auto_start_agent: false,
     auto_complete_without_review: false,
+    complete_at_source: null,
     parent_task_id: null,
     sort_order: 0,
     created_at: '2026-03-28T08:00:00Z',

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -26,7 +26,7 @@ import { useAgentStore } from '@/stores/agent-store'
 import { useAgentAutoStart } from '@/hooks/use-agent-auto-start'
 import { useOverdueNotifications } from '@/hooks/use-overdue-notifications'
 import { useTaskCompletion } from '@/hooks/use-task-completion'
-import { attachmentApi, worktreeApi, settingsApi, updaterApi } from '@/lib/ipc-client'
+import { attachmentApi, worktreeApi, settingsApi, updaterApi, onTaskSourceActionFailed } from '@/lib/ipc-client'
 import { isOverdue, isSnoozed } from '@/lib/utils'
 import { captureAnalyticsEvent, capturePageView } from '@/lib/analytics'
 import { TaskStatus } from '@/types'
@@ -149,6 +149,15 @@ export function AppLayout() {
   // Source-backed tasks ask the user whether to close the task in the source
   // system or only in 20x. `completionDialog` renders that question.
   const { requestComplete, completionDialog } = useTaskCompletion({ onToast: showToast })
+
+  // A completion that the main process could not push to the source sends the
+  // task back to review. Without this the user sees the task reappear with no
+  // reason given.
+  useEffect(() => {
+    return onTaskSourceActionFailed(({ taskTitle, error }) => {
+      showToast(`Could not complete "${taskTitle}" at its source: ${error}`, true)
+    })
+  }, [showToast])
 
   const selectNextActiveTask = useCallback(
     (completedTaskId: string) => {

--- a/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
@@ -1,15 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react'
 import { FeedbackDialog } from './FeedbackDialog'
 
 describe('FeedbackDialog', () => {
-  const onSubmit = vi.fn<(rating: number, comment: string) => void>()
-  const onSkip = vi.fn<() => void>()
+  const onSubmit = vi.fn<(rating: number, comment: string, completeAtSource: boolean) => void>()
+  const onSkip = vi.fn<(completeAtSource: boolean) => void>()
   const onCancel = vi.fn<() => void>()
 
   beforeEach(() => {
     vi.clearAllMocks()
   })
+
+  // Without this the previous test's dialog stays in the DOM and testid
+  // lookups match more than one element.
+  afterEach(cleanup)
 
   function getDialog() {
     return screen.getByRole('dialog')
@@ -58,6 +62,44 @@ describe('FeedbackDialog', () => {
 
     // Submit
     fireEvent.click(within(dialog).getByText('Submit Feedback'))
-    expect(onSubmit).toHaveBeenCalledWith(4, 'Great session!')
+    expect(onSubmit).toHaveBeenCalledWith(4, 'Great session!', true)
+  })
+
+  // ── Source completion choice ──────────────────────────────
+
+  it('hides the source choice for a task with no source', () => {
+    render(<FeedbackDialog open={true} onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    expect(screen.queryByTestId('source-completion-choice')).toBeNull()
+  })
+
+  it('shows the source choice, defaulting to closing it at the source', () => {
+    render(<FeedbackDialog open={true} sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    expect(screen.getByTestId('source-completion-choice')).toBeInTheDocument()
+    expect(screen.getByText('This task came from Notion')).toBeInTheDocument()
+    expect(screen.getByTestId('choice-complete-at-source')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('choice-complete-manually')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('passes completeAtSource=false to onSubmit after picking the manual option', () => {
+    render(<FeedbackDialog open={true} sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    const dialog = getDialog()
+
+    fireEvent.click(screen.getByTestId('choice-complete-manually'))
+    expect(screen.getByTestId('choice-complete-manually')).toHaveAttribute('aria-checked', 'true')
+
+    const starButtons = within(dialog).getAllByRole('button').filter(btn =>
+      btn.getAttribute('type') === 'button' && btn.querySelector('svg')
+    )
+    fireEvent.click(starButtons[4])
+    fireEvent.click(within(dialog).getByText('Submit Feedback'))
+
+    expect(onSubmit).toHaveBeenCalledWith(5, '', false)
+  })
+
+  it('passes the choice to onSkip too, so Skip does not ask again', () => {
+    render(<FeedbackDialog open={true} sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    fireEvent.click(screen.getByTestId('choice-complete-manually'))
+    fireEvent.click(within(getDialog()).getByText('Skip'))
+    expect(onSkip).toHaveBeenCalledWith(false)
   })
 })

--- a/src/renderer/src/components/tasks/FeedbackDialog.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.tsx
@@ -3,18 +3,27 @@ import { Star } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogBody, DialogTitle, DialogDescription } from '@/components/ui/Dialog'
 import { Button } from '@/components/ui/Button'
 import { Textarea } from '@/components/ui/Textarea'
+import { cn } from '@/lib/utils'
 
 interface FeedbackDialogProps {
   open: boolean
-  onSubmit: (rating: number, comment: string) => void
-  onSkip: () => void
+  /**
+   * Display name of the external source, when the task came from one. Set it to
+   * show the completion choice; leave it undefined for a local task.
+   */
+  sourceName?: string | null
+  onSubmit: (rating: number, comment: string, completeAtSource: boolean) => void
+  onSkip: (completeAtSource: boolean) => void
   onCancel: () => void
 }
 
-export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDialogProps) {
+export function FeedbackDialog({ open, sourceName, onSubmit, onSkip, onCancel }: FeedbackDialogProps) {
   const [rating, setRating] = useState(0)
   const [hoveredStar, setHoveredStar] = useState(0)
   const [comment, setComment] = useState('')
+  // Defaults to closing the task at the source, which is what 20x did before
+  // the choice existed.
+  const [completeAtSource, setCompleteAtSource] = useState(true)
 
   // Reset state when dialog opens
   useEffect(() => {
@@ -22,11 +31,12 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDia
       setRating(0)
       setHoveredStar(0)
       setComment('')
+      setCompleteAtSource(true)
     }
   }, [open])
 
   const handleSubmit = () => {
-    if (rating > 0) onSubmit(rating, comment)
+    if (rating > 0) onSubmit(rating, comment, completeAtSource)
   }
 
   return (
@@ -65,8 +75,31 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDia
             onChange={(e) => setComment(e.target.value)}
             rows={3}
           />
+
+          {sourceName && (
+            <div className="flex flex-col gap-2 rounded-lg border border-border/50 p-3" data-testid="source-completion-choice">
+              <span className="text-xs font-medium text-foreground">
+                This task came from {sourceName}
+              </span>
+              <div className="flex gap-2">
+                <ChoiceButton
+                  selected={completeAtSource}
+                  onClick={() => setCompleteAtSource(true)}
+                  testId="choice-complete-at-source"
+                  label={`Close it in ${sourceName}`}
+                />
+                <ChoiceButton
+                  selected={!completeAtSource}
+                  onClick={() => setCompleteAtSource(false)}
+                  testId="choice-complete-manually"
+                  label="I'll do it manually"
+                />
+              </div>
+            </div>
+          )}
+
           <div className="flex gap-2 justify-end">
-            <Button variant="ghost" size="sm" onClick={onSkip}>
+            <Button variant="ghost" size="sm" onClick={() => onSkip(completeAtSource)}>
               Skip
             </Button>
             <Button size="sm" disabled={rating === 0} onClick={handleSubmit}>
@@ -76,5 +109,35 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDia
         </DialogBody>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function ChoiceButton({
+  selected,
+  onClick,
+  label,
+  testId
+}: {
+  selected: boolean
+  onClick: () => void
+  label: string
+  testId: string
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      data-testid={testId}
+      onClick={onClick}
+      className={cn(
+        'flex-1 rounded-md border px-2.5 py-1.5 text-[11px] transition-colors',
+        selected
+          ? 'border-ring bg-accent/60 text-foreground'
+          : 'border-border/50 text-muted-foreground hover:bg-accent/30'
+      )}
+    >
+      {label}
+    </button>
   )
 }

--- a/src/renderer/src/components/tasks/TaskDetailView.test.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.test.tsx
@@ -54,6 +54,7 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     next_occurrence_at: null,
     auto_start_agent: false,
     auto_complete_without_review: false,
+    complete_at_source: null,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
     parent_task_id: null,
@@ -490,7 +491,8 @@ describe('TaskDetailView – recurring task auto-start/auto-complete toggles', (
         recurrence_pattern: '0 9 * * 1-5',
         agent_id: 'agent-1',
         auto_start_agent: false,
-        auto_complete_without_review: false
+        auto_complete_without_review: false,
+        complete_at_source: null
       },
       agents: [makeAgent()],
       onUpdateAutoFlags
@@ -569,7 +571,8 @@ describe('TaskDetailView – recurring task auto-start/auto-complete toggles', (
         recurrence_pattern: '0 9 * * 1-5',
         agent_id: 'agent-1',
         auto_start_agent: false,
-        auto_complete_without_review: false
+        auto_complete_without_review: false,
+        complete_at_source: null
       },
       agents: [makeAgent()],
       onUpdateAutoFlags
@@ -590,7 +593,8 @@ describe('TaskDetailView – recurring task auto-start/auto-complete toggles', (
         recurrence_pattern: '0 9 * * 1-5',
         agent_id: 'agent-1',
         auto_start_agent: false,
-        auto_complete_without_review: false
+        auto_complete_without_review: false,
+        complete_at_source: null
       },
       agents: [makeAgent()],
       onUpdateAutoFlags
@@ -610,7 +614,8 @@ describe('TaskDetailView – recurring task auto-start/auto-complete toggles', (
         recurrence_pattern: '0 9 * * 1-5',
         agent_id: 'agent-1',
         auto_start_agent: true,
-        auto_complete_without_review: true
+        auto_complete_without_review: true,
+        complete_at_source: null
       },
       agents: [makeAgent()],
       onUpdateAutoFlags: vi.fn()

--- a/src/renderer/src/components/tasks/TaskForm.test.tsx
+++ b/src/renderer/src/components/tasks/TaskForm.test.tsx
@@ -37,6 +37,7 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     next_occurrence_at: null,
     auto_start_agent: false,
     auto_complete_without_review: false,
+    complete_at_source: null,
     parent_task_id: null,
     sort_order: 0,
     created_at: '2026-01-01T00:00:00Z',
@@ -73,7 +74,8 @@ describe('TaskForm – auto-start / auto-complete toggles', () => {
       recurrence_pattern: '0 9 * * 1-5',
       agent_id: 'agent-1',
       auto_start_agent: true,
-      auto_complete_without_review: true
+      auto_complete_without_review: true,
+      complete_at_source: null
     })
 
     render(<TaskForm task={task} onSubmit={vi.fn()} onCancel={vi.fn()} />)
@@ -90,7 +92,8 @@ describe('TaskForm – auto-start / auto-complete toggles', () => {
       is_recurring: true,
       recurrence_pattern: '0 9 * * 1-5',
       auto_start_agent: false,
-      auto_complete_without_review: false
+      auto_complete_without_review: false,
+      complete_at_source: null
     })
 
     render(<TaskForm task={task} onSubmit={vi.fn()} onCancel={vi.fn()} />)

--- a/src/renderer/src/components/tasks/TaskHeaderBar.test.tsx
+++ b/src/renderer/src/components/tasks/TaskHeaderBar.test.tsx
@@ -35,6 +35,7 @@ function makeTask(status = TaskStatus.NotStarted): WorkfloTask {
     next_occurrence_at: null,
     auto_start_agent: false,
     auto_complete_without_review: false,
+    complete_at_source: null,
     parent_task_id: null,
     sort_order: 0,
     created_at: '2026-01-01T00:00:00Z',

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -61,6 +61,7 @@ function makeRendererTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     next_occurrence_at: null,
     auto_start_agent: false,
     auto_complete_without_review: false,
+    complete_at_source: null,
     created_at: '2026-01-01T00:00:00Z',
     updated_at: '2026-01-01T00:00:00Z',
     parent_task_id: null,

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -20,6 +20,7 @@ import { useAgentSession } from '@/hooks/use-agent-session'
 import { useAgentStore, SessionStatus } from '@/stores/agent-store'
 import { useSettingsStore, type GitProvider } from '@/stores/settings-store'
 import { useTaskStore } from '@/stores/task-store'
+import { useTaskSourceStore } from '@/stores/task-source-store'
 import { taskApi, worktreeApi, taskSourceApi, onAgentIncompatibleSession, onWorktreeProgress, attachmentApi } from '@/lib/ipc-client'
 import { subscribe } from '@/lib/shared-ipc-listeners'
 import { memo, useEffect, useLayoutEffect, useCallback, useRef, useState, useMemo, type PointerEvent as ReactPointerEvent } from 'react'
@@ -132,6 +133,14 @@ function TaskWorkspaceComponent({
 
   const fetchTasks = useTaskStore((s) => s.fetchTasks)
   const updateTaskInStore = useTaskStore((s) => s.updateTask)
+  const taskSources = useTaskSourceStore((s) => s.sources)
+
+  // Undefined for a local task, which hides the completion choice in the
+  // feedback dialog.
+  const feedbackSourceName = useMemo(() => {
+    if (!task?.source_id) return undefined
+    return taskSources.find((s) => s.id === task.source_id)?.name || task.source || 'the task source'
+  }, [task?.source_id, task?.source, taskSources])
 
   // Derive subtasks reactively from the task store so status changes (e.g., from
   // mobile-initiated sessions) update immediately without needing a re-fetch.
@@ -582,16 +591,19 @@ function TaskWorkspaceComponent({
     }
   }, [session.sessionId, session.messages.length, task?.session_id, onCompleteTask])
 
-  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string) => {
+  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string, completeAtSource: boolean) => {
     if (!task?.agent_id || !task?.id) return
     setShowFeedback(false)
 
-    // Persist feedback + set task to Learning status - prevents auto-stop useEffect
+    // Persist feedback + set task to Learning status - prevents auto-stop useEffect.
+    // `complete_at_source` records the user's answer here, because the learning
+    // session finishes in the main process, where no dialog can be shown.
     console.log('[TaskWorkspace] Setting task status to AgentLearning:', task.id)
     const updatedTask = await taskApi.update(task.id, {
       status: TaskStatus.AgentLearning,
       feedback_rating: rating,
-      feedback_comment: comment || null
+      feedback_comment: comment || null,
+      ...(task.source_id ? { complete_at_source: completeAtSource } : {})
     })
     console.log('[TaskWorkspace] Task status set to AgentLearning, verified:', updatedTask?.status)
 
@@ -659,14 +671,17 @@ Update existing skills that were helpful or create new ones for patterns worth r
     }
   }, [ensureChatSession, sendMessage, session.sessionId, task?.id])
 
-  const handleFeedbackSkip = useCallback(async () => {
+  const handleFeedbackSkip = useCallback(async (completeAtSource: boolean) => {
     if (!task?.id) return
     setShowFeedback(false)
-    // Use the main completion path which calls executeAction for
-    // enterprise tasks (notifying the Workflo backend) before setting
-    // the local status to Completed.
+    // Record the answer first so the completion path does not ask a second
+    // time, then use the main completion path which calls executeAction for
+    // source-backed tasks before setting the local status to Completed.
+    // updateTaskInStore persists through the API and syncs the store, so the
+    // completion path below reads the answer back.
+    if (task.source_id) await updateTaskInStore(task.id, { complete_at_source: completeAtSource })
     await onCompleteTask()
-  }, [task?.id, onCompleteTask])
+  }, [task?.id, task?.source_id, onCompleteTask, updateTaskInStore])
 
   const handleSnooze = useCallback(async (isoString: string) => {
     if (!task) return
@@ -1061,6 +1076,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
 
       <FeedbackDialog
         open={showFeedback}
+        sourceName={feedbackSourceName}
         onSubmit={handleFeedbackSubmit}
         onSkip={handleFeedbackSkip}
         onCancel={() => setShowFeedback(false)}

--- a/src/renderer/src/hooks/use-agent-auto-start.test.tsx
+++ b/src/renderer/src/hooks/use-agent-auto-start.test.tsx
@@ -46,6 +46,7 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     next_occurrence_at: null,
     auto_start_agent: false,
     auto_complete_without_review: false,
+    complete_at_source: null,
     parent_task_id: null,
     sort_order: 0,
     created_at: '2026-01-01T00:00:00Z',

--- a/src/renderer/src/hooks/use-task-completion.test.tsx
+++ b/src/renderer/src/hooks/use-task-completion.test.tsx
@@ -61,6 +61,7 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     next_occurrence_at: null,
     auto_start_agent: false,
     auto_complete_without_review: false,
+    complete_at_source: null,
     parent_task_id: null,
     sort_order: 0,
     created_at: '2026-01-01T00:00:00Z',
@@ -198,6 +199,33 @@ describe('useTaskCompletion', () => {
     await waitFor(() => expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull())
     expect(executeActionMock).not.toHaveBeenCalled()
     expect(updateTaskMock).not.toHaveBeenCalled()
+  })
+
+  it('does not ask again when the feedback dialog already recorded the answer', async () => {
+    storeState.tasks = [makeTask({ source_id: 'src-1', complete_at_source: false })]
+    storeState.sources = [{ id: 'src-1', name: 'Notion' }]
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+
+    await waitFor(() =>
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+    )
+    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
+    expect(executeActionMock).not.toHaveBeenCalled()
+  })
+
+  it('honours a recorded "close it at the source" answer without asking', async () => {
+    storeState.tasks = [makeTask({ source_id: 'src-1', complete_at_source: true })]
+    storeState.sources = [{ id: 'src-1', name: 'Notion' }]
+    render(<Harness />)
+
+    fireEvent.click(screen.getByText('Complete'))
+
+    await waitFor(() =>
+      expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete, 'task-1', 'src-1')
+    )
+    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
   })
 
   it('falls back to the task source label when the source record is not loaded', async () => {

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -101,6 +101,13 @@ export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
       const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
       if (!task) return
       if (task.source_id) {
+        // The feedback dialog asks the same question for tasks that ran an
+        // agent, and records the answer on the task. Honour it instead of
+        // asking a second time.
+        if (task.complete_at_source != null) {
+          await runCompletion(task, options, task.complete_at_source)
+          return
+        }
         setPending({ taskId, options })
         return
       }

--- a/src/renderer/src/hooks/use-tasks.test.tsx
+++ b/src/renderer/src/hooks/use-tasks.test.tsx
@@ -37,6 +37,7 @@ function makeWorkfloTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     next_occurrence_at: null,
     auto_start_agent: false,
     auto_complete_without_review: false,
+    complete_at_source: null,
     created_at: '2024-06-15T12:00:00Z',
     updated_at: '2024-06-15T12:00:00Z',
     parent_task_id: null,

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -269,6 +269,13 @@ export const onTaskUpdated = (callback: (event: { taskId: string; updates: Parti
   return window.electronAPI.onTaskUpdated(callback)
 }
 
+/** Fires when the main process could not push a completion to the task's source. */
+export const onTaskSourceActionFailed = (
+  callback: (event: { taskId: string; taskTitle: string; error: string }) => void
+): (() => void) => {
+  return window.electronAPI.onTaskSourceActionFailed(callback)
+}
+
 export const onTaskCreated = (callback: (event: { task: WorkfloTask }) => void): (() => void) => {
   return window.electronAPI.onTaskCreated(callback)
 }

--- a/src/renderer/src/stores/dashboard-store.test.ts
+++ b/src/renderer/src/stores/dashboard-store.test.ts
@@ -100,6 +100,7 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
     next_occurrence_at: null,
     auto_start_agent: false,
     auto_complete_without_review: false,
+    complete_at_source: null,
     parent_task_id: null,
     sort_order: 0,
     created_at: new Date().toISOString(),

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -491,6 +491,7 @@ interface ElectronAPI {
   onAgentApproval: (callback: (event: AgentApprovalRequest) => void) => () => void
   onAgentIncompatibleSession: (callback: (event: { taskId: string; agentId: string; error: string }) => void) => () => void
   onTaskUpdated: (callback: (event: { taskId: string; updates: Partial<WorkfloTask> }) => void) => () => void
+  onTaskSourceActionFailed: (callback: (event: { taskId: string; taskTitle: string; error: string }) => void) => () => void
   onTaskCreated: (callback: (event: { task: WorkfloTask }) => void) => () => void
   onTaskDeleted: (callback: (event: { taskId: string }) => void) => () => void
   onHeartbeatAlert: (callback: (event: HeartbeatAlertEvent) => void) => () => void

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -319,6 +319,8 @@ export interface WorkfloTask {
   heartbeat_next_check_at?: string | null
   auto_start_agent: boolean
   auto_complete_without_review: boolean
+  /** null = the user has not been asked yet; true = close it at the source; false = manual. */
+  complete_at_source: boolean | null
   parent_task_id: string | null
   sort_order: number
   created_at: string
@@ -342,6 +344,7 @@ export interface CreateTaskDTO {
   recurrence_parent_id?: string | null
   auto_start_agent?: boolean
   auto_complete_without_review?: boolean
+  complete_at_source?: boolean | null
   parent_task_id?: string | null
 }
 
@@ -373,6 +376,7 @@ export interface UpdateTaskDTO {
   heartbeat_next_check_at?: string | null
   auto_start_agent?: boolean
   auto_complete_without_review?: boolean
+  complete_at_source?: boolean | null
   parent_task_id?: string | null
   sort_order?: number
 }

--- a/test/helpers/db-test-helper.ts
+++ b/test/helpers/db-test-helper.ts
@@ -95,6 +95,7 @@ export function createTestDb(): { db: DatabaseManager; rawDb: InstanceType<typeo
       next_occurrence_at TEXT DEFAULT NULL,
       auto_start_agent INTEGER NOT NULL DEFAULT 0,
       auto_complete_without_review INTEGER NOT NULL DEFAULT 0,
+      complete_at_source INTEGER DEFAULT NULL,
       parent_task_id TEXT REFERENCES tasks(id) ON DELETE CASCADE,
       sort_order INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL,


### PR DESCRIPTION
Follow-up to #459. Reported: *"I completed a task from Notion and it still didn't ask me anything."*

## The gap

#459 put the prompt on the renderer completion path only. A task that ran an agent never gets there.

Clicking **Complete** on such a task opens the **feedback** dialog instead (`TaskWorkspace.tsx:578`). Rating the session sets the task to `AgentLearning` and hands it to the main process, which finishes it in `completeTaskAfterAgent` — a second, older copy of the same push logic that calls `executeAction` with no prompt (`agent-manager.ts:3529`). Only the **Skip** button reached the new prompt.

Confirmed against the local DB: the reported task ("Remove Subtotal, `<item type>` from AP bill view", Notion, `feedback_rating = 5`) went down exactly this path.

## Fix

The main process cannot show a dialog, so the answer is captured in the UI and stored on the task.

- The **feedback dialog carries the choice inline** for source-backed tasks — one dialog, not two. It defaults to closing at the source, i.e. the behaviour before the choice existed.
- Both **Submit** and **Skip** pass the answer on. Skip records it first so the existing prompt does not ask twice.
- New nullable column **`complete_at_source`**: `null` = nobody was asked, `true` = close it at the source, `false` = the user updates the source.
- `completeTaskAfterAgent` honours it:

| `complete_at_source` | Source system | Task |
|---|---|---|
| `true` (user chose) | `executeAction` runs | Completed |
| `false` (user chose) | Untouched | Completed |
| `null` (unattended: auto-complete, scheduled, MCP) | `executeAction` runs — unchanged | Completed |

- A new occurrence of a recurring task does not inherit a past answer.

## Second defect: silent failure

When the source refused the completion, `agent-manager.ts:3542` sent the task back to `ready_for_review` and told the user nothing — the task just reappeared. The main process now emits `task:source-action-failed` and the renderer shows the error.

## Schema

`complete_at_source` mirrored across all 7 required locations: `database.ts` (CREATE TABLE ×2, `TaskRow`, `TaskRecord`, Create/Update data, `UPDATABLE_COLUMNS`, `deserializeTask`, migration), `recurrence-scheduler.ts` (`RawTaskRow` + `deserializeTaskRow`), `db-test-helper.ts`, renderer types, mobile store, and 10 test fixture factories.

Migration verified against a copy of a real 1438-task database: the `ALTER TABLE` applies and every existing row reads as `null` (unanswered).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors, warning count unchanged at 122
- [x] `pnpm test:run` — 151 files / 2301 tests pass
- [x] 4 new backend tests (honour `false`, honour `true`, `null` still pushes, failure event emitted)
- [x] 4 new `FeedbackDialog` tests (choice hidden without a source, default, passed to Submit, passed to Skip)
- [x] 2 new hook tests (recorded answer is honoured, no second prompt)
- [x] Non-vacuity verified — restoring the old behaviour fails all 4 of the new decision tests
- [x] Added the missing `afterEach(cleanup)` to `FeedbackDialog.test.tsx`, which was leaking DOM between tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)