### PR TITLE
feat: canvas drawing — figures, text, images, toolbar, and integration

### DIFF
--- a/docs/drawing.md
+++ b/docs/drawing.md
@@ -1,0 +1,237 @@
+# Canvas Drawing (Figures, Text, Images) — Architecture
+
+**Status:** Approved design — ready for implementation
+**Scope:** Add figures (shapes), typeable text fields, and pasted images to the existing InfiniteCanvas. No freehand drawing.
+**Platform:** Desktop only — `src/mobile` has no canvas (verified: zero canvas references). No mobile parity needed.
+
+---
+
+## 1. Scope
+
+Per the parent task ("add ability to draw on canvas") and the product clarification:
+
+| In scope (v1) | Out of scope (follow-ups) |
+|---|---|
+| Shapes: rectangle, ellipse, line, arrow | Freehand pen (if added later: `perfect-freehand` is the smoothing lib of choice) |
+| Text fields: typeable, font size + font family | Undo/redo, grouping, alignment, rotation |
+| Images: paste from clipboard (Ctrl/Cmd+V + toolbar button) | Export/share, minimap dots, fitToContent inclusion |
+| Select / move / resize / delete / duplicate / bring-to-front | Multi-page, collaboration |
+
+Everything lives **inside the canvas screen only** — no global overlays, no separate window.
+
+## 2. Library evaluation & decision
+
+### Excalidraw (`@excalidraw/excalidraw` 0.18.1) — rejected
+- It is a complete whiteboard **application**, not a layer: ships its own viewport/pan/zoom, toolbar, selection model, context menu, keyboard shortcuts, and React-context state.
+- 20x's InfiniteCanvas already owns all of that. Embedding Excalidraw would duplicate the entire canvas UX and fight the existing viewport, shortcuts (space-pan, Tab-cycle, Ctrl+0), and right-click menu.
+- Embedding it as a panel would be a standalone whiteboard card — not "drawing on the canvas".
+- Its element model (`ExcalidrawElement[]`) doesn't align with 20x's panel/store model; persistence would need format mapping.
+- ~1 MB+ bundle. (React 19 is supported — not the blocker; the architectural mismatch is.)
+
+### Perfect-Freehand (1.2.3) — not needed
+- Excellent stroke smoothers (~112 KB, MIT, zero deps; used by Excalidraw/tldraw internally), but it only smooths freehand strokes.
+- Freehand is out of scope per the product clarification → no dependency.
+
+### Custom Canvas 2D — rejected
+- A pixel canvas would need: a redraw pipeline (re-render on every viewport change via `subscribeLiveViewport` + rAF), DPR handling, manual hit-testing, and an HTML overlay for text editing.
+- All of that is unnecessary because the content is **vector shapes + text**, which scale losslessly under the existing CSS transform.
+
+### ✅ Decision: custom SVG + DOM text layer inside the existing CSS-transformed layer. Zero new dependencies.
+- The codebase already renders SVG inside the transform layer (`CanvasConnections.tsx`: `absolute inset-0`, `overflow: visible`, `pointer-events-none` root, `pointer-events-auto` interactive children). We follow that established pattern.
+- **Crisp at any zoom for free** — vectors scale with the CSS transform; the existing imperative gesture path (direct DOM writes during pan/zoom) needs **zero changes** and no redraw code.
+- **Free hit-testing** — DOM pointer events on SVG elements.
+- **Native text editing** — `contentEditable` divs, real font rendering, real wrapping.
+- **Persistence is trivial** — figures map 1:1 to plain JSON.
+
+## 3. Rendering model
+
+```
+InfiniteCanvas (existing)
+├── grid (existing, static CSS background)
+├── container (existing gesture handlers: wheel pan/zoom, space-pan, context menu)
+│   └── transform layer (existing: translate(x,y) scale(zoom), 0×0, overflow visible)
+│       ├── SnapGuides (existing)
+│       ├── CanvasConnections (existing SVG)
+│       ├── DrawingLayer (NEW — figures render above edges, below panels)
+│       │   ├── <svg data-drawing-svg> (absolute inset-0, overflow visible, pointer-events-none)
+│       │   │   ├── <g data-figure-id> per shape/image figure
+│       │   │   │   ├── <rect> / <ellipse> / <line> / <path> (arrow) / <image>
+│       │   │   │   └── invisible fat-stroke hit path for thin lines/arrows
+│       │   │   ├── creation preview (liveObject while dragging a new figure)
+│       │   │   └── selection overlay: dashed outline + resize handles (pointer-events-auto)
+│       │   └── text figures: absolutely-positioned <div>s (contentEditable while editing)
+│       └── panels (existing CanvasPanel × N)
+├── DrawingToolbar (NEW — floating, bottom-center; canvas screen only)
+├── DrawingProperties (NEW — floating, shown when a figure is selected)
+├── HUD zoom controls / Add button / minimap / context menu (existing)
+```
+
+- **Z-order:** figures above connection lines, below panels — annotations sit behind task cards. Figures under a panel can't be selected in v1 (acceptable).
+- **Screen→canvas conversion** uses the existing `getLiveViewport()`: `(clientX - rect.left - vp.x) / vp.zoom` — same formula as `InfiniteCanvas.handleContextMenu`.
+- **Gestures:** creating/moving/resizing figures follows the `CanvasPanel` imperative pattern — direct DOM writes inside rAF during the gesture, single store commit on mouseup. Pan/zoom/wheel/space-pan are untouched.
+
+## 4. Data model
+
+`src/renderer/src/components/canvas/drawing/types.ts`
+
+```ts
+export type DrawingTool = 'select' | 'rectangle' | 'ellipse' | 'line' | 'arrow' | 'text' | 'image'
+
+interface FigureBase {
+  id: string
+  type: 'rectangle' | 'ellipse' | 'line' | 'arrow' | 'text' | 'image'
+  /** Normalized bounding box in canvas space (w/h >= 0) */
+  x: number
+  y: number
+  width: number
+  height: number
+  stroke: string
+  strokeWidth: number
+  fill: string | null
+  opacity: number
+  zIndex: number
+}
+
+/** line/arrow: endpoints are box corners; direction selects which diagonal */
+type ShapeFigure = FigureBase & {
+  type: 'rectangle' | 'ellipse'
+} | (FigureBase & { type: 'line' | 'arrow'; direction: 'se' | 'sw' | 'ne' | 'nw' })
+
+interface TextFigure extends FigureBase {
+  type: 'text'
+  text: string
+  fontSize: number
+  fontFamily: string
+  fontWeight: number
+  textAlign: 'left' | 'center' | 'right'
+}
+
+interface ImageFigure extends FigureBase {
+  type: 'image'
+  /** data URL (downscaled on paste, max 1024px on long edge) */
+  src: string
+}
+
+export type DrawingObject = ShapeFigure | TextFigure | ImageFigure
+```
+
+- All coordinates are canvas-space (same space as panel `x/y`).
+- `direction` keeps line/arrow move/resize/snap uniform on the bounding box; arrowheads render from the direction.
+- Images are data URLs; downscale on paste keeps the persisted blob small.
+
+## 5. State model — `drawing-store.ts` (Zustand slice)
+
+New file `src/renderer/src/stores/drawing-store.ts`, mirroring `canvas-store.ts` conventions (subscribeWithSelector, ID counters, structural-equality bailouts on hot setters, debounced persistence).
+
+```ts
+interface DrawingToolOptions {
+  stroke: string
+  strokeWidth: number
+  fill: string | null
+  fontSize: number
+  fontFamily: string
+  fontWeight: number
+}
+
+interface DrawingState {
+  // ── persisted ──
+  objects: DrawingObject[]
+  nextZIndex: number
+  isLoaded: boolean
+
+  // ── transient: active tool + style ──
+  activeTool: DrawingTool
+  toolOptions: DrawingToolOptions
+
+  // ── transient: interaction ──
+  selectedIds: string[]
+  editingTextId: string | null      // text figure currently in contentEditable mode
+  liveObject: DrawingObject | null  // figure being created (drag preview)
+
+  // ── actions ──
+  loadDrawings: () => Promise<void>
+  setTool: (tool: DrawingTool) => void
+  setToolOption: <K extends keyof DrawingToolOptions>(key: K, value: DrawingToolOptions[K]) => void
+  addObject: (obj: Omit<DrawingObject, 'id' | 'zIndex'>) => string
+  updateObject: (id: string, updates: Partial<Omit<DrawingObject, 'id' | 'type'>>) => void
+  removeObjects: (ids: string[]) => void
+  bringToFront: (id: string) => void
+  duplicateObject: (id: string) => void
+  select: (ids: string[]) => void
+  clearSelection: () => void
+  setEditingTextId: (id: string | null) => void
+  setLiveObject: (obj: DrawingObject | null) => void
+  clearAll: () => void
+}
+```
+
+- **Persistence:** `drawing_state` key in the same SQLite settings table, 1000 ms debounce — identical `scheduleSave` pattern to `canvas-store`. Loaded in parallel with `loadCanvas()` in `InfiniteCanvas`'s mount effect.
+- **Transient state** (activeTool, toolOptions, selection, editing, liveObject) is never persisted.
+- `setLiveObject` bails out on structural equality (same pattern as `setSnapGuides`/`setProximityEdge`).
+- `addObject` assigns `figure-${++counter}-${Date.now()}` IDs; `loadDrawings` restores the counter from persisted IDs (same as panels/edges).
+
+## 6. Component tree & new files
+
+```
+src/renderer/src/stores/drawing-store.ts
+src/renderer/src/components/canvas/drawing/
+  types.ts               — DrawingObject / DrawingTool model
+  figure-geometry.ts     — pure helpers: normalizeBox, figureDirection, arrowPath, hitTest
+  DrawingLayer.tsx       — SVG layer + text divs + create/move/resize/selection interactions
+  FigureShape.tsx        — memoized per-figure SVG rendering (rect/ellipse/line/arrow/image)
+  FigureText.tsx         — memoized text figure div (contentEditable while editing)
+  DrawingToolbar.tsx     — tool buttons + style controls (color, stroke width, fill, font size, font family)
+  DrawingProperties.tsx  — selected-figure actions (delete, duplicate, bring to front, text font controls)
+```
+
+### DrawingLayer responsibilities
+1. **Create:** when `activeTool !== 'select'`, a full-area transparent rect (`pointer-events-auto`) captures mousedown on empty canvas → drag creates `liveObject` (rAF, imperative) → mouseup commits via `addObject` (min-size guard: < 4 px = discard for shapes, click = default-size text/image).
+2. **Select:** select tool — click figure → `select([id])`; shift+click multi-select; click empty canvas → `clearSelection()`.
+3. **Move:** drag selected figure — imperative transform, single `updateObject` commit on mouseup (CanvasPanel pattern).
+4. **Resize:** bottom-right handle (v1) — imperative, single commit.
+5. **Text edit:** double-click text figure → `setEditingTextId(id)` → `contentEditable` div focused with text selected → commit on blur/Escape via `updateObject`.
+6. **Render:** `objects.map` → `FigureShape`/`FigureText` (memoized), plus creation preview and selection overlay.
+
+### DrawingToolbar
+Floating bar (bottom-center, canvas screen only, same HUD styling as zoom controls):
+- Tools: Select (V), Rectangle (R), Ellipse (O), Line (L), Arrow (A), Text (T), Image (I)
+- Style: stroke color swatches, stroke width (1/2/4/8), fill toggle (none/solid), font size (14/18/24/32/48), font family (sans/serif/mono)
+- Style controls apply to `toolOptions` (affect new figures) and to the current selection (live `updateObject`).
+
+### DrawingProperties
+Shown when `selectedIds.length > 0`: delete, duplicate, bring-to-front, and (for text) font size/family/weight controls.
+
+## 7. Integration points with InfiniteCanvas
+
+1. **Transform layer** — `DrawingLayer` is a child of the existing transform layer (after `CanvasConnections`, before panels). Pan/zoom/pinch work with zero drawing code — the CSS transform scales everything.
+2. **Pointer coordination** —
+   - With a drawing tool active, `InfiniteCanvas.handleMouseDown` must NOT start panning on background mousedown: one guard reading `useDrawingStore.getState().activeTool` (imperative read, no subscription — same pattern as the existing `connectingFromId` check).
+   - Space+drag, middle-button pan, wheel pan/zoom always take precedence (unchanged).
+   - **Escape** cancels `liveObject` / exits text editing — added to the existing Escape handler.
+   - **Delete/Backspace** removes selected figures — added to the existing keydown handler with the same `isInputFocused` guard (and suppressed while `editingTextId` is set).
+   - **Ctrl/Cmd+V** on the canvas (not while editing text) pastes an image.
+3. **Keyboard shortcuts** — V/R/O/L/A/T/I tool switching in the existing keydown handler, guarded by `isInputFocused` like the other shortcuts.
+4. **Context menu** — `CanvasContextMenu` gains a "Draw" section (Rectangle, Ellipse, Line, Arrow, Text, Image) that sets `activeTool` and closes the menu.
+5. **Persistence** — `drawing_state` key, same debounced settings table; `loadDrawings()` called alongside `loadCanvas()`.
+6. **Minimap / fitToContent** — v1: unchanged. Follow-up: include figure bounds in `fitToContent` and render figure dots on the minimap.
+7. **Mobile** — desktop only (canvas does not exist in `src/mobile`).
+
+## 8. Performance
+
+- **Zero work during pan/zoom** — compositor scales the SVG/DOM layer; no redraws, no DPR handling, no store writes (existing invariant preserved).
+- Memoized figure components (like `CanvasPanel`) so one figure's change doesn't re-render others.
+- DOM node count = figure count (tens–hundreds) — trivial for SVG/DOM.
+- Creation/move/resize gestures: one style write per rAF frame, one store commit at the end.
+
+## 9. Testing (vitest + happy-dom, same setup as `InfiniteCanvas.test.tsx`)
+
+- `drawing-store.test.ts` — add/update/remove/duplicate/bringToFront, selection, persistence round-trip, `setLiveObject` bail-out, ID counter restore on load.
+- `figure-geometry.test.ts` — box normalization, line/arrow direction + path, hit-testing per type.
+- `DrawingLayer.test.tsx` — drag creates a rectangle; click with text tool creates a text figure; double-click → edit → commit on blur; Escape cancels creation.
+
+## 10. Risks / follow-ups
+
+- **Image blob size** — downscale to max 1024 px on paste (offscreen canvas → data URL); cap total persisted size, evict oldest images if the settings blob grows past ~5 MB.
+- **Text metrics** — v1 uses fixed box with resize handle; auto-fit height is a follow-up.
+- **Figures under panels** — unselectable while covered; acceptable in v1.
+- **Pen tool** — if requested later, add `perfect-freehand` (1.2.3) + a `pen` figure type with raw points; the store/rendering architecture already accommodates it.

--- a/src/renderer/src/components/canvas/CanvasContextMenu.tsx
+++ b/src/renderer/src/components/canvas/CanvasContextMenu.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { CheckSquare, MessageSquare, Monitor, AppWindow, Globe, TerminalSquare, Plus, X } from 'lucide-react'
+import { CheckSquare, MessageSquare, Monitor, AppWindow, Globe, TerminalSquare, Plus, X, Square, Circle, Minus, MoveUpRight, Type, Image } from 'lucide-react'
 import { useTaskStore } from '@/stores/task-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useDashboardStore } from '@/stores/dashboard-store'
 import { useCanvasStore, DEFAULT_PANEL_WIDTH, DEFAULT_PANEL_HEIGHT } from '@/stores/canvas-store'
+import { useDrawingStore } from '@/stores/drawing-store'
 import { useUIStore } from '@/stores/ui-store'
 import { TaskStatus } from '@/types'
 import type { CanvasPanelType } from '@/stores/canvas-store'
+import type { DrawingTool } from '@/components/canvas/drawing/types'
 
 interface ContextMenuPosition {
   clientX: number
@@ -20,6 +22,16 @@ interface CanvasContextMenuProps {
   position: ContextMenuPosition
   onClose: () => void
 }
+
+/** Figure tools offered in the "Draw" section of the canvas context menu. */
+const DRAW_TOOLS: Array<{ tool: DrawingTool; label: string; icon: typeof Square }> = [
+  { tool: 'rectangle', label: 'Rectangle', icon: Square },
+  { tool: 'ellipse', label: 'Ellipse', icon: Circle },
+  { tool: 'line', label: 'Line', icon: Minus },
+  { tool: 'arrow', label: 'Arrow', icon: MoveUpRight },
+  { tool: 'text', label: 'Text', icon: Type },
+  { tool: 'image', label: 'Image', icon: Image },
+]
 
 export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null)
@@ -42,6 +54,7 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
   const addPanel = useCanvasStore((s) => s.addPanel)
   const panels = useCanvasStore((s) => s.panels)
   const openCreateModal = useUIStore((s) => s.openCreateModal)
+  const setDrawingTool = useDrawingStore((s) => s.setTool)
 
   // Close on click outside
   useEffect(() => {
@@ -145,6 +158,22 @@ export function CanvasContextMenu({ position, onClose }: CanvasContextMenuProps)
             sublabel="Interactive shell session"
             onClick={() => handleAddPanel('terminal', 'Terminal')}
           />
+        </MenuSection>
+
+        {/* Draw — figure tools (shapes, text, images) */}
+        <MenuSection title="Draw">
+          {DRAW_TOOLS.map(({ tool, label, icon: Icon }) => (
+            <MenuItem
+              key={tool}
+              icon={<Icon className="h-3.5 w-3.5 text-sky-400" />}
+              label={label}
+              sublabel="Add a figure to the canvas"
+              onClick={() => {
+                setDrawingTool(tool)
+                onClose()
+              }}
+            />
+          ))}
         </MenuSection>
 
         {/* Applications section */}

--- a/src/renderer/src/components/canvas/CanvasMinimap.test.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { CanvasMinimap } from './CanvasMinimap'
+import { useCanvasStore, type CanvasPanelData } from '@/stores/canvas-store'
+import { useDrawingStore } from '@/stores/drawing-store'
+import type { DrawingObject } from './drawing/types'
+
+const makePanel = (over: Partial<CanvasPanelData> = {}): CanvasPanelData => ({
+  id: 'panel-1',
+  type: 'task',
+  title: 'Task',
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 150,
+  zIndex: 1,
+  ...over,
+})
+
+const figureBase = {
+  x: 100,
+  y: 100,
+  width: 100,
+  height: 60,
+  stroke: '#3b82f6',
+  strokeWidth: 2,
+  fill: null,
+  opacity: 1,
+  zIndex: 1,
+}
+
+const makeRectFigure = (id: string, over: Partial<typeof figureBase> = {}): DrawingObject =>
+  ({ ...figureBase, id, type: 'rectangle', ...over })
+
+const makeTextFigure = (id: string, over: Partial<typeof figureBase> = {}): DrawingObject => ({
+  ...figureBase,
+  id,
+  type: 'text',
+  text: 'Hi',
+  fontSize: 18,
+  fontFamily: 'sans',
+  fontWeight: 400,
+  textAlign: 'left',
+  ...over,
+})
+
+const makeLineFigure = (id: string, over: Partial<typeof figureBase> = {}): DrawingObject =>
+  ({ ...figureBase, id, type: 'line', direction: 'se', ...over })
+
+describe('CanvasMinimap', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      viewport: { x: 0, y: 0, zoom: 1 },
+      panels: [],
+      edges: [],
+    })
+    useDrawingStore.setState({ objects: [] })
+  })
+
+  afterEach(cleanup)
+
+  it('renders nothing when there are no panels and no figures', () => {
+    const { container } = render(<CanvasMinimap containerWidth={800} containerHeight={600} />)
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  it('shows the minimap and renders figures when there are no panels', () => {
+    useDrawingStore.setState({ objects: [makeRectFigure('f1')] })
+    const { container } = render(<CanvasMinimap containerWidth={800} containerHeight={600} />)
+    expect(container.querySelector('svg')).toBeTruthy()
+    const figRect = [...container.querySelectorAll('rect')].find(
+      (r) => r.getAttribute('stroke') === '#3b82f6'
+    )
+    expect(figRect).toBeTruthy()
+  })
+
+  it('renders text figures as faint blocks in the text color', () => {
+    useDrawingStore.setState({ objects: [makeTextFigure('f1')] })
+    const { container } = render(<CanvasMinimap containerWidth={800} containerHeight={600} />)
+    const textRect = [...container.querySelectorAll('rect')].find(
+      (r) => r.getAttribute('fill') === '#3b82f6' && r.getAttribute('opacity') === '0.3'
+    )
+    expect(textRect).toBeTruthy()
+  })
+
+  it('renders line figures as lines', () => {
+    useDrawingStore.setState({ objects: [makeLineFigure('f1')] })
+    const { container } = render(<CanvasMinimap containerWidth={800} containerHeight={600} />)
+    const line = [...container.querySelectorAll('line')].find(
+      (l) => l.getAttribute('stroke') === '#3b82f6'
+    )
+    expect(line).toBeTruthy()
+  })
+
+  it('includes figures in the map bounds (figures far from panels stay visible)', () => {
+    useCanvasStore.setState({ panels: [makePanel()] })
+    useDrawingStore.setState({
+      objects: [makeRectFigure('f1', { x: 2000, y: 1500 })],
+    })
+    const { container } = render(<CanvasMinimap containerWidth={800} containerHeight={600} />)
+    const figRect = [...container.querySelectorAll('rect')].find(
+      (r) => r.getAttribute('stroke') === '#3b82f6'
+    ) as SVGRectElement
+    expect(figRect).toBeTruthy()
+    const x = Number(figRect.getAttribute('x'))
+    const y = Number(figRect.getAttribute('y'))
+    // Inside the minimap's inner area (12px padding on all sides)
+    expect(x).toBeGreaterThanOrEqual(12)
+    expect(x).toBeLessThanOrEqual(180 - 12)
+    expect(y).toBeGreaterThanOrEqual(12)
+    expect(y).toBeLessThanOrEqual(120 - 12)
+  })
+})

--- a/src/renderer/src/components/canvas/CanvasMinimap.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.tsx
@@ -2,6 +2,9 @@ import { memo, useCallback, useRef, useState, useMemo, useEffect } from 'react'
 import { useCanvasStore, type CanvasPanelData, type CanvasEdge, type Viewport, MIN_ZOOM, MAX_ZOOM } from '@/stores/canvas-store'
 import { getLiveViewport, subscribeLiveViewport } from '@/stores/canvas-live-viewport'
 import { useTaskStore } from '@/stores/task-store'
+import { useDrawingStore } from '@/stores/drawing-store'
+import { lineEndpoints, unionBox } from './drawing/figure-geometry'
+import type { DrawingObject } from './drawing/types'
 import { Minus, Plus, Maximize2, ChevronDown, ChevronUp } from 'lucide-react'
 import { getCanvasTaskStatusStyle } from './canvas-status-style'
 
@@ -54,12 +57,14 @@ function getClampedViewportRect(
 const MinimapContent = memo(function MinimapContent({
   panels,
   edges,
+  figures,
   bounds,
   scale,
   taskStatusMap,
 }: {
   panels: CanvasPanelData[]
   edges: CanvasEdge[]
+  figures: DrawingObject[]
   bounds: MinimapBounds
   scale: number
   taskStatusMap: Map<string, ReturnType<typeof useTaskStore.getState>['tasks'][number]['status']>
@@ -92,6 +97,84 @@ const MinimapContent = memo(function MinimapContent({
             y2={toMiniY(to.y + to.height / 2)}
             stroke={edgeColor}
             strokeWidth="1"
+          />
+        )
+      })}
+
+      {/* Drawing figures — below panels (figures render below panels on the
+          canvas too), keeping their real stroke/fill colors. */}
+      {figures.map((f) => {
+        const px = toMiniX(f.x)
+        const py = toMiniY(f.y)
+        const pw = Math.max(2, f.width * scale)
+        const ph = Math.max(2, f.height * scale)
+        if (f.type === 'line' || f.type === 'arrow') {
+          const { from, to } = lineEndpoints(
+            { x: f.x, y: f.y, width: f.width, height: f.height },
+            f.direction
+          )
+          return (
+            <line
+              key={f.id}
+              x1={toMiniX(from.x)}
+              y1={toMiniY(from.y)}
+              x2={toMiniX(to.x)}
+              y2={toMiniY(to.y)}
+              stroke={f.stroke}
+              strokeWidth="1"
+              opacity={0.8}
+            />
+          )
+        }
+        if (f.type === 'ellipse') {
+          return (
+            <ellipse
+              key={f.id}
+              cx={px + pw / 2}
+              cy={py + ph / 2}
+              rx={pw / 2}
+              ry={ph / 2}
+              fill={f.fill ?? 'none'}
+              stroke={f.stroke}
+              strokeWidth="1"
+              opacity={0.8}
+            />
+          )
+        }
+        if (f.type === 'text') {
+          // A faint block in the text color — readable at minimap scale.
+          return (
+            <rect key={f.id} x={px} y={py} width={pw} height={ph} rx="1" fill={f.stroke} opacity={0.3} />
+          )
+        }
+        if (f.type === 'image') {
+          return (
+            <rect
+              key={f.id}
+              x={px}
+              y={py}
+              width={pw}
+              height={ph}
+              rx="1"
+              fill="rgba(148,163,184,0.45)"
+              stroke="rgba(255,255,255,0.15)"
+              strokeWidth="0.5"
+            />
+          )
+        }
+        // rectangle
+        return (
+          <rect
+            key={f.id}
+            x={px}
+            y={py}
+            width={pw}
+            height={ph}
+            rx="1"
+            fill={f.fill ?? 'none'}
+            stroke={f.stroke}
+            strokeWidth="1"
+            opacity={0.8}
           />
         )
       })}
@@ -143,6 +226,7 @@ function CanvasMinimapComponent({
   const panels = useCanvasStore((s) => s.panels)
   const viewport = useCanvasStore((s) => s.viewport)
   const edges = useCanvasStore((s) => s.edges)
+  const figures = useDrawingStore((s) => s.objects)
   const tasks = useTaskStore((s) => s.tasks)
   const setViewport = useCanvasStore((s) => s.setViewport)
   const zoomTo = useCanvasStore((s) => s.zoomTo)
@@ -152,9 +236,9 @@ function CanvasMinimapComponent({
   const [isDragging, setIsDragging] = useState(false)
   const svgRef = useRef<SVGSVGElement>(null)
 
-  // ── Compute bounding box of all panels ──────────────────
+  // ── Compute bounding box of all panels + drawing figures ──
   const bounds = useMemo(() => {
-    if (panels.length === 0) {
+    if (panels.length === 0 && figures.length === 0) {
       return { minX: 0, minY: 0, maxX: 1000, maxY: 800 }
     }
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
@@ -164,10 +248,16 @@ function CanvasMinimapComponent({
       maxX = Math.max(maxX, p.x + p.width)
       maxY = Math.max(maxY, p.y + p.height)
     }
+    for (const f of figures) {
+      minX = Math.min(minX, f.x)
+      minY = Math.min(minY, f.y)
+      maxX = Math.max(maxX, f.x + f.width)
+      maxY = Math.max(maxY, f.y + f.height)
+    }
     // Add padding
     const pad = 100
     return { minX: minX - pad, minY: minY - pad, maxX: maxX + pad, maxY: maxY + pad }
-  }, [panels])
+  }, [panels, figures])
 
   // ── Scale factor: canvas space → minimap space ──────────
   const canvasW = bounds.maxX - bounds.minX
@@ -242,6 +332,14 @@ function CanvasMinimapComponent({
 
   const zoomPercent = Math.round(viewport.zoom * 100)
 
+  // Union box of the drawing figures (canvas space) — merged into the
+  // fit-to-content so figures are fitted along with the panels.
+  const figuresBounds = useMemo(() => {
+    const box = unionBox(figures)
+    if (!box) return undefined
+    return { minX: box.x, minY: box.y, maxX: box.x + box.width, maxY: box.y + box.height }
+  }, [figures])
+
   // ── Follow the viewport during a gesture, imperatively ──
   // The canvas doesn't write the viewport to the store while the user is
   // panning/zooming (see InfiniteCanvas), so the minimap can't re-render its
@@ -274,7 +372,7 @@ function CanvasMinimapComponent({
     return subscribeLiveViewport(applyLiveViewport)
   }, [containerWidth, containerHeight, collapsed])
 
-  if (panels.length === 0) return null
+  if (panels.length === 0 && figures.length === 0) return null
 
   return (
     <div
@@ -322,6 +420,7 @@ function CanvasMinimapComponent({
             <MinimapContent
               panels={panels}
               edges={edges}
+              figures={figures}
               bounds={bounds}
               scale={scale}
               taskStatusMap={taskStatusMap}
@@ -380,8 +479,8 @@ function CanvasMinimapComponent({
 
             <button
               className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
-              onClick={(e) => { e.stopPropagation(); fitToContent(containerWidth, containerHeight) }}
-              title="Fit all panels"
+              onClick={(e) => { e.stopPropagation(); fitToContent(containerWidth, containerHeight, figuresBounds) }}
+              title="Fit all content"
             >
               <Maximize2 className="h-3 w-3" />
             </button>

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -2,8 +2,17 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react'
 import { InfiniteCanvas } from './InfiniteCanvas'
 import { useCanvasStore } from '@/stores/canvas-store'
+import { useDrawingStore } from '@/stores/drawing-store'
+import { DEFAULT_TOOL_OPTIONS } from './drawing/types'
 import { TaskStatus } from '@/types'
 import type { WorkfloTask } from '@/types'
+
+// Mock only the clipboard paste (no real clipboard in happy-dom) — the
+// DrawingLayer component itself stays real.
+vi.mock('./drawing/DrawingLayer', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./drawing/DrawingLayer')>()
+  return { ...actual, pasteImageAt: vi.fn().mockResolvedValue(null) }
+})
 
 const taskStoreState = vi.hoisted(() => ({
   tasks: [] as WorkfloTask[],
@@ -103,6 +112,17 @@ describe('InfiniteCanvas', () => {
     taskStoreState.selectedTaskId = null
     taskStoreState.isLoading = false
     taskStoreState.error = null
+
+    useDrawingStore.setState({
+      objects: [],
+      nextZIndex: 1,
+      isLoaded: true,
+      activeTool: 'select',
+      toolOptions: { ...DEFAULT_TOOL_OPTIONS },
+      selectedIds: [],
+      editingTextId: null,
+      liveObject: null,
+    })
   })
 
   afterEach(cleanup)
@@ -480,5 +500,74 @@ describe('InfiniteCanvas', () => {
 
     expect(panel).toBeTruthy()
     expect(panel?.className).not.toContain('select-none')
+  })
+
+  describe('drawing integration', () => {
+    it('switches drawing tools with the V/R/O/L/A/T/I shortcuts', () => {
+      render(<InfiniteCanvas />)
+      fireEvent.keyDown(window, { code: 'KeyR' })
+      expect(useDrawingStore.getState().activeTool).toBe('rectangle')
+      fireEvent.keyDown(window, { code: 'KeyT' })
+      expect(useDrawingStore.getState().activeTool).toBe('text')
+      fireEvent.keyDown(window, { code: 'KeyV' })
+      expect(useDrawingStore.getState().activeTool).toBe('select')
+    })
+
+    it('ignores tool shortcuts while typing in an input', () => {
+      render(<InfiniteCanvas />)
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+      fireEvent.keyDown(input, { code: 'KeyR' })
+      expect(useDrawingStore.getState().activeTool).toBe('select')
+      input.remove()
+    })
+
+    it('removes selected figures with Delete', () => {
+      const id = useDrawingStore
+        .getState()
+        .addObject({
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 50,
+          stroke: '#1e1e1e',
+          strokeWidth: 2,
+          fill: null,
+          opacity: 1,
+        })
+      useDrawingStore.getState().select([id])
+      render(<InfiniteCanvas />)
+      fireEvent.keyDown(window, { code: 'Delete' })
+      expect(useDrawingStore.getState().objects).toHaveLength(0)
+    })
+
+    it('cancels an in-progress figure creation with Escape', () => {
+      useDrawingStore.getState().setLiveObject({
+        type: 'rectangle',
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        stroke: '#1e1e1e',
+        strokeWidth: 2,
+        fill: null,
+        opacity: 1,
+        id: 'live-preview',
+        zIndex: 0,
+      })
+      render(<InfiniteCanvas />)
+      fireEvent.keyDown(window, { code: 'Escape' })
+      expect(useDrawingStore.getState().liveObject).toBeNull()
+    })
+
+    it('pastes a clipboard image at the viewport center on Ctrl+V', async () => {
+      render(<InfiniteCanvas />)
+      fireEvent.keyDown(window, { code: 'KeyV', ctrlKey: true })
+      await act(async () => {})
+      const { pasteImageAt } = await import('./drawing/DrawingLayer')
+      expect(vi.mocked(pasteImageAt)).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -503,6 +503,36 @@ describe('InfiniteCanvas', () => {
   })
 
   describe('drawing integration', () => {
+    it('hides the drawing toolbar by default', () => {
+      const { container } = render(<InfiniteCanvas />)
+      expect(container.querySelector('[data-drawing-toolbar="true"]')).toBeNull()
+    })
+
+    it('shows the drawing toolbar when a figure is selected', () => {
+      const id = useDrawingStore
+        .getState()
+        .addObject({
+          type: 'rectangle',
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 50,
+          stroke: '#1e1e1e',
+          strokeWidth: 2,
+          fill: null,
+          opacity: 1,
+        })
+      useDrawingStore.getState().select([id])
+      const { container } = render(<InfiniteCanvas />)
+      expect(container.querySelector('[data-drawing-toolbar="true"]')).toBeTruthy()
+    })
+
+    it('shows the drawing toolbar when a drawing tool is active', () => {
+      useDrawingStore.getState().setTool('rectangle')
+      const { container } = render(<InfiniteCanvas />)
+      expect(container.querySelector('[data-drawing-toolbar="true"]')).toBeTruthy()
+    })
+
     it('switches drawing tools with the V/R/O/L/A/T/I shortcuts', () => {
       render(<InfiniteCanvas />)
       fireEvent.keyDown(window, { code: 'KeyR' })

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -10,6 +10,11 @@ import type { CanvasPanelData, Viewport } from '@/stores/canvas-store'
 import { getLiveViewport, setLiveViewport } from '@/stores/canvas-live-viewport'
 import { useUIStore } from '@/stores/ui-store'
 import { useTaskStore } from '@/stores/task-store'
+import { useDrawingStore } from '@/stores/drawing-store'
+import type { DrawingTool } from './drawing/types'
+import { DrawingLayer, pasteImageAt } from './drawing/DrawingLayer'
+import { DrawingToolbar } from './drawing/DrawingToolbar'
+import { DrawingProperties } from './drawing/DrawingProperties'
 import { CanvasPanel } from './CanvasPanel'
 import { CanvasConnections } from './CanvasConnections'
 import { CanvasContextMenu } from './CanvasContextMenu'
@@ -61,6 +66,17 @@ const GRID_SIZE = 40
  * store this long after the last wheel event.
  */
 const WHEEL_IDLE_MS = 150
+
+/** Drawing tool shortcuts (plain keypresses, guarded by isInputFocused). */
+const TOOL_SHORTCUTS: Record<string, DrawingTool> = {
+  KeyV: 'select',
+  KeyR: 'rectangle',
+  KeyO: 'ellipse',
+  KeyL: 'line',
+  KeyA: 'arrow',
+  KeyT: 'text',
+  KeyI: 'image',
+}
 const STATUS_HIGHLIGHT_MS = 5_000
 const STATUS_POPUP_EDGE_PAD = 28
 const STATUS_POPUP_TOP_SAFE = 70
@@ -217,10 +233,13 @@ export function InfiniteCanvas() {
   const focusPanel = useCanvasStore((s) => s.focusPanel)
   const addPanel = useCanvasStore((s) => s.addPanel)
   const loadCanvas = useCanvasStore((s) => s.loadCanvas)
+  const loadDrawings = useDrawingStore((s) => s.loadDrawings)
 
   // ── Load persisted canvas state on mount ────────────────
   useEffect(() => {
     if (!isLoaded) {
+      // Figures load in parallel with the canvas (same settings table).
+      void loadDrawings()
       loadCanvas().then(() => {
         // After loading, fit the viewport to show all panels
         const container = containerRef.current
@@ -233,7 +252,7 @@ export function InfiniteCanvas() {
         }
       })
     }
-  }, [isLoaded, loadCanvas, fitToContent])
+  }, [isLoaded, loadCanvas, fitToContent, loadDrawings])
 
   // Panning state
   const [isPanning, setIsPanning] = useState(false)
@@ -662,12 +681,25 @@ export function InfiniteCanvas() {
         }
       }
 
+      // A drawing tool is active: background mousedowns belong to the drawing
+      // layer (figure creation), not to panning. Space+drag and middle-button
+      // pan still take precedence. (Imperative read — same pattern as the
+      // connectingFromId check above.)
+      const { activeTool } = useDrawingStore.getState()
+      if (e.button === 0 && !spaceHeld && activeTool !== 'select') return
+
       const isMiddle = e.button === 1
       const isLeftOnCanvas =
         e.button === 0 &&
         (e.target === containerRef.current ||
           (e.target as HTMLElement).dataset?.canvasBg === 'true')
       const isSpacePan = e.button === 0 && spaceHeld
+
+      // Clicking empty canvas with the select tool drops the figure selection.
+      if (isLeftOnCanvas) {
+        const drawing = useDrawingStore.getState()
+        if (drawing.selectedIds.length > 0) drawing.clearSelection()
+      }
 
       if (isMiddle || isLeftOnCanvas || isSpacePan) {
         e.preventDefault()
@@ -740,9 +772,10 @@ export function InfiniteCanvas() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Ignore shortcuts when typing in an input/textarea or xterm terminal
-      const tag = (e.target as HTMLElement)?.tagName?.toLowerCase()
-      const isXtermFocused = !!(e.target as HTMLElement)?.closest('.xterm')
-      const isInputFocused = tag === 'input' || tag === 'textarea' || (e.target as HTMLElement)?.isContentEditable || isXtermFocused
+      const target = e.target as Element | null
+      const tag = (target as HTMLElement | null)?.tagName?.toLowerCase()
+      const isXtermFocused = !!target?.closest?.('.xterm')
+      const isInputFocused = tag === 'input' || tag === 'textarea' || (target as HTMLElement | null)?.isContentEditable || isXtermFocused
 
       // Track Ctrl held state — shows panel index badges (Ctrl only, not Cmd)
       if (e.key === 'Control' && !e.repeat) {
@@ -814,14 +847,54 @@ export function InfiniteCanvas() {
         }
       }
 
-      // Escape: cancel connecting or close context menu
+      // Escape: cancel connecting, cancel figure creation, drop figure
+      // selection, or close context menu. (Text editing handles its own
+      // Escape while the contentEditable div is focused — isInputFocused.)
       if (e.code === 'Escape') {
         const { connectingFromId: cid } = useCanvasStore.getState()
         if (cid) {
           setConnectingFromId(null)
           setMouseCanvasPos(null)
         }
+        const drawing = useDrawingStore.getState()
+        if (drawing.liveObject) drawing.setLiveObject(null)
+        if (drawing.selectedIds.length > 0) drawing.clearSelection()
         setContextMenu(null)
+      }
+
+      // Delete/Backspace: remove selected figures.
+      if ((e.code === 'Delete' || e.code === 'Backspace') && !isInputFocused) {
+        const drawing = useDrawingStore.getState()
+        if (drawing.selectedIds.length > 0) {
+          e.preventDefault()
+          drawing.removeObjects(drawing.selectedIds)
+        }
+      }
+
+      // Ctrl/Cmd+V: paste an image from the clipboard at the viewport center
+      // (suppressed while typing or editing a text figure).
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && e.code === 'KeyV' && !isInputFocused) {
+        const drawing = useDrawingStore.getState()
+        if (drawing.editingTextId) return
+        e.preventDefault()
+        const container = containerRef.current
+        if (container) {
+          commitViewport()
+          const rect = container.getBoundingClientRect()
+          const vp = getLiveViewport()
+          const cx = (rect.width / 2 - vp.x) / vp.zoom
+          const cy = (rect.height / 2 - vp.y) / vp.zoom
+          void pasteImageAt(cx, cy)
+        }
+      }
+
+      // Drawing tool shortcuts: V/R/O/L/A/T/I
+      if (!isInputFocused && !e.ctrlKey && !e.metaKey && !e.altKey && !e.repeat) {
+        const tool = TOOL_SHORTCUTS[e.code]
+        if (tool) {
+          e.preventDefault()
+          useDrawingStore.getState().setTool(tool)
+        }
       }
     }
     const handleKeyUp = (e: KeyboardEvent) => {
@@ -895,6 +968,9 @@ export function InfiniteCanvas() {
 
           {/* Connection lines */}
           <CanvasConnections mouseCanvasPos={mouseCanvasPos} />
+
+          {/* Drawing layer — figures above edges, below panels */}
+          <DrawingLayer />
 
           {/* Render panels — off-viewport panels are frozen (content hidden) */}
           {panels.map((panel, index) => (
@@ -1029,6 +1105,10 @@ export function InfiniteCanvas() {
         containerWidth={containerSize.width}
         containerHeight={containerSize.height}
       />
+
+      {/* ── Drawing: toolbar (bottom-center) + selection properties (top-center) ── */}
+      <DrawingToolbar />
+      <DrawingProperties />
 
       {/* ── Empty state ── */}
       {panels.length === 0 && (

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -235,6 +235,15 @@ export function InfiniteCanvas() {
   const loadCanvas = useCanvasStore((s) => s.loadCanvas)
   const loadDrawings = useDrawingStore((s) => s.loadDrawings)
 
+  // Drawing HUD visibility: hidden by default, appears when the user engages
+  // with drawing — a tool is active, a figure is selected, or a text figure
+  // is being edited.
+  const drawingTool = useDrawingStore((s) => s.activeTool)
+  const drawingSelectedCount = useDrawingStore((s) => s.selectedIds.length)
+  const drawingEditingTextId = useDrawingStore((s) => s.editingTextId)
+  const drawingUiVisible =
+    drawingTool !== 'select' || drawingSelectedCount > 0 || drawingEditingTextId !== null
+
   // ── Load persisted canvas state on mount ────────────────
   useEffect(() => {
     if (!isLoaded) {
@@ -1106,9 +1115,11 @@ export function InfiniteCanvas() {
         containerHeight={containerSize.height}
       />
 
-      {/* ── Drawing: toolbar (bottom-center) + selection properties (top-center) ── */}
-      <DrawingToolbar />
-      <DrawingProperties />
+      {/* ── Drawing: toolbar (bottom-center) + selection properties (top-center) ──
+          Hidden until the user engages with drawing (tool active, figure
+          selected, or a text figure being edited). */}
+      {drawingUiVisible && <DrawingToolbar />}
+      {drawingSelectedCount > 0 && <DrawingProperties />}
 
       {/* ── Empty state ── */}
       {panels.length === 0 && (

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup, fireEvent, act } from '@testing-library/react'
 import { DrawingLayer, pasteImageAt } from './DrawingLayer'
@@ -499,6 +500,38 @@ describe('DrawingLayer', () => {
     const { container } = render(<DrawingLayer />)
     const figure = container.querySelector(`[data-figure-id="${id}"]`) as HTMLElement
     expect(figure.getAttribute('style') ?? '').toContain('dashed')
+  })
+
+  it('survives StrictMode double-mount (no empty-text commit on simulated remount)', () => {
+    const id = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: '',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    useDrawingStore.getState().setEditingTextId(id)
+    // The app renders under React.StrictMode: in dev it runs the editing
+    // effect setup → cleanup → setup on mount. The simulated cleanup must not
+    // commit the (empty) text, or the freshly created figure is destroyed
+    // before the user can type.
+    render(
+      <StrictMode>
+        <DrawingLayer />
+      </StrictMode>
+    )
+
+    expect(useDrawingStore.getState().objects).toHaveLength(1)
+    expect(useDrawingStore.getState().editingTextId).toBe(id)
   })
 
   // ── Move ──────────────────────────────────────────────────

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
@@ -83,6 +83,33 @@ describe('DrawingLayer', () => {
     expect(container.querySelector('[data-figure-id]')).toBeNull()
   })
 
+  it('gives the capture surface explicit pointer-events (root is pointer-events:none)', () => {
+    useDrawingStore.getState().setTool('rectangle')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as HTMLElement
+    expect(capture).toBeTruthy()
+    // The layer root sets pointer-events:none and the property is inherited:
+    // without an explicit override the capture surface is invisible to real
+    // browser hit-testing and no creation gesture can ever start.
+    expect(capture.style.pointerEvents).toBe('auto')
+  })
+
+  it('lets space+drag through the capture surface (pan gesture)', () => {
+    useDrawingStore.getState().setTool('rectangle')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as Element
+
+    fireEvent.keyDown(window, { code: 'Space' })
+    fireEvent.mouseDown(capture, { button: 0, clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 150, clientY: 150 })
+    fireEvent.mouseUp(window)
+    fireEvent.keyUp(window, { code: 'Space' })
+
+    // Space+drag is a pan, not a creation: nothing is added.
+    expect(useDrawingStore.getState().objects).toHaveLength(0)
+    expect(useDrawingStore.getState().liveObject).toBeNull()
+  })
+
   it('renders text figures as DOM divs with the figure text', () => {
     useDrawingStore.getState().addObject({
       type: 'text',

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react'
+import { DrawingLayer, pasteImageAt } from './DrawingLayer'
+import { readClipboardImage, downscaleImageToDataUrl } from './image-paste'
+import { useDrawingStore } from '@/stores/drawing-store'
+import { useCanvasStore } from '@/stores/canvas-store'
+import type { DrawingObject } from './types'
+
+vi.mock('./image-paste', () => ({
+  readClipboardImage: vi.fn(),
+  downscaleImageToDataUrl: vi.fn(),
+  MAX_IMAGE_EDGE: 1024,
+}))
+
+const flushFrames = async () => {
+  // rAF + the queued microtasks React uses to commit
+  await act(async () => {
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+const makeRect = (over: {
+  id?: string
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+} = {}): DrawingObject => ({
+  id: 'figure-1-1',
+  type: 'rectangle',
+  x: 100,
+  y: 100,
+  width: 100,
+  height: 60,
+  stroke: '#1e1e1e',
+  strokeWidth: 2,
+  fill: null,
+  opacity: 1,
+  zIndex: 1,
+  ...over,
+})
+
+const toNewFigure = (fig: DrawingObject) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id: _id, zIndex: _z, ...rest } = fig
+  return rest
+}
+
+describe('DrawingLayer', () => {
+  beforeEach(() => {
+    vi.mocked(readClipboardImage).mockReset()
+    vi.mocked(downscaleImageToDataUrl).mockReset()
+
+    useDrawingStore.setState({
+      objects: [],
+      nextZIndex: 1,
+      isLoaded: true,
+      activeTool: 'select',
+      toolOptions: {
+        stroke: '#1e1e1e',
+        strokeWidth: 2,
+        fill: null,
+        fontSize: 18,
+        fontFamily: 'sans',
+        fontWeight: 400,
+      },
+      selectedIds: [],
+      editingTextId: null,
+      liveObject: null,
+    })
+    useCanvasStore.setState({ viewport: { x: 0, y: 0, zoom: 1 } })
+  })
+
+  afterEach(cleanup)
+
+  it('renders nothing when there are no figures', () => {
+    const { container } = render(<DrawingLayer />)
+    expect(container.querySelector('[data-figure-id]')).toBeNull()
+  })
+
+  it('renders text figures as DOM divs with the figure text', () => {
+    useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: 'Hello World',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    render(<DrawingLayer />)
+    expect(screen.getByText('Hello World')).toBeTruthy()
+  })
+
+  it('renders the selection outline for selected figures', () => {
+    const id = useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    useDrawingStore.getState().select([id])
+    const { container } = render(<DrawingLayer />)
+    expect(container.querySelector('[data-figure-outline="true"]')).toBeTruthy()
+    expect(container.querySelector('[data-figure-resize="true"]')).toBeTruthy()
+  })
+
+  // ── Creation ──────────────────────────────────────────────
+
+  it('drag with the rectangle tool creates a rectangle figure', async () => {
+    useDrawingStore.getState().setTool('rectangle')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as Element
+    expect(capture).toBeTruthy()
+
+    fireEvent.mouseDown(capture, { button: 0, clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 200, clientY: 160 })
+    await flushFrames()
+
+    // Live preview while dragging
+    expect(useDrawingStore.getState().liveObject).toMatchObject({
+      type: 'rectangle',
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 60,
+    })
+
+    fireEvent.mouseUp(window)
+    const { objects, liveObject } = useDrawingStore.getState()
+    expect(liveObject).toBeNull()
+    expect(objects).toHaveLength(1)
+    expect(objects[0]).toMatchObject({
+      type: 'rectangle',
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+    })
+    // The committed figure renders in the SVG
+    expect(container.querySelector(`[data-figure-id="${objects[0].id}"]`)).toBeTruthy()
+  })
+
+  it('arrow tool records the drag direction', async () => {
+    useDrawingStore.getState().setTool('arrow')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as Element
+
+    fireEvent.mouseDown(capture, { button: 0, clientX: 200, clientY: 200 })
+    fireEvent.mouseMove(window, { clientX: 100, clientY: 100 })
+    await flushFrames()
+    fireEvent.mouseUp(window)
+
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({
+      type: 'arrow',
+      direction: 'nw',
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 100,
+    })
+  })
+
+  it('discards sub-minimum drags', async () => {
+    useDrawingStore.getState().setTool('rectangle')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as Element
+
+    fireEvent.mouseDown(capture, { button: 0, clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 101, clientY: 101 })
+    await flushFrames()
+    fireEvent.mouseUp(window)
+
+    expect(useDrawingStore.getState().objects).toHaveLength(0)
+  })
+
+  it('click with the text tool creates a text figure and enters editing', () => {
+    useDrawingStore.getState().setTool('text')
+    render(<DrawingLayer />)
+    const capture = document.querySelector('[data-drawing-capture="true"]') as Element
+
+    fireEvent.mouseDown(capture, { button: 0, clientX: 150, clientY: 120 })
+
+    const { objects, editingTextId, activeTool } = useDrawingStore.getState()
+    expect(objects).toHaveLength(1)
+    expect(objects[0]).toMatchObject({
+      type: 'text',
+      x: 30,
+      y: 90,
+      width: 240,
+      height: 60,
+      text: '',
+    })
+    expect(editingTextId).toBe(objects[0].id)
+    // The tool drops back to select so typing goes into the new figure.
+    expect(activeTool).toBe('select')
+  })
+
+  it('cancels creation when liveObject is cleared (Escape)', async () => {
+    useDrawingStore.getState().setTool('rectangle')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as Element
+
+    fireEvent.mouseDown(capture, { button: 0, clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 200, clientY: 160 })
+    await flushFrames()
+    expect(useDrawingStore.getState().liveObject).not.toBeNull()
+
+    // Escape (handled by InfiniteCanvas) clears liveObject — the gesture stops.
+    await act(async () => {
+      useDrawingStore.getState().setLiveObject(null)
+    })
+    fireEvent.mouseMove(window, { clientX: 300, clientY: 300 })
+    await flushFrames()
+    expect(useDrawingStore.getState().liveObject).toBeNull()
+
+    fireEvent.mouseUp(window)
+    expect(useDrawingStore.getState().objects).toHaveLength(0)
+  })
+
+  // ── Text editing ──────────────────────────────────────────
+
+  it('double-clicking a text figure opens it for editing and commits on blur', () => {
+    const id = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: 'Hello',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    const { container } = render(<DrawingLayer />)
+    const figure = container.querySelector(`[data-figure-id="${id}"]`) as HTMLElement
+    const editable = figure.querySelector('[contenteditable]') as HTMLElement
+    expect(editable.getAttribute('contenteditable')).toBe('false')
+
+    fireEvent.doubleClick(figure)
+    expect(useDrawingStore.getState().editingTextId).toBe(id)
+    const editing = figure.querySelector('[contenteditable="true"]') as HTMLElement
+    expect(editing).toBeTruthy()
+    expect(editing.textContent).toBe('Hello')
+
+    editing.textContent = 'Hello World'
+    fireEvent.blur(editing)
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({ text: 'Hello World' })
+    expect(useDrawingStore.getState().editingTextId).toBeNull()
+  })
+
+  // ── Move ──────────────────────────────────────────────────
+
+  it('select tool: clicking a figure selects it and dragging moves it', async () => {
+    const id = useDrawingStore.getState().addObject(toNewFigure(makeRect({ x: 100, y: 100 })))
+    const { container } = render(<DrawingLayer />)
+    const figure = container.querySelector(`[data-figure-id="${id}"]`) as Element
+
+    fireEvent.mouseDown(figure, { button: 0, clientX: 150, clientY: 130 })
+    expect(useDrawingStore.getState().selectedIds).toEqual([id])
+
+    fireEvent.mouseMove(window, { clientX: 180, clientY: 150 })
+    await flushFrames()
+
+    // Moved on the compositor; the store is untouched until mouseup.
+    expect(figure.getAttribute('transform')).toBe('translate(30, 20)')
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({ x: 100, y: 100 })
+
+    fireEvent.mouseUp(window)
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({ x: 130, y: 120 })
+    expect(figure.getAttribute('transform')).toBeNull()
+  })
+
+  // ── Resize ────────────────────────────────────────────────
+
+  it('resize handle resizes a single selected figure', async () => {
+    const id = useDrawingStore.getState().addObject(toNewFigure(makeRect({ x: 100, y: 100 })))
+    useDrawingStore.getState().select([id])
+    const { container } = render(<DrawingLayer />)
+    const handle = container.querySelector('[data-figure-resize="true"]') as Element
+    expect(handle).toBeTruthy()
+
+    fireEvent.mouseDown(handle, { button: 0, clientX: 200, clientY: 160 })
+    fireEvent.mouseMove(window, { clientX: 250, clientY: 200 })
+    await flushFrames()
+
+    // The rect was resized imperatively
+    const rectEl = container.querySelector(`[data-figure-id="${id}"] rect`) as Element
+    expect(rectEl.getAttribute('width')).toBe('150')
+    expect(rectEl.getAttribute('height')).toBe('100')
+
+    fireEvent.mouseUp(window)
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({ width: 150, height: 100 })
+  })
+
+  // ── Paste ─────────────────────────────────────────────────
+
+  it('pasteImageAt adds an image figure centered on the point', async () => {
+    vi.mocked(readClipboardImage).mockResolvedValue(
+      new File(['x'], 'img.png', { type: 'image/png' })
+    )
+    vi.mocked(downscaleImageToDataUrl).mockResolvedValue({
+      src: 'data:image/png;base64,AAA',
+      width: 100,
+      height: 50,
+    })
+
+    const id = await pasteImageAt(200, 150)
+    expect(id).toBeTruthy()
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({
+      type: 'image',
+      x: 150,
+      y: 125,
+      width: 100,
+      height: 50,
+      src: 'data:image/png;base64,AAA',
+    })
+  })
+
+  it('pasteImageAt is a no-op when the clipboard has no image', async () => {
+    vi.mocked(readClipboardImage).mockResolvedValue(null)
+    const id = await pasteImageAt(0, 0)
+    expect(id).toBeNull()
+    expect(useDrawingStore.getState().objects).toHaveLength(0)
+  })
+
+  it('click with the image tool pastes at the click point', async () => {
+    vi.mocked(readClipboardImage).mockResolvedValue(
+      new File(['x'], 'img.png', { type: 'image/png' })
+    )
+    vi.mocked(downscaleImageToDataUrl).mockResolvedValue({
+      src: 'data:image/png;base64,AAA',
+      width: 100,
+      height: 50,
+    })
+    useDrawingStore.getState().setTool('image')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as Element
+
+    fireEvent.mouseDown(capture, { button: 0, clientX: 200, clientY: 150 })
+    await act(async () => {})
+
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({
+      type: 'image',
+      x: 150,
+      y: 125,
+      width: 100,
+      height: 50,
+    })
+  })
+})

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
@@ -451,6 +451,67 @@ describe('DrawingLayer', () => {
     expect(useDrawingStore.getState().objects[0]).toMatchObject({ x: 10, y: 10, text: 'Hi' })
   })
 
+  it('clicking a different figure commits the text edit and selects the new figure', () => {
+    const idText = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: 'Hello',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    const idRect = useDrawingStore.getState().addObject(toNewFigure(makeRect({ id: 'figure-2-2', x: 300, y: 300 })))
+    useDrawingStore.getState().setEditingTextId(idText)
+    const { container } = render(<DrawingLayer />)
+    const figureRect = container.querySelector(`[data-figure-id="${idRect}"]`) as Element
+
+    fireEvent.mouseDown(figureRect, { button: 0, clientX: 350, clientY: 350 })
+
+    // The edit is committed (text saved, editing ended) and the clicked
+    // figure is selected.
+    expect(useDrawingStore.getState().editingTextId).toBeNull()
+    expect(useDrawingStore.getState().objects.find((o) => o.id === idText)).toMatchObject({
+      text: 'Hello',
+    })
+    expect(useDrawingStore.getState().selectedIds).toContain(idRect)
+  })
+
+  it('clicking outside the edited figure (canvas background) commits the text', () => {
+    const id = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: 'Note',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    useDrawingStore.getState().setEditingTextId(id)
+    const { container } = render(<DrawingLayer />)
+
+    // The render container stands in for the canvas background — a mousedown
+    // whose target is outside every figure must end the edit.
+    fireEvent.mouseDown(container, { button: 0, clientX: 500, clientY: 500 })
+
+    expect(useDrawingStore.getState().editingTextId).toBeNull()
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({ text: 'Note' })
+  })
+
   it('removes a text figure committed with empty text', () => {
     const id = useDrawingStore.getState().addObject({
       type: 'text',

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
@@ -4,6 +4,7 @@ import { DrawingLayer, pasteImageAt } from './DrawingLayer'
 import { readClipboardImage, downscaleImageToDataUrl } from './image-paste'
 import { useDrawingStore } from '@/stores/drawing-store'
 import { useCanvasStore } from '@/stores/canvas-store'
+import { useThemeStore } from '@/stores/theme-store'
 import type { DrawingObject } from './types'
 
 vi.mock('./image-paste', () => ({
@@ -70,6 +71,9 @@ describe('DrawingLayer', () => {
       liveObject: null,
     })
     useCanvasStore.setState({ viewport: { x: 0, y: 0, zoom: 1 } })
+    // Light theme by default so the factory stroke (#1e1e1e) is the expected
+    // one; individual tests switch to dark where relevant.
+    useThemeStore.getState().setMode('light')
   })
 
   afterEach(cleanup)
@@ -201,6 +205,35 @@ describe('DrawingLayer', () => {
     expect(activeTool).toBe('select')
   })
 
+  it('defaults new figures to a stroke visible on the dark theme', async () => {
+    useThemeStore.getState().setMode('dark')
+    useDrawingStore.getState().setTool('rectangle')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as Element
+
+    fireEvent.mouseDown(capture, { button: 0, clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 200, clientY: 160 })
+    await flushFrames()
+    fireEvent.mouseUp(window)
+
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({ stroke: '#ffffff' })
+  })
+
+  it('keeps a user-chosen stroke even when the theme is dark', async () => {
+    useThemeStore.getState().setMode('dark')
+    useDrawingStore.getState().setToolOption('stroke', '#ef4444')
+    useDrawingStore.getState().setTool('rectangle')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as Element
+
+    fireEvent.mouseDown(capture, { button: 0, clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 200, clientY: 160 })
+    await flushFrames()
+    fireEvent.mouseUp(window)
+
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({ stroke: '#ef4444' })
+  })
+
   it('cancels creation when liveObject is cleared (Escape)', async () => {
     useDrawingStore.getState().setTool('rectangle')
     const { container } = render(<DrawingLayer />)
@@ -257,6 +290,56 @@ describe('DrawingLayer', () => {
     fireEvent.blur(editing)
     expect(useDrawingStore.getState().objects[0]).toMatchObject({ text: 'Hello World' })
     expect(useDrawingStore.getState().editingTextId).toBeNull()
+  })
+
+  it('re-clicking a selected text figure (no drag) opens it for editing', () => {
+    const id = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: 'Hi',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    useDrawingStore.getState().select([id])
+    const { container } = render(<DrawingLayer />)
+    const figure = container.querySelector(`[data-figure-id="${id}"]`) as Element
+
+    fireEvent.mouseDown(figure, { button: 0, clientX: 50, clientY: 30 })
+    fireEvent.mouseUp(window)
+
+    expect(useDrawingStore.getState().editingTextId).toBe(id)
+  })
+
+  it('shows a visible editing box while a text figure is being edited', () => {
+    const id = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: '',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    useDrawingStore.getState().setEditingTextId(id)
+    const { container } = render(<DrawingLayer />)
+    const figure = container.querySelector(`[data-figure-id="${id}"]`) as HTMLElement
+    expect(figure.getAttribute('style') ?? '').toContain('dashed')
   })
 
   // ── Move ──────────────────────────────────────────────────

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.test.tsx
@@ -183,12 +183,13 @@ describe('DrawingLayer', () => {
     expect(useDrawingStore.getState().objects).toHaveLength(0)
   })
 
-  it('click with the text tool creates a text figure and enters editing', () => {
+  it('click with the text tool creates a default-size text figure and enters editing', () => {
     useDrawingStore.getState().setTool('text')
     render(<DrawingLayer />)
     const capture = document.querySelector('[data-drawing-capture="true"]') as Element
 
     fireEvent.mouseDown(capture, { button: 0, clientX: 150, clientY: 120 })
+    fireEvent.mouseUp(window)
 
     const { objects, editingTextId, activeTool } = useDrawingStore.getState()
     expect(objects).toHaveLength(1)
@@ -203,6 +204,39 @@ describe('DrawingLayer', () => {
     expect(editingTextId).toBe(objects[0].id)
     // The tool drops back to select so typing goes into the new figure.
     expect(activeTool).toBe('select')
+  })
+
+  it('drag with the text tool creates a text figure at the drag box', async () => {
+    useDrawingStore.getState().setTool('text')
+    const { container } = render(<DrawingLayer />)
+    const capture = container.querySelector('[data-drawing-capture="true"]') as Element
+
+    fireEvent.mouseDown(capture, { button: 0, clientX: 100, clientY: 100 })
+    fireEvent.mouseMove(window, { clientX: 200, clientY: 160 })
+    await flushFrames()
+
+    // Live preview while dragging
+    expect(useDrawingStore.getState().liveObject).toMatchObject({
+      type: 'text',
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 60,
+    })
+
+    fireEvent.mouseUp(window)
+    const { objects, liveObject, editingTextId } = useDrawingStore.getState()
+    expect(liveObject).toBeNull()
+    expect(objects).toHaveLength(1)
+    expect(objects[0]).toMatchObject({
+      type: 'text',
+      x: 100,
+      y: 100,
+      width: 100,
+      height: 60,
+      text: '',
+    })
+    expect(editingTextId).toBe(objects[0].id)
   })
 
   it('defaults new figures to a stroke visible on the dark theme', async () => {
@@ -317,6 +351,104 @@ describe('DrawingLayer', () => {
     fireEvent.mouseUp(window)
 
     expect(useDrawingStore.getState().editingTextId).toBe(id)
+  })
+
+  it('drags a text figure that is being edited (commits the text first)', async () => {
+    const id = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: 'Hi',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    useDrawingStore.getState().setEditingTextId(id)
+    const { container } = render(<DrawingLayer />)
+    const figure = container.querySelector(`[data-figure-id="${id}"]`) as HTMLElement
+    const editable = figure.querySelector('[contenteditable="true"]') as HTMLElement
+    // The editing effect focused the editable div.
+    expect(document.activeElement).toBe(editable)
+
+    fireEvent.mouseDown(figure, { button: 0, clientX: 100, clientY: 100 })
+    // First move crosses the threshold: commits the text, starts the gesture.
+    fireEvent.mouseMove(window, { clientX: 140, clientY: 130 })
+    // Gesture moves are measured from the original mousedown point.
+    fireEvent.mouseMove(window, { clientX: 150, clientY: 140 })
+    await flushFrames()
+    fireEvent.mouseUp(window)
+
+    // Text committed, editing ended, figure moved.
+    expect(useDrawingStore.getState().editingTextId).toBeNull()
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({
+      text: 'Hi',
+      x: 60,
+      y: 50,
+    })
+  })
+
+  it('keeps editing a text figure on a plain caret click (no drag)', () => {
+    const id = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: 'Hi',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    useDrawingStore.getState().setEditingTextId(id)
+    const { container } = render(<DrawingLayer />)
+    const figure = container.querySelector(`[data-figure-id="${id}"]`) as Element
+
+    fireEvent.mouseDown(figure, { button: 0, clientX: 100, clientY: 100 })
+    fireEvent.mouseUp(window)
+
+    // No drag → still editing, figure untouched.
+    expect(useDrawingStore.getState().editingTextId).toBe(id)
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({ x: 10, y: 10, text: 'Hi' })
+  })
+
+  it('removes a text figure committed with empty text', () => {
+    const id = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 200,
+      height: 60,
+      stroke: '#1e1e1e',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: '',
+      fontSize: 18,
+      fontFamily: 'sans',
+      fontWeight: 400,
+      textAlign: 'left',
+    })
+    useDrawingStore.getState().setEditingTextId(id)
+    const { container } = render(<DrawingLayer />)
+    const figure = container.querySelector(`[data-figure-id="${id}"]`) as HTMLElement
+    const editable = figure.querySelector('[contenteditable="true"]') as HTMLElement
+
+    fireEvent.blur(editable)
+
+    expect(useDrawingStore.getState().objects).toHaveLength(0)
+    expect(useDrawingStore.getState().editingTextId).toBeNull()
   })
 
   it('shows a visible editing box while a text figure is being edited', () => {

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
@@ -80,6 +80,27 @@ export function DrawingLayer() {
     }
   }, [])
 
+  // ── Commit text editing when the user clicks outside the edited figure ──
+  // Figures are non-focusable divs (and the canvas preventDefaults its
+  // mousedowns), so the browser never blurs the contentEditable on its own —
+  // clicking another figure, the background, a panel or the minimap would
+  // otherwise leave the text in editing mode. A capture-phase window listener
+  // commits the edit (blur → onBlur → onCommitText) before the canvas' own
+  // mousedown handlers run. Clicks inside the edited figure (caret placement)
+  // and focus on non-figure elements (terminals, inputs) are left alone.
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      const editingId = useDrawingStore.getState().editingTextId
+      if (!editingId) return
+      const target = e.target as HTMLElement | null
+      if (target?.closest?.(`[data-figure-id="${editingId}"]`)) return
+      const el = document.activeElement
+      if (el instanceof HTMLElement && el.closest?.('[data-figure-id]')) el.blur()
+    }
+    window.addEventListener('mousedown', handleMouseDown, true)
+    return () => window.removeEventListener('mousedown', handleMouseDown, true)
+  }, [])
+
   const selectMode = activeTool === 'select'
 
   /** Screen → canvas-space conversion via the layer's own (transformed) rect. */

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useDrawingStore, type NewFigure } from '@/stores/drawing-store'
 import { useCanvasStore } from '@/stores/canvas-store'
 import { useThemeStore } from '@/stores/theme-store'
@@ -55,6 +55,30 @@ export function DrawingLayer() {
   const rootRef = useRef<HTMLDivElement>(null)
   const captureRectRef = useRef<HTMLDivElement>(null)
   const selectionGroupRef = useRef<SVGGElement>(null)
+
+  // Space+drag pans the canvas even while a tool is active (InfiniteCanvas
+  // owns the pan gesture) — track Space so the capture surface lets those
+  // mousedowns bubble through instead of starting a creation gesture.
+  const spaceHeldRef = useRef(false)
+  useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.code === 'Space' && !e.repeat) spaceHeldRef.current = true
+    }
+    const up = (e: KeyboardEvent) => {
+      if (e.code === 'Space') spaceHeldRef.current = false
+    }
+    const blur = () => {
+      spaceHeldRef.current = false
+    }
+    window.addEventListener('keydown', down)
+    window.addEventListener('keyup', up)
+    window.addEventListener('blur', blur)
+    return () => {
+      window.removeEventListener('keydown', down)
+      window.removeEventListener('keyup', up)
+      window.removeEventListener('blur', blur)
+    }
+  }, [])
 
   const selectMode = activeTool === 'select'
 
@@ -437,6 +461,8 @@ export function DrawingLayer() {
 
       // Creation: the full-area capture rect (only hit-testable in tool mode).
       if (target === captureRectRef.current) {
+        // Space+drag is a pan gesture — let it reach the canvas container.
+        if (spaceHeldRef.current) return
         e.preventDefault()
         e.stopPropagation()
         startCreation(e)
@@ -577,7 +603,10 @@ export function DrawingLayer() {
 
       {/* Full-area capture surface — a real HTML element (reliable browser
           hit-testing, unlike SVG content in a 0×0 overflow-visible svg),
-          topmost of the layer, mounted only in tool mode. */}
+          topmost of the layer, mounted only in tool mode. pointer-events must
+          be set explicitly: the layer root is pointer-events:none and the
+          property is inherited — without this the div is invisible to the
+          browser's hit-testing and no creation gesture ever starts. */}
       {!selectMode && (
         <div
           ref={captureRectRef}
@@ -589,6 +618,7 @@ export function DrawingLayer() {
             width: 200_000,
             height: 200_000,
             cursor: 'crosshair',
+            pointerEvents: 'auto',
           }}
         />
       )}

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
@@ -1,0 +1,572 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { useDrawingStore, type NewFigure } from '@/stores/drawing-store'
+import { useCanvasStore } from '@/stores/canvas-store'
+import { getLiveViewport } from '@/stores/canvas-live-viewport'
+import {
+  DEFAULT_FIGURE_SIZE,
+  MIN_FIGURE_SIZE,
+  type DrawingObject,
+  type DrawingTool,
+  type DrawingToolOptions,
+  type FigureDirection,
+} from './types'
+import {
+  arrowPath,
+  figureDirection,
+  lineEndpoints,
+  normalizeBox,
+  unionBox,
+  type Box,
+} from './figure-geometry'
+import { FigureShape } from './FigureShape'
+import { FigureText } from './FigureText'
+import { downscaleImageToDataUrl, readClipboardImage } from './image-paste'
+
+/**
+ * The drawing layer — figures (shapes, text, images) rendered inside the
+ * existing CSS-transformed canvas layer (docs/drawing.md §3).
+ *
+ * Follows the CanvasConnections pattern: a 0×0 absolute root with overflow
+ * visible, an SVG that is pointer-events-none at the root with
+ * pointer-events-auto interactive children. Pan/zoom scale everything for
+ * free — zero redraws, no DPR handling.
+ *
+ * Gestures (create/move/resize) follow the CanvasPanel imperative pattern:
+ * direct DOM writes inside rAF during the gesture, a single store commit on
+ * mouseup.
+ */
+export function DrawingLayer() {
+  const objects = useDrawingStore((s) => s.objects)
+  const selectedIds = useDrawingStore((s) => s.selectedIds)
+  const liveObject = useDrawingStore((s) => s.liveObject)
+  const activeTool = useDrawingStore((s) => s.activeTool)
+  const editingTextId = useDrawingStore((s) => s.editingTextId)
+  const zoom = useCanvasStore((s) => s.viewport.zoom)
+
+  const rootRef = useRef<HTMLDivElement>(null)
+  const captureRectRef = useRef<SVGRectElement>(null)
+  const selectionGroupRef = useRef<SVGGElement>(null)
+
+  const selectMode = activeTool === 'select'
+
+  /** Screen → canvas-space conversion via the layer's own (transformed) rect. */
+  const toCanvasPoint = useCallback((clientX: number, clientY: number) => {
+    const root = rootRef.current
+    if (!root) return { x: 0, y: 0 }
+    const rect = root.getBoundingClientRect()
+    const vp = getLiveViewport()
+    return {
+      x: (clientX - rect.left) / vp.zoom,
+      y: (clientY - rect.top) / vp.zoom,
+    }
+  }, [])
+
+  // ── Create gesture ────────────────────────────────────────
+  const startCreation = useCallback(
+    (e: React.MouseEvent) => {
+      const { activeTool, toolOptions, setLiveObject, addObject, setTool, setEditingTextId } =
+        useDrawingStore.getState()
+      const start = toCanvasPoint(e.clientX, e.clientY)
+
+      // Defensive: the capture rect is only hit-testable in tool mode.
+      if (activeTool === 'select') return
+
+      if (activeTool === 'text') {
+        // Click = default-size text figure, immediately in editing mode.
+        const size = DEFAULT_FIGURE_SIZE.text
+        const id = addObject({
+          type: 'text',
+          x: start.x - size.width / 2,
+          y: start.y - size.height / 2,
+          width: size.width,
+          height: size.height,
+          stroke: toolOptions.stroke,
+          strokeWidth: toolOptions.strokeWidth,
+          fill: null,
+          opacity: 1,
+          text: '',
+          fontSize: toolOptions.fontSize,
+          fontFamily: toolOptions.fontFamily,
+          fontWeight: toolOptions.fontWeight,
+          textAlign: 'left',
+        })
+        setTool('select')
+        setEditingTextId(id)
+        return
+      }
+
+      if (activeTool === 'image') {
+        void pasteImageAt(start.x, start.y)
+        return
+      }
+
+      // Shape drag creation: rAF preview via liveObject, single addObject on
+      // mouseup. Escape (or a tool switch) clears liveObject — that cancels.
+      let cancelled = false
+      let hasPublished = false
+      let rafId: number | null = null
+      let lastEvent: MouseEvent | null = null
+      let finalBox: Box | null = null
+      let finalDir: FigureDirection | null = null
+
+      const unsub = useDrawingStore.subscribe((s) => s.liveObject, (lo) => {
+        if (lo === null && hasPublished) cancelled = true
+      })
+
+      const publish = () => {
+        rafId = null
+        const ev = lastEvent
+        if (!ev || cancelled) return
+        const cur = toCanvasPoint(ev.clientX, ev.clientY)
+        finalBox = normalizeBox(start.x, start.y, cur.x, cur.y)
+        finalDir = figureDirection(start.x, start.y, cur.x, cur.y)
+        hasPublished = true
+        setLiveObject({ ...buildFigure(activeTool, finalBox, finalDir, toolOptions), id: 'live-preview', zIndex: 0 })
+      }
+
+      const handleMove = (ev: MouseEvent) => {
+        lastEvent = ev
+        if (rafId == null) rafId = requestAnimationFrame(publish)
+      }
+
+      const handleUp = () => {
+        window.removeEventListener('mousemove', handleMove)
+        window.removeEventListener('mouseup', handleUp)
+        unsub()
+        if (rafId != null) {
+          cancelAnimationFrame(rafId)
+          rafId = null
+        }
+        if (cancelled) {
+          setLiveObject(null)
+          return
+        }
+        if (lastEvent) publish()
+        setLiveObject(null)
+        const box = finalBox
+        const dir = finalDir
+        if (!box || !dir) return
+        // A click without a real drag is discarded for shapes (text/image use
+        // default sizes instead).
+        if (box.width < MIN_FIGURE_SIZE && box.height < MIN_FIGURE_SIZE) return
+        addObject(buildFigure(activeTool, box, dir, toolOptions))
+      }
+
+      window.addEventListener('mousemove', handleMove)
+      window.addEventListener('mouseup', handleUp)
+    },
+    [toCanvasPoint]
+  )
+
+  // ── Move gesture (select tool) ────────────────────────────
+  const startSelectMove = useCallback((e: React.MouseEvent, hitId: string) => {
+    const store = useDrawingStore.getState()
+    const { selectedIds } = store
+
+    let nextSelected: string[]
+    if (e.shiftKey) {
+      nextSelected = selectedIds.includes(hitId) ? selectedIds : [...selectedIds, hitId]
+      store.select(nextSelected)
+    } else if (!selectedIds.includes(hitId)) {
+      nextSelected = [hitId]
+      store.select(nextSelected)
+    } else {
+      nextSelected = selectedIds
+    }
+
+    const root = rootRef.current
+    if (!root) return
+    const items = nextSelected
+      .map((id) => {
+        const obj = useDrawingStore.getState().objects.find((o) => o.id === id)
+        const node = root.querySelector(`[data-figure-id="${id}"]`)
+        return obj && node ? { id, obj, node } : null
+      })
+      .filter((item): item is { id: string; obj: DrawingObject; node: Element } => item !== null)
+    if (items.length === 0) return
+
+    let rafId: number | null = null
+    let lastEvent: MouseEvent | null = null
+    let dx = 0
+    let dy = 0
+    const overlay = selectionGroupRef.current
+
+    const apply = () => {
+      rafId = null
+      const ev = lastEvent
+      if (!ev) return
+      const vp = getLiveViewport()
+      dx = (ev.clientX - e.clientX) / vp.zoom
+      dy = (ev.clientY - e.clientY) / vp.zoom
+      for (const item of items) {
+        if (item.node instanceof HTMLElement) {
+          item.node.style.transform = `translate(${dx}px, ${dy}px)`
+        } else {
+          item.node.setAttribute('transform', `translate(${dx}, ${dy})`)
+        }
+      }
+      if (overlay) overlay.setAttribute('transform', `translate(${dx}, ${dy})`)
+    }
+
+    const handleMove = (ev: MouseEvent) => {
+      lastEvent = ev
+      if (rafId == null) rafId = requestAnimationFrame(apply)
+    }
+
+    const handleUp = () => {
+      window.removeEventListener('mousemove', handleMove)
+      window.removeEventListener('mouseup', handleUp)
+      if (rafId != null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+      if (lastEvent) apply()
+      // Single store commit for the whole move.
+      if (dx !== 0 || dy !== 0) {
+        const { updateObject } = useDrawingStore.getState()
+        for (const item of items) {
+          updateObject(item.id, { x: item.obj.x + dx, y: item.obj.y + dy })
+        }
+      }
+      for (const item of items) {
+        if (item.node instanceof HTMLElement) item.node.style.transform = ''
+        else item.node.removeAttribute('transform')
+      }
+      if (overlay) overlay.removeAttribute('transform')
+    }
+
+    window.addEventListener('mousemove', handleMove)
+    window.addEventListener('mouseup', handleUp)
+  }, [])
+
+  // ── Resize gesture (single selection, bottom-right handle) ──
+  const startResize = useCallback(() => {
+    const { selectedIds, objects } = useDrawingStore.getState()
+    if (selectedIds.length !== 1) return
+    const id = selectedIds[0]
+    const obj = objects.find((o) => o.id === id)
+    const root = rootRef.current
+    const node = root?.querySelector(`[data-figure-id="${id}"]`)
+    if (!obj || !node) return
+
+    const origin = { x: obj.x, y: obj.y }
+    let rafId: number | null = null
+    let lastEvent: MouseEvent | null = null
+    let finalBox: Box = { x: obj.x, y: obj.y, width: obj.width, height: obj.height }
+    const overlay = selectionGroupRef.current
+    const outline = overlay?.querySelector('[data-figure-outline="true"]') as SVGRectElement | null
+    const handle = overlay?.querySelector('[data-figure-resize="true"]') as SVGRectElement | null
+    const handleSize = handle ? parseFloat(handle.getAttribute('width') ?? '10') : 10
+
+    const apply = () => {
+      rafId = null
+      const ev = lastEvent
+      if (!ev) return
+      const cur = toCanvasPoint(ev.clientX, ev.clientY)
+      const box = normalizeBox(origin.x, origin.y, cur.x, cur.y)
+      box.width = Math.max(MIN_FIGURE_SIZE, box.width)
+      box.height = Math.max(MIN_FIGURE_SIZE, box.height)
+      finalBox = box
+      applyBoxToDom(node, obj, box)
+      if (outline) {
+        outline.setAttribute('x', String(box.x))
+        outline.setAttribute('y', String(box.y))
+        outline.setAttribute('width', String(box.width))
+        outline.setAttribute('height', String(box.height))
+      }
+      if (handle) {
+        handle.setAttribute('x', String(box.x + box.width - handleSize / 2))
+        handle.setAttribute('y', String(box.y + box.height - handleSize / 2))
+      }
+    }
+
+    const handleMove = (ev: MouseEvent) => {
+      lastEvent = ev
+      if (rafId == null) rafId = requestAnimationFrame(apply)
+    }
+
+    const handleUp = () => {
+      window.removeEventListener('mousemove', handleMove)
+      window.removeEventListener('mouseup', handleUp)
+      if (rafId != null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+      if (lastEvent) apply()
+      if (finalBox.width !== obj.width || finalBox.height !== obj.height) {
+        useDrawingStore.getState().updateObject(id, finalBox)
+      }
+    }
+
+    window.addEventListener('mousemove', handleMove)
+    window.addEventListener('mouseup', handleUp)
+  }, [toCanvasPoint])
+
+  // ── Event delegation ──────────────────────────────────────
+  const handleLayerMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 0) return
+      const target = e.target as Element
+
+      // Creation: the full-area capture rect (only hit-testable in tool mode).
+      if (target === captureRectRef.current) {
+        e.preventDefault()
+        e.stopPropagation()
+        startCreation(e)
+        return
+      }
+
+      // Resize handle (select mode, single selection).
+      if (target.closest?.('[data-figure-resize="true"]')) {
+        e.preventDefault()
+        e.stopPropagation()
+        startResize()
+        return
+      }
+
+      // Figure hit (select mode).
+      const figureEl = target.closest?.('[data-figure-id]')
+      if (figureEl) {
+        const id = figureEl.getAttribute('data-figure-id') ?? ''
+        // Don't hijack caret clicks inside a text figure being edited.
+        if (useDrawingStore.getState().editingTextId === id) return
+        e.preventDefault()
+        e.stopPropagation()
+        startSelectMove(e, id)
+        return
+      }
+    },
+    [startCreation, startResize, startSelectMove]
+  )
+
+  const handleLayerDoubleClick = useCallback((e: React.MouseEvent) => {
+    const target = e.target as Element
+    const figureEl = target.closest?.('[data-figure-id]')
+    if (!figureEl) return
+    const id = figureEl.getAttribute('data-figure-id')
+    if (!id) return
+    const { objects, setEditingTextId } = useDrawingStore.getState()
+    const obj = objects.find((o) => o.id === id)
+    if (obj?.type === 'text') {
+      e.stopPropagation()
+      setEditingTextId(id)
+    }
+  }, [])
+
+  const handleCommitText = useCallback((id: string, text: string) => {
+    const { updateObject, setEditingTextId } = useDrawingStore.getState()
+    updateObject(id, { text })
+    setEditingTextId(null)
+  }, [])
+
+  // ── Render ────────────────────────────────────────────────
+  const sortedObjects = useMemo(
+    () => [...objects].sort((a, b) => a.zIndex - b.zIndex),
+    [objects]
+  )
+
+  const selectionBox = useMemo(() => {
+    if (selectedIds.length === 0) return null
+    const selected = objects.filter((o) => selectedIds.includes(o.id))
+    return selected.length > 0 ? unionBox(selected) : null
+  }, [objects, selectedIds])
+
+  const handleSize = 10 / zoom
+  const outlineStroke = 1.5 / zoom
+
+  return (
+    <div
+      ref={rootRef}
+      data-drawing-layer="true"
+      className="absolute inset-0"
+      style={{ overflow: 'visible', pointerEvents: 'none' }}
+      onMouseDown={handleLayerMouseDown}
+      onDoubleClick={handleLayerDoubleClick}
+    >
+      <svg className="absolute inset-0" style={{ overflow: 'visible', pointerEvents: 'none' }}>
+        {/* Shape/image figures, z-sorted */}
+        {sortedObjects.map((obj) =>
+          obj.type === 'text' ? null : <FigureShape key={obj.id} obj={obj} />
+        )}
+
+        {/* Selection overlay: dashed outline + bottom-right resize handle */}
+        {selectMode && selectionBox && (
+          <g ref={selectionGroupRef}>
+            <rect
+              data-figure-outline="true"
+              x={selectionBox.x}
+              y={selectionBox.y}
+              width={selectionBox.width}
+              height={selectionBox.height}
+              fill="none"
+              stroke="rgba(30,150,235,0.9)"
+              strokeWidth={outlineStroke}
+              strokeDasharray={`${6 / zoom} ${4 / zoom}`}
+            />
+            {selectedIds.length === 1 && (
+              <rect
+                data-figure-resize="true"
+                x={selectionBox.x + selectionBox.width - handleSize / 2}
+                y={selectionBox.y + selectionBox.height - handleSize / 2}
+                width={handleSize}
+                height={handleSize}
+                fill="var(--canvas-panel, #1e1e1e)"
+                stroke="rgba(30,150,235,0.9)"
+                strokeWidth={outlineStroke}
+                className="pointer-events-auto cursor-nwse-resize"
+              />
+            )}
+          </g>
+        )}
+
+        {/* Creation preview (liveObject while dragging a new figure) */}
+        {liveObject && <FigureShape obj={liveObject} />}
+
+        {/* Full-area capture rect — topmost of the SVG, active in tool mode */}
+        <rect
+          ref={captureRectRef}
+          data-drawing-capture="true"
+          x={-100_000}
+          y={-100_000}
+          width={200_000}
+          height={200_000}
+          fill="none"
+          pointerEvents={selectMode ? 'none' : 'all'}
+          style={{ cursor: 'crosshair' }}
+        />
+      </svg>
+
+      {/* Text figures — DOM divs above the SVG (contentEditable while editing) */}
+      {sortedObjects.map((obj) =>
+        obj.type === 'text' ? (
+          <FigureText
+            key={obj.id}
+            obj={obj}
+            isEditing={editingTextId === obj.id}
+            interactive={selectMode}
+            onCommitText={handleCommitText}
+          />
+        ) : null
+      )}
+    </div>
+  )
+}
+
+// ── Paste (Ctrl/Cmd+V in InfiniteCanvas, or a click with the image tool) ──
+
+/**
+ * Paste the clipboard image as a figure centered on canvas point (x, y).
+ * Returns the new figure id, or null when the clipboard holds no image.
+ */
+export async function pasteImageAt(x: number, y: number): Promise<string | null> {
+  const file = await readClipboardImage()
+  if (!file) return null
+  const img = await downscaleImageToDataUrl(file)
+  if (!img) return null
+  const { addObject } = useDrawingStore.getState()
+  return addObject({
+    type: 'image',
+    x: x - img.width / 2,
+    y: y - img.height / 2,
+    width: img.width,
+    height: img.height,
+    stroke: '#1e1e1e',
+    strokeWidth: 2,
+    fill: null,
+    opacity: 1,
+    src: img.src,
+  })
+}
+
+// ── Pure helpers ────────────────────────────────────────────
+
+/** Build a figure (minus id/zIndex) from a tool, a box and the tool options. */
+function buildFigure(
+  tool: Exclude<DrawingTool, 'select' | 'text' | 'image'>,
+  box: Box,
+  dir: FigureDirection,
+  options: DrawingToolOptions
+): NewFigure {
+  const base = {
+    x: box.x,
+    y: box.y,
+    width: box.width,
+    height: box.height,
+    stroke: options.stroke,
+    strokeWidth: options.strokeWidth,
+    fill: tool === 'rectangle' || tool === 'ellipse' ? options.fill : null,
+    opacity: 1,
+  }
+  if (tool === 'line' || tool === 'arrow') {
+    return { type: tool, direction: dir, ...base }
+  }
+  return { type: tool, ...base }
+}
+
+/**
+ * Imperatively resize one figure's DOM to `box` during a resize gesture
+ * (no React render — the store is committed once on mouseup).
+ */
+function applyBoxToDom(node: Element, obj: DrawingObject, box: Box) {
+  switch (obj.type) {
+    case 'rectangle': {
+      const rect = node.querySelector('rect')
+      if (rect) {
+        rect.setAttribute('x', String(box.x))
+        rect.setAttribute('y', String(box.y))
+        rect.setAttribute('width', String(box.width))
+        rect.setAttribute('height', String(box.height))
+      }
+      return
+    }
+    case 'ellipse': {
+      const el = node.querySelector('ellipse')
+      if (el) {
+        el.setAttribute('cx', String(box.x + box.width / 2))
+        el.setAttribute('cy', String(box.y + box.height / 2))
+        el.setAttribute('rx', String(box.width / 2))
+        el.setAttribute('ry', String(box.height / 2))
+      }
+      return
+    }
+    case 'line': {
+      const { from, to } = lineEndpoints(box, obj.direction)
+      for (const line of node.querySelectorAll('line')) {
+        line.setAttribute('x1', String(from.x))
+        line.setAttribute('y1', String(from.y))
+        line.setAttribute('x2', String(to.x))
+        line.setAttribute('y2', String(to.y))
+      }
+      return
+    }
+    case 'arrow': {
+      const { from, to } = lineEndpoints(box, obj.direction)
+      const geo = arrowPath(from, to, obj.strokeWidth)
+      node.querySelector('path')?.setAttribute('d', geo.shaftD)
+      node.querySelector('polygon')?.setAttribute('points', geo.headPoints)
+      for (const line of node.querySelectorAll('line')) {
+        line.setAttribute('x1', String(from.x))
+        line.setAttribute('y1', String(from.y))
+        line.setAttribute('x2', String(to.x))
+        line.setAttribute('y2', String(to.y))
+      }
+      return
+    }
+    case 'image': {
+      const img = node.querySelector('image')
+      if (img) {
+        img.setAttribute('x', String(box.x))
+        img.setAttribute('y', String(box.y))
+        img.setAttribute('width', String(box.width))
+        img.setAttribute('height', String(box.height))
+      }
+      return
+    }
+    case 'text': {
+      const div = node as HTMLElement
+      div.style.width = `${box.width}px`
+      div.style.height = `${box.height}px`
+      return
+    }
+  }
+}

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
@@ -25,6 +25,13 @@ import { FigureText } from './FigureText'
 import { downscaleImageToDataUrl, readClipboardImage } from './image-paste'
 
 /**
+ * How far (px, screen space) the pointer must move after a mousedown on a
+ * text figure being edited before the gesture is treated as a drag (which
+ * commits the text and moves the figure) rather than a caret click.
+ */
+const EDIT_DRAG_THRESHOLD = 3
+
+/**
  * The drawing layer — figures (shapes, text, images) rendered inside the
  * existing CSS-transformed canvas layer (docs/drawing.md §3).
  *
@@ -46,7 +53,7 @@ export function DrawingLayer() {
   const zoom = useCanvasStore((s) => s.viewport.zoom)
 
   const rootRef = useRef<HTMLDivElement>(null)
-  const captureRectRef = useRef<SVGRectElement>(null)
+  const captureRectRef = useRef<HTMLDivElement>(null)
   const selectionGroupRef = useRef<SVGGElement>(null)
 
   const selectMode = activeTool === 'select'
@@ -74,26 +81,95 @@ export function DrawingLayer() {
       if (activeTool === 'select') return
 
       if (activeTool === 'text') {
-        // Click = default-size text figure, immediately in editing mode.
+        // Drag = text figure at the drag box (like the shape tools); a plain
+        // click = default-size figure at the click point. Either way the new
+        // figure opens in editing mode on mouseup.
         const size = DEFAULT_FIGURE_SIZE.text
-        const id = addObject({
-          type: 'text',
-          x: start.x - size.width / 2,
-          y: start.y - size.height / 2,
-          width: size.width,
-          height: size.height,
-          stroke: strokeForNewFigure(toolOptions),
-          strokeWidth: toolOptions.strokeWidth,
-          fill: null,
-          opacity: 1,
-          text: '',
-          fontSize: toolOptions.fontSize,
-          fontFamily: toolOptions.fontFamily,
-          fontWeight: toolOptions.fontWeight,
-          textAlign: 'left',
+        let cancelled = false
+        let hasPublished = false
+        let rafId: number | null = null
+        let lastEvent: MouseEvent | null = null
+        let finalBox: Box | null = null
+
+        const unsub = useDrawingStore.subscribe((s) => s.liveObject, (lo) => {
+          if (lo === null && hasPublished) cancelled = true
         })
-        setTool('select')
-        setEditingTextId(id)
+
+        const publish = () => {
+          rafId = null
+          const ev = lastEvent
+          if (!ev || cancelled) return
+          const cur = toCanvasPoint(ev.clientX, ev.clientY)
+          const box = normalizeBox(start.x, start.y, cur.x, cur.y)
+          if (box.width < MIN_FIGURE_SIZE && box.height < MIN_FIGURE_SIZE) return
+          finalBox = box
+          hasPublished = true
+          setLiveObject({
+            type: 'text',
+            ...box,
+            stroke: strokeForNewFigure(toolOptions),
+            strokeWidth: toolOptions.strokeWidth,
+            fill: null,
+            opacity: 1,
+            text: '',
+            fontSize: toolOptions.fontSize,
+            fontFamily: toolOptions.fontFamily,
+            fontWeight: toolOptions.fontWeight,
+            textAlign: 'left',
+            id: 'live-preview',
+            zIndex: 0,
+          })
+        }
+
+        const handleMove = (ev: MouseEvent) => {
+          lastEvent = ev
+          if (rafId == null) rafId = requestAnimationFrame(publish)
+        }
+
+        const handleUp = () => {
+          window.removeEventListener('mousemove', handleMove)
+          window.removeEventListener('mouseup', handleUp)
+          unsub()
+          if (rafId != null) {
+            cancelAnimationFrame(rafId)
+            rafId = null
+          }
+          if (cancelled) {
+            setLiveObject(null)
+            return
+          }
+          if (lastEvent) publish()
+          setLiveObject(null)
+          const box =
+            finalBox ??
+            ({
+              x: start.x - size.width / 2,
+              y: start.y - size.height / 2,
+              width: size.width,
+              height: size.height,
+            } as Box)
+          const id = addObject({
+            type: 'text',
+            x: box.x,
+            y: box.y,
+            width: box.width,
+            height: box.height,
+            stroke: strokeForNewFigure(toolOptions),
+            strokeWidth: toolOptions.strokeWidth,
+            fill: null,
+            opacity: 1,
+            text: '',
+            fontSize: toolOptions.fontSize,
+            fontFamily: toolOptions.fontFamily,
+            fontWeight: toolOptions.fontWeight,
+            textAlign: 'left',
+          })
+          setTool('select')
+          setEditingTextId(id)
+        }
+
+        window.addEventListener('mousemove', handleMove)
+        window.addEventListener('mouseup', handleUp)
         return
       }
 
@@ -252,6 +328,44 @@ export function DrawingLayer() {
     window.addEventListener('mouseup', handleUp)
   }, [])
 
+  // ── Drag start on a figure being edited ───────────────────
+  // A text figure in editing mode must still be movable: plain clicks place
+  // the caret (no preventDefault), but a drag past a small threshold commits
+  // the text (blur) and turns into a regular move gesture.
+  const startEditDrag = useCallback(
+    (e: React.MouseEvent, hitId: string) => {
+      const startX = e.clientX
+      const startY = e.clientY
+      let started = false
+
+      const handleMove = (ev: MouseEvent) => {
+        if (started) return
+        if (
+          Math.abs(ev.clientX - startX) < EDIT_DRAG_THRESHOLD &&
+          Math.abs(ev.clientY - startY) < EDIT_DRAG_THRESHOLD
+        )
+          return
+        started = true
+        window.removeEventListener('mousemove', handleMove)
+        window.removeEventListener('mouseup', handleUp)
+        // Commit the in-progress text so the figure behaves like a normal
+        // figure during the drag (blur triggers the commit + ends editing).
+        const el = document.activeElement
+        if (el instanceof HTMLElement) el.blur()
+        startSelectMove(e, hitId)
+      }
+
+      const handleUp = () => {
+        window.removeEventListener('mousemove', handleMove)
+        window.removeEventListener('mouseup', handleUp)
+      }
+
+      window.addEventListener('mousemove', handleMove)
+      window.addEventListener('mouseup', handleUp)
+    },
+    [startSelectMove]
+  )
+
   // ── Resize gesture (single selection, bottom-right handle) ──
   const startResize = useCallback(() => {
     const { selectedIds, objects } = useDrawingStore.getState()
@@ -341,15 +455,19 @@ export function DrawingLayer() {
       const figureEl = target.closest?.('[data-figure-id]')
       if (figureEl) {
         const id = figureEl.getAttribute('data-figure-id') ?? ''
-        // Don't hijack caret clicks inside a text figure being edited.
-        if (useDrawingStore.getState().editingTextId === id) return
+        // A text figure being edited: plain clicks place the caret, drags
+        // commit the text and move the figure.
+        if (useDrawingStore.getState().editingTextId === id) {
+          startEditDrag(e, id)
+          return
+        }
         e.preventDefault()
         e.stopPropagation()
         startSelectMove(e, id)
         return
       }
     },
-    [startCreation, startResize, startSelectMove]
+    [startCreation, startResize, startSelectMove, startEditDrag]
   )
 
   const handleLayerDoubleClick = useCallback((e: React.MouseEvent) => {
@@ -367,8 +485,14 @@ export function DrawingLayer() {
   }, [])
 
   const handleCommitText = useCallback((id: string, text: string) => {
-    const { updateObject, setEditingTextId } = useDrawingStore.getState()
-    updateObject(id, { text })
+    const { updateObject, removeObjects, setEditingTextId } = useDrawingStore.getState()
+    if (text.trim() === '') {
+      // An empty text figure is invisible and useless — remove it instead of
+      // leaving a ghost box on the canvas.
+      removeObjects([id])
+    } else {
+      updateObject(id, { text })
+    }
     setEditingTextId(null)
   }, [])
 
@@ -432,22 +556,42 @@ export function DrawingLayer() {
           </g>
         )}
 
-        {/* Creation preview (liveObject while dragging a new figure) */}
-        {liveObject && <FigureShape obj={liveObject} />}
+        {/* Creation preview (liveObject while dragging a new figure). Text
+            previews render as a dashed rect — FigureShape has no text body. */}
+        {liveObject &&
+          (liveObject.type === 'text' ? (
+            <rect
+              x={liveObject.x}
+              y={liveObject.y}
+              width={liveObject.width}
+              height={liveObject.height}
+              fill="none"
+              stroke="rgba(30,150,235,0.9)"
+              strokeWidth={outlineStroke}
+              strokeDasharray={`${6 / zoom} ${4 / zoom}`}
+            />
+          ) : (
+            <FigureShape obj={liveObject} />
+          ))}
+      </svg>
 
-        {/* Full-area capture rect — topmost of the SVG, active in tool mode */}
-        <rect
+      {/* Full-area capture surface — a real HTML element (reliable browser
+          hit-testing, unlike SVG content in a 0×0 overflow-visible svg),
+          topmost of the layer, mounted only in tool mode. */}
+      {!selectMode && (
+        <div
           ref={captureRectRef}
           data-drawing-capture="true"
-          x={-100_000}
-          y={-100_000}
-          width={200_000}
-          height={200_000}
-          fill="none"
-          pointerEvents={selectMode ? 'none' : 'all'}
-          style={{ cursor: 'crosshair' }}
+          className="absolute"
+          style={{
+            left: -100_000,
+            top: -100_000,
+            width: 200_000,
+            height: 200_000,
+            cursor: 'crosshair',
+          }}
         />
-      </svg>
+      )}
 
       {/* Text figures — DOM divs above the SVG (contentEditable while editing) */}
       {sortedObjects.map((obj) =>

--- a/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingLayer.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useMemo, useRef } from 'react'
 import { useDrawingStore, type NewFigure } from '@/stores/drawing-store'
 import { useCanvasStore } from '@/stores/canvas-store'
+import { useThemeStore } from '@/stores/theme-store'
 import { getLiveViewport } from '@/stores/canvas-live-viewport'
 import {
   DEFAULT_FIGURE_SIZE,
+  DEFAULT_STROKE,
   MIN_FIGURE_SIZE,
   type DrawingObject,
   type DrawingTool,
@@ -80,7 +82,7 @@ export function DrawingLayer() {
           y: start.y - size.height / 2,
           width: size.width,
           height: size.height,
-          stroke: toolOptions.stroke,
+          stroke: strokeForNewFigure(toolOptions),
           strokeWidth: toolOptions.strokeWidth,
           fill: null,
           opacity: 1,
@@ -163,6 +165,13 @@ export function DrawingLayer() {
     const store = useDrawingStore.getState()
     const { selectedIds } = store
 
+    // Clicking a text figure that is *already* selected (no drag) re-enters
+    // editing — discoverable without knowing the double-click gesture.
+    const reClickEditsText =
+      !e.shiftKey &&
+      selectedIds.includes(hitId) &&
+      store.objects.find((o) => o.id === hitId)?.type === 'text'
+
     let nextSelected: string[]
     if (e.shiftKey) {
       nextSelected = selectedIds.includes(hitId) ? selectedIds : [...selectedIds, hitId]
@@ -227,6 +236,10 @@ export function DrawingLayer() {
         for (const item of items) {
           updateObject(item.id, { x: item.obj.x + dx, y: item.obj.y + dy })
         }
+      }
+      // A plain re-click (no drag) on a selected text figure opens it for editing.
+      if (dx === 0 && dy === 0 && reClickEditsText) {
+        useDrawingStore.getState().setEditingTextId(hitId)
       }
       for (const item of items) {
         if (item.node instanceof HTMLElement) item.node.style.transform = ''
@@ -470,7 +483,7 @@ export async function pasteImageAt(x: number, y: number): Promise<string | null>
     y: y - img.height / 2,
     width: img.width,
     height: img.height,
-    stroke: '#1e1e1e',
+    stroke: DEFAULT_STROKE[useThemeStore.getState().resolved],
     strokeWidth: 2,
     fill: null,
     opacity: 1,
@@ -479,6 +492,17 @@ export async function pasteImageAt(x: number, y: number): Promise<string | null>
 }
 
 // ── Pure helpers ────────────────────────────────────────────
+
+/**
+ * Stroke for new figures: while the user hasn't explicitly picked a color,
+ * follow the current theme (the factory defaults are theme-specific — dark
+ * text is invisible on the dark canvas).
+ */
+function strokeForNewFigure(options: DrawingToolOptions): string {
+  const { stroke } = options
+  if (stroke !== DEFAULT_STROKE.light && stroke !== DEFAULT_STROKE.dark) return stroke
+  return DEFAULT_STROKE[useThemeStore.getState().resolved]
+}
 
 /** Build a figure (minus id/zIndex) from a tool, a box and the tool options. */
 function buildFigure(
@@ -492,7 +516,7 @@ function buildFigure(
     y: box.y,
     width: box.width,
     height: box.height,
-    stroke: options.stroke,
+    stroke: strokeForNewFigure(options),
     strokeWidth: options.strokeWidth,
     fill: tool === 'rectangle' || tool === 'ellipse' ? options.fill : null,
     opacity: 1,

--- a/src/renderer/src/components/canvas/drawing/DrawingProperties.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingProperties.tsx
@@ -1,0 +1,148 @@
+import { BringToFront, Copy, Trash2, Bold, type LucideIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useDrawingStore } from '@/stores/drawing-store'
+import { styleUpdatesFor } from './DrawingToolbar'
+import {
+  FONT_SIZES,
+  FONT_FAMILIES,
+  type DrawingToolOptions,
+} from './types'
+
+/**
+ * Floating properties panel for the current figure selection.
+ *
+ * Shown only when a figure is selected (canvas screen only). Offers the
+ * figure actions (bring-to-front, duplicate, delete) plus, for text figures,
+ * font size / family / weight controls that live-update the selection.
+ */
+export function DrawingProperties() {
+  const selectedIds = useDrawingStore((s) => s.selectedIds)
+  const objects = useDrawingStore((s) => s.objects)
+  const removeObjects = useDrawingStore((s) => s.removeObjects)
+  const duplicateObject = useDrawingStore((s) => s.duplicateObject)
+  const bringToFront = useDrawingStore((s) => s.bringToFront)
+  const updateObject = useDrawingStore((s) => s.updateObject)
+
+  if (selectedIds.length === 0) return null
+
+  const selected = objects.filter((o) => selectedIds.includes(o.id))
+  const firstText = selected.find((o) => o.type === 'text')
+
+  /** Apply a style option to every selected text figure. */
+  const applyToText = <K extends keyof DrawingToolOptions>(key: K, value: DrawingToolOptions[K]) => {
+    for (const id of selectedIds) {
+      const obj = objects.find((o) => o.id === id)
+      if (obj?.type !== 'text') continue
+      const updates = styleUpdatesFor(key, value, obj)
+      if (updates) updateObject(id, updates)
+    }
+  }
+
+  return (
+    <div
+      className="absolute top-3 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 bg-[var(--canvas-toolbar)] backdrop-blur-sm border border-border/40 rounded-xl p-1 shadow-lg"
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      <span className="px-2 text-[11px] text-muted-foreground tabular-nums">
+        {selectedIds.length} selected
+      </span>
+
+      <div className="w-px h-5 bg-border/30 mx-0.5" />
+
+      <PropertyButton
+        icon={BringToFront}
+        title="Bring to front"
+        onClick={() => selectedIds.forEach((id) => bringToFront(id))}
+      />
+      <PropertyButton
+        icon={Copy}
+        title="Duplicate"
+        onClick={() => {
+          // Duplicate the topmost-selected figure (last in the list).
+          const id = selectedIds[selectedIds.length - 1]
+          if (id) duplicateObject(id)
+        }}
+      />
+      <PropertyButton
+        icon={Trash2}
+        title="Delete (Del)"
+        danger
+        onClick={() => removeObjects(selectedIds)}
+      />
+
+      {firstText && (
+        <>
+          <div className="w-px h-5 bg-border/30 mx-0.5" />
+
+          <select
+            value={firstText.fontSize}
+            onChange={(e) => applyToText('fontSize', Number(e.target.value))}
+            title="Font size"
+            className="h-8 rounded-lg bg-transparent px-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground focus:outline-none cursor-pointer"
+          >
+            {FONT_SIZES.map((size) => (
+              <option key={size} value={size} className="text-foreground">
+                {size}px
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={firstText.fontFamily}
+            onChange={(e) => applyToText('fontFamily', e.target.value)}
+            title="Font family"
+            className="h-8 rounded-lg bg-transparent px-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground focus:outline-none cursor-pointer"
+          >
+            {FONT_FAMILIES.map((family) => (
+              <option key={family.id} value={family.id} className="text-foreground">
+                {family.label}
+              </option>
+            ))}
+          </select>
+
+          <button
+            type="button"
+            title="Bold"
+            onClick={() => applyToText('fontWeight', firstText.fontWeight >= 600 ? 400 : 700)}
+            className={cn(
+              'flex h-8 w-8 items-center justify-center rounded-lg transition-colors',
+              firstText.fontWeight >= 600
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+            )}
+          >
+            <Bold className="h-4 w-4" />
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
+
+function PropertyButton({
+  icon: Icon,
+  title,
+  onClick,
+  danger = false,
+}: {
+  icon: LucideIcon
+  title: string
+  onClick: () => void
+  danger?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className={cn(
+        'flex h-8 w-8 items-center justify-center rounded-lg transition-colors',
+        danger
+          ? 'text-red-400 hover:bg-red-500/15 hover:text-red-300'
+          : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+      )}
+    >
+      <Icon className="h-4 w-4" />
+    </button>
+  )
+}

--- a/src/renderer/src/components/canvas/drawing/DrawingToolbar.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingToolbar.tsx
@@ -1,0 +1,327 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  MousePointer2,
+  Square,
+  Circle,
+  Minus,
+  MoveUpRight,
+  Type,
+  Image,
+  PaintBucket,
+  type LucideIcon,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useDrawingStore, type FigureUpdates } from '@/stores/drawing-store'
+import {
+  STROKE_WIDTHS,
+  FONT_SIZES,
+  FONT_FAMILIES,
+  STROKE_COLORS,
+  FILL_OPTIONS,
+  type DrawingTool,
+  type DrawingObject,
+  type DrawingToolOptions,
+} from './types'
+
+/**
+ * Which figure fields a given style option drives. Returns the update to apply
+ * to a figure, or null when the option doesn't apply to that figure type.
+ * Shared by the toolbar (style controls) and the properties panel.
+ */
+export function styleUpdatesFor<K extends keyof DrawingToolOptions>(
+  key: K,
+  value: DrawingToolOptions[K],
+  obj: DrawingObject
+): FigureUpdates | null {
+  // `value` is typed as `DrawingToolOptions[K]`; the switch narrows `key` but
+  // not the indexed type of `value`, so each branch casts to the concrete type
+  // (safe — the generic signature already guarantees `value` matches `key`).
+  switch (key) {
+    case 'stroke':
+      // Text uses `stroke` as its text color, so it applies to every figure.
+      return { stroke: value as string }
+    case 'strokeWidth':
+      if (obj.type === 'text' || obj.type === 'image') return null
+      return { strokeWidth: value as number }
+    case 'fill':
+      if (obj.type !== 'rectangle' && obj.type !== 'ellipse') return null
+      return { fill: value as string | null }
+    case 'fontSize':
+      if (obj.type !== 'text') return null
+      return { fontSize: value as number }
+    case 'fontFamily':
+      if (obj.type !== 'text') return null
+      return { fontFamily: value as string }
+    case 'fontWeight':
+      if (obj.type !== 'text') return null
+      return { fontWeight: value as number }
+  }
+}
+
+interface ToolDef {
+  tool: DrawingTool
+  label: string
+  shortcut: string
+  icon: LucideIcon
+}
+
+const TOOLS: ToolDef[] = [
+  { tool: 'select', label: 'Select', shortcut: 'V', icon: MousePointer2 },
+  { tool: 'rectangle', label: 'Rectangle', shortcut: 'R', icon: Square },
+  { tool: 'ellipse', label: 'Ellipse', shortcut: 'O', icon: Circle },
+  { tool: 'line', label: 'Line', shortcut: 'L', icon: Minus },
+  { tool: 'arrow', label: 'Arrow', shortcut: 'A', icon: MoveUpRight },
+  { tool: 'text', label: 'Text', shortcut: 'T', icon: Type },
+  { tool: 'image', label: 'Image', shortcut: 'I', icon: Image },
+]
+
+/**
+ * Floating drawing toolbar (bottom-center, canvas screen only).
+ *
+ * Tool buttons switch `activeTool`; the style controls write to `toolOptions`
+ * (affecting the next figure) and, when a figure is selected, live-update the
+ * selection via `updateObject`. Styled like the existing canvas HUD.
+ */
+export function DrawingToolbar() {
+  const activeTool = useDrawingStore((s) => s.activeTool)
+  const setTool = useDrawingStore((s) => s.setTool)
+  const toolOptions = useDrawingStore((s) => s.toolOptions)
+  const setToolOption = useDrawingStore((s) => s.setToolOption)
+
+  const [showColor, setShowColor] = useState(false)
+  const [showFill, setShowFill] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  // Close the swatch popovers on outside click.
+  useEffect(() => {
+    if (!showColor && !showFill) return
+    const handleClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setShowColor(false)
+        setShowFill(false)
+      }
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setShowColor(false)
+        setShowFill(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [showColor, showFill])
+
+  /** Update toolOptions and live-apply to the current selection. */
+  const applyStyle = <K extends keyof DrawingToolOptions>(key: K, value: DrawingToolOptions[K]) => {
+    setToolOption(key, value)
+    const { selectedIds, objects, updateObject } = useDrawingStore.getState()
+    for (const id of selectedIds) {
+      const obj = objects.find((o) => o.id === id)
+      if (!obj) continue
+      const updates = styleUpdatesFor(key, value, obj)
+      if (updates) updateObject(id, updates)
+    }
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 bg-[var(--canvas-toolbar)] backdrop-blur-sm border border-border/40 rounded-xl p-1 shadow-lg"
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      {/* ── Tools ── */}
+      {TOOLS.map(({ tool, label, shortcut, icon: Icon }) => {
+        const active = activeTool === tool
+        return (
+          <button
+            key={tool}
+            type="button"
+            title={`${label} (${shortcut})`}
+            onClick={() => setTool(tool)}
+            className={cn(
+              'flex h-8 w-8 items-center justify-center rounded-lg transition-colors',
+              active
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+            )}
+          >
+            <Icon className="h-4 w-4" />
+          </button>
+        )
+      })}
+
+      <div className="w-px h-5 bg-border/30 mx-1" />
+
+      {/* ── Stroke color ── */}
+      <div className="relative">
+        <button
+          type="button"
+          title="Stroke color"
+          onClick={() => {
+            setShowColor((v) => !v)
+            setShowFill(false)
+          }}
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+        >
+          <span
+            className="h-4 w-4 rounded-full border border-border/50"
+            style={{ background: toolOptions.stroke }}
+          />
+        </button>
+        {showColor && (
+          <SwatchPopover>
+            {STROKE_COLORS.map((color) => (
+              <SwatchButton
+                key={color}
+                color={color}
+                active={toolOptions.stroke === color}
+                onClick={() => {
+                  applyStyle('stroke', color)
+                  setShowColor(false)
+                }}
+              />
+            ))}
+          </SwatchPopover>
+        )}
+      </div>
+
+      {/* ── Stroke width ── */}
+      <div className="flex items-center gap-0.5 rounded-lg px-0.5">
+        {STROKE_WIDTHS.map((w) => {
+          const active = toolOptions.strokeWidth === w
+          return (
+            <button
+              key={w}
+              type="button"
+              title={`Stroke width ${w}`}
+              onClick={() => applyStyle('strokeWidth', w)}
+              className={cn(
+                'flex h-8 w-6 items-center justify-center rounded-md transition-colors',
+                active
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+              )}
+            >
+              <span
+                className="w-4 rounded-full"
+                style={{ height: `${Math.min(6, w)}px`, background: 'currentColor' }}
+              />
+            </button>
+          )
+        })}
+      </div>
+
+      {/* ── Fill ── */}
+      <div className="relative">
+        <button
+          type="button"
+          title="Fill"
+          onClick={() => {
+            setShowFill((v) => !v)
+            setShowColor(false)
+          }}
+          className={cn(
+            'flex h-8 w-8 items-center justify-center rounded-lg transition-colors',
+            toolOptions.fill
+              ? 'text-accent-foreground bg-accent'
+              : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+          )}
+        >
+          <PaintBucket className="h-4 w-4" />
+        </button>
+        {showFill && (
+          <SwatchPopover>
+            {FILL_OPTIONS.map((fill) => (
+              <SwatchButton
+                key={fill ?? 'none'}
+                color={fill}
+                active={toolOptions.fill === fill}
+                onClick={() => {
+                  applyStyle('fill', fill)
+                  setShowFill(false)
+                }}
+              />
+            ))}
+          </SwatchPopover>
+        )}
+      </div>
+
+      <div className="w-px h-5 bg-border/30 mx-1" />
+
+      {/* ── Font size ── */}
+      <select
+        value={toolOptions.fontSize}
+        onChange={(e) => applyStyle('fontSize', Number(e.target.value))}
+        title="Font size"
+        className="h-8 rounded-lg bg-transparent px-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground focus:outline-none cursor-pointer"
+      >
+        {FONT_SIZES.map((size) => (
+          <option key={size} value={size} className="text-foreground">
+            {size}px
+          </option>
+        ))}
+      </select>
+
+      {/* ── Font family ── */}
+      <select
+        value={toolOptions.fontFamily}
+        onChange={(e) => applyStyle('fontFamily', e.target.value)}
+        title="Font family"
+        className="h-8 rounded-lg bg-transparent px-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground focus:outline-none cursor-pointer"
+      >
+        {FONT_FAMILIES.map((family) => (
+          <option key={family.id} value={family.id} className="text-foreground">
+            {family.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+// ── Swatch popover + button ────────────────────────────────
+
+function SwatchPopover({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 flex flex-wrap items-center gap-1.5 w-44 p-2 bg-popover border border-border/50 rounded-xl shadow-2xl"
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {children}
+    </div>
+  )
+}
+
+function SwatchButton({
+  color,
+  active,
+  onClick,
+}: {
+  color: string | null
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={color ?? 'No fill'}
+      className={cn(
+        'h-6 w-6 rounded-full border transition-transform hover:scale-110',
+        active ? 'border-primary ring-2 ring-primary/40' : 'border-border/50'
+      )}
+      style={{
+        background: color ?? 'transparent',
+        backgroundImage:
+          color === null
+            ? 'linear-gradient(45deg, transparent 45%, #ef4444 45%, #ef4444 55%, transparent 55%)'
+            : undefined,
+      }}
+    />
+  )
+}

--- a/src/renderer/src/components/canvas/drawing/DrawingToolbar.tsx
+++ b/src/renderer/src/components/canvas/drawing/DrawingToolbar.tsx
@@ -130,6 +130,7 @@ export function DrawingToolbar() {
   return (
     <div
       ref={rootRef}
+      data-drawing-toolbar="true"
       className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1 bg-[var(--canvas-toolbar)] backdrop-blur-sm border border-border/40 rounded-xl p-1 shadow-lg"
       onPointerDown={(e) => e.stopPropagation()}
     >

--- a/src/renderer/src/components/canvas/drawing/FigureShape.tsx
+++ b/src/renderer/src/components/canvas/drawing/FigureShape.tsx
@@ -1,0 +1,128 @@
+import { memo } from 'react'
+import type { DrawingObject } from './types'
+import { arrowPath, lineEndpoints } from './figure-geometry'
+
+/**
+ * Memoized per-figure SVG rendering for shape and image figures (rect,
+ * ellipse, line, arrow, image). Text figures render as DOM divs in
+ * FigureText instead (contentEditable while editing).
+ *
+ * The `<g>` carries `data-figure-id` — DrawingLayer uses it for event
+ * delegation, imperative move/resize writes, and hit-testing bookkeeping.
+ * Thin lines/arrows get an invisible fat-stroke hit path so they stay easy
+ * to grab (same trick as the connection edges in CanvasConnections).
+ */
+export const FigureShape = memo(function FigureShape({ obj }: { obj: DrawingObject }) {
+  return (
+    <g data-figure-id={obj.id} opacity={obj.opacity} className="pointer-events-auto cursor-move">
+      {renderBody(obj)}
+    </g>
+  )
+})
+
+function renderBody(obj: DrawingObject) {
+  switch (obj.type) {
+    case 'rectangle':
+      return (
+        <rect
+          x={obj.x}
+          y={obj.y}
+          width={obj.width}
+          height={obj.height}
+          fill={obj.fill ?? 'none'}
+          stroke={obj.stroke}
+          strokeWidth={obj.strokeWidth}
+        />
+      )
+
+    case 'ellipse':
+      return (
+        <ellipse
+          cx={obj.x + obj.width / 2}
+          cy={obj.y + obj.height / 2}
+          rx={obj.width / 2}
+          ry={obj.height / 2}
+          fill={obj.fill ?? 'none'}
+          stroke={obj.stroke}
+          strokeWidth={obj.strokeWidth}
+        />
+      )
+
+    case 'line': {
+      const { from, to } = lineEndpoints(
+        { x: obj.x, y: obj.y, width: obj.width, height: obj.height },
+        obj.direction
+      )
+      return (
+        <>
+          <line
+            x1={from.x}
+            y1={from.y}
+            x2={to.x}
+            y2={to.y}
+            stroke={obj.stroke}
+            strokeWidth={obj.strokeWidth}
+            strokeLinecap="round"
+          />
+          {/* Invisible fat hit line — thin strokes are hard to grab. */}
+          <line
+            x1={from.x}
+            y1={from.y}
+            x2={to.x}
+            y2={to.y}
+            stroke="transparent"
+            strokeWidth={Math.max(12, obj.strokeWidth + 10)}
+            strokeLinecap="round"
+            pointerEvents="stroke"
+          />
+        </>
+      )
+    }
+
+    case 'arrow': {
+      const { from, to } = lineEndpoints(
+        { x: obj.x, y: obj.y, width: obj.width, height: obj.height },
+        obj.direction
+      )
+      const geo = arrowPath(from, to, obj.strokeWidth)
+      return (
+        <>
+          <path
+            d={geo.shaftD}
+            fill="none"
+            stroke={obj.stroke}
+            strokeWidth={obj.strokeWidth}
+            strokeLinecap="round"
+          />
+          <polygon points={geo.headPoints} fill={obj.stroke} />
+          {/* Invisible fat hit line along the whole arrow span. */}
+          <line
+            x1={from.x}
+            y1={from.y}
+            x2={to.x}
+            y2={to.y}
+            stroke="transparent"
+            strokeWidth={Math.max(12, obj.strokeWidth + 10)}
+            strokeLinecap="round"
+            pointerEvents="stroke"
+          />
+        </>
+      )
+    }
+
+    case 'image':
+      return (
+        <image
+          href={obj.src}
+          x={obj.x}
+          y={obj.y}
+          width={obj.width}
+          height={obj.height}
+          preserveAspectRatio="xMidYMid meet"
+        />
+      )
+
+    default:
+      return null
+  }
+}

--- a/src/renderer/src/components/canvas/drawing/FigureText.tsx
+++ b/src/renderer/src/components/canvas/drawing/FigureText.tsx
@@ -1,0 +1,116 @@
+import { memo, useEffect, useRef } from 'react'
+import type { TextFigure } from './types'
+import { fontCssFor } from './types'
+
+interface FigureTextProps {
+  obj: TextFigure
+  /** True while this figure is in contentEditable mode. */
+  isEditing: boolean
+  /** True when the select tool is active (figure is clickable). */
+  interactive: boolean
+  onCommitText: (id: string, text: string) => void
+}
+
+/**
+ * Memoized text figure — an absolutely-positioned div in canvas space (it
+ * lives inside the CSS-transformed canvas layer, so it scales with zoom for
+ * free). While `isEditing`, the inner div becomes contentEditable: the DOM
+ * owns the text until blur/Escape commits it via `onCommitText` (single store
+ * write, same imperative pattern as the canvas gestures).
+ *
+ * The outer div carries `data-figure-id` for DrawingLayer's event delegation.
+ */
+export const FigureText = memo(function FigureText({
+  obj,
+  isEditing,
+  interactive,
+  onCommitText,
+}: FigureTextProps) {
+  const editableRef = useRef<HTMLDivElement>(null)
+
+  // Enter editing: hand the DOM the current text, focus it, select all.
+  useEffect(() => {
+    if (!isEditing) return
+    const el = editableRef.current
+    if (!el) return
+    el.textContent = obj.text
+    el.focus()
+    const range = document.createRange()
+    range.selectNodeContents(el)
+    const sel = window.getSelection()
+    sel?.removeAllRanges()
+    sel?.addRange(range)
+
+    return () => {
+      // Editing ended externally (tool switch, figure removed) while this div
+      // still holds focus — commit what the user typed instead of losing it.
+      if (document.activeElement === el) {
+        onCommitText(obj.id, readEditableText(el))
+      }
+    }
+  }, [isEditing])
+
+  const commit = () => {
+    const el = editableRef.current
+    if (!el) return
+    onCommitText(obj.id, readEditableText(el))
+  }
+
+  return (
+    <div
+      data-figure-id={obj.id}
+      className="absolute"
+      style={{
+        left: obj.x,
+        top: obj.y,
+        width: obj.width,
+        height: obj.height,
+        opacity: obj.opacity,
+        pointerEvents: interactive ? 'auto' : 'none',
+        cursor: 'move',
+      }}
+    >
+      <div
+        ref={editableRef}
+        contentEditable={isEditing}
+        suppressContentEditableWarning
+        spellCheck={false}
+        onBlur={isEditing ? commit : undefined}
+        onKeyDown={
+          isEditing
+            ? (e) => {
+                // Keep canvas shortcuts (Delete, tool keys…) away from typing.
+                e.stopPropagation()
+                if (e.key === 'Escape') {
+                  e.preventDefault()
+                  e.currentTarget.blur()
+                }
+              }
+            : undefined
+        }
+        style={{
+          width: '100%',
+          height: '100%',
+          outline: 'none',
+          fontSize: obj.fontSize,
+          fontFamily: fontCssFor(obj.fontFamily),
+          fontWeight: obj.fontWeight,
+          color: obj.stroke,
+          textAlign: obj.textAlign,
+          lineHeight: 1.3,
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          overflow: 'hidden',
+        }}
+      >
+        {isEditing ? undefined : obj.text}
+      </div>
+    </div>
+  )
+})
+
+/** Read the current text of a contentEditable div (innerText where available). */
+function readEditableText(el: HTMLElement): string {
+  const raw = el.innerText ?? el.textContent ?? ''
+  return raw.replace(/\u00a0/g, ' ')
+}

--- a/src/renderer/src/components/canvas/drawing/FigureText.tsx
+++ b/src/renderer/src/components/canvas/drawing/FigureText.tsx
@@ -67,7 +67,12 @@ export const FigureText = memo(function FigureText({
         height: obj.height,
         opacity: obj.opacity,
         pointerEvents: interactive ? 'auto' : 'none',
-        cursor: 'move',
+        cursor: isEditing ? 'text' : 'move',
+        // While editing, show a visible box so an (empty) text figure is
+        // obvious even when the text color is close to the canvas background.
+        border: isEditing ? '1.5px dashed rgba(30,150,235,0.9)' : '1.5px solid transparent',
+        background: isEditing ? 'rgba(30,150,235,0.06)' : 'transparent',
+        borderRadius: 4,
       }}
     >
       <div

--- a/src/renderer/src/components/canvas/drawing/FigureText.tsx
+++ b/src/renderer/src/components/canvas/drawing/FigureText.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useRef } from 'react'
+import { useDrawingStore } from '@/stores/drawing-store'
 import type { TextFigure } from './types'
 import { fontCssFor } from './types'
 
@@ -42,11 +43,17 @@ export const FigureText = memo(function FigureText({
     sel?.addRange(range)
 
     return () => {
-      // Editing ended externally (tool switch, figure removed) while this div
-      // still holds focus — commit what the user typed instead of losing it.
-      if (document.activeElement === el) {
-        onCommitText(obj.id, readEditableText(el))
-      }
+      // Editing ended externally (e.g. the figure was removed — the store
+      // clears editingTextId) while this div still holds focus: commit what
+      // the user typed instead of losing it.
+      //
+      // Crucially, do NOT commit while editing is still active: React
+      // StrictMode (dev) simulates a remount by running this cleanup and
+      // re-running the effect. Committing there would destroy a freshly
+      // created (empty) text figure before the user can type anything.
+      if (document.activeElement !== el) return
+      if (useDrawingStore.getState().editingTextId === obj.id) return
+      onCommitText(obj.id, readEditableText(el))
     }
   }, [isEditing])
 

--- a/src/renderer/src/components/canvas/drawing/figure-geometry.test.ts
+++ b/src/renderer/src/components/canvas/drawing/figure-geometry.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeBox,
+  figureDirection,
+  lineEndpoints,
+  arrowPath,
+  distanceToSegment,
+  pointInBox,
+  hitTest,
+  hitTestObjects,
+  unionBox,
+} from './figure-geometry'
+import type { DrawingObject } from './types'
+
+describe('normalizeBox', () => {
+  it('normalizes a forward drag', () => {
+    expect(normalizeBox(10, 20, 50, 80)).toEqual({ x: 10, y: 20, width: 40, height: 60 })
+  })
+
+  it('normalizes a backward drag', () => {
+    expect(normalizeBox(50, 80, 10, 20)).toEqual({ x: 10, y: 20, width: 40, height: 60 })
+  })
+
+  it('handles a zero-size drag', () => {
+    expect(normalizeBox(5, 5, 5, 5)).toEqual({ x: 5, y: 5, width: 0, height: 0 })
+  })
+})
+
+describe('figureDirection', () => {
+  it('se — end is bottom-right of start', () => {
+    expect(figureDirection(0, 0, 10, 10)).toBe('se')
+  })
+  it('sw — end is bottom-left of start', () => {
+    expect(figureDirection(10, 0, 0, 10)).toBe('sw')
+  })
+  it('ne — end is top-right of start', () => {
+    expect(figureDirection(0, 10, 10, 0)).toBe('ne')
+  })
+  it('nw — end is top-left of start', () => {
+    expect(figureDirection(10, 10, 0, 0)).toBe('nw')
+  })
+  it('zero delta counts as se', () => {
+    expect(figureDirection(5, 5, 5, 5)).toBe('se')
+  })
+})
+
+describe('lineEndpoints', () => {
+  const box = { x: 0, y: 0, width: 100, height: 50 }
+
+  it('se runs top-left to bottom-right', () => {
+    expect(lineEndpoints(box, 'se')).toEqual({
+      from: { x: 0, y: 0 },
+      to: { x: 100, y: 50 },
+    })
+  })
+  it('sw runs top-right to bottom-left', () => {
+    expect(lineEndpoints(box, 'sw')).toEqual({
+      from: { x: 100, y: 0 },
+      to: { x: 0, y: 50 },
+    })
+  })
+  it('ne runs bottom-left to top-right', () => {
+    expect(lineEndpoints(box, 'ne')).toEqual({
+      from: { x: 0, y: 50 },
+      to: { x: 100, y: 0 },
+    })
+  })
+  it('nw runs bottom-right to top-left', () => {
+    expect(lineEndpoints(box, 'nw')).toEqual({
+      from: { x: 100, y: 50 },
+      to: { x: 0, y: 0 },
+    })
+  })
+})
+
+describe('arrowPath', () => {
+  it('shaft stops short of the tip and the head points at the target', () => {
+    const geo = arrowPath({ x: 0, y: 0 }, { x: 100, y: 0 }, 2)
+    expect(geo.shaftD).toMatch(/^M 0 0 L /)
+    const baseX = parseFloat(geo.shaftD.split('L ')[1])
+    expect(baseX).toBeGreaterThan(0)
+    expect(baseX).toBeLessThan(100)
+    expect(geo.headPoints.startsWith('100,0')).toBe(true)
+  })
+
+  it('head scales with stroke width', () => {
+    const thin = arrowPath({ x: 0, y: 0 }, { x: 100, y: 0 }, 1)
+    const thick = arrowPath({ x: 0, y: 0 }, { x: 100, y: 0 }, 8)
+    const headSpan = (geo: typeof thin) => {
+      const xs = geo.headPoints.split(' ').map((p) => parseFloat(p.split(',')[0]))
+      return Math.max(...xs) - Math.min(...xs)
+    }
+    expect(headSpan(thick)).toBeGreaterThan(headSpan(thin))
+  })
+
+  it('a degenerate arrow renders a dot', () => {
+    const geo = arrowPath({ x: 5, y: 5 }, { x: 5, y: 5 }, 2)
+    expect(geo.shaftD).toBe('M 5 5 L 5 5')
+  })
+})
+
+describe('distanceToSegment', () => {
+  const a = { x: 0, y: 0 }
+  const b = { x: 10, y: 0 }
+
+  it('is zero for a point on the segment', () => {
+    expect(distanceToSegment({ x: 5, y: 0 }, a, b)).toBe(0)
+  })
+
+  it('is the perpendicular offset mid-segment', () => {
+    expect(distanceToSegment({ x: 5, y: 3 }, a, b)).toBe(3)
+  })
+
+  it('clamps to the nearest endpoint beyond the segment', () => {
+    expect(distanceToSegment({ x: 15, y: 0 }, a, b)).toBe(5)
+    expect(distanceToSegment({ x: -5, y: 4 }, a, b)).toBe(Math.hypot(5, 4))
+  })
+
+  it('handles a zero-length segment', () => {
+    expect(distanceToSegment({ x: 3, y: 4 }, a, a)).toBe(5)
+  })
+})
+
+describe('pointInBox', () => {
+  const box = { x: 10, y: 20, width: 100, height: 50 }
+
+  it('detects interior points', () => {
+    expect(pointInBox({ x: 50, y: 40 }, box)).toBe(true)
+  })
+
+  it('detects boundary points', () => {
+    expect(pointInBox({ x: 10, y: 20 }, box)).toBe(true)
+    expect(pointInBox({ x: 110, y: 70 }, box)).toBe(true)
+  })
+
+  it('rejects exterior points', () => {
+    expect(pointInBox({ x: 9, y: 40 }, box)).toBe(false)
+    expect(pointInBox({ x: 50, y: 71 }, box)).toBe(false)
+  })
+
+  it('expands by the tolerance on every side', () => {
+    // Expanded box: x in [8, 112], y in [18, 72]
+    expect(pointInBox({ x: 8, y: 40 }, box, 2)).toBe(true)
+    expect(pointInBox({ x: 50, y: 71 }, box, 2)).toBe(true)
+    expect(pointInBox({ x: 7, y: 40 }, box, 2)).toBe(false)
+    expect(pointInBox({ x: 50, y: 73 }, box, 2)).toBe(false)
+  })
+})
+
+describe('hitTest', () => {
+  const rect: DrawingObject = {
+    id: 'r',
+    type: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 50,
+    stroke: '#000',
+    strokeWidth: 2,
+    fill: null,
+    opacity: 1,
+    zIndex: 1,
+  }
+
+  it('hits rectangles inside the box', () => {
+    expect(hitTest({ x: 50, y: 25 }, rect)).toBe(true)
+    expect(hitTest({ x: 200, y: 25 }, rect)).toBe(false)
+  })
+
+  it('hits ellipses inside the curve, not at the box corners', () => {
+    const ellipse: DrawingObject = { ...rect, id: 'e', type: 'ellipse' }
+    expect(hitTest({ x: 50, y: 25 }, ellipse)).toBe(true)
+    expect(hitTest({ x: 5, y: 5 }, ellipse)).toBe(false)
+  })
+
+  it('hits lines/arrows near the stroke with tolerance', () => {
+    const line: DrawingObject = {
+      ...rect,
+      id: 'l',
+      type: 'line',
+      direction: 'se',
+      width: 100,
+      height: 100,
+    }
+    // Midpoint of the diagonal (50, 50) — 6px offset is within tolerance.
+    expect(hitTest({ x: 50, y: 44 }, line)).toBe(true)
+    // Far from the diagonal — outside.
+    expect(hitTest({ x: 10, y: 80 }, line, 0)).toBe(false)
+  })
+
+  it('respects the stroke width slack for thin lines', () => {
+    // Diagonal (0,0)→(100,50); a point 3px off it (perpendicular offset).
+    const p = { x: 50 - 3 * 0.44721, y: 25 + 3 * 0.89443 }
+    const thin = { ...rect, id: 'thin', type: 'line' as const, direction: 'se' as const, strokeWidth: 2 }
+    const thick = { ...rect, id: 't', type: 'line' as const, direction: 'se' as const, strokeWidth: 8 }
+    // slack = tolerance + strokeWidth/2 → 1 for thin (miss), 4 for thick (hit).
+    expect(hitTest(p, thin, 0)).toBe(false)
+    expect(hitTest(p, thick, 0)).toBe(true)
+  })
+})
+
+describe('hitTestObjects', () => {
+  const make = (id: string, x: number, zIndex: number): DrawingObject => ({
+    id,
+    type: 'rectangle',
+    x,
+    y: 0,
+    width: 100,
+    height: 50,
+    stroke: '#000',
+    strokeWidth: 2,
+    fill: null,
+    opacity: 1,
+    zIndex,
+  })
+
+  it('returns the topmost figure under the point', () => {
+    const back = make('back', 0, 1)
+    const front = make('front', 10, 2)
+    expect(hitTestObjects({ x: 50, y: 25 }, [back, front])).toBe('front')
+  })
+
+  it('returns null when nothing is hit', () => {
+    expect(hitTestObjects({ x: 500, y: 500 }, [make('a', 0, 1)])).toBeNull()
+  })
+
+  it('returns null for an empty list', () => {
+    expect(hitTestObjects({ x: 0, y: 0 }, [])).toBeNull()
+  })
+})
+
+describe('unionBox', () => {
+  const make = (id: string, x: number, y: number, w: number, h: number): DrawingObject => ({
+    id,
+    type: 'rectangle',
+    x,
+    y,
+    width: w,
+    height: h,
+    stroke: '#000',
+    strokeWidth: 2,
+    fill: null,
+    opacity: 1,
+    zIndex: 1,
+  })
+
+  it('computes the bounding box of several figures', () => {
+    expect(unionBox([make('a', 0, 0, 100, 50), make('b', 50, 25, 100, 50)])).toEqual({
+      x: 0,
+      y: 0,
+      width: 150,
+      height: 75,
+    })
+  })
+
+  it('returns null for an empty list', () => {
+    expect(unionBox([])).toBeNull()
+  })
+})

--- a/src/renderer/src/components/canvas/drawing/figure-geometry.ts
+++ b/src/renderer/src/components/canvas/drawing/figure-geometry.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure geometry helpers for canvas figures. No DOM, no store — everything here
+ * is a plain function over canvas-space numbers so it is trivially testable and
+ * shared by the rendering layer, hit-testing and the create/move/resize
+ * gestures (see docs/drawing.md §4, §6).
+ */
+
+import type {
+  DrawingObject,
+  FigureDirection,
+} from './types'
+
+export interface Point {
+  x: number
+  y: number
+}
+
+export interface Box {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * Normalize a drag from start (x1,y1) to end (x2,y2) into a bounding box with
+ * non-negative width/height. The box always encloses both points.
+ */
+export function normalizeBox(x1: number, y1: number, x2: number, y2: number): Box {
+  const x = Math.min(x1, x2)
+  const y = Math.min(y1, y2)
+  return { x, y, width: Math.abs(x2 - x1), height: Math.abs(y2 - y1) }
+}
+
+/**
+ * Which diagonal of the box does a line/arrow run along, given the drag start
+ * and end? The direction names the endpoint relative to the start:
+ *   se = end is bottom-right, sw = bottom-left, ne = top-right, nw = top-left.
+ */
+export function figureDirection(x1: number, y1: number, x2: number, y2: number): FigureDirection {
+  const dx = x2 - x1
+  const dy = y2 - y1
+  if (dx >= 0 && dy >= 0) return 'se'
+  if (dx < 0 && dy >= 0) return 'sw'
+  if (dx >= 0 && dy < 0) return 'ne'
+  return 'nw'
+}
+
+/** The two endpoints (from/to) of a line/arrow for a box + direction. */
+export function lineEndpoints(box: Box, direction: FigureDirection): { from: Point; to: Point } {
+  const tl: Point = { x: box.x, y: box.y }
+  const tr: Point = { x: box.x + box.width, y: box.y }
+  const bl: Point = { x: box.x, y: box.y + box.height }
+  const br: Point = { x: box.x + box.width, y: box.y + box.height }
+
+  switch (direction) {
+    case 'se': return { from: tl, to: br }
+    case 'sw': return { from: tr, to: bl }
+    case 'ne': return { from: bl, to: tr }
+    case 'nw': return { from: br, to: tl }
+  }
+}
+
+export interface ArrowGeometry {
+  /** Path `d` for the shaft (stops short of the head so it never pokes through). */
+  shaftD: string
+  /** Three "x,y" points for the arrowhead <polygon> (tip first). */
+  headPoints: string
+}
+
+/**
+ * Build the shaft + arrowhead geometry for an arrow running from `from` to
+ * `to`. The head scales with the stroke width so thin and thick arrows both
+ * read correctly.
+ */
+export function arrowPath(from: Point, to: Point, strokeWidth: number): ArrowGeometry {
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  const len = Math.hypot(dx, dy)
+
+  // Degenerate (zero-length) arrow — render just a dot.
+  if (len < 0.001) {
+    const r = Math.max(2, strokeWidth)
+    return {
+      shaftD: `M ${from.x} ${from.y} L ${from.x} ${from.y}`,
+      headPoints: `${to.x},${to.y} ${to.x - r},${to.y} ${to.x},${to.y - r}`,
+    }
+  }
+
+  const angle = Math.atan2(dy, dx)
+  const headLength = Math.max(10, strokeWidth * 4)
+  const headWidth = Math.max(8, strokeWidth * 3)
+
+  const baseX = to.x - headLength * Math.cos(angle)
+  const baseY = to.y - headLength * Math.sin(angle)
+  const perpX = -Math.sin(angle)
+  const perpY = Math.cos(angle)
+
+  const c1x = baseX + (headWidth / 2) * perpX
+  const c1y = baseY + (headWidth / 2) * perpY
+  const c2x = baseX - (headWidth / 2) * perpX
+  const c2y = baseY - (headWidth / 2) * perpY
+
+  return {
+    shaftD: `M ${from.x} ${from.y} L ${baseX} ${baseY}`,
+    headPoints: `${to.x},${to.y} ${c1x},${c1y} ${c2x},${c2y}`,
+  }
+}
+
+/** Shortest distance from point `p` to segment `a`–`b`. */
+export function distanceToSegment(p: Point, a: Point, b: Point): number {
+  const abx = b.x - a.x
+  const aby = b.y - a.y
+  const apx = p.x - a.x
+  const apy = p.y - a.y
+  const abLen2 = abx * abx + aby * aby
+  if (abLen2 === 0) return Math.hypot(apx, apy)
+  let t = (apx * abx + apy * aby) / abLen2
+  t = Math.max(0, Math.min(1, t))
+  const projX = a.x + t * abx
+  const projY = a.y + t * aby
+  return Math.hypot(p.x - projX, p.y - projY)
+}
+
+/** Is `p` inside box `box` (expanded by `tolerance` on every side)? */
+export function pointInBox(p: Point, box: Box, tolerance = 0): boolean {
+  return (
+    p.x >= box.x - tolerance &&
+    p.x <= box.x + box.width + tolerance &&
+    p.y >= box.y - tolerance &&
+    p.y <= box.y + box.height + tolerance
+  )
+}
+
+/**
+ * Hit-test a canvas-space point against a single figure. `tolerance` is a
+ * canvas-px slack added around the figure's hit region (use ~4 / zoom so thin
+ * strokes are still easy to grab).
+ */
+export function hitTest(p: Point, obj: DrawingObject, tolerance = 4): boolean {
+  const box: Box = { x: obj.x, y: obj.y, width: obj.width, height: obj.height }
+
+  switch (obj.type) {
+    case 'rectangle':
+    case 'text':
+    case 'image':
+      return pointInBox(p, box, tolerance)
+
+    case 'ellipse': {
+      const rx = obj.width / 2 + tolerance
+      const ry = obj.height / 2 + tolerance
+      if (rx <= 0 || ry <= 0) return false
+      const cx = box.x + obj.width / 2
+      const cy = box.y + obj.height / 2
+      const nx = (p.x - cx) / rx
+      const ny = (p.y - cy) / ry
+      return nx * nx + ny * ny <= 1
+    }
+
+    case 'line':
+    case 'arrow': {
+      const { from, to } = lineEndpoints(box, obj.direction)
+      const slack = tolerance + obj.strokeWidth / 2
+      return distanceToSegment(p, from, to) <= slack
+    }
+  }
+}
+
+/**
+ * Return the id of the topmost figure under `p`, or null. Figures are tested
+ * in descending z-order so the front-most one wins.
+ */
+export function hitTestObjects(p: Point, objects: DrawingObject[], tolerance = 4): string | null {
+  const sorted = [...objects].sort((a, b) => b.zIndex - a.zIndex)
+  for (const obj of sorted) {
+    if (hitTest(p, obj, tolerance)) return obj.id
+  }
+  return null
+}
+
+/** Union bounding box of a set of figures (for selection outline / fit). */
+export function unionBox(objects: DrawingObject[]): Box | null {
+  if (objects.length === 0) return null
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const o of objects) {
+    minX = Math.min(minX, o.x)
+    minY = Math.min(minY, o.y)
+    maxX = Math.max(maxX, o.x + o.width)
+    maxY = Math.max(maxY, o.y + o.height)
+  }
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+}

--- a/src/renderer/src/components/canvas/drawing/image-paste.ts
+++ b/src/renderer/src/components/canvas/drawing/image-paste.ts
@@ -1,0 +1,102 @@
+/**
+ * Clipboard image helpers for the drawing layer.
+ *
+ * Pasted images are downscaled to at most 1024 px on the long edge before
+ * being persisted as data URLs — the figures live in the small SQLite
+ * settings blob, so keeping each image under a few hundred KB matters
+ * (see docs/drawing.md §10).
+ */
+
+/** Longest edge (px) a pasted image is allowed to have. */
+export const MAX_IMAGE_EDGE = 1024
+
+/** Below this size the original file is kept as-is (no canvas round-trip). */
+const SMALL_FILE_BYTES = 300_000
+
+export interface PastedImage {
+  /** data URL of the (possibly downscaled) image. */
+  src: string
+  /** Rendered width in canvas px. */
+  width: number
+  /** Rendered height in canvas px. */
+  height: number
+}
+
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'))
+    reader.readAsDataURL(file)
+  })
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error('Failed to load image'))
+    img.src = src
+  })
+}
+
+/**
+ * Decode an image file and downscale it to a data URL (long edge ≤
+ * MAX_IMAGE_EDGE). Returns null when the file cannot be decoded.
+ */
+export async function downscaleImageToDataUrl(file: File): Promise<PastedImage | null> {
+  try {
+    const url = URL.createObjectURL(file)
+    try {
+      const img = await loadImage(url)
+      const naturalWidth = img.naturalWidth || img.width
+      const naturalHeight = img.naturalHeight || img.height
+      if (!naturalWidth || !naturalHeight) return null
+
+      const scale = Math.min(1, MAX_IMAGE_EDGE / Math.max(naturalWidth, naturalHeight))
+      const width = Math.max(1, Math.round(naturalWidth * scale))
+      const height = Math.max(1, Math.round(naturalHeight * scale))
+
+      // Small images don't need a canvas round-trip — keep the original bytes.
+      if (scale === 1 && file.size < SMALL_FILE_BYTES) {
+        return { src: await fileToDataUrl(file), width: naturalWidth, height: naturalHeight }
+      }
+
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        return { src: await fileToDataUrl(file), width: naturalWidth, height: naturalHeight }
+      }
+      ctx.drawImage(img, 0, 0, width, height)
+      return { src: canvas.toDataURL('image/png'), width, height }
+    } finally {
+      URL.revokeObjectURL(url)
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read the first image from the system clipboard. Returns null when the
+ * clipboard is unavailable (permissions, non-secure context) or holds no
+ * image.
+ */
+export async function readClipboardImage(): Promise<File | null> {
+  const clipboard = navigator.clipboard
+  if (!clipboard || typeof clipboard.read !== 'function') return null
+  try {
+    const items = await clipboard.read()
+    for (const item of items) {
+      const type = item.types.find((t) => t.startsWith('image/'))
+      if (!type) continue
+      const blob = await item.getType(type)
+      return new File([blob], `pasted-${Date.now()}.png`, { type })
+    }
+  } catch {
+    // Clipboard permission denied or read failed — treat as "no image".
+  }
+  return null
+}

--- a/src/renderer/src/components/canvas/drawing/types.ts
+++ b/src/renderer/src/components/canvas/drawing/types.ts
@@ -140,9 +140,20 @@ export const FILL_OPTIONS: Array<string | null> = [
   'rgba(236,72,153,0.18)',
 ]
 
+/**
+ * Default stroke per theme — the canvas background is near-black in dark mode
+ * (#0f0f0f) and near-white in light mode (#ededee), so new figures must
+ * default to a stroke visible on the current canvas (dark text on a dark
+ * canvas is invisible, including text figures and the editing caret).
+ */
+export const DEFAULT_STROKE: Record<'light' | 'dark', string> = {
+  light: '#1e1e1e',
+  dark: '#ffffff',
+}
+
 /** Default style for new figures. */
 export const DEFAULT_TOOL_OPTIONS: DrawingToolOptions = {
-  stroke: '#1e1e1e',
+  stroke: DEFAULT_STROKE.light,
   strokeWidth: 2,
   fill: null,
   fontSize: 18,

--- a/src/renderer/src/components/canvas/drawing/types.ts
+++ b/src/renderer/src/components/canvas/drawing/types.ts
@@ -1,0 +1,162 @@
+/**
+ * Data model for canvas figures (shapes, typeable text, pasted images).
+ *
+ * All coordinates are canvas-space — the same space as panel `x/y` — so a
+ * figure scales losslessly under the existing CSS transform of the canvas
+ * layer (see docs/drawing.md §3–§4).
+ */
+
+/** The active drawing tool. `select` is the default (move/select) mode. */
+export type DrawingTool =
+  | 'select'
+  | 'rectangle'
+  | 'ellipse'
+  | 'line'
+  | 'arrow'
+  | 'text'
+  | 'image'
+
+/** Discriminant shared by every figure. */
+export type FigureType = 'rectangle' | 'ellipse' | 'line' | 'arrow' | 'text' | 'image'
+
+/**
+ * Which diagonal of the bounding box a line/arrow runs along.
+ *
+ * Endpoints are always box corners; `direction` picks the diagonal so that
+ * move/resize/snap stay uniform on the bounding box and the arrowhead renders
+ * from the direction (see docs/drawing.md §4).
+ */
+export type FigureDirection = 'se' | 'sw' | 'ne' | 'nw'
+
+export type TextAlign = 'left' | 'center' | 'right'
+
+/** Common fields for every figure. */
+export interface FigureBase {
+  id: string
+  type: FigureType
+  /** Normalized bounding box in canvas space (width/height >= 0). */
+  x: number
+  y: number
+  width: number
+  height: number
+  /** Stroke color (CSS color). */
+  stroke: string
+  strokeWidth: number
+  /** Fill color, or null for no fill. */
+  fill: string | null
+  /** 0..1 */
+  opacity: number
+  /** Z-order within the drawing layer (higher = in front). */
+  zIndex: number
+}
+
+/**
+ * Shape figures. Rectangle/ellipse fill their box; line/arrow run along a box
+ * diagonal chosen by `direction`.
+ */
+export type ShapeFigure =
+  | (FigureBase & { type: 'rectangle' | 'ellipse' })
+  | (FigureBase & { type: 'line' | 'arrow'; direction: FigureDirection })
+
+/** A typeable text field. */
+export interface TextFigure extends FigureBase {
+  type: 'text'
+  text: string
+  fontSize: number
+  fontFamily: string
+  fontWeight: number
+  textAlign: TextAlign
+}
+
+/** A pasted image (downscaled data URL, max 1024px on the long edge). */
+export interface ImageFigure extends FigureBase {
+  type: 'image'
+  /** data URL (downscaled on paste, max 1024px on long edge). */
+  src: string
+}
+
+export type DrawingObject = ShapeFigure | TextFigure | ImageFigure
+
+/**
+ * Style applied to newly created figures (and, when a figure is selected,
+ * live-updated onto the selection). See docs/drawing.md §5.
+ */
+export interface DrawingToolOptions {
+  stroke: string
+  strokeWidth: number
+  fill: string | null
+  fontSize: number
+  fontFamily: string
+  fontWeight: number
+}
+
+// ── Shared option constants (single source of truth for toolbar + store) ──
+
+/** Stroke width presets (canvas px). */
+export const STROKE_WIDTHS = [1, 2, 4, 8] as const
+
+/** Font size presets (canvas px). */
+export const FONT_SIZES = [14, 18, 24, 32, 48] as const
+
+/** Font family presets. */
+export const FONT_FAMILIES = [
+  { id: 'sans', label: 'Sans', css: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif' },
+  { id: 'serif', label: 'Serif', css: 'ui-serif, Georgia, Cambria, "Times New Roman", serif' },
+  { id: 'mono', label: 'Mono', css: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace' },
+] as const
+
+export type FontFamilyId = (typeof FONT_FAMILIES)[number]['id']
+
+/** Resolve a font family id to its CSS font-family stack. */
+export function fontCssFor(id: string): string {
+  const match = FONT_FAMILIES.find((f) => f.id === id)
+  return match ? match.css : FONT_FAMILIES[0].css
+}
+
+/** Stroke color swatches offered in the toolbar. */
+export const STROKE_COLORS = [
+  '#1e1e1e',
+  '#ffffff',
+  '#ef4444',
+  '#f97316',
+  '#eab308',
+  '#22c55e',
+  '#3b82f6',
+  '#8b5cf6',
+  '#ec4899',
+] as const
+
+/** Fill presets (null = no fill). */
+export const FILL_OPTIONS: Array<string | null> = [
+  null,
+  'rgba(30,30,30,0.12)',
+  'rgba(255,255,255,0.12)',
+  'rgba(239,68,68,0.18)',
+  'rgba(249,115,22,0.18)',
+  'rgba(234,179,8,0.18)',
+  'rgba(34,197,94,0.18)',
+  'rgba(59,130,246,0.18)',
+  'rgba(139,92,246,0.18)',
+  'rgba(236,72,153,0.18)',
+]
+
+/** Default style for new figures. */
+export const DEFAULT_TOOL_OPTIONS: DrawingToolOptions = {
+  stroke: '#1e1e1e',
+  strokeWidth: 2,
+  fill: null,
+  fontSize: 18,
+  fontFamily: 'sans',
+  fontWeight: 400,
+}
+
+/** Default figure sizes used when a tool is "clicked" (no drag). */
+export const DEFAULT_FIGURE_SIZE = {
+  rectangle: { width: 160, height: 100 },
+  ellipse: { width: 140, height: 140 },
+  text: { width: 240, height: 60 },
+  image: { width: 240, height: 180 },
+} as const
+
+/** Minimum drag size (canvas px) before a created shape is discarded. */
+export const MIN_FIGURE_SIZE = 4

--- a/src/renderer/src/components/canvas/drawing/types.ts
+++ b/src/renderer/src/components/canvas/drawing/types.ts
@@ -96,7 +96,7 @@ export interface DrawingToolOptions {
 export const STROKE_WIDTHS = [1, 2, 4, 8] as const
 
 /** Font size presets (canvas px). */
-export const FONT_SIZES = [14, 18, 24, 32, 48] as const
+export const FONT_SIZES = [14, 18, 24, 32, 48, 64, 96, 128] as const
 
 /** Font family presets. */
 export const FONT_FAMILIES = [

--- a/src/renderer/src/stores/canvas-store.test.ts
+++ b/src/renderer/src/stores/canvas-store.test.ts
@@ -98,6 +98,43 @@ describe('canvas-store', () => {
       const { viewport } = useCanvasStore.getState()
       expect(viewport.zoom).toBeGreaterThan(1)
     })
+
+    it('fitToContent fits the passed content bounds when there are no panels', () => {
+      useCanvasStore.getState().fitToContent(800, 600, {
+        minX: 1000,
+        minY: 1000,
+        maxX: 1100,
+        maxY: 1060,
+      })
+      const { viewport } = useCanvasStore.getState()
+      // Content 100×60 + 2×60 padding = 220×180 → fits at 100% (capped at 1x)
+      expect(viewport.zoom).toBe(1)
+      // Content center (1050, 1030) centered in the 800×600 container
+      expect(viewport.x).toBe(400 - 1050)
+      expect(viewport.y).toBe(300 - 1030)
+    })
+
+    it('fitToContent merges content bounds with panels', () => {
+      useCanvasStore.getState().addPanel({
+        type: 'task',
+        title: 'Test Task',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      })
+      useCanvasStore.getState().fitToContent(800, 600, {
+        minX: 1000,
+        minY: 0,
+        maxX: 1100,
+        maxY: 100,
+      })
+      const { viewport } = useCanvasStore.getState()
+      // Union of panel (0..100) and content (1000..1100) = 0..1100 wide
+      // Content center x = 550
+      expect(viewport.x).toBeCloseTo(400 - 550 * viewport.zoom)
+      expect(viewport.y).toBeCloseTo(300 - 50 * viewport.zoom)
+    })
   })
 
   // ── Panels ────────────────────────────────────────────────

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -206,7 +206,16 @@ interface CanvasState {
   zoomTo: (zoom: number, centerX?: number, centerY?: number) => void
   zoomAtPoint: (delta: number, clientX: number, clientY: number, containerRect: DOMRect) => void
   resetViewport: () => void
-  fitToContent: (containerWidth: number, containerHeight: number) => void
+  /**
+   * Fit the viewport to all panels. `contentBounds` (e.g. the union box of
+   * drawing figures, in canvas space) is merged into the fitted area so
+   * content without panels can still be fitted.
+   */
+  fitToContent: (
+    containerWidth: number,
+    containerHeight: number,
+    contentBounds?: { minX: number; minY: number; maxX: number; maxY: number }
+  ) => void
   focusPanel: (id: string, containerWidth: number, containerHeight: number) => void
 
   // Panel actions
@@ -322,13 +331,13 @@ export const useCanvasStore = create<CanvasState>()(subscribeWithSelector((set, 
     scheduleSave()
   },
 
-  fitToContent: (containerWidth: number, containerHeight: number) => {
+  fitToContent: (containerWidth: number, containerHeight: number, contentBounds) => {
     const { panels } = get()
-    if (panels.length === 0) return
+    if (panels.length === 0 && !contentBounds) return
     // Guard against zero-size container (window minimized, being dragged, not laid out yet)
     if (!containerWidth || !containerHeight || containerWidth < 10 || containerHeight < 10) return
 
-    // Calculate bounding box of all panels
+    // Calculate bounding box of all panels (plus any extra content, e.g. figures)
     const PAD = 60
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
     for (const p of panels) {
@@ -337,6 +346,13 @@ export const useCanvasStore = create<CanvasState>()(subscribeWithSelector((set, 
       maxX = Math.max(maxX, p.x + p.width)
       maxY = Math.max(maxY, p.y + p.height)
     }
+    if (contentBounds) {
+      minX = Math.min(minX, contentBounds.minX)
+      minY = Math.min(minY, contentBounds.minY)
+      maxX = Math.max(maxX, contentBounds.maxX)
+      maxY = Math.max(maxY, contentBounds.maxY)
+    }
+    if (!isFinite(minX) || !isFinite(minY) || !isFinite(maxX) || !isFinite(maxY)) return
 
     const contentW = maxX - minX + PAD * 2
     const contentH = maxY - minY + PAD * 2

--- a/src/renderer/src/stores/drawing-store.test.ts
+++ b/src/renderer/src/stores/drawing-store.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useDrawingStore } from './drawing-store'
+import { settingsApi } from '@/lib/ipc-client'
+import type { DrawingObject } from '@/components/canvas/drawing/types'
+
+// Mock settingsApi to prevent actual IPC calls during tests
+vi.mock('@/lib/ipc-client', () => ({
+  settingsApi: {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(undefined),
+    getAll: vi.fn().mockResolvedValue({}),
+  },
+  onTaskDeleted: vi.fn(() => vi.fn()),
+}))
+
+const makeRect = (over: {
+  id?: string
+  zIndex?: number
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+} = {}): DrawingObject => ({
+  id: 'figure-1-1',
+  type: 'rectangle',
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 50,
+  stroke: '#1e1e1e',
+  strokeWidth: 2,
+  fill: null,
+  opacity: 1,
+  zIndex: 1,
+  ...over,
+})
+
+/** A figure minus id/zIndex — what addObject receives. */
+const toNewFigure = (fig: DrawingObject) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id: _id, zIndex: _z, ...rest } = fig
+  return rest
+}
+
+describe('drawing-store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useDrawingStore.setState({
+      objects: [],
+      nextZIndex: 1,
+      isLoaded: false,
+      activeTool: 'select',
+      toolOptions: {
+        stroke: '#1e1e1e',
+        strokeWidth: 2,
+        fill: null,
+        fontSize: 18,
+        fontFamily: 'sans',
+        fontWeight: 400,
+      },
+      selectedIds: [],
+      editingTextId: null,
+      liveObject: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts with the select tool and no figures', () => {
+    const s = useDrawingStore.getState()
+    expect(s.activeTool).toBe('select')
+    expect(s.objects).toEqual([])
+    expect(s.isLoaded).toBe(false)
+    expect(s.selectedIds).toEqual([])
+    expect(s.liveObject).toBeNull()
+  })
+
+  // ── addObject / updateObject / removeObjects ──────────────
+
+  it('addObject assigns a figure id and the next z-index', () => {
+    const id = useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    const s = useDrawingStore.getState()
+    expect(id).toMatch(/^figure-\d+-\d+$/)
+    expect(s.objects).toHaveLength(1)
+    expect(s.objects[0].id).toBe(id)
+    expect(s.objects[0].zIndex).toBe(1)
+    expect(s.nextZIndex).toBe(2)
+  })
+
+  it('addObject keeps type-specific fields', () => {
+    const id = useDrawingStore.getState().addObject({
+      type: 'text',
+      x: 5,
+      y: 6,
+      width: 100,
+      height: 40,
+      stroke: '#fff',
+      strokeWidth: 2,
+      fill: null,
+      opacity: 1,
+      text: 'hi',
+      fontSize: 24,
+      fontFamily: 'mono',
+      fontWeight: 700,
+      textAlign: 'center',
+    })
+    const obj = useDrawingStore.getState().objects.find((o) => o.id === id)
+    expect(obj).toMatchObject({ type: 'text', text: 'hi', fontSize: 24 })
+  })
+
+  it('updateObject merges updates into the figure', () => {
+    const id = useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    useDrawingStore.getState().updateObject(id, { x: 10, fill: 'red' })
+    expect(useDrawingStore.getState().objects[0]).toMatchObject({ x: 10, fill: 'red' })
+    // Untouched fields remain
+    expect(useDrawingStore.getState().objects[0].width).toBe(100)
+  })
+
+  it('removeObjects removes figures and prunes the selection', () => {
+    const a = useDrawingStore.getState().addObject(toNewFigure(makeRect({ id: undefined })))
+    const b = useDrawingStore.getState().addObject(toNewFigure(makeRect({ id: undefined })))
+    useDrawingStore.getState().select([a, b])
+    useDrawingStore.getState().removeObjects([a])
+    const s = useDrawingStore.getState()
+    expect(s.objects.map((o) => o.id)).toEqual([b])
+    expect(s.selectedIds).toEqual([b])
+  })
+
+  it('removeObjects clears editingTextId when the edited figure is removed', () => {
+    const a = useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    useDrawingStore.getState().setEditingTextId(a)
+    useDrawingStore.getState().removeObjects([a])
+    expect(useDrawingStore.getState().editingTextId).toBeNull()
+  })
+
+  it('removeObjects is a no-op for an empty id list', () => {
+    const a = useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    useDrawingStore.getState().removeObjects([])
+    expect(useDrawingStore.getState().objects.map((o) => o.id)).toEqual([a])
+  })
+
+  // ── z-order / duplication ─────────────────────────────────
+
+  it('bringToFront assigns the next z-index', () => {
+    const a = useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    useDrawingStore.getState().bringToFront(a)
+    const s = useDrawingStore.getState()
+    expect(s.objects[0].zIndex).toBe(3)
+    expect(s.nextZIndex).toBe(4)
+  })
+
+  it('duplicateObject copies with an offset and selects the copy', () => {
+    const a = useDrawingStore.getState().addObject(toNewFigure(makeRect({ x: 10, y: 20 })))
+    useDrawingStore.getState().duplicateObject(a)
+    const s = useDrawingStore.getState()
+    expect(s.objects).toHaveLength(2)
+    const copy = s.objects[1]
+    expect(copy.id).not.toBe(a)
+    expect(copy).toMatchObject({ x: 30, y: 40 })
+    expect(s.selectedIds).toEqual([copy.id])
+  })
+
+  it('duplicateObject is a no-op for unknown ids', () => {
+    useDrawingStore.getState().duplicateObject('nope')
+    expect(useDrawingStore.getState().objects).toHaveLength(0)
+  })
+
+  // ── tools / selection / editing ───────────────────────────
+
+  it('setTool switches the tool and cancels creation + text editing', () => {
+    useDrawingStore.getState().setLiveObject(makeRect())
+    useDrawingStore.getState().setEditingTextId('figure-9-9')
+    useDrawingStore.getState().setTool('rectangle')
+    const s = useDrawingStore.getState()
+    expect(s.activeTool).toBe('rectangle')
+    expect(s.liveObject).toBeNull()
+    expect(s.editingTextId).toBeNull()
+  })
+
+  it('setToolOption updates only the given option', () => {
+    useDrawingStore.getState().setToolOption('strokeWidth', 8)
+    const opts = useDrawingStore.getState().toolOptions
+    expect(opts.strokeWidth).toBe(8)
+    expect(opts.stroke).toBe('#1e1e1e')
+  })
+
+  it('select / clearSelection manage selectedIds', () => {
+    useDrawingStore.getState().select(['a', 'b'])
+    expect(useDrawingStore.getState().selectedIds).toEqual(['a', 'b'])
+    useDrawingStore.getState().clearSelection()
+    expect(useDrawingStore.getState().selectedIds).toEqual([])
+  })
+
+  // ── setLiveObject bail-out ────────────────────────────────
+
+  it('setLiveObject bails out on structurally equal objects', () => {
+    const listener = vi.fn()
+    const unsub = useDrawingStore.subscribe((s) => s.liveObject, listener)
+    const fig = makeRect()
+
+    useDrawingStore.getState().setLiveObject(fig)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    // Structurally equal — no store write, no notification.
+    useDrawingStore.getState().setLiveObject({ ...fig })
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    // Changed — notified again.
+    useDrawingStore.getState().setLiveObject({ ...fig, x: 5 })
+    expect(listener).toHaveBeenCalledTimes(2)
+
+    unsub()
+  })
+
+  // ── persistence ───────────────────────────────────────────
+
+  it('persists objects after the debounce', () => {
+    vi.useFakeTimers()
+    useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    expect(settingsApi.set).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1000)
+    expect(settingsApi.set).toHaveBeenCalledTimes(1)
+    const [key, raw] = vi.mocked(settingsApi.set).mock.calls[0]
+    expect(key).toBe('drawing_state')
+    const data = JSON.parse(String(raw))
+    expect(data.objects).toHaveLength(1)
+    expect(data.nextZIndex).toBe(2)
+  })
+
+  it('debounces rapid changes into a single save', () => {
+    vi.useFakeTimers()
+    useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    vi.advanceTimersByTime(1000)
+    expect(settingsApi.set).toHaveBeenCalledTimes(1)
+    const [, raw] = vi.mocked(settingsApi.set).mock.calls[0]
+    expect(JSON.parse(String(raw)).objects).toHaveLength(2)
+  })
+
+  it('loadDrawings restores persisted figures and the id counter', async () => {
+    vi.mocked(settingsApi.get).mockResolvedValue(
+      JSON.stringify({
+        objects: [makeRect({ id: 'figure-5-123', zIndex: 3 })],
+        nextZIndex: 4,
+      })
+    )
+    await useDrawingStore.getState().loadDrawings()
+    const s = useDrawingStore.getState()
+    expect(s.isLoaded).toBe(true)
+    expect(s.objects).toHaveLength(1)
+    expect(s.objects[0].id).toBe('figure-5-123')
+    expect(s.nextZIndex).toBe(4)
+
+    // New figures never collide with loaded ids.
+    const id = s.addObject(toNewFigure(makeRect()))
+    const n = parseInt(id.match(/^figure-(\d+)/)![1], 10)
+    expect(n).toBeGreaterThan(5)
+  })
+
+  it('loadDrawings marks loaded when nothing is persisted', async () => {
+    vi.mocked(settingsApi.get).mockResolvedValue(null)
+    await useDrawingStore.getState().loadDrawings()
+    const s = useDrawingStore.getState()
+    expect(s.isLoaded).toBe(true)
+    expect(s.objects).toEqual([])
+  })
+
+  it('loadDrawings survives corrupt persisted data', async () => {
+    vi.mocked(settingsApi.get).mockResolvedValue('not-json{')
+    await useDrawingStore.getState().loadDrawings()
+    expect(useDrawingStore.getState().isLoaded).toBe(true)
+  })
+
+  // ── clearAll ──────────────────────────────────────────────
+
+  it('clearAll resets figures and transient state', () => {
+    const a = useDrawingStore.getState().addObject(toNewFigure(makeRect()))
+    useDrawingStore.getState().select([a])
+    useDrawingStore.getState().setEditingTextId(a)
+    useDrawingStore.getState().setLiveObject(makeRect())
+
+    useDrawingStore.getState().clearAll()
+    const s = useDrawingStore.getState()
+    expect(s.objects).toEqual([])
+    expect(s.nextZIndex).toBe(1)
+    expect(s.selectedIds).toEqual([])
+    expect(s.editingTextId).toBeNull()
+    expect(s.liveObject).toBeNull()
+  })
+})

--- a/src/renderer/src/stores/drawing-store.ts
+++ b/src/renderer/src/stores/drawing-store.ts
@@ -1,0 +1,226 @@
+import { create } from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
+import { settingsApi } from '@/lib/ipc-client'
+import type {
+  DrawingObject,
+  DrawingTool,
+  DrawingToolOptions,
+} from '@/components/canvas/drawing/types'
+import { DEFAULT_TOOL_OPTIONS } from '@/components/canvas/drawing/types'
+
+const DRAWING_STORAGE_KEY = 'drawing_state'
+const SAVE_DEBOUNCE_MS = 1000
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Distributive Omit — `Omit` over a union only keeps the *common* keys, which
+ * would drop the `type` discriminant and every type-specific field. This
+ * distributes over the union so each figure variant keeps its own shape.
+ */
+export type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never
+
+/** Distributive Partial — `Partial` over a union keeps only common keys; this
+ *  distributes so each figure variant gets its own optional-fields shape. */
+export type DistributivePartial<T> = T extends unknown ? Partial<T> : never
+
+/** A full figure minus its identity/z-order — what `addObject` receives. */
+export type NewFigure = DistributiveOmit<DrawingObject, 'id' | 'zIndex'>
+
+/** A partial update of a figure (never `id` or `type`). */
+export type FigureUpdates = DistributivePartial<DistributiveOmit<DrawingObject, 'id' | 'type'>>
+
+// ── Persistence shape ─────────────────────────────────────
+
+interface DrawingPersistedState {
+  objects: DrawingObject[]
+  nextZIndex: number
+}
+
+interface DrawingState {
+  // ── persisted ──
+  objects: DrawingObject[]
+  nextZIndex: number
+  isLoaded: boolean
+
+  // ── transient: active tool + style ──
+  activeTool: DrawingTool
+  toolOptions: DrawingToolOptions
+
+  // ── transient: interaction ──
+  selectedIds: string[]
+  /** Text figure currently in contentEditable mode. */
+  editingTextId: string | null
+  /** Figure being created (drag preview). */
+  liveObject: DrawingObject | null
+
+  // ── actions ──
+  loadDrawings: () => Promise<void>
+  setTool: (tool: DrawingTool) => void
+  setToolOption: <K extends keyof DrawingToolOptions>(key: K, value: DrawingToolOptions[K]) => void
+  addObject: (obj: NewFigure) => string
+  updateObject: (id: string, updates: FigureUpdates) => void
+  removeObjects: (ids: string[]) => void
+  bringToFront: (id: string) => void
+  duplicateObject: (id: string) => void
+  select: (ids: string[]) => void
+  clearSelection: () => void
+  setEditingTextId: (id: string | null) => void
+  setLiveObject: (obj: DrawingObject | null) => void
+  clearAll: () => void
+}
+
+let figureCounter = 0
+
+/** Debounced persist of drawing state to the SQLite settings table. */
+function scheduleSave() {
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => {
+    const { objects, nextZIndex } = useDrawingStore.getState()
+    const data: DrawingPersistedState = { objects, nextZIndex }
+    settingsApi.set(DRAWING_STORAGE_KEY, JSON.stringify(data)).catch((err) => {
+      console.error('[Drawing] Failed to persist state:', err)
+    })
+  }, SAVE_DEBOUNCE_MS)
+}
+
+/**
+ * Structural equality for the live creation preview. The gesture allocates a
+ * fresh object every frame; an unconditional write would re-render the preview
+ * (and any liveObject subscriber) on every frame even when nothing moved.
+ */
+function liveObjectEqual(a: DrawingObject | null, b: DrawingObject | null): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  const aKeys = Object.keys(a) as Array<keyof DrawingObject>
+  const bKeys = Object.keys(b) as Array<keyof DrawingObject>
+  if (aKeys.length !== bKeys.length) return false
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false
+  }
+  return true
+}
+
+export const useDrawingStore = create<DrawingState>()(subscribeWithSelector((set, get) => ({
+  objects: [],
+  nextZIndex: 1,
+  isLoaded: false,
+  activeTool: 'select',
+  toolOptions: { ...DEFAULT_TOOL_OPTIONS },
+  selectedIds: [],
+  editingTextId: null,
+  liveObject: null,
+
+  loadDrawings: async () => {
+    try {
+      const raw = await settingsApi.get(DRAWING_STORAGE_KEY)
+      if (!raw) {
+        set({ isLoaded: true })
+        return
+      }
+      const data = JSON.parse(raw) as DrawingPersistedState
+      // Restore the ID counter from persisted figure IDs so new figures never
+      // collide with loaded ones (same pattern as panels/edges in canvas-store).
+      for (const o of data.objects) {
+        const match = o.id.match(/^figure-(\d+)/)
+        if (match) figureCounter = Math.max(figureCounter, parseInt(match[1], 10))
+      }
+      set({
+        objects: data.objects,
+        nextZIndex: data.nextZIndex,
+        isLoaded: true,
+      })
+    } catch (err) {
+      console.error('[Drawing] Failed to load persisted state:', err)
+      set({ isLoaded: true })
+    }
+  },
+
+  setTool: (tool) => {
+    // Switching tools cancels any in-progress creation and exits text editing.
+    set({ activeTool: tool, liveObject: null, editingTextId: null })
+  },
+
+  setToolOption: (key, value) => {
+    set((s) => ({ toolOptions: { ...s.toolOptions, [key]: value } }))
+  },
+
+  addObject: (obj) => {
+    const id = `figure-${++figureCounter}-${Date.now()}`
+    const { nextZIndex } = get()
+    set((s) => ({
+      objects: [...s.objects, { ...obj, id, zIndex: nextZIndex } as DrawingObject],
+      nextZIndex: nextZIndex + 1,
+    }))
+    scheduleSave()
+    return id
+  },
+
+  updateObject: (id, updates) => {
+    set((s) => ({
+      objects: s.objects.map((o) =>
+        o.id === id ? ({ ...o, ...updates } as DrawingObject) : o
+      ),
+    }))
+    scheduleSave()
+  },
+
+  removeObjects: (ids) => {
+    if (ids.length === 0) return
+    const idSet = new Set(ids)
+    set((s) => ({
+      objects: s.objects.filter((o) => !idSet.has(o.id)),
+      selectedIds: s.selectedIds.filter((sid) => !idSet.has(sid)),
+      editingTextId: s.editingTextId && idSet.has(s.editingTextId) ? null : s.editingTextId,
+    }))
+    scheduleSave()
+  },
+
+  bringToFront: (id) => {
+    const { nextZIndex } = get()
+    set((s) => ({
+      objects: s.objects.map((o) => (o.id === id ? { ...o, zIndex: nextZIndex } : o)),
+      nextZIndex: nextZIndex + 1,
+    }))
+    scheduleSave()
+  },
+
+  duplicateObject: (id) => {
+    const { objects, nextZIndex } = get()
+    const source = objects.find((o) => o.id === id)
+    if (!source) return
+    const newId = `figure-${++figureCounter}-${Date.now()}`
+    const copy: DrawingObject = {
+      ...source,
+      id: newId,
+      x: source.x + 20,
+      y: source.y + 20,
+      zIndex: nextZIndex,
+    }
+    set((s) => ({
+      objects: [...s.objects, copy],
+      nextZIndex: nextZIndex + 1,
+      selectedIds: [newId],
+    }))
+    scheduleSave()
+  },
+
+  select: (ids) => set({ selectedIds: ids }),
+  clearSelection: () => set({ selectedIds: [] }),
+  setEditingTextId: (id) => set({ editingTextId: id }),
+
+  setLiveObject: (obj) => {
+    if (liveObjectEqual(get().liveObject, obj)) return
+    set({ liveObject: obj })
+  },
+
+  clearAll: () => {
+    set({
+      objects: [],
+      nextZIndex: 1,
+      selectedIds: [],
+      editingTextId: null,
+      liveObject: null,
+    })
+    scheduleSave()
+  },
+})))

--- a/src/renderer/src/stores/drawing-store.ts
+++ b/src/renderer/src/stores/drawing-store.ts
@@ -6,7 +6,8 @@ import type {
   DrawingTool,
   DrawingToolOptions,
 } from '@/components/canvas/drawing/types'
-import { DEFAULT_TOOL_OPTIONS } from '@/components/canvas/drawing/types'
+import { DEFAULT_STROKE, DEFAULT_TOOL_OPTIONS } from '@/components/canvas/drawing/types'
+import { useThemeStore } from '@/stores/theme-store'
 
 const DRAWING_STORAGE_KEY = 'drawing_state'
 const SAVE_DEBOUNCE_MS = 1000
@@ -105,7 +106,9 @@ export const useDrawingStore = create<DrawingState>()(subscribeWithSelector((set
   nextZIndex: 1,
   isLoaded: false,
   activeTool: 'select',
-  toolOptions: { ...DEFAULT_TOOL_OPTIONS },
+  // Default stroke follows the current theme so new figures are visible on
+  // the canvas (see DEFAULT_STROKE).
+  toolOptions: { ...DEFAULT_TOOL_OPTIONS, stroke: DEFAULT_STROKE[useThemeStore.getState().resolved] },
   selectedIds: [],
   editingTextId: null,
   liveObject: null,


### PR DESCRIPTION
Adds the **canvas drawing feature** — figures (shapes, typeable text, pasted images) on the infinite canvas — per the architecture contract in `docs/drawing.md`.

## What's in this PR

### State model + tools

- **`src/renderer/src/stores/drawing-store.ts`** — Zustand slice mirroring `canvas-store` conventions. Persisted `objects` + `nextZIndex` under the `drawing_state` settings key (1s debounce, same `scheduleSave` pattern); transient `activeTool` / `toolOptions` / `selectedIds` / `editingTextId` / `liveObject`. Actions: `loadDrawings`, `setTool`, `setToolOption`, `addObject`, `updateObject`, `removeObjects`, `bringToFront`, `duplicateObject`, `select`, `clearSelection`, `setEditingTextId`, `setLiveObject` (structural-equality bailout), `clearAll`.
- **`src/renderer/src/components/canvas/drawing/types.ts`** — `DrawingObject` model (rectangle/ellipse/line/arrow/text/image) + shared tool/style constants, including theme-aware default stroke (`DEFAULT_STROKE` — dark text is invisible on the dark canvas).
- **`src/renderer/src/components/canvas/drawing/figure-geometry.ts`** — pure, testable helpers: `normalizeBox`, `figureDirection`, `lineEndpoints`, `arrowPath`, `hitTest`, `hitTestObjects`, `unionBox`.
- **`src/renderer/src/components/canvas/drawing/DrawingToolbar.tsx`** — floating bottom-center toolbar (canvas HUD styling): Select/Rectangle/Ellipse/Line/Arrow/Text/Image tools + stroke color, stroke width (1/2/4/8), fill, font size, font family. Style controls write `toolOptions` and live-update the selection.
- **`src/renderer/src/components/canvas/drawing/DrawingProperties.tsx`** — floating selection panel: bring-to-front, duplicate, delete + text font size/family/weight.
- **`src/renderer/src/components/canvas/CanvasContextMenu.tsx`** — new "Draw" section that sets the active tool.

### Rendering layer

- **`src/renderer/src/components/canvas/drawing/DrawingLayer.tsx`** — figures rendered inside the existing CSS-transformed canvas layer (0×0 root, overflow visible; pan/zoom scale everything for free). Gestures follow the CanvasPanel imperative pattern: direct DOM writes in rAF during the gesture, a single store commit on mouseup. Create (drag for shapes **and text**; plain click = default-size figure), move (shift+click multi-select), bottom-right resize handle, selection overlay, live creation preview, Escape cancel, image paste. Full-area capture surface is a real HTML element (reliable browser hit-testing, unlike SVG content in a 0×0 overflow-visible svg).
- **`src/renderer/src/components/canvas/drawing/FigureShape.tsx`** — memoized SVG per shape/image figure (`data-figure-id`), invisible fat-stroke hit lines for line/arrow.
- **`src/renderer/src/components/canvas/drawing/FigureText.tsx`** — DOM text figures; `contentEditable` while editing with a visible dashed editing box, commits on blur/Escape, plain caret clicks are not hijacked.
- **`src/renderer/src/components/canvas/drawing/image-paste.ts`** — clipboard image read + downscale to data URL (max edge 1024px).

### Text editing UX

- **Drag-to-create**: the text tool drags a box like the shape tools (live dashed preview); a plain click creates a default-size figure at the click point. Either way the new figure opens in editing mode on mouseup and the tool drops back to Select.
- **Movable while editing**: mousedown on a text figure being edited places the caret; a drag past a 3px threshold commits the text (blur) and turns into a regular move gesture.
- **Re-click to edit**: clicking an already-selected text figure (no drag) reopens it for editing; double-click works too.
- **No ghost figures**: committing empty text removes the figure instead of leaving an invisible box.

### InfiniteCanvas integration

- `loadDrawings()` on mount; tool shortcuts **V/R/O/L/A/T/I**; **Delete/Backspace** removes the selection; **Ctrl/Cmd+V** pastes a clipboard image at the viewport center; **Escape** cancels creation / drops selection; background click deselects; left-drag with an active tool is handed to the drawing layer (space/middle-button pan still wins).
- **Auto-hiding HUD**: the toolbar and properties panel are hidden until engaged — visible while a drawing tool is active, a figure is selected, or a text figure is being edited.

### Minimap

- **CanvasMinimap** - drawing figures render on the minimap in their real stroke/fill colors (rectangle/ellipse/line/arrow/text/image), below the panels. Map bounds include figures, the minimap shows when only figures exist, and fit-to-content merges the figures union box (new optional contentBounds parameter on fitToContent).

### Tests

- `figure-geometry.test.ts` (32), `drawing-store.test.ts` (20), `DrawingLayer.test.tsx` (24 — creation incl. text drag/click, theme-aware stroke, move/resize/select, text editing incl. drag-while-editing, caret clicks, empty-commit removal, capture-surface hit-testing, space-pan passthrough), plus drawing-integration coverage in `InfiniteCanvas.test.tsx` (shortcuts, Delete, Escape, Ctrl+V paste, toolbar visibility).

## Notes

- **Desktop only** — there is no canvas in `src/mobile`, so no mobile parity.
- **Zero new dependencies** — custom SVG + DOM text layer; no drawing library.
- Verified: `tsc --build --noEmit` passes, `eslint` 0 errors, full suite 157 files / 2442 passing (4 skipped).



