### PR TITLE
fix: populate agent context files with selected skills only

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -194,19 +194,24 @@ describe('AgentManager skill file paths', () => {
   })
 
   describe('writeSkillFiles', () => {
-    it('writes and documents only the skills selected for the task', async () => {
-      const selectedSkill = makeSkillRecord({ id: 'selected', name: 'selected-skill' })
+    it('merges task and agent skill selections, removes duplicates, and excludes unselected skills', async () => {
+      const taskSkill = makeSkillRecord({ id: 'task-skill', name: 'task-skill' })
+      const sharedSkill = makeSkillRecord({ id: 'shared-skill', name: 'shared-skill' })
+      const agentSkill = makeSkillRecord({ id: 'agent-skill', name: 'agent-skill' })
       const unselectedSkill = makeSkillRecord({ id: 'unselected', name: 'unselected-skill' })
       const mockDb = {
-        ...createMockDb({ coding_agent: 'codex', skill_ids: ['selected'] }),
+        ...createMockDb({
+          coding_agent: 'codex',
+          skill_ids: ['shared-skill', 'agent-skill'],
+        }),
         getTask: vi.fn(() => ({
           id: 'task-1',
           title: 'Test Task',
           repos: ['org/repo'],
-          skill_ids: ['selected'],
+          skill_ids: ['task-skill', 'shared-skill'],
         })),
-        getSkills: vi.fn(() => [selectedSkill, unselectedSkill]),
-        getSkillsByIds: vi.fn(() => [selectedSkill]),
+        getSkills: vi.fn(() => [taskSkill, sharedSkill, agentSkill, unselectedSkill]),
+        getSkillsByIds: vi.fn(() => [taskSkill, sharedSkill, agentSkill]),
       } as unknown as ConstructorParameters<typeof AgentManager>[0]
       manager = new AgentManager(mockDb)
 
@@ -214,16 +219,26 @@ describe('AgentManager skill file paths', () => {
 
       const writes = mockedWriteFileAsync.mock.calls
       const writeFilePaths = writes.map(c => c[0] as string)
-      expect(writeFilePaths).toContain('/tmp/test-workspace/.agents/skills/selected-skill/SKILL.md')
+      expect(writeFilePaths).toContain('/tmp/test-workspace/.agents/skills/task-skill/SKILL.md')
+      expect(writeFilePaths).toContain('/tmp/test-workspace/.agents/skills/shared-skill/SKILL.md')
+      expect(writeFilePaths).toContain('/tmp/test-workspace/.agents/skills/agent-skill/SKILL.md')
       expect(writeFilePaths).not.toContain('/tmp/test-workspace/.agents/skills/unselected-skill/SKILL.md')
-      expect((mockDb as any).getSkillsByIds).toHaveBeenCalledWith(['selected'])
+      expect((mockDb as any).getSkillsByIds).toHaveBeenCalledWith([
+        'task-skill',
+        'shared-skill',
+        'agent-skill',
+      ])
       expect((mockDb as any).getSkills).not.toHaveBeenCalled()
 
       const agentsMd = writes.find(c => c[0] === '/tmp/test-workspace/AGENTS.md')?.[1] as string
       const claudeMd = writes.find(c => c[0] === '/tmp/test-workspace/CLAUDE.md')?.[1] as string
-      expect(agentsMd).toContain('selected-skill')
+      expect(agentsMd).toContain('task-skill')
+      expect(agentsMd).toContain('shared-skill')
+      expect(agentsMd).toContain('agent-skill')
       expect(agentsMd).not.toContain('unselected-skill')
-      expect(claudeMd).toContain('selected-skill')
+      expect(claudeMd).toContain('task-skill')
+      expect(claudeMd).toContain('shared-skill')
+      expect(claudeMd).toContain('agent-skill')
       expect(claudeMd).not.toContain('unselected-skill')
     })
 

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -194,6 +194,66 @@ describe('AgentManager skill file paths', () => {
   })
 
   describe('writeSkillFiles', () => {
+    it('writes and documents only the skills selected for the task', async () => {
+      const selectedSkill = makeSkillRecord({ id: 'selected', name: 'selected-skill' })
+      const unselectedSkill = makeSkillRecord({ id: 'unselected', name: 'unselected-skill' })
+      const mockDb = {
+        ...createMockDb({ coding_agent: 'codex', skill_ids: ['selected'] }),
+        getTask: vi.fn(() => ({
+          id: 'task-1',
+          title: 'Test Task',
+          repos: ['org/repo'],
+          skill_ids: ['selected'],
+        })),
+        getSkills: vi.fn(() => [selectedSkill, unselectedSkill]),
+        getSkillsByIds: vi.fn(() => [selectedSkill]),
+      } as unknown as ConstructorParameters<typeof AgentManager>[0]
+      manager = new AgentManager(mockDb)
+
+      await (manager as any).writeSkillFiles('task-1', 'agent-1', '/tmp/test-workspace')
+
+      const writes = mockedWriteFileAsync.mock.calls
+      const writeFilePaths = writes.map(c => c[0] as string)
+      expect(writeFilePaths).toContain('/tmp/test-workspace/.agents/skills/selected-skill/SKILL.md')
+      expect(writeFilePaths).not.toContain('/tmp/test-workspace/.agents/skills/unselected-skill/SKILL.md')
+      expect((mockDb as any).getSkillsByIds).toHaveBeenCalledWith(['selected'])
+      expect((mockDb as any).getSkills).not.toHaveBeenCalled()
+
+      const agentsMd = writes.find(c => c[0] === '/tmp/test-workspace/AGENTS.md')?.[1] as string
+      const claudeMd = writes.find(c => c[0] === '/tmp/test-workspace/CLAUDE.md')?.[1] as string
+      expect(agentsMd).toContain('selected-skill')
+      expect(agentsMd).not.toContain('unselected-skill')
+      expect(claudeMd).toContain('selected-skill')
+      expect(claudeMd).not.toContain('unselected-skill')
+    })
+
+    it('does not write or document any skills when none are selected', async () => {
+      const mockDb = {
+        ...createMockDb({ coding_agent: 'codex' }),
+        getTask: vi.fn(() => ({
+          id: 'task-1',
+          title: 'Test Task',
+          repos: ['org/repo'],
+          skill_ids: null,
+        })),
+        getSkills: vi.fn(() => [makeSkillRecord()]),
+        getSkillsByIds: vi.fn(() => [makeSkillRecord()]),
+      } as unknown as ConstructorParameters<typeof AgentManager>[0]
+      manager = new AgentManager(mockDb)
+
+      await (manager as any).writeSkillFiles('task-1', 'agent-1', '/tmp/test-workspace')
+
+      const writes = mockedWriteFileAsync.mock.calls
+      expect(writes.some(c => (c[0] as string).endsWith('/SKILL.md'))).toBe(false)
+      expect((mockDb as any).getSkills).not.toHaveBeenCalled()
+      expect((mockDb as any).getSkillsByIds).not.toHaveBeenCalled()
+
+      const agentsMd = writes.find(c => c[0] === '/tmp/test-workspace/AGENTS.md')?.[1] as string
+      const claudeMd = writes.find(c => c[0] === '/tmp/test-workspace/CLAUDE.md')?.[1] as string
+      expect(agentsMd).toContain('No skills configured for this session.')
+      expect(claudeMd).toContain('No skills are available for this session.')
+    })
+
     it('writes SKILL.md files to .claude/skills/ for Claude Code agents', async () => {
       const mockDb = createMockDb({ coding_agent: 'claude-code' })
       manager = new AgentManager(mockDb)

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -1078,7 +1078,8 @@ export class AgentManager extends EventEmitter {
 
   /**
    * Writes only selected SKILL.md files to the workspace directory.
-   * Priority: task.skill_ids > agent.config.skill_ids > no skills.
+   * Merges task and agent selections, removes duplicates, and never falls back
+   * to all skills.
    * Also generates AGENTS.md and CLAUDE.md with skill directory.
    */
   private async writeSkillFiles(taskId: string, agentId: string, workspaceDir: string): Promise<void> {
@@ -1086,7 +1087,10 @@ export class AgentManager extends EventEmitter {
       const task = this.db.getTask(taskId)
       const agent = this.db.getAgent(agentId)
       const agentConfig = agent?.config
-      const skillIds = task?.skill_ids ?? agentConfig?.skill_ids ?? []
+      const skillIds = [...new Set([
+        ...(task?.skill_ids ?? []),
+        ...(agentConfig?.skill_ids ?? []),
+      ])]
       const skills = skillIds.length > 0 ? this.db.getSkillsByIds(skillIds) : []
 
       // Write individual SKILL.md files using async I/O so the event loop

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -1077,8 +1077,8 @@ export class AgentManager extends EventEmitter {
   }
 
   /**
-   * Resolves and writes SKILL.md files to the workspace directory.
-   * Priority: task.skill_ids > agent.config.skill_ids > all skills.
+   * Writes only selected SKILL.md files to the workspace directory.
+   * Priority: task.skill_ids > agent.config.skill_ids > no skills.
    * Also generates AGENTS.md and CLAUDE.md with skill directory.
    */
   private async writeSkillFiles(taskId: string, agentId: string, workspaceDir: string): Promise<void> {
@@ -1086,19 +1086,8 @@ export class AgentManager extends EventEmitter {
       const task = this.db.getTask(taskId)
       const agent = this.db.getAgent(agentId)
       const agentConfig = agent?.config
-
-      // Resolve which skill IDs to use
-      let skillIds: string[] | undefined
-      if (task?.skill_ids !== null && task?.skill_ids !== undefined) {
-        skillIds = task.skill_ids
-      } else if (agentConfig?.skill_ids !== undefined) {
-        skillIds = agentConfig.skill_ids
-      }
-      // undefined = all skills
-
-      const skills = skillIds === undefined
-        ? this.db.getSkills()
-        : this.db.getSkillsByIds(skillIds)
+      const skillIds = task?.skill_ids ?? agentConfig?.skill_ids ?? []
+      const skills = skillIds.length > 0 ? this.db.getSkillsByIds(skillIds) : []
 
       // Write individual SKILL.md files using async I/O so the event loop
       // can process IPC/rendering between writes (avoids startup UI freeze).


### PR DESCRIPTION
## Summary
- Merge task-selected and agent-selected skill IDs, with duplicates removed.
- Populate AGENTS.md and CLAUDE.md with only that merged selection.
- Remove the fallback that included every available skill when no skills were selected.
- Write no skill files or context entries when both selections are empty.
- Add regression coverage for task skills, agent skills, duplicate IDs, unselected skills, and empty selections.

## Root cause
The workspace generator treated an undefined skill selection as a request for every skill. The first fix then gave task skills priority over agent skills. The corrected implementation merges both selected sets and removes duplicate IDs.

## Test plan
- [x] Agent manager tests: 119 passed
- [x] TypeScript typecheck
- [x] ESLint on changed files (no errors; one existing warning)

Generated with [Claude Code](https://claude.com/claude-code)