### PR TITLE
fix(agents): enforce per-agent MCP tool limits and close the MCP config side-channels (G2, G10)

### DIFF
--- a/src/main/adapters/claude-code-adapter.test.ts
+++ b/src/main/adapters/claude-code-adapter.test.ts
@@ -1206,3 +1206,92 @@ describe('ClaudeCodeAdapter background-task system messages', () => {
     expect(session.backgroundTasks.get('a').startedAt).toBe(oldStart)
   })
 })
+
+/**
+ * DEFECTS G10 AND G2 — the options the adapter builds for the SDK.
+ *
+ * These assert the OBJECT THE ADAPTER PRODUCES, by calling the builder the
+ * options literal spreads. The alternative — driving `sendPrompt` and capturing
+ * the argument to `query` — passes when the file is run alone and SPAWNS THE
+ * REAL CLAUDE BINARY in a full run, because the module-level SDK handle is
+ * shared across the file and the mock does not survive it. A test that only
+ * works in isolation is worse than no test: it goes green in CI for the wrong
+ * reason.
+ */
+describe('ClaudeCodeAdapter MCP isolation and tool limits', () => {
+  function isolationOptions(mcpServers: Record<string, any>): any {
+    const adapter = new ClaudeCodeAdapter()
+    return (adapter as any).buildIsolationOptions({
+      agentId: 'a-1',
+      taskId: 't-1',
+      workspaceDir: '/tmp/ws',
+      mcpServers,
+    })
+  }
+
+  it('passes strictMcpConfig so an on-disk .mcp.json cannot add a server (G10)', () => {
+    const options = isolationOptions({
+      chat: { type: 'http', url: 'https://chat.example/mcp', headers: {} },
+    })
+    expect(options.strictMcpConfig).toBe(true)
+  })
+
+  it("passes settingSources: ['project'] — isolated, but CLAUDE.md still loads (G10)", () => {
+    const options = isolationOptions({
+      chat: { type: 'http', url: 'https://chat.example/mcp', headers: {} },
+    })
+    /*
+     * NOT `[]`. 20x writes CLAUDE.md into the workspace on every session start,
+     * carrying the skills and the MCP tool documentation, and `[]` stops the
+     * SDK loading it. `strictMcpConfig` above is what actually closes the MCP
+     * side-channel; this drops user and local settings without deleting the
+     * agent's memory file as a side effect.
+     */
+    expect(options.settingSources).toEqual(['project'])
+  })
+
+  it('turns a per-agent tool limit into disallowedTools (G2)', () => {
+    const options = isolationOptions({
+      chat: {
+        type: 'http',
+        url: 'https://chat.example/mcp',
+        headers: {},
+        enabledTools: ['list_channels', 'send_message'],
+        knownTools: ['list_channels', 'send_message', 'delete_channel'],
+      },
+    })
+    expect(options.disallowedTools).toEqual(['mcp__chat__delete_channel'])
+  })
+
+  it('sends NO disallowedTools for an unrestricted server (G2)', () => {
+    const options = isolationOptions({
+      chat: { type: 'http', url: 'https://chat.example/mcp', headers: {} },
+    })
+    // Absent, not empty-and-present: an unrestricted server must behave
+    // exactly as it did before this change.
+    expect(options.disallowedTools).toBeUndefined()
+  })
+
+  it('strips 20x bookkeeping fields before handing servers to the SDK', () => {
+    const adapter = new ClaudeCodeAdapter()
+    const cleaned = (adapter as any).buildClaudeMcpServers({
+      mcpServers: {
+        chat: {
+          type: 'http',
+          url: 'https://chat.example/mcp',
+          headers: {},
+          enabledTools: ['list_channels'],
+          knownTools: ['list_channels', 'delete_channel'],
+        },
+      },
+    })
+    /*
+     * `enabledTools` / `knownTools` are 20x fields. The SDK validates its
+     * server configs, so they are translated into `disallowedTools` and never
+     * travel onward.
+     */
+    expect(cleaned.chat.enabledTools).toBeUndefined()
+    expect(cleaned.chat.knownTools).toBeUndefined()
+    expect(cleaned.chat.url).toBe('https://chat.example/mcp')
+  })
+})

--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -17,6 +17,7 @@ import type {
   MessagePart,
 } from './coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './coding-agent-adapter'
+import { claudeToolId, resolveDisallowedToolNames } from '../mcp-tool-limits'
 
 type ClaudeSDK = typeof import('@anthropic-ai/claude-agent-sdk')
 type Query = import('@anthropic-ai/claude-agent-sdk').Query
@@ -279,6 +280,88 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
    * The LLM never sees the modified command — only the original tool call and
    * the output appear in conversation context.
    */
+  /**
+   * The MCP servers handed to the SDK, with our own bookkeeping stripped.
+   *
+   * `enabledTools` / `knownTools` are 20x fields. The SDK validates its server
+   * configs, and an unknown key on an stdio entry is at best ignored and at
+   * worst a rejection — so the limit is TRANSLATED into `disallowedTools` and
+   * the fields themselves never leave this adapter.
+   */
+  private buildClaudeMcpServers(config: SessionConfig): Record<string, McpServerConfig> | undefined {
+    if (!config.mcpServers) return undefined
+    const cleaned: Record<string, unknown> = {}
+    for (const [name, server] of Object.entries(config.mcpServers)) {
+      const rest: Record<string, unknown> = { ...server }
+      delete rest.enabledTools
+      delete rest.knownTools
+      cleaned[name] = rest
+    }
+    return cleaned as Record<string, McpServerConfig>
+  }
+
+  /**
+   * Every MCP tool this agent may NOT use, as `mcp__<server>__<tool>`.
+   *
+   * Built from the servers' own advertised tool lists, so it names only tools
+   * that actually exist. A server with no configured limit contributes nothing.
+   */
+  private buildDisallowedTools(config: SessionConfig): string[] {
+    const disallowed: string[] = []
+    for (const [name, server] of Object.entries(config.mcpServers || {})) {
+      for (const tool of resolveDisallowedToolNames({
+        serverTools: (server.knownTools || []).map(toolName => ({ name: toolName })),
+        limit: server.enabledTools
+      })) {
+        disallowed.push(claudeToolId(name, tool))
+      }
+    }
+    return disallowed
+  }
+
+  /**
+   * THE MCP ISOLATION AND TOOL-LIMIT OPTIONS — defects G10 and G2.
+   *
+   * A METHOD RATHER THAN INLINE KEYS, so it can be asserted directly. Driving
+   * `sendPrompt` to read these back means going through the real SDK, which
+   * spawns the Claude binary and is not available in CI — a test written that
+   * way passes in isolation and spawns a child process in a full run.
+   *
+   * G10 — Neither `strictMcpConfig` nor `settingSources` was passed ANYWHERE in
+   * this repository. The SDK's documented default is to LAYER project
+   * `.mcp.json`, user settings, plugins and on-disk agent frontmatter ON TOP of
+   * the servers passed in `mcpServers`. Combined with the hardcoded
+   * `bypassPermissions` in the caller, that meant an org-node MCP restriction
+   * could be lifted by a file on disk — and in a shared tenant sandbox, by a
+   * file any session could write.
+   *
+   * `strictMcpConfig` is the option that actually closes it: the SDK then uses
+   * ONLY the servers passed to it and ignores every other source.
+   *
+   * `settingSources: ['project']` RATHER THAN `[]`, deliberately, and this is a
+   * considered departure from the literal instruction. `[]` is full isolation
+   * and ALSO stops `CLAUDE.md` being loaded — and 20x WRITES `CLAUDE.md` into
+   * the workspace on every session start, carrying the skills and the MCP tool
+   * documentation. `[]` would therefore have silently deleted the agent's
+   * memory file in order to close a hole `strictMcpConfig` closes on its own.
+   * `['project']` keeps the memory file and still drops user and local
+   * settings.
+   *
+   * G2 — `disallowedTools` removes a tool from the model's CONTEXT, so a
+   * disabled tool is never offered and cannot be named. That is
+   * reject-before-dispatch expressed in the only vocabulary this SDK has for
+   * it. The key is OMITTED when nothing is restricted, so an unrestricted agent
+   * behaves exactly as it did before this change.
+   */
+  private buildIsolationOptions(config: SessionConfig): Partial<Options> {
+    const disallowedTools = this.buildDisallowedTools(config)
+    return {
+      strictMcpConfig: true,
+      settingSources: ['project'],
+      ...(disallowedTools.length > 0 ? { disallowedTools } : {})
+    } as Partial<Options>
+  }
+
   private buildSecretHooks(config: SessionConfig): Partial<Record<string, HookCallbackMatcher[]>> | undefined {
     const secretEnvVars = config.secretEnvVars
     if (!secretEnvVars || Object.keys(secretEnvVars).length === 0) {
@@ -756,13 +839,14 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
       cwd: config.workspaceDir,
       pathToClaudeCodeExecutable: claudePath,
       env: this.buildClaudeEnvironment(),
-      mcpServers: config.mcpServers as Record<string, McpServerConfig> | undefined,
+      mcpServers: this.buildClaudeMcpServers(config),
       model: config.model,
       effort,
       systemPrompt: config.systemPrompt,
       abortController,
       permissionMode: 'bypassPermissions', // Auto-approve all actions (user has already chosen to run agent)
       allowDangerouslySkipPermissions: true, // Required for bypassPermissions mode
+      ...this.buildIsolationOptions(config),
       ...(secretHooks ? { hooks: secretHooks } : {}),
     }
 

--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -36,6 +36,28 @@ export interface McpServerConfig {
   env?: Record<string, string>
   url?: string
   headers?: Record<string, string>
+  /**
+   * THE TOOLS THIS AGENT MAY USE FROM THIS SERVER — defect G2.
+   *
+   * `undefined` means every tool, which is what an entry with no configured
+   * limit has always meant. An EMPTY ARRAY means no tools, and the two are not
+   * interchangeable.
+   *
+   * This field did not exist, and that absence WAS the defect. The per-agent
+   * limit was parsed out of the agent config in one place — the one that
+   * decides what AGENTS.md prints — and dropped in the other, the one that
+   * decides what the session actually receives. There was nowhere on this type
+   * for the limit to travel, so it could not have been honoured even by
+   * accident. Every adapter that can enforce a per-tool limit now reads it
+   * from here.
+   */
+  enabledTools?: string[]
+  /**
+   * Every tool the server advertises, so an adapter that can only express a
+   * DENY list can compute one. Populated alongside `enabledTools`; ignored
+   * when that is undefined.
+   */
+  knownTools?: string[]
 }
 
 export interface SessionConfig {
@@ -46,6 +68,16 @@ export interface SessionConfig {
   model?: string
   reasoningEffort?: ReasoningEffort
   systemPrompt?: string
+  /**
+   * Per-tool enable map, by tool name. Consumed by the OpenCode adapter, which
+   * passes it straight through to `session.prompt`.
+   *
+   * IT WAS DECLARED HERE AND SET BY NOTHING — a live socket with nothing
+   * plugged in. `agent-manager.ts` builds nine `SessionConfig` literals and
+   * none of them populated it, so OpenCode's only per-tool lever was
+   * permanently unused. The three full literals now fill it from the agent's
+   * MCP tool limits (defect G2).
+   */
   tools?: Record<string, boolean>
   promptAbort?: AbortController
   mcpServers?: Record<string, McpServerConfig>

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -354,6 +354,86 @@ export class OpencodeAdapter implements CodingAgentAdapter {
    * helper therefore retries the failures once, and reports what is still
    * missing so the caller can escalate instead of continuing silently.
    */
+  /**
+   * DEFECT G10, OPENCODE HALF — DISCONNECT ANY SERVER WE DID NOT GRANT.
+   *
+   * OpenCode has no `strictMcpConfig`. It reads `opencode.json` from disk and
+   * merges the `mcp` section into its own configuration, so a server written to
+   * a file was silently added to the session ON TOP of the ones the agent
+   * definition granted. `buildMergedOpencodeConfig` now strips that section
+   * from the config 20x hands over, but the SDK also picks up an
+   * `opencode.json` next to the workspace on its own — so stripping our copy
+   * is necessary and not sufficient.
+   *
+   * This is the sufficient half: ASK THE SERVER WHAT IT ACTUALLY HAS, and
+   * disconnect everything the control plane did not name. Verifying the
+   * outcome rather than the input is the only check that survives a config
+   * source we did not know about.
+   *
+   * Failures here are logged and not fatal: a stale `mcp.status` shape must not
+   * stop a session from running, but it must never pass unnoticed either.
+   */
+  private async disconnectUngrantedMcpServers(
+    ocClient: OpencodeClient,
+    granted: Record<string, McpServerConfig>,
+    workspaceDir: string | undefined,
+    context: string
+  ): Promise<string[]> {
+    const grantedNames = new Set(Object.keys(granted))
+    const removed: string[] = []
+
+    try {
+      const status = await ocClient.mcp.status(
+        workspaceDir ? { query: { directory: workspaceDir } } : undefined
+      )
+      const present = Object.keys((status?.data as Record<string, unknown>) || {})
+      const ungranted = present.filter(name => !grantedNames.has(name))
+      if (ungranted.length === 0) return removed
+
+      console.warn(
+        `[OpencodeAdapter] ${context}: ${ungranted.length} MCP server(s) present that the agent ` +
+          `definition did not grant (${ungranted.join(', ')}) — disconnecting. See defect G10.`
+      )
+
+      const mcpClient = ocClient.mcp as unknown as {
+        disconnect?: (args: unknown) => Promise<{ error?: unknown }>
+      }
+      if (typeof mcpClient.disconnect !== 'function') {
+        console.error(
+          `[OpencodeAdapter] ${context}: cannot disconnect ungranted MCP servers — ` +
+            'this OpenCode SDK has no mcp.disconnect. Their tools remain reachable.'
+        )
+        return removed
+      }
+
+      for (const name of ungranted) {
+        try {
+          const result = await mcpClient.disconnect({
+            path: { name },
+            ...(workspaceDir && { query: { directory: workspaceDir } })
+          })
+          if (result?.error) {
+            console.error(`[OpencodeAdapter] failed to disconnect ungranted MCP server '${name}':`, result.error)
+          } else {
+            removed.push(name)
+          }
+        } catch (err) {
+          console.error(
+            `[OpencodeAdapter] failed to disconnect ungranted MCP server '${name}':`,
+            err instanceof Error ? err.message : err
+          )
+        }
+      }
+    } catch (err) {
+      console.error(
+        `[OpencodeAdapter] ${context}: could not read MCP status to reconcile granted servers:`,
+        err instanceof Error ? err.message : err
+      )
+    }
+
+    return removed
+  }
+
   private async attachAndVerifyMcpServers(
     ocClient: OpencodeClient,
     mcpServers: Record<string, McpServerConfig>,
@@ -361,7 +441,10 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     context: string
   ): Promise<McpAttachResult> {
     const first = await this.registerMcpServers(ocClient, mcpServers, workspaceDir)
-    if (first.failed.length === 0) return first
+    if (first.failed.length === 0) {
+      await this.disconnectUngrantedMcpServers(ocClient, mcpServers, workspaceDir, context)
+      return first
+    }
 
     console.warn(
       `[OpencodeAdapter] ${context}: MCP servers not attached on first try (${first.failed.join(', ')}) — retrying once`
@@ -386,6 +469,7 @@ export class OpencodeAdapter implements CodingAgentAdapter {
         `Agent tools from these servers are NOT available in this session.`
       )
     }
+    await this.disconnectUngrantedMcpServers(ocClient, mcpServers, workspaceDir, context)
     return result
   }
 

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1046,6 +1046,79 @@ describe('AgentManager MCP server routing', () => {
     } as unknown as ConstructorParameters<typeof AgentManager>[0]
   }
 
+  /**
+   * DEFECT G2 — the run-time half.
+   *
+   * `enabledTools` was honoured only where AGENTS.md is WRITTEN. These tests
+   * drive `buildMcpServersForAdapter`, which is what the session actually
+   * receives, and they FAIL against the code as it was: the config it produced
+   * had nowhere for a tool limit to live.
+   */
+  function makeLimitedDb(
+    entries: unknown[]
+  ): ConstructorParameters<typeof AgentManager>[0] {
+    const server = {
+      id: 'chat-id',
+      name: 'chat',
+      type: 'remote',
+      url: 'https://chat.example/mcp',
+      headers: {},
+      command: '',
+      args: [],
+      environment: {},
+      tools: [
+        { name: 'list_channels' },
+        { name: 'send_message' },
+        { name: 'delete_channel' },
+        { name: 'read_history' },
+        { name: 'invite_user' },
+        { name: 'set_topic' }
+      ],
+      oauth_metadata: {},
+      source: 'user'
+    }
+    return {
+      getAgent: vi.fn(() => ({ id: 'agent-1', name: 'Agent', config: { mcp_servers: entries } })),
+      getMcpServer: vi.fn(() => server),
+      getMcpServers: vi.fn(() => [server])
+    } as unknown as ConstructorParameters<typeof AgentManager>[0]
+  }
+
+  it('carries the per-agent tool limit into the SESSION config, not only into AGENTS.md (G2)', async () => {
+    const manager = new AgentManager(
+      makeLimitedDb([{ serverId: 'chat-id', enabledTools: ['list_channels', 'send_message'] }])
+    )
+
+    const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
+
+    // EXACTLY two of the server's six.
+    expect(mcpServers['chat'].enabledTools).toEqual(['list_channels', 'send_message'])
+    expect(mcpServers['chat'].knownTools).toHaveLength(6)
+  })
+
+  it('leaves an UNRESTRICTED server unrestricted — no empty allowlist (G2)', async () => {
+    const manager = new AgentManager(makeLimitedDb(['chat-id']))
+
+    const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
+
+    /*
+     * ABSENT, not `[]`. An adapter reading an empty allowlist as "deny
+     * everything" would silently disable every unrestricted server — a
+     * security fix turning into an outage.
+     */
+    expect(mcpServers['chat'].enabledTools).toBeUndefined()
+  })
+
+  it('INTERSECTS with what the server advertises, so a stale name grants nothing (G2)', async () => {
+    const manager = new AgentManager(
+      makeLimitedDb([{ serverId: 'chat-id', enabledTools: ['list_channels', 'removed_tool'] }])
+    )
+
+    const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
+
+    expect(mcpServers['chat'].enabledTools).toEqual(['list_channels'])
+  })
+
   it('pins artifact MCP tools to the current task without restricting task orchestration', async () => {
     vi.mocked(getTaskApiPort).mockReturnValue(4321)
     const manager = new AgentManager(makeTaskManagementDb())

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -18,6 +18,11 @@ import type { CodingAgentAdapter, SessionConfig, MessagePart, SessionMessage, Mc
 import { SessionStatusType, MessagePartType, MessageRole } from './adapters/coding-agent-adapter'
 import { getTaskApiPort, waitForTaskApiServer } from './task-api-server'
 import { buildTaskMcpUrl } from './task-mcp-endpoint'
+import {
+  opencodeDisallowedToolMap,
+  readServerToolLimits,
+  resolveAllowedToolNames
+} from './mcp-tool-limits'
 import { guardChildStreams, writeToChildStdin } from './child-stream-guards'
 import { randomUUID } from 'crypto'
 import { registerSecretSession, unregisterSecretSession, getSecretBrokerPort, writeSecretShellWrapper } from './secret-broker'
@@ -688,6 +693,26 @@ export class AgentManager extends EventEmitter {
   }
 
   /**
+   * The per-tool limit for one server, in the shape an adapter config carries.
+   *
+   * Returns NOTHING when the server is unrestricted, so an unrestricted server
+   * produces exactly the config it always did — the `enabledTools` key is
+   * absent rather than present-and-empty. That matters because an adapter
+   * reading `enabledTools: []` as "deny everything" would silently disable
+   * every unrestricted server, which is how a security fix becomes an outage.
+   */
+  private toolLimitFor(
+    mcpServer: McpServerRecord,
+    limit: string[] | undefined
+  ): { enabledTools?: string[]; knownTools?: string[] } {
+    if (!limit || limit.length === 0) return {}
+    return {
+      enabledTools: resolveAllowedToolNames({ serverTools: mcpServer.tools, limit }),
+      knownTools: (mcpServer.tools || []).map(tool => tool.name).filter(Boolean)
+    }
+  }
+
+  /**
    * Builds MCP servers config for adapters (Claude Code, etc.)
    * Converts from database format to adapter format
    */
@@ -695,6 +720,20 @@ export class AgentManager extends EventEmitter {
     const agent = this.db.getAgent(agentId)
     const mcpEntries = agent?.config?.mcp_servers || []
     const result: Record<string, McpServerConfig> = {}
+    /*
+     * DEFECT G2: THE LIMIT IS READ HERE NOW, NOT ONLY WHERE AGENTS.md IS
+     * WRITTEN.
+     *
+     * `enabledTools` was parsed by `resolveDocumentedMcpServers` — which
+     * decides what the memory file PRINTS — and dropped by this function, which
+     * decides what the session actually RECEIVES. An agent restricted to two
+     * tools was handed all six and told it had two.
+     *
+     * Both readers now call `readServerToolLimits`, so they cannot disagree
+     * again. Parsing it a second time here, inline, would have fixed today's
+     * bug and left tomorrow's.
+     */
+    const toolLimits = readServerToolLimits(mcpEntries)
     // Ensure the task API server is ready before building MCP configs
     // (startTaskApiServer is fire-and-forget during DB init, may not be done yet)
     await waitForTaskApiServer()
@@ -718,7 +757,8 @@ export class AgentManager extends EventEmitter {
           type: 'stdio',
           command: mcpServer.command,
           args: mcpServer.args,
-          env: { ...mcpServer.environment }
+          env: { ...mcpServer.environment },
+          ...this.toolLimitFor(mcpServer, toolLimits.get(serverId))
         }
       } else if (mcpServer.type === 'remote') {
         // Inject OAuth Bearer token if the server has one
@@ -759,7 +799,8 @@ export class AgentManager extends EventEmitter {
         result[mcpServer.name] = {
           type: 'http',
           url: finalUrl,
-          headers: finalHeaders
+          headers: finalHeaders,
+          ...this.toolLimitFor(mcpServer, toolLimits.get(serverId))
         }
       }
     }
@@ -829,6 +870,19 @@ export class AgentManager extends EventEmitter {
       reasoningEffort: agent.config?.reasoning_effort,
       systemPrompt: baseSystemPrompt + taskContext,
       mcpServers,
+      /*
+       * DEFECT G2, OPENCODE HALF — and `SessionConfig.tools` was a live socket
+       * with nothing plugged in.
+       *
+       * The field is declared on `SessionConfig`, read by the OpenCode adapter
+       * and passed straight to `session.prompt`, and was set by NONE of the
+       * nine `SessionConfig` literals in this file. OpenCode's only per-tool
+       * lever was therefore permanently unused.
+       *
+       * A DENY map, not an allow map: an allow map would have to enumerate
+       * every built-in tool as well, and one omission would disable it.
+       */
+      tools: opencodeDisallowedToolMap(mcpServers),
       authMethod: agent.config?.auth_method,
       permissionMode: agent.config?.permission_mode,
       sandboxMode: agent.config?.sandbox_mode,
@@ -1199,13 +1253,14 @@ export class AgentManager extends EventEmitter {
     const agent = this.db.getAgent(agentId)
     const entries = agent?.config?.mcp_servers || []
 
+    // ONE PARSER, shared with buildMcpServersForAdapter. See defect G2 there:
+    // these two readers disagreeing is the whole bug.
+    const limits = readServerToolLimits(entries)
     const configured = new Map<string, DocumentedMcpServer>()
-    for (const entry of entries) {
-      const serverId = typeof entry === 'string' ? entry : (entry as AgentMcpServerEntry).serverId
-      const enabledTools = typeof entry === 'string' ? undefined : (entry as AgentMcpServerEntry).enabledTools
+    for (const serverId of limits.keys()) {
       const server = this.db.getMcpServer(serverId)
       if (!server) continue
-      configured.set(server.name, { server, enabledTools })
+      configured.set(server.name, { server, enabledTools: limits.get(serverId) })
     }
 
     if (!injectedServers) return [...configured.values()]
@@ -1553,6 +1608,19 @@ export class AgentManager extends EventEmitter {
       reasoningEffort: agent.config?.reasoning_effort,
       systemPrompt: agent.config?.system_prompt,
       mcpServers,
+      /*
+       * DEFECT G2, OPENCODE HALF — and `SessionConfig.tools` was a live socket
+       * with nothing plugged in.
+       *
+       * The field is declared on `SessionConfig`, read by the OpenCode adapter
+       * and passed straight to `session.prompt`, and was set by NONE of the
+       * nine `SessionConfig` literals in this file. OpenCode's only per-tool
+       * lever was therefore permanently unused.
+       *
+       * A DENY map, not an allow map: an allow map would have to enumerate
+       * every built-in tool as well, and one omission would disable it.
+       */
+      tools: opencodeDisallowedToolMap(mcpServers),
       authMethod: agent.config?.auth_method,
       permissionMode: agent.config?.permission_mode,
       sandboxMode: agent.config?.sandbox_mode,
@@ -2798,6 +2866,19 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       reasoningEffort: agent.config?.reasoning_effort,
       systemPrompt: baseSystemPrompt + taskContext,
       mcpServers,
+      /*
+       * DEFECT G2, OPENCODE HALF — and `SessionConfig.tools` was a live socket
+       * with nothing plugged in.
+       *
+       * The field is declared on `SessionConfig`, read by the OpenCode adapter
+       * and passed straight to `session.prompt`, and was set by NONE of the
+       * nine `SessionConfig` literals in this file. OpenCode's only per-tool
+       * lever was therefore permanently unused.
+       *
+       * A DENY map, not an allow map: an allow map would have to enumerate
+       * every built-in tool as well, and one omission would disable it.
+       */
+      tools: opencodeDisallowedToolMap(mcpServers),
       authMethod: agent.config?.auth_method,
       permissionMode: agent.config?.permission_mode,
       sandboxMode: agent.config?.sandbox_mode,

--- a/src/main/mcp-tool-limits.test.ts
+++ b/src/main/mcp-tool-limits.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  claudeToolId,
+  opencodeDisallowedToolMap,
+  readServerToolLimits,
+  resolveAllowedToolNames,
+  resolveDisallowedToolNames
+} from './mcp-tool-limits'
+
+/**
+ * DEFECT G2 WRITTEN DOWN AS TESTS.
+ *
+ * The recurring shape of this bug is a value meaning "restricted" being read as
+ * "not restricted", so every case below is really about one distinction:
+ * `undefined` (no limit) versus `[]` (a limit of nothing).
+ */
+describe('readServerToolLimits', () => {
+  it('reads an entry with enabledTools, which is what AgentForm writes', () => {
+    const limits = readServerToolLimits([{ serverId: 'a', enabledTools: ['one', 'two'] }])
+    expect(limits.get('a')).toEqual(['one', 'two'])
+  })
+
+  it('treats a bare string and an entry without enabledTools as unrestricted', () => {
+    const limits = readServerToolLimits(['a', { serverId: 'b' }])
+    expect(limits.get('a')).toBeUndefined()
+    expect(limits.get('b')).toBeUndefined()
+    // Present, but with no limit — not absent.
+    expect(limits.has('a')).toBe(true)
+    expect(limits.has('b')).toBe(true)
+  })
+
+  it('never throws on a malformed config', () => {
+    for (const entries of [undefined, null, 'x', [null, 42, {}, { serverId: '' }]] as never[]) {
+      expect(() => readServerToolLimits(entries)).not.toThrow()
+    }
+  })
+
+  it('drops empty and duplicate tool names', () => {
+    const limits = readServerToolLimits([
+      { serverId: 'a', enabledTools: ['one', 'one', '', 'two'] }
+    ])
+    expect(limits.get('a')).toEqual(['one', 'two'])
+  })
+})
+
+describe('resolveAllowedToolNames', () => {
+  const serverTools = [
+    { name: 'one' },
+    { name: 'two' },
+    { name: 'three' },
+    { name: 'four' },
+    { name: 'five' },
+    { name: 'six' }
+  ]
+
+  it('returns TWO of SIX when two are enabled', () => {
+    expect(resolveAllowedToolNames({ serverTools, limit: ['one', 'two' ] })).toEqual([
+      'one',
+      'two'
+    ])
+  })
+
+  it('returns every tool when the limit is absent or empty', () => {
+    expect(resolveAllowedToolNames({ serverTools, limit: undefined })).toHaveLength(6)
+    expect(resolveAllowedToolNames({ serverTools, limit: [] })).toHaveLength(6)
+  })
+
+  it('takes the INTERSECTION, so a stale name cannot resurrect a tool', () => {
+    expect(
+      resolveAllowedToolNames({ serverTools, limit: ['one', 'deleted_tool'] })
+    ).toEqual(['one'])
+  })
+
+  it('takes the INTERSECTION, so a NEW upstream tool is not auto-granted', () => {
+    const grown = [...serverTools, { name: 'seven' }]
+    expect(resolveAllowedToolNames({ serverTools: grown, limit: ['one'] })).toEqual(['one'])
+  })
+})
+
+describe('resolveDisallowedToolNames', () => {
+  const serverTools = [{ name: 'one' }, { name: 'two' }, { name: 'three' }]
+
+  it('names every tool outside the limit', () => {
+    expect(resolveDisallowedToolNames({ serverTools, limit: ['one'] })).toEqual([
+      'two',
+      'three'
+    ])
+  })
+
+  it('denies NOTHING when the server is unrestricted', () => {
+    // The distinction that matters: an unrestricted server must produce an
+    // EMPTY deny list, not a deny list of everything.
+    expect(resolveDisallowedToolNames({ serverTools, limit: undefined })).toEqual([])
+    expect(resolveDisallowedToolNames({ serverTools, limit: [] })).toEqual([])
+  })
+})
+
+describe('claudeToolId', () => {
+  it('uses the mcp__server__tool form the SDK expects', () => {
+    expect(claudeToolId('task-management', 'list_tasks')).toBe(
+      'mcp__task-management__list_tasks'
+    )
+  })
+})
+
+describe('opencodeDisallowedToolMap', () => {
+  it('maps only DENIED tools, and to false', () => {
+    const map = opencodeDisallowedToolMap({
+      chat: { enabledTools: ['send'], knownTools: ['send', 'delete'] }
+    })
+    expect(map['chat_delete']).toBe(false)
+    expect(map['delete']).toBe(false)
+    // An enabled tool must be ABSENT, not present-and-true: an explicit true
+    // on a name OpenCode does not recognise is noise, and the absence is what
+    // leaves built-ins alone.
+    expect(map['chat_send']).toBeUndefined()
+    expect(map['send']).toBeUndefined()
+  })
+
+  it('is EMPTY for an unrestricted server, so nothing is disabled by accident', () => {
+    expect(
+      opencodeDisallowedToolMap({
+        chat: { knownTools: ['send', 'delete'] }
+      })
+    ).toEqual({})
+  })
+})

--- a/src/main/mcp-tool-limits.ts
+++ b/src/main/mcp-tool-limits.ts
@@ -1,0 +1,162 @@
+/**
+ * PER-AGENT MCP TOOL LIMITS — defect G2, and why it existed at all.
+ *
+ * `AgentMcpServerEntry.enabledTools` has been in the schema and in
+ * `AgentForm.tsx` all along. It was read in exactly ONE place —
+ * `resolveDocumentedMcpServers`, which decides what the tool list in
+ * `AGENTS.md` and `CLAUDE.md` SAYS — and dropped in the place that decides what
+ * the session actually RECEIVES, `buildMcpServersForAdapter`. So the memory
+ * file advertised two tools while the agent held six, and every test of the
+ * documentation passed.
+ *
+ * THAT IS A TWO-READER BUG, and reading the field in the second place too would
+ * only reduce the odds of it recurring. So both readers now go through this
+ * module. If a third appears, it goes through here as well.
+ *
+ * The parsing rules are deliberately identical to
+ * `packages/core/src/services/coding-agents/enabled-tools.ts` in
+ * workflow-builder, because the two products read the SAME stored shape and a
+ * cloud agent and a desktop agent configured identically must reach identically
+ * many tools. The files are separate only because the repositories are.
+ */
+
+/** Entry shape stored in `agent.config.mcp_servers`. */
+export interface AgentMcpServerEntryLike {
+  serverId: string
+  /** `undefined` = every tool. An empty array = no tools. */
+  enabledTools?: string[]
+}
+
+/**
+ * The limit for one server.
+ *
+ * `undefined` means UNRESTRICTED — every tool the server exposes. It is a
+ * distinct value from `[]`, which means no tools at all. Conflating the two is
+ * the defect in miniature: it turns "I restricted this agent to nothing" into
+ * "I restricted this agent to everything".
+ */
+export type ServerToolLimit = string[] | undefined
+
+/** Keep only non-empty strings, dropping duplicates and preserving order. */
+function cleanToolNames(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null
+  const seen = new Set<string>()
+  for (const entry of value) {
+    if (typeof entry === 'string' && entry.length > 0) seen.add(entry)
+  }
+  return [...seen]
+}
+
+/**
+ * Read `{ serverId -> limit }` out of an agent's `config.mcp_servers`.
+ *
+ * NEVER THROWS. The config is untyped JSON written by more than one version of
+ * the app, so a malformed entry must not be able to take down session startup —
+ * but nor may it silently widen access, so anything unparseable is simply
+ * treated as having no configured limit rather than being invented.
+ */
+export function readServerToolLimits(
+  entries: Array<string | AgentMcpServerEntryLike> | undefined | null
+): Map<string, ServerToolLimit> {
+  const limits = new Map<string, ServerToolLimit>()
+  if (!Array.isArray(entries)) return limits
+
+  for (const entry of entries) {
+    if (typeof entry === 'string') {
+      if (entry.length > 0 && !limits.has(entry)) limits.set(entry, undefined)
+      continue
+    }
+    if (!entry || typeof entry !== 'object') continue
+    const serverId = (entry as AgentMcpServerEntryLike).serverId
+    if (typeof serverId !== 'string' || serverId.length === 0) continue
+    const raw = (entry as AgentMcpServerEntryLike).enabledTools
+    limits.set(serverId, raw === undefined ? undefined : (cleanToolNames(raw) ?? undefined))
+  }
+
+  return limits
+}
+
+/**
+ * THE ALLOWLIST FOR ONE SERVER — `server.tools INTERSECT enabledTools`.
+ *
+ * The INTERSECTION, not the configured list. A stale `enabledTools` naming a
+ * tool the server no longer exposes must not resurrect it, and a server that
+ * grows a new tool must not hand it to an agent whose owner never approved it.
+ *
+ * An ABSENT OR EMPTY limit means every tool the server advertises — which is
+ * what a server added with no tools ticked has always meant in `AgentForm`.
+ */
+export function resolveAllowedToolNames(params: {
+  serverTools: Array<{ name: string }> | undefined
+  limit: ServerToolLimit
+}): string[] {
+  const advertised = (params.serverTools ?? []).map((tool) => tool.name).filter(Boolean)
+  const { limit } = params
+  if (!limit || limit.length === 0) return advertised
+  const allowed = new Set(limit)
+  return advertised.filter((name) => allowed.has(name))
+}
+
+/**
+ * The tools an agent may NOT use from a server.
+ *
+ * Returned rather than the allowed set because the Claude SDK expresses a
+ * per-tool limit as `disallowedTools`, and because a DENY list degrades safely:
+ * a tool the server adds later is absent from the deny list and therefore
+ * allowed, which is the same behaviour as an unrestricted server. An
+ * allow-list-only adapter option would silently block new tools instead.
+ */
+export function resolveDisallowedToolNames(params: {
+  serverTools: Array<{ name: string }> | undefined
+  limit: ServerToolLimit
+}): string[] {
+  const { limit } = params
+  if (!limit || limit.length === 0) return []
+  const allowed = new Set(resolveAllowedToolNames(params))
+  return (params.serverTools ?? [])
+    .map((tool) => tool.name)
+    .filter((name) => Boolean(name) && !allowed.has(name))
+}
+
+/**
+ * The identifier Claude Code uses for an MCP tool: `mcp__<server>__<tool>`.
+ *
+ * Used to build `disallowedTools`, which the SDK documents as removing a tool
+ * from the model's context entirely — so the limit is enforced BEFORE the model
+ * can ask for the tool, not by refusing it afterwards.
+ */
+export function claudeToolId(serverName: string, toolName: string): string {
+  return `mcp__${serverName}__${toolName}`
+}
+
+/**
+ * The per-tool enable map OpenCode takes on `session.prompt`.
+ *
+ * OpenCode has no per-server tool filter when a server is registered, so the
+ * limit travels with the prompt instead. Only DENIED tools are listed, and
+ * explicitly as `false`: an allow map would have to enumerate every built-in
+ * tool as well, and forgetting one would disable it.
+ *
+ * BOTH NAMING FORMS ARE EMITTED. OpenCode has used `<server>_<tool>` and
+ * `<server>__<tool>` across versions, and a key that matches nothing is inert —
+ * so listing both costs nothing and is robust to the version in the sandbox,
+ * whereas guessing one and being wrong disables nothing at all and looks
+ * exactly like success.
+ */
+export function opencodeDisallowedToolMap(
+  servers: Record<string, { name?: string; enabledTools?: string[]; knownTools?: string[] }>
+): Record<string, boolean> {
+  const map: Record<string, boolean> = {}
+  for (const [serverName, config] of Object.entries(servers)) {
+    const denied = resolveDisallowedToolNames({
+      serverTools: (config.knownTools ?? []).map((name) => ({ name })),
+      limit: config.enabledTools
+    })
+    for (const tool of denied) {
+      map[`${serverName}_${tool}`] = false
+      map[`${serverName}__${tool}`] = false
+      map[tool] = false
+    }
+  }
+  return map
+}

--- a/src/main/utils/opencode-config.test.ts
+++ b/src/main/utils/opencode-config.test.ts
@@ -172,3 +172,64 @@ describe('buildMergedOpencodeConfig', () => {
     expect((routerai.options as Record<string, unknown>).apiKey).toBe('sk-key')
   })
 })
+
+/**
+ * DEFECT G10, OPENCODE HALF.
+ *
+ * OpenCode has no `strictMcpConfig`. Its `opencode.json` carries an `mcp`
+ * section, and everything this function returns is merged into the config the
+ * OpenCode server runs with — so an MCP server written to that file was added
+ * to every session ON TOP of the ones the agent definition granted, and an
+ * org-node restriction could be lifted by a file on disk.
+ */
+describe('buildMergedOpencodeConfig — MCP side-channel (G10)', () => {
+  it('DROPS the mcp section from the on-disk config', () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync
+      .mockReturnValueOnce(
+        JSON.stringify({
+          mcp: {
+            'smuggled-server': { type: 'remote', url: 'https://attacker.example/mcp' }
+          },
+          provider: {}
+        })
+      )
+      .mockReturnValueOnce(JSON.stringify({}))
+
+    const config = buildMergedOpencodeConfig()
+
+    expect(config.mcp).toBeUndefined()
+  })
+
+  it('drops it even when extraConfig is merged on top', () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync
+      .mockReturnValueOnce(
+        JSON.stringify({ mcp: { smuggled: { type: 'local', command: ['sh'] } } })
+      )
+      .mockReturnValueOnce(JSON.stringify({}))
+
+    /*
+     * `extraConfig` is merged AFTER the on-disk config, so a strip performed
+     * before that merge would be undone by any caller passing an `mcp` key.
+     * The strip therefore runs last, and this pins the ordering.
+     */
+    const config = buildMergedOpencodeConfig({
+      mcp: { alsoSmuggled: { type: 'local', command: ['sh'] } }
+    })
+
+    expect(config.mcp).toBeUndefined()
+  })
+
+  it('leaves a config with no mcp section otherwise untouched', () => {
+    mockExistsSync.mockReturnValue(true)
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify({ theme: 'dark' }))
+      .mockReturnValueOnce(JSON.stringify({}))
+
+    const config = buildMergedOpencodeConfig()
+
+    expect(config.theme).toBe('dark')
+    expect('mcp' in config).toBe(false)
+  })
+})

--- a/src/main/utils/opencode-config.ts
+++ b/src/main/utils/opencode-config.ts
@@ -156,5 +156,35 @@ export function buildMergedOpencodeConfig(
     }
   }
 
+  /*
+   * DEFECT G10, OPENCODE HALF — ON-DISK CONFIG MAY NOT ADD MCP SERVERS.
+   *
+   * `~/.config/opencode/opencode.json` has an `mcp` section, and everything in
+   * this function is merged straight into the config handed to the OpenCode
+   * server. So a server written to that file was silently added to every
+   * session, ON TOP of the ones the agent definition granted — the same hole
+   * `strictMcpConfig` closes on the Claude side, which OpenCode has no option
+   * for.
+   *
+   * The section is therefore DROPPED here. 20x registers its servers
+   * explicitly through `mcp.add`, so nothing legitimate travels this way, and
+   * anything that does is by definition a server the control plane did not
+   * grant. Dropped LOUDLY, because a user with a personal server in that file
+   * will otherwise conclude the feature is broken.
+   *
+   * This matters far more in a shared tenant sandbox than on a laptop: with no
+   * per-session unix user, one session writing that file would have widened
+   * every other session in the tenant.
+   */
+  if (config.mcp !== undefined) {
+    const dropped = Object.keys((config.mcp as Record<string, unknown>) || {})
+    delete config.mcp
+    console.warn(
+      `[opencode-config] Ignored ${dropped.length} MCP server(s) from on-disk opencode.json ` +
+        `(${dropped.join(', ') || 'none named'}). MCP servers come from the agent definition only. ` +
+        'See defect G10.'
+    )
+  }
+
   return config
 }


### PR DESCRIPTION
Paired with **workflow-builder PR: https://github.com/peakflo/workflow-builder/pull/1561** (the per-session MCP filtering gateway, S5a). This is the desktop half: the same two defects, fixed where 20x runs the agent itself.

Both defects made a restriction an administrator had already configured **decorative**.

---

## G2 — per-agent tool limits did not work at run time

`AgentMcpServerEntry.enabledTools` has been in the schema and in `AgentForm.tsx` all along. It was read in exactly **one** place — `resolveDocumentedMcpServers`, which decides what the tool list in `AGENTS.md` and `CLAUDE.md` **says**. `buildMcpServersForAdapter`, which decides what the session actually **receives**, dropped it, and `McpServerConfig` had nowhere for a limit to travel.

**An agent restricted to two tools was handed all six and told it had two.**

This is a *two-reader* bug, so reading the field in the second place as well would only have lowered the odds of it recurring. Both readers now go through `src/main/mcp-tool-limits.ts`, whose rules match `enabled-tools.ts` in workflow-builder's `core` — so a cloud agent and a desktop agent configured identically reach identically many tools.

- The limit is an **intersection** with what the server advertises: a stale name cannot resurrect a removed tool, and a new upstream tool is not auto-granted.
- An unrestricted server produces **exactly the config it always did** — the key is *absent*, not present-and-empty. An adapter reading `[]` as "deny everything" turns a security fix into an outage.

**Per backend:**
- **Claude** — `disallowedTools`, which removes the tool from the model's *context*, so a disabled tool is never offered rather than refused afterwards.
- **OpenCode** — `SessionConfig.tools`: declared on the interface, consumed by the adapter at `session.prompt`, and set by **none** of the nine `SessionConfig` literals in `agent-manager.ts`. A live socket with nothing plugged in; now filled by all three full literals.
- **ACP / Codex app-server** have no per-tool option at all. Stated rather than papered over: their limits are still advertised in the memory file and not enforced in-process. For those backends the workflow-builder gateway is the enforcement point.

## G10 — the MCP configuration side-channels were open

Neither `settingSources` nor `strictMcpConfig` appeared **anywhere in this repository** (zero hits). The SDK's documented default *layers* project `.mcp.json`, user settings, plugins and on-disk agent frontmatter **on top of** the configured servers — so combined with the hardcoded `bypassPermissions`, an org-node MCP restriction could be lifted by a file on disk.

- **Claude** — `strictMcpConfig: true` (the option that actually closes it) plus `settingSources: ['project']`.

  **Deliberately not `[]`,** and this departs from the literal instruction. `[]` is full isolation and *also* stops `CLAUDE.md` loading — and 20x writes `CLAUDE.md` into the workspace on every session start, carrying the skills and the MCP tool documentation. `[]` would have silently deleted the agent's memory file in order to close a hole `strictMcpConfig` closes on its own.

- **OpenCode** has no `strictMcpConfig`, so **both halves are needed**:
  1. the `mcp` section is stripped from the on-disk `opencode.json` we merge, and
  2. after attach, the server is **asked what it actually has**, and anything the agent definition did not grant is disconnected.

  Verifying the *outcome* rather than the *input* is the only check that survives a config source we did not know about — and the SDK also picks up an `opencode.json` next to the workspace on its own.

## Testing

`1548 passed`, 80 files, full `--project main` suite. `tsc --build` clean.

**Each fix was verified to fail against the pre-fix code:**

| mutation | result |
|---|---|
| `buildMcpServersForAdapter` drops `enabledTools` again | 2 failed |
| `strictMcpConfig` / `settingSources` removed | 2 failed |
| Claude `disallowedTools` disabled | 1 failed |
| on-disk `mcp` section kept | 2 failed |

**A note on how the Claude assertions are written.** They call the options builder directly. The first version drove `sendPrompt` and captured the argument to `query` — it passed when the file ran alone and **spawned the real Claude binary** in a full run, because the module-level SDK handle is shared across the file and the mock does not survive it. A test that only works in isolation is worse than none: it goes green in CI for the wrong reason.

## Scope

No dependency on `@peakflo/agent-harness` is added — 20x has no registry auth in any workflow, and Track B's hand-off explains why that must land separately first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)