### PR TITLE
fix: bump SCHEMA_VERSION so the complete_at_source migration runs

### DIFF
--- a/src/main/database-migration.test.ts
+++ b/src/main/database-migration.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import RawDatabase from 'better-sqlite3'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { app } from 'electron'
+import { DatabaseManager } from './database'
+
+/**
+ * These tests exercise the REAL startup path — `initialize()` — instead of the
+ * injected in-memory schema used by `createTestDb()`.
+ *
+ * That distinction matters. `createTestDb()` builds the tables from its own
+ * `CREATE TABLE` copy, so it proves nothing about whether a migration actually
+ * runs on an existing install. A column added to `runMigrations()` without
+ * bumping `SCHEMA_VERSION` passed every other test in this repo and still
+ * shipped broken: `initialize()` only calls `runMigrations()` when the stored
+ * version is LOWER than `SCHEMA_VERSION`, so returning users never got it.
+ */
+describe('DatabaseManager migrations on an existing install', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), '20x-migration-'))
+    vi.mocked(app.getPath).mockReturnValue(dir)
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function openRaw() {
+    return new RawDatabase(join(dir, 'pf-desktop.db'))
+  }
+
+  function taskColumns(raw: InstanceType<typeof RawDatabase>): string[] {
+    return (raw.pragma('table_info(tasks)') as { name: string }[]).map((c) => c.name)
+  }
+
+  it('creates a fresh database that already has every task column', () => {
+    const db = new DatabaseManager()
+    db.initialize()
+    db.close?.()
+
+    const raw = openRaw()
+    expect(taskColumns(raw)).toContain('complete_at_source')
+    raw.close()
+  })
+
+  /**
+   * The regression this file exists for. Simulates a returning user: the column
+   * is missing and the stored schema version is one behind. Startup must add it.
+   */
+  it('adds a column that a returning user is missing', () => {
+    const first = new DatabaseManager()
+    first.initialize()
+    first.close?.()
+
+    // Roll the database back to the previous release's shape.
+    const raw = openRaw()
+    raw.exec('ALTER TABLE tasks DROP COLUMN complete_at_source')
+    raw.prepare("UPDATE settings SET value = ? WHERE key = '__schema_version'").run('8')
+    expect(taskColumns(raw)).not.toContain('complete_at_source')
+    raw.close()
+
+    const second = new DatabaseManager()
+    second.initialize()
+    second.close?.()
+
+    const after = openRaw()
+    expect(taskColumns(after)).toContain('complete_at_source')
+    after.close()
+  })
+
+  /**
+   * Guards the gate itself. If someone adds an `ALTER TABLE` to
+   * `runMigrations()` but leaves `SCHEMA_VERSION` alone, a returning user whose
+   * stored version already equals `SCHEMA_VERSION` gets nothing — which is
+   * exactly how `complete_at_source` shipped missing.
+   */
+  it('does not run migrations when the stored version already matches', () => {
+    const first = new DatabaseManager()
+    first.initialize()
+    first.close?.()
+
+    const raw = openRaw()
+    const stored = raw
+      .prepare("SELECT value FROM settings WHERE key = '__schema_version'")
+      .get() as { value: string }
+    // Drop the column WITHOUT lowering the version — the gate must skip it.
+    raw.exec('ALTER TABLE tasks DROP COLUMN complete_at_source')
+    raw.close()
+
+    const second = new DatabaseManager()
+    second.initialize()
+    second.close?.()
+
+    const after = openRaw()
+    expect(taskColumns(after)).not.toContain('complete_at_source')
+    after.close()
+
+    // Documents the coupling: a new migration is only reachable by raising this.
+    expect(Number(stored.value)).toBeGreaterThanOrEqual(9)
+  })
+})

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -936,9 +936,19 @@ function deserializeInstalledPlugin(row: InstalledPluginRow): InstalledPluginRec
   }
 }
 
-// Bump this whenever new migrations are added so returning users skip
-// the full migration check on startup.
-const SCHEMA_VERSION = 8
+/**
+ * Bump this whenever new migrations are added so returning users skip
+ * the full migration check on startup.
+ *
+ * ⚠️ `runMigrations()` is ONLY called when the stored version is LOWER than
+ * this number (see `initialize()`). Adding an `ALTER TABLE` to `runMigrations()`
+ * without bumping this leaves the column missing on every existing install, and
+ * every write to it fails with "no such column" at runtime. Tests pass, because
+ * they build the schema from `CREATE TABLE`, not from the migration path.
+ *
+ * 8 → 9: tasks.complete_at_source
+ */
+const SCHEMA_VERSION = 9
 
 export class DatabaseManager {
   public db!: Database.Database

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -21,6 +21,7 @@ import { useAgentStore, SessionStatus } from '@/stores/agent-store'
 import { useSettingsStore, type GitProvider } from '@/stores/settings-store'
 import { useTaskStore } from '@/stores/task-store'
 import { useTaskSourceStore } from '@/stores/task-source-store'
+import { useProgressToastStore } from '@/stores/progress-toast-store'
 import { taskApi, worktreeApi, taskSourceApi, onAgentIncompatibleSession, onWorktreeProgress, attachmentApi } from '@/lib/ipc-client'
 import { subscribe } from '@/lib/shared-ipc-listeners'
 import { memo, useEffect, useLayoutEffect, useCallback, useRef, useState, useMemo, type PointerEvent as ReactPointerEvent } from 'react'
@@ -134,6 +135,8 @@ function TaskWorkspaceComponent({
   const fetchTasks = useTaskStore((s) => s.fetchTasks)
   const updateTaskInStore = useTaskStore((s) => s.updateTask)
   const taskSources = useTaskSourceStore((s) => s.sources)
+  const showProgressToast = useProgressToastStore((s) => s.show)
+  const failProgressToast = useProgressToastStore((s) => s.fail)
 
   // Undefined for a local task, which hides the completion choice in the
   // feedback dialog.
@@ -599,12 +602,29 @@ function TaskWorkspaceComponent({
     // `complete_at_source` records the user's answer here, because the learning
     // session finishes in the main process, where no dialog can be shown.
     console.log('[TaskWorkspace] Setting task status to AgentLearning:', task.id)
-    const updatedTask = await taskApi.update(task.id, {
-      status: TaskStatus.AgentLearning,
-      feedback_rating: rating,
-      feedback_comment: comment || null,
-      ...(task.source_id ? { complete_at_source: completeAtSource } : {})
-    })
+    let updatedTask: WorkfloTask | null | undefined
+    try {
+      updatedTask = await taskApi.update(task.id, {
+        status: TaskStatus.AgentLearning,
+        feedback_rating: rating,
+        feedback_comment: comment || null,
+        ...(task.source_id ? { complete_at_source: completeAtSource } : {})
+      })
+    } catch (error) {
+      // The dialog is already closed at this point, so a rejected write left the
+      // task untouched with nothing on screen — the user just saw the dialog
+      // vanish and nothing happen. Say so and let them retry.
+      console.error('[TaskWorkspace] Failed to record feedback:', error)
+      // `fail` is a no-op unless the toast already exists, so show it first.
+      const toastId = `feedback-${task.id}`
+      showProgressToast(toastId, 'Feedback not saved')
+      failProgressToast(
+        toastId,
+        `Could not save feedback for "${task.title}": ${error instanceof Error ? error.message : String(error)}`
+      )
+      setShowFeedback(true)
+      return
+    }
     console.log('[TaskWorkspace] Task status set to AgentLearning, verified:', updatedTask?.status)
 
     // Build feedback prompt


### PR DESCRIPTION
Follow-up to #462. Reported: *"if I choose 'I'll do it manually', nothing happens to the task in 20x."*

## Root cause

#462 added the `complete_at_source` `ALTER TABLE` to `runMigrations()` — but left `SCHEMA_VERSION` at 8.

```ts
const currentVersion = this.getSchemaVersion()
if (currentVersion < SCHEMA_VERSION) {   // 8 < 8 → false
  this.runMigrations()
}
```

Every existing install already stores version 8, so `runMigrations()` never ran and the column was never created. Fresh installs were fine, because `CREATE TABLE` has it — which is why this was invisible.

Every write to the column then failed with `no such column: complete_at_source`. That write is in `handleFeedbackSubmit`, un-caught, **after** `setShowFeedback(false)`. So the dialog closed, the promise rejected, and the task was never set to `AgentLearning` — no feedback, no completion, no error. Exactly the reported symptom, and it affected **both** choices, not just the manual one.

Confirmed on the reporter's install: v0.0.132 (contains #462), `__schema_version = 8`, `PRAGMA table_info(tasks)` has no `complete_at_source`.

## Why no test caught it

`createTestDb()` builds the schema from its own `CREATE TABLE` copy and never calls `initialize()`. The migration path had **zero** coverage, so a migration that could never run still passed 2301 tests.

## Fix

- `SCHEMA_VERSION` 8 → 9, with a comment stating the coupling and why tests hide it.
- **`src/main/database-migration.test.ts`** — new, drives the real `initialize()` against a temp `userData` dir (`app.getPath` is already mocked in `test/setup-main.ts`):
  1. a fresh database has the column;
  2. a returning user missing the column and one version behind **gets it on startup**;
  3. the version gate is what makes that work — dropping the column without lowering the version leaves it missing.
- `handleFeedbackSubmit` catches a failed write, shows an error toast, and reopens the dialog rather than vanishing.

## Behaviour once the column exists

Both choices give feedback and complete the task, as expected:

| Choice | Learning session | Source system | Task |
|---|---|---|---|
| Close it in `<source>` | runs | push runs | Completed |
| I'll do it manually | runs | untouched | Completed |

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors, warnings unchanged at 122
- [x] `pnpm test:run` — 153 files / 2348 pass
- [x] Non-vacuity: reverting `SCHEMA_VERSION` to 8 fails 2 of the 3 new tests. The fresh-database test still passes — which is precisely the blind spot that let this ship.

## Note for existing installs

Users on v0.0.132 stay broken until a build with this lands; their stored version is 8 and the column is absent. No data repair is needed — the migration adds the column as `NULL`, which reads as "not answered" and preserves prior behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)