### PR TITLE
fix: route OpenCode question answers correctly

### DIFF
--- a/docs/mobile-api-spec.md
+++ b/docs/mobile-api-spec.md
@@ -477,7 +477,7 @@ The agent's response streams via WebSocket `agent:output` events.
 
 Respond to an agent's permission request OR answer an agent's question.
 
-This single endpoint handles **two distinct interaction types** — the backend dispatches to the correct adapter method automatically:
+This single endpoint handles **two distinct interaction types**. Set `responseType` for a question so an adapter that supports both interactions uses its question endpoint:
 
 1. **Permission requests** (ACP/Codex adapters) — agent needs approval for a risky action (e.g., running a bash command). These arrive via `agent:status` with `status: "waiting_approval"` and may include a `pendingApproval` object.
 2. **Questions** (Claude Code / all adapters) — agent asks the user a structured question with options. These arrive as `agent:output` events with `partType: "question"` and `data.tool.questions` array rendered inline in the transcript.
@@ -493,25 +493,27 @@ This single endpoint handles **two distinct interaction types** — the backend 
 ```json
 {
   "approved": true,
-  "message": "JWT"
+  "message": "JWT",
+  "responseType": "question"
 }
 ```
 
-| Field      | Type      | Required | Description |
-|------------|-----------|----------|-------------|
-| `approved` | `boolean` | Yes      | `true` to approve/answer, `false` to reject |
-| `message`  | `string`  | No       | The answer text (for questions) or optional context (for permissions) |
+| Field          | Type                         | Required | Description |
+|----------------|------------------------------|----------|-------------|
+| `approved`     | `boolean`                    | Yes      | `true` to approve/answer, `false` to reject |
+| `message`      | `string`                     | No       | The answer text (for questions) or optional context (for permissions) |
+| `responseType` | `"permission" \| "question"` | No       | Use `"question"` when the user answers a structured question |
 
 **For single-question answers**, pass the selected option label directly:
 
 ```json
-{ "approved": true, "message": "JWT" }
+{ "approved": true, "message": "JWT", "responseType": "question" }
 ```
 
 **For multi-question answers**, format as `"Header: Answer"` pairs separated by newlines:
 
 ```json
-{ "approved": true, "message": "Auth Method: JWT\nToken Storage: HttpOnly Cookie" }
+{ "approved": true, "message": "Auth Method: JWT\nToken Storage: HttpOnly Cookie", "responseType": "question" }
 ```
 
 **For permission rejections:**

--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -834,6 +834,44 @@ describe('OpencodeAdapter', () => {
       }
     })
 
+    it('sends selected question labels as ordered answer arrays to OpenCode', async () => {
+      const adapter = new OpencodeAdapter()
+      await (adapter as any).sdkLoading
+      const mockReply = vi.fn().mockResolvedValue({ data: true, error: null })
+      ;(adapter as any).v2Client = {
+        question: {
+          list: vi.fn().mockResolvedValue({
+            data: [{
+              id: 'que_123',
+              sessionID: 'ses_abc',
+              questions: [{
+                header: 'Commit strategy',
+                question: 'How should I commit?',
+                options: [
+                  { label: 'Commit with --no-verify (Recommended)', description: 'Skip the hook' },
+                  { label: 'Install functions deps first', description: 'Install dependencies' }
+                ]
+              }]
+            }],
+            error: null
+          }),
+          reply: mockReply
+        }
+      }
+
+      await adapter.respondToQuestion(
+        'ses_abc',
+        { answer: 'Commit with --no-verify (Recommended)' },
+        { workspaceDir: '/workspace/task_1' } as any
+      )
+
+      expect(mockReply).toHaveBeenCalledWith({
+        requestID: 'que_123',
+        answers: [['Commit with --no-verify (Recommended)']],
+        directory: '/workspace/task_1'
+      })
+    })
+
     it('autoApprovePermission falls back to raw fetch when V2 SDK is not loaded', async () => {
       const adapter = new OpencodeAdapter()
       ;(adapter as any).v2Client = null

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1950,6 +1950,43 @@ describe('AgentManager session ID re-keying redirect', () => {
     await expect(mgr.respondToPermission('unknown-id', true)).rejects.toThrow('Session not found: unknown-id')
   })
 
+  it('routes an explicit question response to the question method when the adapter also handles permissions', async () => {
+    const { mgr, session } = createManagerWithSession()
+    const dualAdapter = {
+      ...session.adapter,
+      respondToQuestion: vi.fn(async () => undefined),
+      respondToApproval: vi.fn(async () => true),
+    }
+    session.adapter = dualAdapter
+    vi.spyOn(mgr as any, 'getAdapter').mockReturnValue(dualAdapter)
+    vi.spyOn(mgr as any, 'buildSessionConfig').mockResolvedValue({ workspaceDir: '/tmp/ws' })
+
+    await mgr.respondToPermission('temp-id', true, 'Deployment: Staging', undefined, 'question')
+
+    expect(dualAdapter.respondToQuestion).toHaveBeenCalledWith(
+      'temp-id',
+      { Deployment: 'Staging' },
+      { workspaceDir: '/tmp/ws' }
+    )
+    expect(dualAdapter.respondToApproval).not.toHaveBeenCalled()
+  })
+
+  it('keeps an untyped response on the permission method for a dual-purpose adapter', async () => {
+    const { mgr, session } = createManagerWithSession()
+    const dualAdapter = {
+      ...session.adapter,
+      respondToQuestion: vi.fn(async () => undefined),
+      respondToApproval: vi.fn(async () => true),
+    }
+    session.adapter = dualAdapter
+    vi.spyOn(mgr as any, 'getAdapter').mockReturnValue(dualAdapter)
+
+    await mgr.respondToPermission('temp-id', true, 'Yes')
+
+    expect(dualAdapter.respondToApproval).toHaveBeenCalledWith('temp-id', true, 'approved')
+    expect(dualAdapter.respondToQuestion).not.toHaveBeenCalled()
+  })
+
   it('abortSession resolves re-keyed session via redirect map', async () => {
     const { mgr, session } = createManagerWithSession()
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -4338,7 +4338,13 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     }
   }
 
-  async respondToPermission(sessionId: string, approved: boolean, message?: string, optionId?: string): Promise<void> {
+  async respondToPermission(
+    sessionId: string,
+    approved: boolean,
+    message?: string,
+    optionId?: string,
+    responseType?: 'permission' | 'question'
+  ): Promise<void> {
     let session = this.sessions.get(sessionId)
 
     // Fallback: session ID may have been re-keyed (temp → real) by pollSingleSession.
@@ -4360,38 +4366,14 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
 
     const adapter = this.getAdapter(session.agentId)
 
-    // --- ACP adapters: use respondToApproval (permission-style options) ---
-    if (adapter && 'respondToApproval' in adapter && typeof (adapter as unknown as AcpAdapter).respondToApproval === 'function') {
-      let selectedOption = optionId
-      if (!selectedOption && message) {
-        const answerMap: Record<string, string> = {
-          'Always': 'approved-for-session',
-          'Yes': 'approved',
-          'No, provide feedback': 'abort',
-          'No': 'abort'
-        }
-        selectedOption = answerMap[message] || (approved ? 'approved' : 'abort')
-      }
-      console.log(`[AgentManager] Responding to ACP adapter approval with: ${selectedOption}`)
-      // OpenCode adapter returns boolean (true=handled, false=no permission found).
-      // AcpAdapter returns void. Cast to boolean|void to handle both.
-      const handled = await (adapter as unknown as { respondToApproval: (sid: string, approved: boolean, opt?: string) => Promise<boolean | void> }).respondToApproval(sessionId, approved, selectedOption)
+    const approvalAdapter = adapter && 'respondToApproval' in adapter
+      && typeof (adapter as unknown as AcpAdapter).respondToApproval === 'function'
 
-      // If no pending permission was found (stale prompt after watchdog abort
-      // or app restart), send a continuation message so the session recovers.
-      // AcpAdapter returns void (undefined), which won't match === false.
-      if (handled === false && approved) {
-        console.log(`[AgentManager] No pending permission found for ${sessionId}, sending continuation message to recover session`)
-        this.doSendAdapterMessage(session, sessionId, 'continue').catch((err) => {
-          console.error(`[AgentManager] Continuation message failed for session ${sessionId}:`, err)
-          this.handleSessionError(sessionId, session!, err)
-        })
-      }
-      return
-    }
-
-    // --- Adapters with respondToQuestion: pass structured answers ---
-    if (adapter && typeof adapter.respondToQuestion === 'function') {
+    // --- Question responses: pass structured answers ---
+    // OpenCode implements both response methods. The renderer must identify a
+    // question response so it does not go to the permission endpoint first.
+    if (adapter && typeof adapter.respondToQuestion === 'function'
+      && (responseType === 'question' || !approvalAdapter)) {
       if (!approved) {
         console.log(`[AgentManager] Question rejected for session ${sessionId}`)
         session.status = 'idle'
@@ -4451,6 +4433,36 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         console.log(`[AgentManager] Restarting polling after question answer for session ${sessionId}`)
         session.pollingStarted = true
         this.startAdapterPolling(sessionId, session.adapter, adapterConfig)
+      }
+      return
+    }
+
+    // --- ACP/OpenCode permission responses: use permission-style options ---
+    if (approvalAdapter) {
+      let selectedOption = optionId
+      if (!selectedOption && message) {
+        const answerMap: Record<string, string> = {
+          'Always': 'approved-for-session',
+          'Yes': 'approved',
+          'No, provide feedback': 'abort',
+          'No': 'abort'
+        }
+        selectedOption = answerMap[message] || (approved ? 'approved' : 'abort')
+      }
+      console.log(`[AgentManager] Responding to ACP adapter approval with: ${selectedOption}`)
+      // OpenCode adapter returns boolean (true=handled, false=no permission found).
+      // AcpAdapter returns void. Cast to boolean|void to handle both.
+      const handled = await (adapter as unknown as { respondToApproval: (sid: string, approved: boolean, opt?: string) => Promise<boolean | void> }).respondToApproval(sessionId, approved, selectedOption)
+
+      // If no pending permission was found (stale prompt after watchdog abort
+      // or app restart), send a continuation message so the session recovers.
+      // AcpAdapter returns void (undefined), which won't match === false.
+      if (handled === false && approved) {
+        console.log(`[AgentManager] No pending permission found for ${sessionId}, sending continuation message to recover session`)
+        this.doSendAdapterMessage(session, sessionId, 'continue').catch((err) => {
+          console.error(`[AgentManager] Continuation message failed for session ${sessionId}:`, err)
+          this.handleSessionError(sessionId, session!, err)
+        })
       }
       return
     }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -448,8 +448,8 @@ export function registerIpcHandlers(
     }
   )
 
-  ipcMain.handle('agentSession:approve', async (_, sessionId: string, approved: boolean, message?: string) => {
-    await agentManager.respondToPermission(sessionId, approved, message)
+  ipcMain.handle('agentSession:approve', async (_, sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question') => {
+    await agentManager.respondToPermission(sessionId, approved, message, undefined, responseType)
     return { success: true }
   })
 

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -805,9 +805,13 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
   const approveMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/approve$/)
   if (approveMatch) {
     const sessionId = approveMatch[1]
-    const { approved, message } = params as { approved: boolean; message?: string }
+    const { approved, message, responseType } = params as {
+      approved: boolean
+      message?: string
+      responseType?: 'permission' | 'question'
+    }
     if (typeof approved !== 'boolean') throw Object.assign(new Error('approved (boolean) is required'), { status: 400 })
-    await agent.respondToPermission(sessionId, approved, message)
+    await agent.respondToPermission(sessionId, approved, message, undefined, responseType)
     return { success: true }
   }
 

--- a/src/mobile/api/client.ts
+++ b/src/mobile/api/client.ts
@@ -108,8 +108,8 @@ export const api = {
       post<{ sessionId: string }>(`/api/sessions/${encodeURIComponent(sessionId)}/resume`, { agentId, taskId }),
     send: (sessionId: string, message: string, taskId?: string, agentId?: string, attachments?: Array<{ id: string; filename: string; size: number; mime_type: string }>) =>
       post<{ success: boolean; newSessionId?: string }>(`/api/sessions/${encodeURIComponent(sessionId)}/send`, { message, taskId, agentId, attachments }),
-    approve: (sessionId: string, approved: boolean, message?: string) =>
-      post<{ success: boolean }>(`/api/sessions/${encodeURIComponent(sessionId)}/approve`, { approved, message }),
+    approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question') =>
+      post<{ success: boolean }>(`/api/sessions/${encodeURIComponent(sessionId)}/approve`, { approved, message, responseType }),
     sync: (sessionId: string) =>
       post<{ success: boolean; status: string }>(`/api/sessions/${encodeURIComponent(sessionId)}/sync`),
     abort: (sessionId: string) =>

--- a/src/mobile/pages/ConversationPage.tsx
+++ b/src/mobile/pages/ConversationPage.tsx
@@ -232,7 +232,7 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
       if (!currentSession?.sessionId) return
       try {
         if (isQuestion) {
-          await api.sessions.approve(currentSession.sessionId, true, message)
+          await api.sessions.approve(currentSession.sessionId, true, message, 'question')
           captureAnalyticsEvent('agent_approval_responded', {
             task_id: taskId,
             agent_id: currentSession.agentId,
@@ -281,7 +281,7 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
       const currentSession = useAgentStore.getState().sessions.get(taskId)
       if (!currentSession?.sessionId || !activeQuestionId) return
       try {
-        await api.sessions.approve(currentSession.sessionId, true, answer)
+        await api.sessions.approve(currentSession.sessionId, true, answer, 'question')
         captureAnalyticsEvent('agent_approval_responded', {
           task_id: taskId,
           agent_id: currentSession.agentId,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -111,8 +111,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('agentSession:send', sessionId, message, taskId, agentId, attachments),
     sendByTaskId: (taskId: string, message: string, attachments?: Array<{ id: string; filename: string; size: number; mime_type: string }>): Promise<{ success: boolean; sessionId: string | null; newSessionId?: string }> =>
       ipcRenderer.invoke('agentSession:sendByTaskId', taskId, message, attachments),
-    approve: (sessionId: string, approved: boolean, message?: string): Promise<{ success: boolean }> =>
-      ipcRenderer.invoke('agentSession:approve', sessionId, approved, message),
+    approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question'): Promise<{ success: boolean }> =>
+      responseType
+        ? ipcRenderer.invoke('agentSession:approve', sessionId, approved, message, responseType)
+        : ipcRenderer.invoke('agentSession:approve', sessionId, approved, message),
     syncSkills: (sessionId: string): Promise<{ created: string[]; updated: string[]; unchanged: string[] }> =>
       ipcRenderer.invoke('agentSession:syncSkills', sessionId),
     syncSkillsForTask: (taskId: string): Promise<{ created: string[]; updated: string[]; unchanged: string[] }> =>

--- a/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
@@ -63,7 +63,7 @@ export function TranscriptPanelContent({ taskId }: TranscriptPanelContentProps) 
         questionIndex >= 0 &&
         !currentMessages.slice(questionIndex + 1).some((m) => m.role === 'user')
       if (hasActiveQuestion) {
-        await approve(true, message)
+        await approve(true, message, 'question')
         return
       }
 

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -304,7 +304,7 @@ describe('TaskWorkspace – stale triage session cleanup', () => {
     fireEvent.click(screen.getByTestId('mock-send'))
 
     await waitFor(() => {
-      expect(window.electronAPI.agentSession.approve).toHaveBeenCalledWith('session-1', true, 'approved')
+      expect(window.electronAPI.agentSession.approve).toHaveBeenCalledWith('session-1', true, 'approved', 'question')
     })
     expect(window.electronAPI.agentSession.send).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -540,7 +540,7 @@ function TaskWorkspaceComponent({
       const hasActiveQuestion = questionIndex >= 0
         && !messages.slice(questionIndex + 1).some((m) => m.role === 'user')
       if (hasActiveQuestion) {
-        await approve(true, message)
+        await approve(true, message, 'question')
         return
       }
 

--- a/src/renderer/src/hooks/use-agent-session.ts
+++ b/src/renderer/src/hooks/use-agent-session.ts
@@ -214,10 +214,10 @@ export function useAgentSession(taskId: string | undefined) {
   )
 
   const approve = useCallback(
-    async (approved: boolean, message?: string) => {
+    async (approved: boolean, message?: string, responseType?: 'permission' | 'question') => {
       const currentSession = useAgentStore.getState().sessions.get(taskId!)
       if (!currentSession?.sessionId) throw new Error('No active session')
-      await agentSessionApi.approve(currentSession.sessionId, approved, message)
+      await agentSessionApi.approve(currentSession.sessionId, approved, message, responseType)
       captureAnalyticsEvent('agent_approval_responded', {
         task_id: taskId,
         agent_id: currentSession.agentId,

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -154,8 +154,10 @@ export const agentSessionApi = {
     return window.electronAPI.agentSession.sendByTaskId(taskId, message, attachments)
   },
 
-  approve: (sessionId: string, approved: boolean, message?: string): Promise<{ success: boolean }> => {
-    return window.electronAPI.agentSession.approve(sessionId, approved, message)
+  approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question'): Promise<{ success: boolean }> => {
+    return responseType
+      ? window.electronAPI.agentSession.approve(sessionId, approved, message, responseType)
+      : window.electronAPI.agentSession.approve(sessionId, approved, message)
   },
 
   syncSkills: (sessionId: string): Promise<SkillSyncResult> => {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -252,7 +252,7 @@ interface ElectronAPI {
     stopByTaskId: (taskId: string) => Promise<AgentSessionSuccessResult & { sessionId: string | null }>
     send: (sessionId: string, message: string, taskId?: string, agentId?: string, attachments?: AgentMessageAttachment[]) => Promise<AgentSessionSuccessResult & { newSessionId?: string }>
     sendByTaskId: (taskId: string, message: string, attachments?: AgentMessageAttachment[]) => Promise<AgentSessionSuccessResult & { sessionId: string | null; newSessionId?: string }>
-    approve: (sessionId: string, approved: boolean, message?: string) => Promise<AgentSessionSuccessResult>
+    approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question') => Promise<AgentSessionSuccessResult>
     syncSkills: (sessionId: string) => Promise<SkillSyncResult>
     syncSkillsForTask: (taskId: string) => Promise<SkillSyncResult>
     learnFromSession: (sessionId: string, message: string) => Promise<SkillSyncResult>


### PR DESCRIPTION
## Summary
- distinguish structured question answers from permission decisions across desktop, canvas, and mobile
- route OpenCode answers to question.reply with ordered nested answer arrays
- preserve permission routing for adapters that support both interaction types
- document the mobile API response type

## Root cause
20x sent selected OpenCode question options through the permission handler. The real failed session recorded the question tool as aborted instead of receiving the answer.

## Verification
- reproduced from real session logs
- live OpenCode 1.17.10 HTTP test passed
- live repository OpencodeAdapter test passed
- 194 focused tests passed
- pnpm typecheck passed