### PR TITLE
fix: never push a status change to the source when the user chose 'I'll do it manually'

### DIFF
--- a/src/main/mobile-api-server.test.ts
+++ b/src/main/mobile-api-server.test.ts
@@ -99,6 +99,16 @@ describe('mobile-api-server: route matching', () => {
     expect(updateRegex.test('/api/tasks/')).toBe(false)
     expect(updateRegex.test('/api/tasks/some-id')).toBe(true)
   })
+
+  it('POST /api/tasks/:id/complete is distinct from the update route', () => {
+    const completeRegex = /^\/api\/tasks\/([^/]+)\/complete$/
+    const updateRegex = /^\/api\/tasks\/([^/]+)$/
+    expect(completeRegex.test('/api/tasks/some-id/complete')).toBe(true)
+    // The update route must NOT swallow the /complete path
+    expect(updateRegex.test('/api/tasks/some-id/complete')).toBe(false)
+    // And the base path must not match the complete route
+    expect(completeRegex.test('/api/tasks/some-id')).toBe(false)
+  })
 })
 
 describe('mobile-api-server: auth', () => {

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -725,6 +725,27 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
     return task
   }
 
+  // POST /api/tasks/:id/complete — complete a task, closing it at its source
+  // when the user chooses to (matches the desktop completion flow). Reuses
+  // completeTaskWithoutReview, which honours the recorded complete_at_source
+  // answer and leaves a task the source refuses in review.
+  const taskCompleteMatch = pathname.match(/^\/api\/tasks\/([^/]+)\/complete$/)
+  if (taskCompleteMatch) {
+    const taskId = taskCompleteMatch[1]
+    const task = db.getTask(taskId)
+    if (!task) throw Object.assign(new Error('Task not found'), { status: 404 })
+    const { completeAtSource } = params as { completeAtSource?: boolean }
+    if (task.source_id && completeAtSource !== undefined) {
+      db.updateTask(taskId, { complete_at_source: completeAtSource })
+    }
+    const completed = await agent.completeTaskWithoutReview(taskId)
+    const fresh = db.getTask(taskId)
+    if (fresh) {
+      broadcastToMobileClients('task:updated', { taskId, updates: fresh })
+    }
+    return { completed, status: fresh?.status }
+  }
+
   // POST /api/tasks/:id — update task
   const taskUpdateMatch = pathname.match(/^\/api\/tasks\/([^/]+)$/)
   if (taskUpdateMatch) {

--- a/src/main/sync-manager.test.ts
+++ b/src/main/sync-manager.test.ts
@@ -143,7 +143,7 @@ describe('SyncManager', () => {
       ;(registry.get as unknown as ReturnType<typeof vi.fn>).mockReturnValue(plugin)
       ;(db.getMcpServer as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'srv-1' })
 
-      await syncManager.exportTaskUpdate('t1', { status: 'completed' })
+      await syncManager.exportTaskUpdate('t1', { status: 'completed', complete_at_source: false })
       expect(plugin.exportUpdate).not.toHaveBeenCalled()
     })
 
@@ -178,8 +178,13 @@ describe('SyncManager', () => {
       ;(registry.get as unknown as ReturnType<typeof vi.fn>).mockReturnValue(plugin)
       ;(db.getMcpServer as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'srv-1' })
 
-      await syncManager.exportTaskUpdate('t1', { status: 'completed' })
-      expect(plugin.exportUpdate).toHaveBeenCalled()
+      await syncManager.exportTaskUpdate('t1', { status: 'completed', complete_at_source: true })
+      expect(plugin.exportUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 't1' }),
+        { status: 'completed' },
+        {},
+        expect.anything()
+      )
     })
   })
 

--- a/src/main/sync-manager.test.ts
+++ b/src/main/sync-manager.test.ts
@@ -131,6 +131,56 @@ describe('SyncManager', () => {
       await syncManager.exportTaskUpdate('t1', { title: 'New' })
       expect(plugin.exportUpdate).toHaveBeenCalled()
     })
+
+    it('does not push a status change when the user chose "I\'ll do it manually"', async () => {
+      const plugin = makeMockPlugin()
+      ;(db.getTask as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        id: 't1', source_id: 'src-1', external_id: 'ext-1', complete_at_source: false
+      })
+      ;(db.getTaskSource as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        id: 'src-1', plugin_id: 'test', mcp_server_id: 'srv-1', config: {}
+      })
+      ;(registry.get as unknown as ReturnType<typeof vi.fn>).mockReturnValue(plugin)
+      ;(db.getMcpServer as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'srv-1' })
+
+      await syncManager.exportTaskUpdate('t1', { status: 'completed' })
+      expect(plugin.exportUpdate).not.toHaveBeenCalled()
+    })
+
+    it('still syncs non-status edits when the user chose "I\'ll do it manually"', async () => {
+      const plugin = makeMockPlugin()
+      ;(db.getTask as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        id: 't1', source_id: 'src-1', external_id: 'ext-1', complete_at_source: false
+      })
+      ;(db.getTaskSource as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        id: 'src-1', plugin_id: 'test', mcp_server_id: 'srv-1', config: {}
+      })
+      ;(registry.get as unknown as ReturnType<typeof vi.fn>).mockReturnValue(plugin)
+      ;(db.getMcpServer as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'srv-1' })
+
+      await syncManager.exportTaskUpdate('t1', { title: 'New', status: 'in_progress' })
+      expect(plugin.exportUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 't1' }),
+        { title: 'New' },
+        {},
+        expect.anything()
+      )
+    })
+
+    it('pushes a status change when the user chose to close it at the source', async () => {
+      const plugin = makeMockPlugin()
+      ;(db.getTask as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        id: 't1', source_id: 'src-1', external_id: 'ext-1', complete_at_source: true
+      })
+      ;(db.getTaskSource as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        id: 'src-1', plugin_id: 'test', mcp_server_id: 'srv-1', config: {}
+      })
+      ;(registry.get as unknown as ReturnType<typeof vi.fn>).mockReturnValue(plugin)
+      ;(db.getMcpServer as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'srv-1' })
+
+      await syncManager.exportTaskUpdate('t1', { status: 'completed' })
+      expect(plugin.exportUpdate).toHaveBeenCalled()
+    })
   })
 
   describe('executeAction', () => {

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -143,6 +143,8 @@ export class SyncManager {
     if (task.complete_at_source === false && 'status' in fields) {
       delete fields.status
     }
+    // Internal completion control — never a source field.
+    delete fields.complete_at_source
     if (Object.keys(fields).length === 0) return
 
     const ctx = this.buildContext(source.mcp_server_id || undefined, task.source_id || undefined)

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -135,10 +135,20 @@ export class SyncManager {
     const plugin = this.pluginRegistry.get(source.plugin_id)
     if (!plugin) return
 
+    // The user picked "I'll do it manually", meaning they close the task in the
+    // source system themselves. A status change in 20x must then stay local —
+    // pushing it (e.g. marking the Notion page done) would complete the ticket
+    // at the source against their explicit choice. Other edits still sync.
+    const fields = { ...changedFields }
+    if (task.complete_at_source === false && 'status' in fields) {
+      delete fields.status
+    }
+    if (Object.keys(fields).length === 0) return
+
     const ctx = this.buildContext(source.mcp_server_id || undefined, task.source_id || undefined)
     const config = this.getConfig(source)
 
-    await plugin.exportUpdate(task, changedFields, config, ctx)
+    await plugin.exportUpdate(task, fields, config, ctx)
   }
 
   async executeAction(

--- a/src/mobile/api/client.ts
+++ b/src/mobile/api/client.ts
@@ -57,6 +57,8 @@ export const api = {
     get: (id: string) => get<unknown>(`/api/tasks/${encodeURIComponent(id)}`),
     create: (data: unknown) => post<unknown>('/api/tasks', data),
     update: (id: string, data: unknown) => post<unknown>(`/api/tasks/${encodeURIComponent(id)}`, data),
+    complete: (id: string, completeAtSource: boolean) =>
+      post<{ completed: boolean; status?: string }>(`/api/tasks/${encodeURIComponent(id)}/complete`, { completeAtSource }),
     reorderSubtasks: (parentId: string, orderedIds: string[]) =>
       post<{ success: boolean }>('/api/tasks/reorder-subtasks', { parentId, orderedIds })
   },

--- a/src/mobile/pages/TaskDetailPage.test.tsx
+++ b/src/mobile/pages/TaskDetailPage.test.tsx
@@ -8,6 +8,24 @@ import { useArtifactStore } from '../stores/artifact-store'
 
 const mockNavigate = vi.fn()
 
+// Route a source-backed completion through the server without a network call.
+const { completeMock } = vi.hoisted(() => ({
+  completeMock: vi.fn(async () => ({ completed: true, status: 'completed' }))
+}))
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      tasks: {
+        ...actual.api.tasks,
+        complete: completeMock
+      }
+    }
+  }
+})
+
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
     id: 'task-1',
@@ -27,6 +45,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     external_id: null,
     source_id: null,
     source: 'manual',
+    complete_at_source: null,
     skill_ids: null,
     snoozed_until: null,
     resolution: null,
@@ -320,5 +339,38 @@ describe('TaskDetailPage', () => {
     expect(container.textContent).toContain('Subtask')
 
     unmount()
+  })
+
+  it('asks a source-backed task which completion to use instead of completing directly', () => {
+    const task = makeTask({ source_id: 'src-1', source: 'Notion' })
+    useTaskStore.setState({ tasks: [task], isLoading: false })
+
+    const { getByTestId, getByText, queryByTestId } = render(
+      <TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />
+    )
+
+    // The completion choice must be shown, not a direct completion
+    fireEvent.click(getByTestId('main-cta-complete'))
+    expect(getByText('Complete in Notion?')).toBeTruthy()
+
+    // Cancel leaves the task open
+    fireEvent.click(getByText('Cancel'))
+    expect(queryByTestId('main-cta-complete')).toBeTruthy()
+  })
+
+  it('completes a source-backed task locally via /complete when the user picks manual', () => {
+    completeMock.mockClear()
+    const task = makeTask({ source_id: 'src-1', source: 'Notion' })
+    useTaskStore.setState({ tasks: [task], isLoading: false })
+
+    const { getByTestId, getByText } = render(
+      <TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />
+    )
+
+    fireEvent.click(getByTestId('main-cta-complete'))
+    // "I'll do it manually" routes to the source-honouring completion endpoint
+    // with completeAtSource=false, so the ticket is not closed at the source.
+    fireEvent.click(getByText("I'll do it manually"))
+    expect(completeMock).toHaveBeenCalledWith('task-1', false)
   })
 })

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -84,8 +84,10 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
   const initSession = useAgentStore((s) => s.initSession)
   const endSession = useAgentStore((s) => s.endSession)
 
-  const [showFeedback, setShowFeedback] = useState(false)
-  const [showCompleteChoice, setShowCompleteChoice] = useState(false)
+  // Single modal is reused for both a feedback completion (agent session) and a
+  // plain source completion (no agent): the shared FeedbackModal shows the
+  // 5-star rating/comment only when withFeedback is true.
+  const [completeModal, setCompleteModal] = useState<{ withFeedback: boolean } | null>(null)
   const [activeSection, setActiveSection] = useState<'details' | 'artifacts'>('details')
   const artifactsByTask = useArtifactStore((s) => s.artifactsByTask)
   const hydrateArtifacts = useArtifactStore((s) => s.hydrate)
@@ -182,28 +184,31 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
     if (!task) return
     // Always show feedback when an agent is assigned (there may be a session to learn from)
     if (task.agent_id) {
-      setShowFeedback(true)
+      setCompleteModal({ withFeedback: true })
     } else if (task.source_id && task.complete_at_source == null) {
-      // A source-backed task with no recorded answer asks which to use, like
-      // the desktop "Complete in {source}?" dialog.
-      setShowCompleteChoice(true)
+      // A source-backed task with no recorded answer asks which to use — reuse
+      // the same modal, without the rating/comment section.
+      setCompleteModal({ withFeedback: false })
     } else {
       await completeTaskNow(task, task.complete_at_source !== false)
     }
   }, [task, completeTaskNow])
 
-  const handleCompleteChoice = useCallback(
-    async (completeAtSource: boolean) => {
-      if (!task) return
-      setShowCompleteChoice(false)
-      await completeTaskNow(task, completeAtSource)
-    },
-    [task, completeTaskNow]
-  )
+  const handleCompleteAtSource = useCallback(async () => {
+    if (!task) return
+    setCompleteModal(null)
+    await completeTaskNow(task, true)
+  }, [task, completeTaskNow])
+
+  const handleCompleteManually = useCallback(async () => {
+    if (!task) return
+    setCompleteModal(null)
+    await completeTaskNow(task, false)
+  }, [task, completeTaskNow])
 
   const handleFeedbackSubmit = useCallback(async (rating: number, comment: string, completeAtSource: boolean) => {
     if (!task || !task.agent_id) return
-    setShowFeedback(false)
+    setCompleteModal(null)
 
     // 1. Set task to AgentLearning status with feedback (matches desktop flow).
     //    complete_at_source records the answer for the backend completion, which
@@ -246,7 +251,7 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
 
   const handleFeedbackSkip = useCallback(async (completeAtSource: boolean) => {
     if (!task) return
-    setShowFeedback(false)
+    setCompleteModal(null)
     await completeTaskNow(task, completeAtSource)
   }, [task, completeTaskNow])
 
@@ -809,24 +814,18 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
         )}
       </div>
 
-      {/* Feedback modal */}
-      {showFeedback && (
+      {/* Shared feedback / completion modal. Shows the 5-star rating and comment
+        only for a feedback completion (withFeedback), otherwise the plain
+        completion choice — one modal, no separate dialog. */}
+      {completeModal && (
         <FeedbackModal
+          withFeedback={completeModal.withFeedback}
           sourceName={completeSourceName}
           onSubmit={handleFeedbackSubmit}
           onSkip={handleFeedbackSkip}
-          onCancel={() => setShowFeedback(false)}
-        />
-      )}
-
-      {/* Complete-at-source choice (mirrors desktop CompleteAtSourceDialog) */}
-      {showCompleteChoice && (
-        <CompleteChoiceModal
-          taskTitle={task?.title || ''}
-          sourceName={completeSourceName || 'the task source'}
-          onCompleteAtSource={() => handleCompleteChoice(true)}
-          onCompleteManually={() => handleCompleteChoice(false)}
-          onCancel={() => setShowCompleteChoice(false)}
+          onCancel={() => setCompleteModal(null)}
+          onCompleteAtSource={handleCompleteAtSource}
+          onCompleteManually={handleCompleteManually}
         />
       )}
     </div>
@@ -950,20 +949,27 @@ function SubtasksSection({ subtasks, onNavigateToTask, onReorderSubtasks }: { su
 }
 
 function FeedbackModal({
+  withFeedback,
   sourceName,
   onSubmit,
   onSkip,
-  onCancel
+  onCancel,
+  onCompleteAtSource,
+  onCompleteManually
 }: {
+  /** True for an agent completion (shows 5-star rating + comment). False for a plain source completion. */
+  withFeedback: boolean
   sourceName?: string | null
   onSubmit: (rating: number, comment: string, completeAtSource: boolean) => void
   onSkip: (completeAtSource: boolean) => void
   onCancel: () => void
+  onCompleteAtSource: () => void
+  onCompleteManually: () => void
 }) {
   const [rating, setRating] = useState(0)
   const [comment, setComment] = useState('')
   // Defaults to closing the task at the source, which is what 20x did before
-  // the choice existed (matches desktop FeedbackDialog).
+  // the choice existed (matches desktop).
   const [completeAtSource, setCompleteAtSource] = useState(true)
 
   return (
@@ -974,50 +980,69 @@ function FeedbackModal({
       {/* Modal */}
       <div className="relative z-50 w-full max-w-md mx-4 mb-4 bg-card border border-border rounded-xl shadow-xl animate-in slide-in-from-bottom-4 duration-200">
         <div className="px-5 pt-5 pb-2">
-          <h2 className="text-base font-semibold text-foreground">Session Feedback</h2>
-          <p className="text-xs text-muted-foreground mt-1">Rate this session to help the agent improve</p>
+          {withFeedback ? (
+            <>
+              <h2 className="text-base font-semibold text-foreground">Session Feedback</h2>
+              <p className="text-xs text-muted-foreground mt-1">Rate this session to help the agent improve</p>
+            </>
+          ) : (
+            <>
+              <h2 className="text-base font-semibold text-foreground">
+                {sourceName ? `Complete in ${sourceName}?` : 'Complete this task?'}
+              </h2>
+              <p className="text-xs text-muted-foreground mt-1">
+                {sourceName
+                  ? `20x can close it there for you, or you can mark it complete here only and update ${sourceName} yourself.`
+                  : 'Choose how this task completes.'}
+              </p>
+            </>
+          )}
         </div>
 
-        {/* Star rating */}
-        <div className="flex gap-2 justify-center py-4">
-          {[1, 2, 3, 4, 5].map((star) => (
-            <button
-              key={star}
-              type="button"
-              onClick={() => setRating(star)}
-              className="p-1 active:scale-110 transition-transform"
-            >
-              <svg
-                className={`h-8 w-8 transition-colors ${
-                  star <= rating
-                    ? 'fill-amber-400 text-amber-400'
-                    : 'text-muted-foreground/30 fill-none'
-                }`}
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-              </svg>
-            </button>
-          ))}
-        </div>
+        {/* Star rating + comment — only for a feedback completion */}
+        {withFeedback && (
+          <>
+            <div className="flex gap-2 justify-center py-4">
+              {[1, 2, 3, 4, 5].map((star) => (
+                <button
+                  key={star}
+                  type="button"
+                  onClick={() => setRating(star)}
+                  className="p-1 active:scale-110 transition-transform"
+                >
+                  <svg
+                    className={`h-8 w-8 transition-colors ${
+                      star <= rating
+                        ? 'fill-amber-400 text-amber-400'
+                        : 'text-muted-foreground/30 fill-none'
+                    }`}
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                  </svg>
+                </button>
+              ))}
+            </div>
+            <div className="px-5">
+              <textarea
+                placeholder="Optional feedback..."
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                rows={3}
+                className="w-full bg-transparent border border-input rounded-md px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring/30 resize-none"
+              />
+            </div>
+          </>
+        )}
 
-        {/* Comment */}
-        <div className="px-5">
-          <textarea
-            placeholder="Optional feedback..."
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-            rows={3}
-            className="w-full bg-transparent border border-input rounded-md px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring/30 resize-none"
-          />
-        </div>
-
-        {/* Source completion choice (mirrors desktop FeedbackDialog) */}
-        {sourceName && (
+        {/* Source completion choice (mirrors desktop FeedbackDialog). Shown only
+        alongside the rating form — a plain completion uses the action buttons
+        below. */}
+        {withFeedback && sourceName && (
           <div className="mx-5 rounded-lg border border-border/50 p-3 space-y-2">
             <span className="block text-xs font-medium text-foreground">
               This task came from {sourceName}
@@ -1039,19 +1064,44 @@ function FeedbackModal({
 
         {/* Actions */}
         <div className="flex gap-2 justify-end px-5 py-4">
-          <button
-            onClick={() => onSkip(completeAtSource)}
-            className="h-9 px-4 text-sm text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
-          >
-            Skip
-          </button>
-          <button
-            onClick={() => { if (rating > 0) onSubmit(rating, comment, completeAtSource) }}
-            disabled={rating === 0}
-            className="h-9 px-4 text-sm font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >
-            Submit
-          </button>
+          {withFeedback ? (
+            <>
+              <button
+                onClick={() => onSkip(completeAtSource)}
+                className="h-9 px-4 text-sm text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
+              >
+                Skip
+              </button>
+              <button
+                onClick={() => { if (rating > 0) onSubmit(rating, comment, completeAtSource) }}
+                disabled={rating === 0}
+                className="h-9 px-4 text-sm font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                Submit Feedback
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={onCancel}
+                className="h-9 px-4 text-sm text-muted-foreground hover:text-foreground rounded-md transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={onCompleteManually}
+                className="h-9 px-4 text-sm font-medium border border-border text-foreground rounded-md hover:bg-accent/60 transition-colors"
+              >
+                I'll do it manually
+              </button>
+              <button
+                onClick={onCompleteAtSource}
+                className="h-9 px-4 text-sm font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
+              >
+                Complete at source
+              </button>
+            </>
+          )}
         </div>
       </div>
     </div>
@@ -1082,55 +1132,6 @@ function ChoiceButton({
     >
       {label}
     </button>
-  )
-}
-
-function CompleteChoiceModal({
-  taskTitle,
-  sourceName,
-  onCompleteAtSource,
-  onCompleteManually,
-  onCancel
-}: {
-  taskTitle: string
-  sourceName: string
-  onCompleteAtSource: () => void
-  onCompleteManually: () => void
-  onCancel: () => void
-}) {
-  return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
-      <div className="fixed inset-0 bg-black/60" onClick={onCancel} />
-      <div className="relative z-50 w-full max-w-md mx-4 mb-4 bg-card border border-border rounded-xl shadow-xl p-5 space-y-4 animate-in slide-in-from-bottom-4 duration-200">
-        <div className="space-y-1">
-          <h2 className="text-base font-semibold text-foreground">Complete in {sourceName}?</h2>
-          <p className="text-xs text-muted-foreground">
-            "{taskTitle}" came from {sourceName}. 20x can close it there for you, or you can
-            mark it complete here only and update {sourceName} yourself.
-          </p>
-        </div>
-        <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
-          <button
-            onClick={onCancel}
-            className="h-9 px-4 text-sm text-muted-foreground hover:text-foreground rounded-md transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={onCompleteManually}
-            className="h-9 px-4 text-sm font-medium border border-border text-foreground rounded-md hover:bg-accent/60 transition-colors"
-          >
-            I'll do it manually
-          </button>
-          <button
-            onClick={onCompleteAtSource}
-            className="h-9 px-4 text-sm font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
-          >
-            Complete at source
-          </button>
-        </div>
-      </div>
-    </div>
   )
 }
 

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -85,6 +85,7 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
   const endSession = useAgentStore((s) => s.endSession)
 
   const [showFeedback, setShowFeedback] = useState(false)
+  const [showCompleteChoice, setShowCompleteChoice] = useState(false)
   const [activeSection, setActiveSection] = useState<'details' | 'artifacts'>('details')
   const artifactsByTask = useArtifactStore((s) => s.artifactsByTask)
   const hydrateArtifacts = useArtifactStore((s) => s.hydrate)
@@ -156,26 +157,62 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
     if (session?.sessionId) _stopSession(session.sessionId)
   }, [session?.sessionId, _stopSession])
 
+  // Display name of the source this task came from, when it has one. Shown in
+  // the completion choice, mirroring the desktop dialog.
+  const completeSourceName = useMemo(() => {
+    if (!task?.source_id) return undefined
+    return task.source || 'the task source'
+  }, [task?.source_id, task?.source])
+
+  // Completes a task the way the desktop does: a source-backed task honours
+  // the recorded answer — closing the ticket at the source when the user chose
+  // to, local-only otherwise. Tasks without a source just mark Completed.
+  const completeTaskNow = useCallback(
+    async (t: Task, completeAtSource: boolean) => {
+      if (t.source_id) {
+        await api.tasks.complete(t.id, completeAtSource)
+      } else {
+        await updateTask(t.id, { status: TaskStatus.Completed })
+      }
+    },
+    [updateTask]
+  )
+
   const handleCompleteTask = useCallback(async () => {
     if (!task) return
     // Always show feedback when an agent is assigned (there may be a session to learn from)
     if (task.agent_id) {
       setShowFeedback(true)
+    } else if (task.source_id && task.complete_at_source == null) {
+      // A source-backed task with no recorded answer asks which to use, like
+      // the desktop "Complete in {source}?" dialog.
+      setShowCompleteChoice(true)
     } else {
-      // No agent — complete directly
-      await updateTask(task.id, { status: TaskStatus.Completed })
+      await completeTaskNow(task, task.complete_at_source !== false)
     }
-  }, [task, updateTask])
+  }, [task, completeTaskNow])
 
-  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string) => {
+  const handleCompleteChoice = useCallback(
+    async (completeAtSource: boolean) => {
+      if (!task) return
+      setShowCompleteChoice(false)
+      await completeTaskNow(task, completeAtSource)
+    },
+    [task, completeTaskNow]
+  )
+
+  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string, completeAtSource: boolean) => {
     if (!task || !task.agent_id) return
     setShowFeedback(false)
 
-    // 1. Set task to AgentLearning status with feedback (matches desktop flow)
+    // 1. Set task to AgentLearning status with feedback (matches desktop flow).
+    //    complete_at_source records the answer for the backend completion, which
+    //    honours it when the learning session finishes.
     await updateTask(task.id, {
       status: TaskStatus.AgentLearning,
       feedback_rating: rating,
-      feedback_comment: comment || null
+      feedback_comment: comment || null,
+      ...(task.source_id ? { complete_at_source: completeAtSource } : {})
     })
 
     // 2. Build the same feedback prompt as desktop
@@ -197,21 +234,21 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
         // Backend agent-manager will sync skills and auto-transition to Completed
         // when the session becomes idle (via transitionToIdle AgentLearning check)
       } else {
-        // No session at all — just mark as completed with feedback
-        await updateTask(task.id, { status: TaskStatus.Completed })
+        // No session at all — just complete, honouring the source choice
+        await completeTaskNow(task, completeAtSource)
       }
     } catch (e) {
       console.error('Failed to send feedback to agent:', e)
       // Fallback: complete the task even if learning session fails
-      await updateTask(task.id, { status: TaskStatus.Completed })
+      await completeTaskNow(task, completeAtSource)
     }
-  }, [task, session, updateTask, initSession])
+  }, [task, session, updateTask, initSession, completeTaskNow])
 
-  const handleFeedbackSkip = useCallback(async () => {
+  const handleFeedbackSkip = useCallback(async (completeAtSource: boolean) => {
     if (!task) return
     setShowFeedback(false)
-    await updateTask(task.id, { status: TaskStatus.Completed })
-  }, [task, updateTask])
+    await completeTaskNow(task, completeAtSource)
+  }, [task, completeTaskNow])
 
   // Skills available for this agent — must be before conditional return (Rules of Hooks)
   const agentSkills = useMemo(() => {
@@ -775,9 +812,21 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
       {/* Feedback modal */}
       {showFeedback && (
         <FeedbackModal
+          sourceName={completeSourceName}
           onSubmit={handleFeedbackSubmit}
           onSkip={handleFeedbackSkip}
           onCancel={() => setShowFeedback(false)}
+        />
+      )}
+
+      {/* Complete-at-source choice (mirrors desktop CompleteAtSourceDialog) */}
+      {showCompleteChoice && (
+        <CompleteChoiceModal
+          taskTitle={task?.title || ''}
+          sourceName={completeSourceName || 'the task source'}
+          onCompleteAtSource={() => handleCompleteChoice(true)}
+          onCompleteManually={() => handleCompleteChoice(false)}
+          onCancel={() => setShowCompleteChoice(false)}
         />
       )}
     </div>
@@ -900,9 +949,22 @@ function SubtasksSection({ subtasks, onNavigateToTask, onReorderSubtasks }: { su
   )
 }
 
-function FeedbackModal({ onSubmit, onSkip, onCancel }: { onSubmit: (rating: number, comment: string) => void; onSkip: () => void; onCancel: () => void }) {
+function FeedbackModal({
+  sourceName,
+  onSubmit,
+  onSkip,
+  onCancel
+}: {
+  sourceName?: string | null
+  onSubmit: (rating: number, comment: string, completeAtSource: boolean) => void
+  onSkip: (completeAtSource: boolean) => void
+  onCancel: () => void
+}) {
   const [rating, setRating] = useState(0)
   const [comment, setComment] = useState('')
+  // Defaults to closing the task at the source, which is what 20x did before
+  // the choice existed (matches desktop FeedbackDialog).
+  const [completeAtSource, setCompleteAtSource] = useState(true)
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
@@ -954,20 +1016,117 @@ function FeedbackModal({ onSubmit, onSkip, onCancel }: { onSubmit: (rating: numb
           />
         </div>
 
+        {/* Source completion choice (mirrors desktop FeedbackDialog) */}
+        {sourceName && (
+          <div className="mx-5 rounded-lg border border-border/50 p-3 space-y-2">
+            <span className="block text-xs font-medium text-foreground">
+              This task came from {sourceName}
+            </span>
+            <div className="flex gap-2">
+              <ChoiceButton
+                selected={completeAtSource}
+                onClick={() => setCompleteAtSource(true)}
+                label={`Close it in ${sourceName}`}
+              />
+              <ChoiceButton
+                selected={!completeAtSource}
+                onClick={() => setCompleteAtSource(false)}
+                label="I'll do it manually"
+              />
+            </div>
+          </div>
+        )}
+
         {/* Actions */}
         <div className="flex gap-2 justify-end px-5 py-4">
           <button
-            onClick={onSkip}
+            onClick={() => onSkip(completeAtSource)}
             className="h-9 px-4 text-sm text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
           >
             Skip
           </button>
           <button
-            onClick={() => { if (rating > 0) onSubmit(rating, comment) }}
+            onClick={() => { if (rating > 0) onSubmit(rating, comment, completeAtSource) }}
             disabled={rating === 0}
             className="h-9 px-4 text-sm font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           >
             Submit
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ChoiceButton({
+  selected,
+  onClick,
+  label
+}: {
+  selected: boolean
+  onClick: () => void
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      onClick={onClick}
+      className={cn(
+        'flex-1 rounded-md border px-2.5 py-1.5 text-[11px] transition-colors',
+        selected
+          ? 'border-ring bg-accent/60 text-foreground'
+          : 'border-border/50 text-muted-foreground active:bg-accent/30'
+      )}
+    >
+      {label}
+    </button>
+  )
+}
+
+function CompleteChoiceModal({
+  taskTitle,
+  sourceName,
+  onCompleteAtSource,
+  onCompleteManually,
+  onCancel
+}: {
+  taskTitle: string
+  sourceName: string
+  onCompleteAtSource: () => void
+  onCompleteManually: () => void
+  onCancel: () => void
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
+      <div className="fixed inset-0 bg-black/60" onClick={onCancel} />
+      <div className="relative z-50 w-full max-w-md mx-4 mb-4 bg-card border border-border rounded-xl shadow-xl p-5 space-y-4 animate-in slide-in-from-bottom-4 duration-200">
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold text-foreground">Complete in {sourceName}?</h2>
+          <p className="text-xs text-muted-foreground">
+            "{taskTitle}" came from {sourceName}. 20x can close it there for you, or you can
+            mark it complete here only and update {sourceName} yourself.
+          </p>
+        </div>
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
+          <button
+            onClick={onCancel}
+            className="h-9 px-4 text-sm text-muted-foreground hover:text-foreground rounded-md transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onCompleteManually}
+            className="h-9 px-4 text-sm font-medium border border-border text-foreground rounded-md hover:bg-accent/60 transition-colors"
+          >
+            I'll do it manually
+          </button>
+          <button
+            onClick={onCompleteAtSource}
+            className="h-9 px-4 text-sm font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
+          >
+            Complete at source
           </button>
         </div>
       </div>

--- a/src/renderer/src/hooks/use-task-completion.test.tsx
+++ b/src/renderer/src/hooks/use-task-completion.test.tsx
@@ -134,7 +134,10 @@ describe('useTaskCompletion', () => {
     await waitFor(() =>
       expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete, 'task-1', 'src-1')
     )
-    expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+    expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
+      status: TaskStatus.Completed,
+      complete_at_source: true
+    })
     await waitFor(() => expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull())
   })
 
@@ -147,7 +150,10 @@ describe('useTaskCompletion', () => {
     fireEvent.click(await screen.findByTestId('complete-manually'))
 
     await waitFor(() =>
-      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
+        status: TaskStatus.Completed,
+        complete_at_source: false
+      })
     )
     expect(executeActionMock).not.toHaveBeenCalled()
     expect(onToast).toHaveBeenCalledWith('"Fix the login bug" completed in 20x only')
@@ -209,7 +215,10 @@ describe('useTaskCompletion', () => {
     fireEvent.click(screen.getByText('Complete'))
 
     await waitFor(() =>
-      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
+        status: TaskStatus.Completed,
+        complete_at_source: false
+      })
     )
     expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
     expect(executeActionMock).not.toHaveBeenCalled()
@@ -225,6 +234,10 @@ describe('useTaskCompletion', () => {
     await waitFor(() =>
       expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete, 'task-1', 'src-1')
     )
+    expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
+      status: TaskStatus.Completed,
+      complete_at_source: true
+    })
     expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
   })
 

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -74,7 +74,12 @@ export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
             return false
           }
         }
-        await updateTask(task.id, { status: TaskStatus.Completed })
+        await updateTask(task.id, {
+          status: TaskStatus.Completed,
+          // Record the user's completion choice so a later update does not push
+          // a source completion against it (see SyncManager.exportTaskUpdate).
+          ...(task.source_id ? { complete_at_source: atSource } : {})
+        })
       } catch (err) {
         console.error('Failed to complete task:', err)
         onToast?.('Failed to complete task', true)


### PR DESCRIPTION
## Summary

A task that came from an external source (Notion, Linear, ...) was still being closed at the source even after the user picked **"I'll do it manually"** in the feedback dialog and clicked **Skip**.

**Root cause:** completing the task locally goes through `useTaskStore.updateTask`, which fires a background `exportUpdate` for any change. That export blindly pushed the new `completed` status upstream, so `notion-plugin.exportUpdate` marked the page Done — right after the user said they'd do it manually (`complete_at_source = false`).

**The fix:**
- `SyncManager.exportTaskUpdate` now drops the `status` field from the export when `complete_at_source === false`, and skips the plugin call entirely if nothing else changed. Other edits (title, priority, due date) still sync.
- `useTaskCompletion` records the user's completion choice (`complete_at_source`) on the task, so the no-session **"Complete manually"** dialog path is covered by the same guard.

## Behaviour

| Choice | External system | Local state |
|---|---|---|
| Complete at source | Plugin action runs (previous behaviour) | Completed |
| Do it manually | Untouched | Completed |
| Cancel | Untouched | Stays open |

Not affected: the main-process auto-complete path (`completeTaskWithoutReview`) already honoured `complete_at_source`; this closes the renderer `exportUpdate` gap that bypassed it.

## Test plan
- [x] `sync-manager.test.ts` — new cases: status dropped when `complete_at_source=false`, non-status edits still sync, status still pushed when `complete_at_source=true`
- [x] `use-task-completion.test.tsx` — expectations updated for recorded `complete_at_source`
- [x] `pnpm typecheck` passes, eslint clean