### PR TITLE
feat: replace agent-browser CDP integration with in-app browser MCP broker

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,7 @@ import { GitHubIssuesPlugin } from './plugins/github-issues-plugin'
 import { NotionPlugin } from './plugins/notion-plugin'
 import { YouTrackPlugin } from './plugins/youtrack-plugin'
 import { registerIpcHandlers } from './ipc-handlers'
+import { panelBrowserBroker } from './panel-browser-broker'
 import { VoiceSessionManager } from './voice/voice-session-manager'
 import { assistantTextParts, sinceLastUserMessage } from './voice/voice-answer-parts'
 import { EnterpriseAuth } from './enterprise-auth'
@@ -365,8 +366,9 @@ function createWindow(): void {
   })
 
   // SAFETY: Prevent the main window from ever navigating away from the app.
-  // This guards against agent-browser or CDP accidentally targeting the main
-  // window instead of a webview panel.
+  // Defense in depth for the panel browser broker: only registered canvas
+  // browser panels are addressable by agents, so this should never fire —
+  // but if anything ever drives the main window off-app, block it here.
   //
   // Layer 1: will-navigate (catches user-initiated navigations — NOT CDP)
   mainWindow.webContents.on('will-navigate', (event, url) => {
@@ -378,10 +380,8 @@ function createWindow(): void {
     }
   })
 
-  // Layer 2: Recovery — if CDP Page.navigate bypasses will-navigate and the main
-  // window ends up on a non-app URL, detect it and reload the app immediately.
-  // This is a safety net, not prevention — the window briefly shows the wrong page
-  // then snaps back to the app.
+  // Layer 2: Recovery — snap the app back if the main window ever ends up on a
+  // non-app URL despite the guard above. Safety net, not prevention.
   const appUrl = is.dev && process.env['ELECTRON_RENDERER_URL']
     ? process.env['ELECTRON_RENDERER_URL']
     : null // file:// URL set after loadFile
@@ -807,11 +807,12 @@ protocol.registerSchemesAsPrivileged([
 // Initialize crash logger as early as possible
 initCrashLogger()
 
-// Enable Chrome DevTools Protocol (CDP) on a fixed port so that agent-browser
-// (and other CDP clients) can connect to webview tabs embedded in the canvas.
-// Port 0 lets Chromium pick a free port; we read it back via the /json endpoint.
-const CDP_PORT = 19222
-app.commandLine.appendSwitch('remote-debugging-port', String(CDP_PORT))
+// NOTE: The app intentionally does NOT expose a --remote-debugging-port.
+// Canvas browser panels are driven by agents through the in-app panel browser
+// broker (panel-browser-broker.ts) via browser_* MCP tools — only registered
+// panels are addressable, so the main window can never be reached or
+// navigated away by an agent. A global debug port would expose every target
+// (main window = first page target) to any local process.
 
 // ── Anti-bot-detection for embedded browser panels ─────────────────────────
 // Some sites (Xero, banking portals) use Akamai's WAF which fingerprints
@@ -1223,6 +1224,8 @@ app.on('before-quit', async (event) => {
   if (isShuttingDown) {
     return
   }
+
+  panelBrowserBroker.stopAll()
 
   event.preventDefault()
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, shell, Notification, app, session, webContents } from 'electron'
+import { ipcMain, dialog, shell, Notification, app, session } from 'electron'
 import * as childProcess from 'child_process'
 import { copyFileSync, existsSync, unlinkSync, readdirSync, statSync, readFileSync, rmSync } from 'fs'
 import { join, basename, extname } from 'path'
@@ -8,6 +8,7 @@ import WebSocket from 'ws'
 import { startTunnel, stopTunnel, getTunnelUrl, isTunnelActive } from './tunnel-manager'
 import { getPendingPin } from './mobile-api-server'
 import { setTaskApiUiState } from './task-api-server'
+import { panelBrowserBroker } from './panel-browser-broker'
 import type {
   DatabaseManager,
   CreateTaskData,
@@ -2061,43 +2062,25 @@ else:
     }
   })
 
-  // ── Browser CDP ─────────────────────────────────────────
-  // Returns the CDP (Chrome DevTools Protocol) port that agent-browser
-  // can use to connect to webview tabs on the canvas.
-  ipcMain.handle('browser:getCdpPort', () => {
-    return { port: 19222 }
+  // ── Browser panel broker ────────────────────────────────
+  // Canvas browser panels register themselves here so agents can drive them
+  // through browser_* MCP tools. Only registered panels are addressable; the
+  // main app window is never registered and there is no global debug port.
+  ipcMain.handle('browser:registerBrokerPanel', (_event, payload: { panelId: string; webContentsId: number; taskIds: string[] }) => {
+    if (!payload || typeof payload.panelId !== 'string' || typeof payload.webContentsId !== 'number') {
+      return { success: false }
+    }
+    const taskIds = Array.isArray(payload.taskIds) ? payload.taskIds.filter((t): t is string => typeof t === 'string') : []
+    if (!panelBrowserBroker.setPanelTasks(payload.panelId, taskIds)) {
+      panelBrowserBroker.registerPanel(payload.panelId, payload.webContentsId, taskIds)
+    }
+    return { success: true }
   })
 
-  // Returns the CDP target ID for a webview given its webContentsId.
-  // This allows the renderer to store the target ID on the panel data,
-  // so agent-browser can connect directly via ws://localhost:19222/devtools/page/<targetId>
-  ipcMain.handle('browser:getTargetId', async (_event, webContentsId: number) => {
-    try {
-      const wc = webContents.fromId(webContentsId)
-      if (!wc) return { targetId: null }
-
-      // Use the debugger API to get the CDP target info
-      try {
-        wc.debugger.attach('1.3')
-        const { targetInfo } = await wc.debugger.sendCommand('Target.getTargetInfo')
-        const targetId = targetInfo?.targetId || null
-        wc.debugger.detach()
-        return { targetId }
-      } catch {
-        try { wc.debugger.detach() } catch { /* already detached */ }
-        // Fallback: query CDP /json/list and match by URL
-        const wcUrl = wc.getURL()
-        if (!wcUrl) return { targetId: null }
-        const res = await fetch(`http://localhost:19222/json/list`)
-        const targets = await res.json()
-        const match = targets.find((t: { url: string; type: string }) =>
-          t.type === 'webview' && t.url === wcUrl
-        )
-        return { targetId: match?.id || null }
-      }
-    } catch {
-      return { targetId: null }
-    }
+  ipcMain.handle('browser:unregisterBrokerPanel', (_event, panelId: string) => {
+    if (typeof panelId !== 'string') return { success: false }
+    panelBrowserBroker.unregisterPanel(panelId)
+    return { success: true }
   })
 
   // ── External Chrome auth flow ──────────────────────────────────────────
@@ -2310,35 +2293,6 @@ else:
       // Kill Chrome if still running
       try { chromeProc.kill() } catch { /* */ }
       throw err
-    }
-  })
-
-  // Returns all webview CDP targets. Called from the renderer to resolve
-  // CDP target IDs without CORS issues (renderer can't fetch localhost:19222).
-  ipcMain.handle('browser:getCdpTargets', async () => {
-    try {
-      const res = await fetch('http://localhost:19222/json/list')
-      const targets = (await res.json()) as Array<{ id: string; url: string; type: string; title: string }>
-      // agent-browser's `tab` command shows only page + webview targets (not iframes,
-      // service workers, etc.) and sorts them: pages first, then webviews.
-      // We replicate that ordering so the renderer can compute the exact tab ID.
-      const tabTargets = targets
-        .filter((t) => t.type === 'page' || t.type === 'webview')
-        .sort((a, b) => {
-          // page before webview (matches agent-browser ordering)
-          if (a.type === 'page' && b.type !== 'page') return -1
-          if (a.type !== 'page' && b.type === 'page') return 1
-          return 0
-        })
-      return tabTargets.map((t, i) => ({
-        id: t.id,
-        url: t.url,
-        title: t.title,
-        type: t.type,
-        tabId: `t${i + 1}`,
-      }))
-    } catch {
-      return []
     }
   })
 

--- a/src/main/mcp-servers/task-management-core.ts
+++ b/src/main/mcp-servers/task-management-core.ts
@@ -527,6 +527,125 @@ const mastermindTools = [
   }
 ]
 
+// Browser-panel tools. They drive canvas "Agent Browser" panels through the
+// in-app broker — no external CLI, no global debug port, and only panels
+// edge-connected to the calling task are addressable.
+const taskParam = { type: 'string', description: 'Task ID' }
+const panelIdParam = { type: 'string', description: 'Optional canvas panel ID from browser_list_panels. Omit when exactly one browser panel is linked to the task.' }
+const browserTools = [
+  {
+    name: 'browser_list_panels',
+    description: 'List the canvas browser panels linked to this task. Returns panel_id, url and title for each.',
+    inputSchema: { type: 'object', properties: { task_id: taskParam }, required: ['task_id'] }
+  },
+  {
+    name: 'browser_navigate',
+    description: 'Navigate a browser panel to a URL.',
+    inputSchema: {
+      type: 'object',
+      properties: { task_id: taskParam, url: { type: 'string', description: 'URL to load' }, panel_id: panelIdParam },
+      required: ['task_id', 'url']
+    }
+  },
+  {
+    name: 'browser_snapshot',
+    description: 'Capture interactive elements of a browser panel as @e1…@eN refs (role, name, value). Refs are used by browser_click/browser_type/browser_scroll.',
+    inputSchema: { type: 'object', properties: { task_id: taskParam, panel_id: panelIdParam }, required: ['task_id'] }
+  },
+  {
+    name: 'browser_click',
+    description: 'Click an element by snapshot ref (@e3) or CSS selector.',
+    inputSchema: {
+      type: 'object',
+      properties: { task_id: taskParam, target: { type: 'string', description: '@ref from browser_snapshot or a CSS selector' }, panel_id: panelIdParam },
+      required: ['task_id', 'target']
+    }
+  },
+  {
+    name: 'browser_type',
+    description: 'Type text into an input/textarea/select by ref or CSS selector. Set submit=true to press Enter afterwards.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: taskParam,
+        target: { type: 'string', description: '@ref from browser_snapshot or a CSS selector' },
+        text: { type: 'string' },
+        submit: { type: 'boolean', description: 'Press Enter / submit the form after typing' },
+        panel_id: panelIdParam
+      },
+      required: ['task_id', 'target', 'text']
+    }
+  },
+  {
+    name: 'browser_press_key',
+    description: 'Press a key on the focused element: Enter, Tab, Escape, Backspace, Delete, Space, ArrowUp/Down/Left/Right, Home, End, PageUp, PageDown or a single character.',
+    inputSchema: {
+      type: 'object',
+      properties: { task_id: taskParam, key: { type: 'string' }, panel_id: panelIdParam },
+      required: ['task_id', 'key']
+    }
+  },
+  {
+    name: 'browser_scroll',
+    description: 'Scroll the page (direction up/down/left/right, optional amount in px) or bring an element into view via target.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: taskParam,
+        direction: { type: 'string', enum: ['up', 'down', 'left', 'right'] },
+        amount: { type: 'number', description: 'Pixels to scroll (default 600)' },
+        target: { type: 'string', description: '@ref or CSS selector to scroll into view instead' },
+        panel_id: panelIdParam
+      },
+      required: ['task_id']
+    }
+  },
+  {
+    name: 'browser_get',
+    description: 'Read page facts: what=url | title | text.',
+    inputSchema: {
+      type: 'object',
+      properties: { task_id: taskParam, what: { type: 'string', enum: ['url', 'title', 'text'] }, panel_id: panelIdParam },
+      required: ['task_id', 'what']
+    }
+  },
+  {
+    name: 'browser_wait',
+    description: 'Wait until a CSS selector exists, text appears in the page, or the URL contains a fragment.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: taskParam,
+        mode: { type: 'string', enum: ['selector', 'text', 'url'] },
+        value: { type: 'string' },
+        timeout_ms: { type: 'number', description: 'Default 10000, max 60000' },
+        panel_id: panelIdParam
+      },
+      required: ['task_id', 'mode', 'value']
+    }
+  },
+  {
+    name: 'browser_screenshot',
+    description: 'Capture a PNG screenshot of a browser panel; returns the saved file path.',
+    inputSchema: { type: 'object', properties: { task_id: taskParam, panel_id: panelIdParam }, required: ['task_id'] }
+  },
+  {
+    name: 'browser_back',
+    description: 'Go back in a browser panel history.',
+    inputSchema: { type: 'object', properties: { task_id: taskParam, panel_id: panelIdParam }, required: ['task_id'] }
+  },
+  {
+    name: 'browser_forward',
+    description: 'Go forward in a browser panel history.',
+    inputSchema: { type: 'object', properties: { task_id: taskParam, panel_id: panelIdParam }, required: ['task_id'] }
+  },
+  {
+    name: 'browser_reload',
+    description: 'Reload a browser panel page.',
+    inputSchema: { type: 'object', properties: { task_id: taskParam, panel_id: panelIdParam }, required: ['task_id'] }
+  }
+]
+
 // Subtask-scoped tools (can only access parent task + sibling subtasks)
 const subtaskTools = [
   {
@@ -786,8 +905,8 @@ async function handleScopedCall(
 /** The tools a session may see. This is the whole answer to "which tools to serve". */
 export function listToolsForScope(scope: TaskMcpScope) {
   return isScopedSession(scope)
-    ? [...subtaskTools, ...sharedTools]
-    : [...mastermindTools, ...sharedTools]
+    ? [...subtaskTools, ...browserTools, ...sharedTools]
+    : [...mastermindTools, ...browserTools, ...sharedTools]
 }
 
 /**

--- a/src/main/panel-browser-broker.test.ts
+++ b/src/main/panel-browser-broker.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// The broker only touches Electron APIs inside its command methods; the pure
+// helpers under test here need nothing from it.
+vi.mock('electron', () => ({
+  app: {},
+  webContents: { fromId: () => null }
+}))
+
+import {
+  buildClickScript,
+  buildGetScript,
+  buildPressScript,
+  buildScrollScript,
+  buildSnapshotScript,
+  buildTypeScript,
+  buildWaitScript,
+  normalizeRef,
+  panelBrowserBroker,
+  parseSnapshotResult,
+  resolveKeyName,
+  resolvePanelForTask,
+  unwrapEval,
+  type PanelRegistry
+} from './panel-browser-broker'
+
+function registry(entries: Array<[string, { webContentsId: number; taskIds: string[] }]>): PanelRegistry {
+  return new Map(entries.map(([id, v]) => [id, { webContentsId: v.webContentsId, taskIds: new Set(v.taskIds) }]))
+}
+
+describe('resolvePanelForTask', () => {
+  const reg = registry([
+    ['p1', { webContentsId: 11, taskIds: ['tA'] }],
+    ['p2', { webContentsId: 12, taskIds: ['tA', 'tB'] }]
+  ])
+
+  it('auto-binds when exactly one panel is linked to the task', () => {
+    expect(resolvePanelForTask(reg, 'tB')).toEqual({ ok: true, panelId: 'p2' })
+  })
+
+  it('rejects ambiguity instead of guessing', () => {
+    const r = resolvePanelForTask(reg, 'tA')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toContain('p1, p2')
+  })
+
+  it('errors with guidance when nothing is linked', () => {
+    const r = resolvePanelForTask(registry([]), 'tX')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toContain('No browser panel is linked')
+  })
+
+  it('accepts an explicit linked panel_id', () => {
+    expect(resolvePanelForTask(reg, 'tA', 'p1')).toEqual({ ok: true, panelId: 'p1' })
+  })
+
+  it('rejects an unlinked or unknown panel_id', () => {
+    const unlinked = resolvePanelForTask(reg, 'tB', 'p1')
+    expect(unlinked.ok).toBe(false)
+    const unknown = resolvePanelForTask(reg, 'tA', 'nope')
+    expect(unknown.ok).toBe(false)
+    if (!unknown.ok) expect(unknown.error).toContain('Unknown browser panel')
+  })
+})
+
+describe('normalizeRef', () => {
+  it('strips the @ prefix', () => {
+    expect(normalizeRef('@e12')).toBe('e12')
+    expect(normalizeRef('e3')).toBe('e3')
+  })
+})
+
+describe('snapshot script + parser round-trip', () => {
+  it('script labels elements with data-bx-ref and caps output', () => {
+    const script = buildSnapshotScript()
+    expect(script).toContain('data-bx-ref')
+    expect(script).toContain('120')
+    expect(script.trim().startsWith('(() =>')).toBe(true)
+  })
+
+  it('parses a well-formed payload', () => {
+    const payload = JSON.stringify({ url: 'https://x.io', title: 'X', elements: [{ ref: 'e1', role: 'button', name: 'Go' }] })
+    expect(parseSnapshotResult(payload)).toMatchObject({ url: 'https://x.io', title: 'X' })
+  })
+
+  it('rejects malformed payloads', () => {
+    expect(parseSnapshotResult(null)).toHaveProperty('error')
+    expect(parseSnapshotResult('not json')).toHaveProperty('error')
+    expect(parseSnapshotResult('{}')).toHaveProperty('error')
+  })
+})
+
+describe('interaction scripts', () => {
+  it('click resolves refs via data-bx-ref', () => {
+    const script = buildClickScript('@e7')
+    expect(script).toContain('[data-bx-ref=\\"e7\\"]')
+  })
+
+  it('click treats non-ref input as a CSS selector', () => {
+    expect(buildClickScript('#submit')).toContain('"#submit"')
+  })
+
+  it('type embeds text safely and supports submit', () => {
+    const script = buildTypeScript('@e2', 'he said "hi"', true)
+    expect(script).toContain('"he said \\"hi\\""')
+    expect(script).toContain('requestSubmit')
+  })
+
+  it('press maps known keys and rejects unknown ones', () => {
+    expect(buildPressScript('Enter')).toContain('"keyCode":13')
+    expect(buildPressScript('arrowdown')).toContain('"keyCode":40')
+    expect(resolveKeyName('q')).toMatchObject({ key: 'Q' })
+    expect(buildPressScript('meta+shift+p')).toContain('Unsupported key')
+  })
+
+  it('scroll defaults downward and honors direction', () => {
+    expect(buildScrollScript()).toContain('window.scrollBy(0, 600)')
+    expect(buildScrollScript('up')).toContain('window.scrollBy(0, -600)')
+    expect(buildScrollScript(undefined, undefined, '@e1')).toContain('scrollIntoView')
+  })
+
+  it('get covers url/title/text only', () => {
+    expect(buildGetScript('url')).toContain('location.href')
+    expect(buildGetScript('title')).toContain('document.title')
+    expect(buildGetScript('text')).toContain('innerText')
+    expect(buildGetScript('cookies')).toContain('error')
+  })
+
+  it('wait bounds its timeout and escapes values', () => {
+    expect(buildWaitScript('text', 'Done', 500)).toContain('"Done"')
+    expect(buildWaitScript('selector', '.ok', 999999)).not.toContain('999999')
+    expect(buildWaitScript('url', 'dashboard', 5000)).toContain('location.href.includes("dashboard")')
+  })
+})
+
+describe('unwrapEval', () => {
+  it('parses JSON strings into objects', () => {
+    expect(unwrapEval('{"ok":true}')).toEqual({ ok: true })
+  })
+  it('wraps non-JSON strings as values', () => {
+    expect(unwrapEval('plain')).toEqual({ ok: true, value: 'plain' })
+  })
+  it('passes objects through', () => {
+    expect(unwrapEval({ ok: false })).toEqual({ ok: false })
+  })
+})
+
+describe('registry lifecycle', () => {
+  it('register/unregister/list track linkage without touching live webContents', () => {
+    // listPanels tolerates dead webContents ids (returns empty url/title).
+    panelBrowserBroker.registerPanel('px', 999_999, ['taskZ'])
+    expect(panelBrowserBroker.listPanels('taskZ')).toEqual([{ panelId: 'px', url: '', title: '' }])
+    expect(panelBrowserBroker.listPanels('other')).toEqual([])
+    expect(panelBrowserBroker.setPanelTasks('missing', [])).toBe(false)
+    expect(panelBrowserBroker.unregisterPanel('px')).toBe(true)
+    expect(panelBrowserBroker.unregisterPanel('px')).toBe(false)
+    panelBrowserBroker.stopAll()
+  })
+})

--- a/src/main/panel-browser-broker.test.ts
+++ b/src/main/panel-browser-broker.test.ts
@@ -83,6 +83,10 @@ describe('snapshot script + parser round-trip', () => {
     expect(parseSnapshotResult(payload)).toMatchObject({ url: 'https://x.io', title: 'X' })
   })
 
+  it('accepts an already-parsed object (executeJavaScript may return it unwrapped)', () => {
+    expect(parseSnapshotResult({ url: 'https://x.io', title: 'X', elements: [] })).toMatchObject({ url: 'https://x.io' })
+  })
+
   it('rejects malformed payloads', () => {
     expect(parseSnapshotResult(null)).toHaveProperty('error')
     expect(parseSnapshotResult('not json')).toHaveProperty('error')

--- a/src/main/panel-browser-broker.ts
+++ b/src/main/panel-browser-broker.ts
@@ -169,17 +169,26 @@ export function buildTypeScript(refOrSelector: string, text: string, submit?: bo
   return `(async () => {
   const el = document.querySelector(${queryFor(refOrSelector)});
   if (!el) return JSON.stringify({ error: 'Stale or unknown target — run browser_snapshot again.' });
-  el.focus();
-  if (el.tagName === 'SELECT') {
+  const tag = el.tagName;
+  if (tag === 'SELECT') {
     el.value = ${JSON.stringify(text)};
     el.dispatchEvent(new Event('change', { bubbles: true }));
-  } else {
-    const proto = el.tagName === 'TEXTAREA' ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+  } else if ((tag === 'INPUT' || tag === 'TEXTAREA') && !el.readOnly) {
+    el.focus();
+    const proto = tag === 'TEXTAREA' ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
     const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
     if (setter) setter.call(el, ${JSON.stringify(text)});
-    else el.textContent = ${JSON.stringify(text)};
+    else el.value = ${JSON.stringify(text)};
     el.dispatchEvent(new Event('input', { bubbles: true }));
     el.dispatchEvent(new Event('change', { bubbles: true }));
+  } else if (el.isContentEditable) {
+    el.focus();
+    el.textContent = ${JSON.stringify(text)};
+    el.dispatchEvent(new InputEvent('input', { bubbles: true }));
+  } else {
+    // Not an editable element (e.g. a link or button was passed): report
+    // instead of throwing "Illegal invocation" from the native value setter.
+    return JSON.stringify({ error: 'Target "${refOrSelector.replace(/"/g, '')}" is not an editable element (role: ' + (el.getAttribute('role') || tag.toLowerCase()) + '). Pick an input/textarea ref from browser_snapshot.' });
   }
   if (${submit ? 'true' : 'false'}) {
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
@@ -297,6 +306,23 @@ export function unwrapEval(raw: unknown): Record<string, unknown> {
   }
   if (raw && typeof raw === 'object') return raw as Record<string, unknown>
   return { ok: true }
+}
+
+/**
+ * Guarantees a command settles even when the page cannot answer — e.g. an
+ * in-page polling loop starved by background timer throttling, or a renderer
+ * busy in a modal loop. Without this a tool call could hang forever.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  fallback: T
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(fallback), Math.max(ms, 0))
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
 }
 
 // ── Broker ───────────────────────────────────────────────────────────────────
@@ -453,14 +479,35 @@ export class PanelBrowserBroker {
     return this.evalOnResolved(taskId, panelId, buildGetScript(what))
   }
 
-  wait(taskId: string, mode: 'selector' | 'text' | 'url', value: string, timeoutMs?: number, panelId?: string | null): Promise<Record<string, unknown>> {
-    return this.evalOnResolved(taskId, panelId, buildWaitScript(mode, value, timeoutMs ?? 10000))
+  async wait(taskId: string, mode: 'selector' | 'text' | 'url', value: string, timeoutMs?: number, panelId?: string | null): Promise<Record<string, unknown>> {
+    const resolved = this.resolve(taskId, panelId)
+    if (!resolved.ok) return resolved
+    const budget = Math.max(500, Math.min(timeoutMs ?? 10000, 60000))
+    if (mode === 'url') {
+      // Poll from the Node side: background/hidden panels throttle in-page
+      // timers, so a page-side polling loop can miss its own deadline.
+      const started = Date.now()
+      const deadline = started + budget
+      for (;;) {
+        const url = resolved.wc.getURL()
+        if (url.includes(value)) return { ok: true, waitedMs: Date.now() - started, url }
+        if (Date.now() >= deadline) {
+          return { error: `Timed out after ${budget}ms waiting for url: ${value}`, url }
+        }
+        await new Promise((r) => setTimeout(r, 250))
+      }
+    }
+    return withTimeout(
+      this.evalOnResolved(taskId, panelId, buildWaitScript(mode, value, budget)),
+      budget + 5000,
+      { error: `Timed out after ${budget + 5000}ms waiting for ${mode}: ${value}` }
+    )
   }
 
   private async evalOnResolved(taskId: string, panelId: string | null | undefined, script: string): Promise<Record<string, unknown>> {
     const resolved = this.resolve(taskId, panelId)
     if (!resolved.ok) return resolved
-    return this.eval(resolved.wc, script)
+    return withTimeout(this.eval(resolved.wc, script), 30000, { error: 'Timed out after 30s — the page did not answer (it may be navigating or throttled in the background).' })
   }
 
   async screenshot(taskId: string, panelId?: string | null): Promise<Record<string, unknown>> {

--- a/src/main/panel-browser-broker.ts
+++ b/src/main/panel-browser-broker.ts
@@ -126,16 +126,21 @@ export interface SnapshotResult {
   elements: SnapshotElement[]
 }
 
-/** Parses the stringified-JSON payload returned by buildSnapshotScript(). */
+/** Parses the payload returned by buildSnapshotScript() — object or JSON string. */
 export function parseSnapshotResult(raw: unknown): SnapshotResult | { error: string } {
-  if (typeof raw !== 'string') return { error: 'Unexpected snapshot result shape' }
-  try {
-    const parsed = JSON.parse(raw) as SnapshotResult
-    if (!parsed || !Array.isArray(parsed.elements)) return { error: 'Malformed snapshot payload' }
-    return parsed
-  } catch {
+  let parsed: unknown = raw
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return { error: 'Malformed snapshot payload' }
+    }
+  }
+  const snap = parsed as SnapshotResult | null
+  if (!snap || typeof snap !== 'object' || !Array.isArray(snap.elements)) {
     return { error: 'Malformed snapshot payload' }
   }
+  return snap
 }
 
 function queryFor(refOrSelector: string): string {
@@ -421,7 +426,9 @@ export class PanelBrowserBroker {
   async snapshot(taskId: string, panelId?: string | null): Promise<Record<string, unknown>> {
     const resolved = this.resolve(taskId, panelId)
     if (!resolved.ok) return resolved
-    const result = parseSnapshotResult((await this.eval(resolved.wc, buildSnapshotScript())).value)
+    const evalResult = await this.eval(resolved.wc, buildSnapshotScript())
+    if (evalResult.error) return evalResult
+    const result = parseSnapshotResult(evalResult)
     if ('error' in result) return result
     return result as unknown as Record<string, unknown>
   }

--- a/src/main/panel-browser-broker.ts
+++ b/src/main/panel-browser-broker.ts
@@ -1,0 +1,475 @@
+/**
+ * Panel Browser Broker.
+ *
+ * Lets agent sessions drive the canvas browser panels (<webview>) through
+ * `browser_*` MCP tools served by the Task API server, with two hard
+ * guarantees that the previous agent-browser + global CDP port integration
+ * could not give:
+ *
+ *  1. The main app window is unreachable. Panels must be registered here
+ *     explicitly (the renderer registers each browser panel with the task ids
+ *     it is edge-connected to), and only registered panels can be addressed.
+ *     Nothing else — including the main window — is ever exposed, and there is
+ *     no debug port to enumerate targets from.
+ *  2. Addressing is exact and stable. Commands name a canvas panelId (auto-
+ *     bound when exactly one browser panel is linked to the calling task), so
+ *     there are no positional tab indexes to go stale.
+ *
+ * Everything runs on plain Electron APIs (loadURL / executeJavaScript /
+ * capturePage) — no debugger attachment, no CDP sockets.
+ */
+import { app, webContents } from 'electron'
+import { mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+// ── Pure helpers (unit-tested without Electron) ─────────────────────────────
+
+export interface RegisteredPanel {
+  webContentsId: number
+  taskIds: Set<string>
+}
+
+export type PanelRegistry = Map<string, RegisteredPanel>
+
+export interface ResolvedPanel {
+  ok: true
+  panelId: string
+}
+
+export interface PanelResolutionError {
+  ok: false
+  error: string
+}
+
+/**
+ * Picks which panel a command may act on. With an explicit panel_id it must
+ * exist AND be linked to the calling task. Without one, auto-binds when
+ * exactly one panel is linked to the task; ambiguity is an error, not a guess.
+ */
+export function resolvePanelForTask(
+  registry: PanelRegistry,
+  taskId: string,
+  panelId?: string | null
+): ResolvedPanel | PanelResolutionError {
+  if (!(registry instanceof Map)) return { ok: false, error: 'Broker registry unavailable' }
+
+  if (panelId) {
+    const panel = registry.get(panelId)
+    if (!panel) {
+      return { ok: false, error: `Unknown browser panel "${panelId}". Use browser_list_panels.` }
+    }
+    if (!panel.taskIds.has(taskId)) {
+      return { ok: false, error: `Browser panel "${panelId}" is not linked to this task. Use browser_list_panels.` }
+    }
+    return { ok: true, panelId }
+  }
+
+  const linked = [...registry.entries()].filter(([, p]) => p.taskIds.has(taskId))
+  if (linked.length === 0) {
+    return { ok: false, error: 'No browser panel is linked to this task. Connect one on the canvas (globe handle on the task panel).' }
+  }
+  if (linked.length > 1) {
+    const list = linked.map(([id]) => id).join(', ')
+    return { ok: false, error: `Multiple browser panels are linked to this task (${list}). Pass panel_id.` }
+  }
+  return { ok: true, panelId: linked[0][0] }
+}
+
+/** Normalizes "@e12" / "e12" ref values to their element attribute value. */
+export function normalizeRef(ref: string): string {
+  return ref.startsWith('@') ? ref.slice(1) : ref
+}
+
+const SNAPSHOT_ELEMENT_CAP = 120
+
+/**
+ * Builds the injected script behind browser_snapshot: labels every visible
+ * interactive element with data-bx-ref="eN" and returns a compact JSON line
+ * per element — the same @ref ergonomics agents know from agent-browser.
+ */
+export function buildSnapshotScript(): string {
+  return `(() => {
+  const SEL = 'a[href],button,input,select,textarea,[role=button],[role=link],[role=checkbox],[role=tab],[role=switch],[onclick],[contenteditable=true],summary';
+  const out = [];
+  let i = 0;
+  for (const el of document.querySelectorAll(SEL)) {
+    if (out.length >= ${SNAPSHOT_ELEMENT_CAP}) break;
+    const r = el.getBoundingClientRect();
+    if (r.width < 2 || r.height < 2) continue;
+    const st = getComputedStyle(el);
+    if (st.visibility === 'hidden' || st.display === 'none' || Number(st.opacity) === 0) continue;
+    const ref = 'e' + (++i);
+    el.setAttribute('data-bx-ref', ref);
+    out.push({
+      ref,
+      role: el.getAttribute('role') || el.tagName.toLowerCase(),
+      name: (el.getAttribute('aria-label') || el.innerText || el.getAttribute('placeholder') || el.getAttribute('title') || '').trim().replace(/\\s+/g, ' ').slice(0, 80),
+      value: ['INPUT','SELECT','TEXTAREA'].includes(el.tagName) ? String(el.value ?? '').slice(0, 60) : undefined,
+      href: el.tagName === 'A' ? (el.getAttribute('href') || '').slice(0, 120) : undefined
+    });
+  }
+  return JSON.stringify({ url: location.href, title: document.title, elements: out });
+})()`
+}
+
+export interface SnapshotElement {
+  ref: string
+  role: string
+  name?: string
+  value?: string
+  href?: string
+}
+
+export interface SnapshotResult {
+  url: string
+  title: string
+  elements: SnapshotElement[]
+}
+
+/** Parses the stringified-JSON payload returned by buildSnapshotScript(). */
+export function parseSnapshotResult(raw: unknown): SnapshotResult | { error: string } {
+  if (typeof raw !== 'string') return { error: 'Unexpected snapshot result shape' }
+  try {
+    const parsed = JSON.parse(raw) as SnapshotResult
+    if (!parsed || !Array.isArray(parsed.elements)) return { error: 'Malformed snapshot payload' }
+    return parsed
+  } catch {
+    return { error: 'Malformed snapshot payload' }
+  }
+}
+
+function queryFor(refOrSelector: string): string {
+  const looksLikeRef = /^@?e\d+$/.test(refOrSelector.trim())
+  if (!looksLikeRef) {
+    // Treat anything else as a CSS selector.
+    return JSON.stringify(refOrSelector)
+  }
+  return JSON.stringify(`[data-bx-ref="${normalizeRef(refOrSelector.trim())}"]`)
+}
+
+/** Clicks a snapshot ref (or CSS selector), scrolling it into view first. */
+export function buildClickScript(refOrSelector: string): string {
+  return `(async () => {
+  const el = document.querySelector(${queryFor(refOrSelector)});
+  if (!el) return JSON.stringify({ error: 'Stale or unknown target "${refOrSelector.replace(/"/g, '')}" — run browser_snapshot again.' });
+  el.scrollIntoView({ block: 'center' });
+  await new Promise(r => setTimeout(r, 50));
+  el.click();
+  return JSON.stringify({ ok: true });
+})()`
+}
+
+/** Focuses an element and sets its value with React-compatible events. */
+export function buildTypeScript(refOrSelector: string, text: string, submit?: boolean): string {
+  return `(async () => {
+  const el = document.querySelector(${queryFor(refOrSelector)});
+  if (!el) return JSON.stringify({ error: 'Stale or unknown target — run browser_snapshot again.' });
+  el.focus();
+  if (el.tagName === 'SELECT') {
+    el.value = ${JSON.stringify(text)};
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  } else {
+    const proto = el.tagName === 'TEXTAREA' ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(proto, 'value').set;
+    if (setter) setter.call(el, ${JSON.stringify(text)});
+    else el.textContent = ${JSON.stringify(text)};
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+  if (${submit ? 'true' : 'false'}) {
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+    const form = el.closest('form');
+    if (form) form.requestSubmit ? form.requestSubmit() : form.submit();
+  }
+  return JSON.stringify({ ok: true });
+})()`
+}
+
+const KEY_CODES: Record<string, { key: string; code: string; keyCode: number }> = {
+  enter: { key: 'Enter', code: 'Enter', keyCode: 13 },
+  tab: { key: 'Tab', code: 'Tab', keyCode: 9 },
+  escape: { key: 'Escape', code: 'Escape', keyCode: 27 },
+  backspace: { key: 'Backspace', code: 'Backspace', keyCode: 8 },
+  delete: { key: 'Delete', code: 'Delete', keyCode: 46 },
+  space: { key: ' ', code: 'Space', keyCode: 32 },
+  arrowup: { key: 'ArrowUp', code: 'ArrowUp', keyCode: 38 },
+  arrowdown: { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 },
+  arrowleft: { key: 'ArrowLeft', code: 'ArrowLeft', keyCode: 37 },
+  arrowright: { key: 'ArrowRight', code: 'ArrowRight', keyCode: 39 },
+  home: { key: 'Home', code: 'Home', keyCode: 36 },
+  end: { key: 'End', code: 'End', keyCode: 35 },
+  pageup: { key: 'PageUp', code: 'PageUp', keyCode: 33 },
+  pagedown: { key: 'PageDown', code: 'PageDown', keyCode: 34 }
+}
+
+/** Maps user-facing key names ("Enter", "arrowdown") to CDP-style key data. */
+export function resolveKeyName(key: string): { key: string; code: string; keyCode: number } | null {
+  const k = KEY_CODES[key.toLowerCase()]
+  if (k) return k
+  if (/^[a-z0-9]$/i.test(key)) {
+    return { key: key.toUpperCase(), code: `Key${key.toUpperCase()}`, keyCode: key.toUpperCase().charCodeAt(0) }
+  }
+  return null
+}
+
+/** Dispatches a keydown/keypress/keyup sequence on the focused element. */
+export function buildPressScript(key: string): string {
+  const k = resolveKeyName(key)
+  if (!k) return `JSON.stringify({ error: 'Unsupported key ${JSON.stringify(key)} — use Enter, Tab, Escape, Backspace, Delete, Space, ArrowUp/Down/Left/Right, Home, End, PageUp, PageDown or a single character.' })`
+  const init = JSON.stringify(k)
+  return `(() => {
+  const target = document.activeElement || document.body;
+  const opts = { ...${init}, bubbles: true, cancelable: true };
+  target.dispatchEvent(new KeyboardEvent('keydown', opts));
+  target.dispatchEvent(new KeyboardEvent('keypress', opts));
+  target.dispatchEvent(new KeyboardEvent('keyup', opts));
+  return JSON.stringify({ ok: true });
+})()`
+}
+
+/** Scrolls the page or, when given a target, that element into view. */
+export function buildScrollScript(direction?: string, amount?: number, refOrSelector?: string): string {
+  const delta = typeof amount === 'number' && amount > 0 ? Math.round(amount) : 600
+  if (refOrSelector) {
+    return `(() => {
+  const el = document.querySelector(${queryFor(refOrSelector)});
+  if (!el) return JSON.stringify({ error: 'Stale or unknown target — run browser_snapshot again.' });
+  el.scrollIntoView({ block: 'center' });
+  return JSON.stringify({ ok: true });
+})()`
+  }
+  const dy = direction?.toLowerCase() === 'up' ? -delta : direction?.toLowerCase() === 'left' ? -delta : direction?.toLowerCase() === 'right' ? delta : delta
+  const dx = direction?.toLowerCase() === 'left' || direction?.toLowerCase() === 'right' ? dy : 0
+  const scrollY = dx === 0 ? dy : 0
+  return `(() => { window.scrollBy(0, ${scrollY}); return JSON.stringify({ ok: true, scrollY: window.scrollY }); })()`
+}
+
+/** Reads page-level facts: url, title or full text content. */
+export function buildGetScript(what: string): string {
+  switch (what) {
+    case 'url':
+      return `(() => JSON.stringify({ url: location.href }))()`
+    case 'title':
+      return `(() => JSON.stringify({ title: document.title }))()`
+    case 'text':
+      return `(() => JSON.stringify({ text: (document.body?.innerText || '').slice(0, 20000) }))()`
+    default:
+      return `JSON.stringify({ error: 'what must be "url", "title" or "text"' })`
+  }
+}
+
+/** Waits until a selector appears, text shows up, or the URL changes. */
+export function buildWaitScript(mode: 'selector' | 'text' | 'url', value: string, timeoutMs: number): string {
+  const t = Math.max(500, Math.min(timeoutMs || 10000, 60000))
+  return `(async () => {
+  const t0 = Date.now();
+  for (;;) {
+    let hit = false;
+    ${
+      mode === 'selector'
+        ? `hit = !!document.querySelector(${JSON.stringify(value)});`
+        : mode === 'text'
+          ? `hit = (document.body?.innerText || '').includes(${JSON.stringify(value)});`
+          : `hit = location.href.includes(${JSON.stringify(value)});`
+    }
+    if (hit) return JSON.stringify({ ok: true, waitedMs: Date.now() - t0 });
+    if (Date.now() - t0 >= ${t}) return JSON.stringify({ error: 'Timed out after ${t}ms waiting for ${mode}: ${value.replace(/[\\"]|<\/script/g, '')}' });
+    await new Promise(r => setTimeout(r, 250));
+  }
+})()`
+}
+
+/** Parses whatever executeJavaScript resolved into a plain object. */
+export function unwrapEval(raw: unknown): Record<string, unknown> {
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw)
+      if (parsed && typeof parsed === 'object') return parsed as Record<string, unknown>
+    } catch {
+      return { ok: true, value: raw }
+    }
+  }
+  if (raw && typeof raw === 'object') return raw as Record<string, unknown>
+  return { ok: true }
+}
+
+// ── Broker ───────────────────────────────────────────────────────────────────
+
+export class PanelBrowserBroker {
+  private registry: PanelRegistry = new Map()
+
+  registerPanel(panelId: string, webContentsId: number, taskIds: string[]): void {
+    this.registry.set(panelId, { webContentsId, taskIds: new Set(taskIds) })
+  }
+
+  /** Replaces just the task linkage (edges changed), keeping the webContentsId. */
+  setPanelTasks(panelId: string, taskIds: string[]): boolean {
+    const panel = this.registry.get(panelId)
+    if (!panel) return false
+    panel.taskIds = new Set(taskIds)
+    return true
+  }
+
+  unregisterPanel(panelId: string): boolean {
+    return this.registry.delete(panelId)
+  }
+
+  listPanels(taskId: string): Array<{ panelId: string; url: string; title: string }> {
+    const out: Array<{ panelId: string; url: string; title: string }> = []
+    for (const [panelId, entry] of this.registry) {
+      if (!entry.taskIds.has(taskId)) continue
+      const wc = this.getLiveWebContents(entry.webContentsId)
+      out.push({
+        panelId,
+        url: wc ? wc.getURL() : '',
+        title: wc ? wc.getTitle() : ''
+      })
+    }
+    return out
+  }
+
+  stopAll(): void {
+    this.registry.clear()
+  }
+
+  private getLiveWebContents(webContentsId: number): Electron.WebContents | null {
+    if (typeof webContentsId !== 'number') return null
+    try {
+      const wc = webContents.fromId(webContentsId)
+      return wc && !wc.isDestroyed() ? wc : null
+    } catch {
+      return null
+    }
+  }
+
+  /** Resolves the live webContents for a task-scoped command, or an error object. */
+  private resolve(taskId: string, panelId?: string | null):
+    | { ok: true; wc: Electron.WebContents }
+    | { ok: false; error: string } {
+    const resolved = resolvePanelForTask(this.registry, taskId, panelId)
+    if (!resolved.ok) return { ok: false, error: resolved.error }
+    const entry = this.registry.get(resolved.panelId)!
+    const wc = this.getLiveWebContents(entry.webContentsId)
+    if (!wc) {
+      this.registry.delete(resolved.panelId)
+      return { ok: false, error: 'That browser panel was closed. Use browser_list_panels.' }
+    }
+    return { ok: true, wc }
+  }
+
+  private async eval(wc: Electron.WebContents, script: string): Promise<Record<string, unknown>> {
+    try {
+      return unwrapEval(await wc.executeJavaScript(script, true))
+    } catch (err) {
+      return { error: (err as Error).message }
+    }
+  }
+
+  async navigate(taskId: string, url: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    const resolved = this.resolve(taskId, panelId)
+    if (!resolved.ok) return resolved
+    let target = (url || '').trim()
+    if (!/^https?:\/\//i.test(target)) target = 'https://' + target
+    try {
+      await resolved.wc.loadURL(target)
+      return { ok: true, url: resolved.wc.getURL(), title: resolved.wc.getTitle() }
+    } catch (err) {
+      // loadURL rejects on did-fail-load (e.g. ERR_ABORTED on client redirects)
+      // but the page may still have navigated — report where it actually landed.
+      const current = resolved.wc.getURL()
+      if (current && current !== 'about:blank' && !resolved.wc.isLoading()) {
+        return { ok: true, url: current, title: resolved.wc.getTitle(), note: (err as Error).message }
+      }
+      return { error: `Navigation failed: ${(err as Error).message}` }
+    }
+  }
+
+  private historyStep(taskId: string, fn: (wc: Electron.WebContents) => void, panelId?: string | null): Promise<Record<string, unknown>> {
+    const resolved = this.resolve(taskId, panelId)
+    if (!resolved.ok) return Promise.resolve(resolved)
+    return new Promise((resolve) => {
+      const wc = resolved.wc
+      const done = (): void => {
+        cleanup()
+        resolve({ ok: true, url: wc.getURL() })
+      }
+      const timer = setTimeout(done, 15000)
+      const cleanup = (): void => {
+        clearTimeout(timer)
+        wc.removeListener('did-stop-loading', done)
+        wc.removeListener('did-navigate', done)
+      }
+      wc.once('did-stop-loading', done)
+      wc.once('did-navigate', done)
+      fn(wc)
+    })
+  }
+
+  back(taskId: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    return this.historyStep(taskId, (wc) => wc.goBack(), panelId)
+  }
+
+  forward(taskId: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    return this.historyStep(taskId, (wc) => wc.goForward(), panelId)
+  }
+
+  reload(taskId: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    return this.historyStep(taskId, (wc) => wc.reload(), panelId)
+  }
+
+  async snapshot(taskId: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    const resolved = this.resolve(taskId, panelId)
+    if (!resolved.ok) return resolved
+    const result = parseSnapshotResult((await this.eval(resolved.wc, buildSnapshotScript())).value)
+    if ('error' in result) return result
+    return result as unknown as Record<string, unknown>
+  }
+
+  click(taskId: string, target: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    return this.evalOnResolved(taskId, panelId, buildClickScript(target))
+  }
+
+  type(taskId: string, target: string, text: string, submit?: boolean, panelId?: string | null): Promise<Record<string, unknown>> {
+    return this.evalOnResolved(taskId, panelId, buildTypeScript(target, text, submit))
+  }
+
+  pressKey(taskId: string, key: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    return this.evalOnResolved(taskId, panelId, buildPressScript(key))
+  }
+
+  scroll(taskId: string, direction?: string, amount?: number, target?: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    return this.evalOnResolved(taskId, panelId, buildScrollScript(direction, amount, target))
+  }
+
+  get(taskId: string, what: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    return this.evalOnResolved(taskId, panelId, buildGetScript(what))
+  }
+
+  wait(taskId: string, mode: 'selector' | 'text' | 'url', value: string, timeoutMs?: number, panelId?: string | null): Promise<Record<string, unknown>> {
+    return this.evalOnResolved(taskId, panelId, buildWaitScript(mode, value, timeoutMs ?? 10000))
+  }
+
+  private async evalOnResolved(taskId: string, panelId: string | null | undefined, script: string): Promise<Record<string, unknown>> {
+    const resolved = this.resolve(taskId, panelId)
+    if (!resolved.ok) return resolved
+    return this.eval(resolved.wc, script)
+  }
+
+  async screenshot(taskId: string, panelId?: string | null): Promise<Record<string, unknown>> {
+    const resolved = this.resolve(taskId, panelId)
+    if (!resolved.ok) return resolved
+    try {
+      const image = await resolved.wc.capturePage()
+      const dir = join(app.getPath('temp'), '20x-browser-screenshots')
+      mkdirSync(dir, { recursive: true })
+      const file = join(dir, `${taskId}-${Date.now()}.png`)
+      writeFileSync(file, image.toPNG())
+      return { ok: true, path: file }
+    } catch (err) {
+      return { error: `Screenshot failed: ${(err as Error).message}` }
+    }
+  }
+}
+
+export const panelBrowserBroker = new PanelBrowserBroker()

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -35,6 +35,7 @@ import {
   readRegisteredTaskArtifactFile,
   writeRegisteredTaskArtifactFile
 } from './artifacts'
+import { panelBrowserBroker } from './panel-browser-broker'
 
 let server: HttpServer | null = null
 let port: number | null = null
@@ -1118,6 +1119,97 @@ export async function handleRoute(db: DatabaseManager, route: string, params: Re
       }
     }
 
+    // ── Browser-panel tools (panel-scoped broker; see panel-browser-broker.ts) ──
+    case '/browser_list_panels': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      return { panels: panelBrowserBroker.listPanels(taskId) }
+    }
+
+    case '/browser_navigate': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      if (typeof params.url !== 'string' || !params.url.trim()) return { error: 'url is required' }
+      return panelBrowserBroker.navigate(taskId, params.url, str(params.panel_id))
+    }
+
+    case '/browser_snapshot': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      return panelBrowserBroker.snapshot(taskId, str(params.panel_id))
+    }
+
+    case '/browser_click': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      if (typeof params.target !== 'string' || !params.target) return { error: 'target (@ref or CSS selector) is required' }
+      return panelBrowserBroker.click(taskId, params.target, str(params.panel_id))
+    }
+
+    case '/browser_type': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      if (typeof params.target !== 'string' || !params.target) return { error: 'target (@ref or CSS selector) is required' }
+      if (typeof params.text !== 'string') return { error: 'text is required' }
+      return panelBrowserBroker.type(taskId, params.target, params.text, params.submit === true, str(params.panel_id))
+    }
+
+    case '/browser_press_key': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      if (typeof params.key !== 'string' || !params.key) return { error: 'key is required' }
+      return panelBrowserBroker.pressKey(taskId, params.key, str(params.panel_id))
+    }
+
+    case '/browser_scroll': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      const direction = typeof params.direction === 'string' ? params.direction : undefined
+      const amount = typeof params.amount === 'number' ? params.amount : undefined
+      const target = typeof params.target === 'string' ? params.target : undefined
+      return panelBrowserBroker.scroll(taskId, direction, amount, target, str(params.panel_id))
+    }
+
+    case '/browser_get': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      const what = typeof params.what === 'string' ? params.what : ''
+      if (what !== 'url' && what !== 'title' && what !== 'text') return { error: 'what must be url | title | text' }
+      return panelBrowserBroker.get(taskId, what, str(params.panel_id))
+    }
+
+    case '/browser_wait': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      const mode = params.mode
+      if (mode !== 'selector' && mode !== 'text' && mode !== 'url') return { error: 'mode must be selector | text | url' }
+      if (typeof params.value !== 'string' || !params.value) return { error: 'value is required' }
+      return panelBrowserBroker.wait(
+        taskId,
+        mode,
+        params.value,
+        typeof params.timeout_ms === 'number' ? params.timeout_ms : undefined,
+        str(params.panel_id)
+      )
+    }
+
+    case '/browser_screenshot': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      return panelBrowserBroker.screenshot(taskId, str(params.panel_id))
+    }
+
+    case '/browser_back':
+    case '/browser_forward':
+    case '/browser_reload': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      const panelId = str(params.panel_id)
+      if (route === '/browser_back') return panelBrowserBroker.back(taskId, panelId)
+      if (route === '/browser_forward') return panelBrowserBroker.forward(taskId, panelId)
+      return panelBrowserBroker.reload(taskId, panelId)
+    }
+
     default:
       return { error: 'Unknown route' }
   }
@@ -1126,6 +1218,10 @@ export async function handleRoute(db: DatabaseManager, route: string, params: Re
 function safeParseArray(raw: string | null | undefined): unknown[] {
   const parsed = JSON.parse((raw as string) || '[]')
   return Array.isArray(parsed) ? parsed : (parsed != null && parsed !== '' ? [parsed] : [])
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined
 }
 
 function parseTask(task: Record<string, unknown>) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -690,12 +690,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     }
   },
   browser: {
-    getCdpPort: (): Promise<{ port: number }> =>
-      ipcRenderer.invoke('browser:getCdpPort'),
-    getTargetId: (webContentsId: number): Promise<{ targetId: string | null }> =>
-      ipcRenderer.invoke('browser:getTargetId', webContentsId),
-    getCdpTargets: (): Promise<Array<{ id: string; url: string; title: string }>> =>
-      ipcRenderer.invoke('browser:getCdpTargets'),
+    registerBrokerPanel: (payload: { panelId: string; webContentsId: number; taskIds: string[] }): Promise<{ success: boolean }> =>
+      ipcRenderer.invoke('browser:registerBrokerPanel', payload),
+    unregisterBrokerPanel: (panelId: string): Promise<{ success: boolean }> =>
+      ipcRenderer.invoke('browser:unregisterBrokerPanel', panelId),
     openExternalAuth: (loginUrl: string): Promise<{ success: boolean; finalUrl: string; cookieCount: number }> =>
       ipcRenderer.invoke('browser:openExternalAuth', loginUrl)
   }

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -18,9 +18,6 @@ interface BrowserPanelContentProps {
   streamPort?: number
 }
 
-/** CDP port exposed by the Electron app for agent-browser to connect to */
-const CDP_PORT = 19222
-
 /**
  * Build a real Chrome user-agent.  We replace the entire UA rather than
  * stripping tokens — a hardcoded real-Chrome string is the safest way to
@@ -42,9 +39,10 @@ function getChromeUserAgent(): string {
 /**
  * Canvas panel with a real Electron <webview> — a fully interactive browser.
  *
- * The agent can control this browser via CDP (connecting to the webview's
- * debugger port), and the user sees + interacts with the same page live
- * on the canvas.
+ * The panel registers itself (webContentsId + linked task ids) with the
+ * in-app panel browser broker, so agents can drive it through browser_* MCP
+ * tools. Only registered panels are addressable — the main app window never
+ * is. The user sees + interacts with the same page live on the canvas.
  */
 export function BrowserPanelContent({
   panelId,
@@ -105,53 +103,81 @@ export function BrowserPanelContent({
     return unsub
   }, [panelId])
 
-  // ── Resolve CDP target ID once the webview is ready ──────
-  // The webview exposes getWebContentsId() which we send to main process
-  // to get the CDP target ID — stored on the panel for agent-browser to use.
-  const cdpTargetResolved = useRef(false)
+  // ── Broker registration ──────────────────────────────────
+  // The panel is registered with the in-app broker together with the task ids
+  // it is edge-connected to, so browser_* MCP tools can address exactly this
+  // panel for those tasks. Re-registered whenever edges or the webContentsId
+  // change; released when the panel unmounts.
+  const [linkedTaskIds, setLinkedTaskIds] = useState<string[]>([])
+
+  useEffect(() => {
+    function computeLinkedTasks(): string[] {
+      const { edges, panels } = useCanvasStore.getState()
+      const ids: string[] = []
+      for (const e of edges) {
+        if (e.edgeType !== 'browser') continue
+        if (e.fromPanelId !== panelId && e.toPanelId !== panelId) continue
+        const otherId = e.fromPanelId === panelId ? e.toPanelId : e.fromPanelId
+        const other = panels.find((p) => p.id === otherId)
+        if (other?.type === 'task' && other.refId) ids.push(other.refId)
+      }
+      return ids
+    }
+
+    setLinkedTaskIds(computeLinkedTasks())
+    // Only re-compute when edges change, not on every panel position change.
+    const unsub = useCanvasStore.subscribe(
+      (state) => state.edges,
+      () => {
+        setLinkedTaskIds(computeLinkedTasks())
+      }
+    )
+    return unsub
+  }, [panelId])
+
+  const registerWithBroker = useCallback(() => {
+    let wcId: number | undefined
+    try {
+      wcId = webviewRef.current?.getWebContentsId?.()
+    } catch {
+      return
+    }
+    if (!wcId || wcId <= 0) return
+    updatePanel(panelId, { webContentsId: wcId })
+    try {
+      void window.electronAPI?.browser
+        ?.registerBrokerPanel({ panelId, webContentsId: wcId, taskIds: linkedTaskIds })
+        ?.catch(() => {})
+    } catch {
+      // IPC bridge unavailable (tests) — ignore
+    }
+  }, [panelId, linkedTaskIds, updatePanel])
+
+  useEffect(() => {
+    registerWithBroker()
+  }, [registerWithBroker])
+
   useEffect(() => {
     const wv = webviewRef.current
-    if (!wv || cdpTargetResolved.current) return
+    if (!wv) return
+    wv.addEventListener('dom-ready', registerWithBroker)
+    wv.addEventListener('did-navigate', registerWithBroker)
+    return () => {
+      wv.removeEventListener('dom-ready', registerWithBroker)
+      wv.removeEventListener('did-navigate', registerWithBroker)
+    }
+  }, [registerWithBroker])
 
-    const resolveTargetId = async () => {
+  useEffect(() => {
+    const pid = panelId
+    return () => {
       try {
-        // First try via IPC (uses debugger API or CDP match in main process)
-        const wcId = wv.getWebContentsId?.()
-        console.log(`[BrowserPanel:${panelId}] webContentsId=${wcId}, url=${wv.getURL?.()?.slice(0, 60)}`)
-        if (wcId) {
-          // Store webContentsId on panel for reliable CDP target resolution
-          updatePanel(panelId, { webContentsId: wcId })
-          const result = await window.electronAPI.browser.getTargetId(wcId)
-          if (result.targetId) {
-            cdpTargetResolved.current = true
-            updatePanel(panelId, { cdpTargetId: result.targetId, webContentsId: wcId })
-            return
-          }
-        }
-
-        // Fallback: query CDP targets via IPC (avoids CORS) and match by webview URL
-        const wvUrl = wv.getURL?.()
-        if (!wvUrl) return
-        const targets = await window.electronAPI.browser.getCdpTargets()
-        const match = targets.find((t) => t.url === wvUrl)
-        if (match) {
-          cdpTargetResolved.current = true
-          updatePanel(panelId, { cdpTargetId: match.id })
-        }
+        void window.electronAPI?.browser?.unregisterBrokerPanel(pid)?.catch(() => {})
       } catch {
-        // Silently ignore — webview may not be ready yet
+        // IPC bridge unavailable (tests) — ignore
       }
     }
-
-    wv.addEventListener('did-navigate', resolveTargetId)
-    wv.addEventListener('dom-ready', resolveTargetId)
-    // Also try immediately in case it's already loaded
-    resolveTargetId()
-    return () => {
-      wv.removeEventListener('did-navigate', resolveTargetId)
-      wv.removeEventListener('dom-ready', resolveTargetId)
-    }
-  }, [panelId, updatePanel])
+  }, [panelId])
 
   // ── Webview event wiring ──────────────────────────────────
   // Debounce store updates to avoid re-render storms from SPA sites (e.g. Google Maps)
@@ -458,11 +484,11 @@ function BrowserUrlBar({
       {connectedTaskName && (
         <div
           className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-orange-500/10 border border-orange-500/20 flex-shrink-0"
-          title={`Connected to "${connectedTaskName}" — agent can control this browser via CDP port ${CDP_PORT}`}
+          title={`Connected to "${connectedTaskName}" — agent controls this panel via browser_* tools (in-app broker)`}
         >
           <Zap className="h-2.5 w-2.5 text-orange-400" />
           <span className="text-[9px] font-medium text-orange-400/80 whitespace-nowrap">
-            CDP
+            AGENT
           </span>
         </div>
       )}

--- a/src/renderer/src/stores/canvas-store.ts
+++ b/src/renderer/src/stores/canvas-store.ts
@@ -3,7 +3,6 @@ import { subscribeWithSelector } from 'zustand/middleware'
 import { settingsApi } from '@/lib/ipc-client'
 
 const CANVAS_STORAGE_KEY = 'canvas_state'
-const CDP_PORT = 19222
 let saveTimer: ReturnType<typeof setTimeout> | null = null
 const SAVE_DEBOUNCE_MS = 1000
 
@@ -15,6 +14,19 @@ const CANVAS_DEBUG =
 
 function clog(...args: unknown[]): void {
   if (CANVAS_DEBUG) console.log(...args)
+}
+
+/**
+ * Fire-and-forget release of a browser panel from the agent-facing broker
+ * when its canvas panel goes away. Safe to call for any panel type — only
+ * registered panels are affected.
+ */
+function releaseBrokerPanel(panelId: string): void {
+  try {
+    void window.electronAPI?.browser?.unregisterBrokerPanel(panelId)?.catch(() => {})
+  } catch {
+    // IPC bridge unavailable (tests) — ignore
+  }
 }
 
 // ── Panel types ────────────────────────────────────────────
@@ -32,9 +44,7 @@ export interface CanvasPanelData {
   browserSessionId?: string
   /** WebSocket streaming port (for browser panels) */
   streamPort?: number
-  /** CDP target ID for this webview — used to connect agent-browser directly */
-  cdpTargetId?: string
-  /** Electron webContentsId for this webview — used to resolve CDP target via IPC */
+  /** Electron webContentsId for this webview — used to register the panel with the broker */
   webContentsId?: number
   title: string
   x: number
@@ -413,6 +423,7 @@ export const useCanvasStore = create<CanvasState>()(subscribeWithSelector((set, 
   },
 
   removePanel: (id) => {
+    releaseBrokerPanel(id)
     get().removeEdgesForPanel(id)
     set((s) => ({ panels: s.panels.filter((p) => p.id !== id) }))
     scheduleSave()
@@ -422,6 +433,7 @@ export const useCanvasStore = create<CanvasState>()(subscribeWithSelector((set, 
     const { panels } = get()
     const panelsToRemove = panels.filter((p) => p.refId === refId)
     for (const p of panelsToRemove) {
+      releaseBrokerPanel(p.id)
       get().removeEdgesForPanel(p.id)
     }
     set((s) => ({
@@ -449,6 +461,9 @@ export const useCanvasStore = create<CanvasState>()(subscribeWithSelector((set, 
   },
 
   clearPanels: () => {
+    for (const p of get().panels) {
+      releaseBrokerPanel(p.id)
+    }
     set({ panels: [], edges: [], nextZIndex: 1 })
     scheduleSave()
   },
@@ -690,21 +705,6 @@ function notifyAgentOfBrowserConnection(
   const taskPanel = fromPanel?.type === 'task' ? fromPanel : toPanel?.type === 'task' ? toPanel : null
   const browserPanel = fromPanel?.type === 'browser' ? fromPanel : toPanel?.type === 'browser' ? toPanel : null
 
-  // Read fresh panel data from store — the `panels` parameter is a snapshot from
-  // edge creation and may have stale webContentsId from localStorage persistence.
-  const freshBrowserPanel = browserPanel
-    ? useCanvasStore.getState().panels.find((p) => p.id === browserPanel.id) || browserPanel
-    : browserPanel
-
-  clog('[BrowserEdge] notifyAgentOfBrowserConnection called', {
-    fromPanelId, toPanelId,
-    fromType: fromPanel?.type, toType: toPanel?.type,
-    taskRefId: taskPanel?.refId, browserPanelId: freshBrowserPanel?.id,
-    browserUrl: freshBrowserPanel?.url, browserTitle: freshBrowserPanel?.title,
-    browserCdpTargetId: freshBrowserPanel?.cdpTargetId,
-    browserWebContentsId: freshBrowserPanel?.webContentsId,
-  })
-
   if (!taskPanel?.refId || !browserPanel) {
     clog('[BrowserEdge] BAIL: no taskPanel.refId or no browserPanel')
     return
@@ -714,17 +714,15 @@ function notifyAgentOfBrowserConnection(
     const [{ useAgentStore }, { agentSessionApi }, { useTaskStore }] = await Promise.all([
       import('./agent-store'),
       import('@/lib/ipc-client'),
-      import('./task-store'),
+      import('./task-store')
     ])
 
     const taskId = taskPanel.refId!
     let session = useAgentStore.getState().getSession(taskId)
-    clog('[BrowserEdge] session state', { taskId, sessionId: session?.sessionId, agentId: session?.agentId })
 
     // If no active session, auto-start or resume the task
     if (!session?.sessionId) {
       const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
-      clog('[BrowserEdge] no session, looking up task', { taskId, agentId: task?.agent_id, sessionId: task?.session_id })
       if (!task?.agent_id) {
         clog('[BrowserEdge] BAIL: no agent_id on task')
         return
@@ -750,7 +748,6 @@ function notifyAgentOfBrowserConnection(
           initSession(taskId, sessionId, task.agent_id)
         }
         session = useAgentStore.getState().getSession(taskId)
-        clog('[BrowserEdge] session after auto-start', { sessionId: session?.sessionId })
       } catch (err) {
         console.error('[BrowserEdge] Failed to auto-start/resume task:', err)
         return
@@ -762,98 +759,23 @@ function notifyAgentOfBrowserConnection(
       return
     }
 
-    // Re-read fresh panel data — webContentsId may have been updated since edge creation
-    const bp = useCanvasStore.getState().panels.find((p) => p.id === browserPanel.id) || browserPanel
-    const browserTitle = bp.title || 'Browser'
-    const browserUrl = bp.url || ''
+    const browserTitle = browserPanel.title || 'Browser'
 
-    // Resolve which agent-browser tab ID (t1, t2, t3...) corresponds to this
-    // browser panel's webview. Uses webContentsId for reliable direct lookup.
-    let tabId: string | null = null
-    const resolveTab = async (attempt: number): Promise<string | null> => {
-      const allTargets = await window.electronAPI.browser.getCdpTargets()
-      const webviews = allTargets.filter((t) => t.type === 'webview')
-      clog(`[BrowserEdge] resolveTab attempt=${attempt}`, {
-        allTargets: allTargets.map((t) => ({ tabId: t.tabId, type: t.type, url: t.url?.slice(0, 60) })),
-        webviewsCount: webviews.length,
-        browserUrl,
-        webContentsId: bp.webContentsId,
-      })
-      if (webviews.length === 0) return null
-
-      let match: typeof webviews[0] | null = null
-
-      // 1. Best: use webContentsId → getTargetId for exact CDP target, then find its tabId
-      if (!match && bp.webContentsId) {
-        try {
-          const result = await window.electronAPI.browser.getTargetId(bp.webContentsId)
-          if (result.targetId) {
-            match = allTargets.find((t) => t.id === result.targetId) || null
-            if (match) clog('[BrowserEdge] matched by webContentsId→getTargetId', match.tabId)
-          }
-        } catch { /* debugger API failed */ }
-      }
-
-      // 2. Match by URL
-      if (!match && browserUrl) {
-        const urlBase = browserUrl.split('?')[0].split('#')[0]
-        match = webviews.find((t) => t.url.startsWith(urlBase)) || null
-        if (match) clog('[BrowserEdge] matched by URL', { tabId: match.tabId, matchUrl: match.url?.slice(0, 60) })
-      }
-
-      // 3. Last resort — first available webview
-      if (!match) {
-        match = webviews[0] || null
-        if (match) clog('[BrowserEdge] fallback to first webview', match.tabId)
-      }
-
-      return match?.tabId || null
-    }
-
-    try {
-      for (let attempt = 0; attempt < 3; attempt++) {
-        tabId = await resolveTab(attempt)
-        if (tabId) break
-        clog(`[BrowserEdge] no tab found, retrying in 1s (attempt ${attempt + 1}/3)`)
-        await new Promise((r) => setTimeout(r, 1000))
-      }
-    } catch (err) {
-      console.error('[BrowserEdge] resolveTab error:', err)
-    }
-
-    clog('[BrowserEdge] final result', { tabId, browserTitle, browserUrl })
-
-    if (!tabId) {
-      agentSessionApi.send(
+    agentSessionApi
+      .send(
         session.sessionId,
-        `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas.\n\n` +
-        `The browser panel is loading. To connect once ready:\n` +
-        `  agent-browser connect ${CDP_PORT}\n` +
-        `  agent-browser tab    # find the [webview] target\n` +
-        `  agent-browser tab <tN>   # switch to the webview\n\n` +
-        `Then use commands normally (open, snapshot, click, etc.).\n` +
-        `Do NOT interact with the [page] target — that is the main app window.`,
+        `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas. You now control it directly.\n\n` +
+        `Use the browser_* tools (served through your task-management MCP connection):\n` +
+        `  browser_list_panels   # see the linked panel\n` +
+        `  browser_snapshot      # get @e1..@eN element refs\n` +
+        `  browser_navigate <url>\n` +
+        `  browser_click @ref / browser_type @ref <text> / browser_get url|title|text\n\n` +
+        `Refs come from browser_snapshot and stay valid until the page navigates.\n` +
+        `The user sees everything you do in real time on the canvas.`,
         taskPanel.refId!,
         session.agentId
-      ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
-      return
-    }
-
-    agentSessionApi.send(
-      session.sessionId,
-      `[System] A browser panel "${browserTitle}" has been connected to your task on the canvas. You now have access to control it.\n\n` +
-      `To use the browser, run these commands:\n` +
-      `  agent-browser connect ${CDP_PORT}\n` +
-      `  agent-browser tab ${tabId}\n\n` +
-      `Then use commands normally:\n` +
-      `  agent-browser open <url>\n` +
-      `  agent-browser snapshot -i\n` +
-      `  agent-browser click <ref>\n\n` +
-      `Do NOT use "agent-browser tab t1" — that is the main app window.\n` +
-      `The user can see everything you do in the browser in real time on the canvas.`,
-      taskPanel.refId!,
-      session.agentId
-    ).catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
+      )
+      .catch((err: unknown) => console.error('[Canvas] Failed to notify agent of browser connection:', err))
   }
 
   resolveAndNotify().catch(() => {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -500,9 +500,8 @@ interface ElectronAPI {
   onWorkspaceCleanupProgress: (callback: (event: WorkspaceCleanupProgressEvent) => void) => () => void
   onGithubDeviceCode: (callback: (code: string) => void) => () => void
   browser: {
-    getCdpPort: () => Promise<{ port: number }>
-    getTargetId: (webContentsId: number) => Promise<{ targetId: string | null }>
-    getCdpTargets: () => Promise<Array<{ id: string; url: string; title: string; type: string; tabId: string }>>
+    registerBrokerPanel: (payload: { panelId: string; webContentsId: number; taskIds: string[] }) => Promise<{ success: boolean }>
+    unregisterBrokerPanel: (panelId: string) => Promise<{ success: boolean }>
     openExternalAuth: (loginUrl: string) => Promise<{ success: boolean; finalUrl: string; cookieCount: number }>
   }
   ui: {


### PR DESCRIPTION
## Problem

Canvas "Agent Browser" panels were driven by the external `agent-browser` CLI through the app-wide `--remote-debugging-port=19222`. Two failures, one dangerous:

1. **Main-screen overwrite via t1 (dangerous).** The 20x window is itself a Chromium `[page]` target and sorts first on the shared debug port — it *is* `t1`. CDP `Page.navigate` bypasses the `will-navigate` guard, so a single stray `agent-browser open` against `t1` replaced the entire app UI. The existing `did-navigate` recovery only shortened the visible glitch.
2. **Control rarely stayed on the same tab.** Agents addressed webviews by positional tab ids (`t1..tN`) recomputed from `/json/list` ordering (replicated in two places that could diverge). Target churn from popups/devtools/webview recreation shifted indices mid-session; upstream agent-browser changelogs (v0.26 stable tab ids, v0.34 session-to-tab binding / fixed tab hijacking) confirm this class of race is inherent to shared-port + positional addressing.

A loopback debug port also let **any local process** enumerate all targets and read cookies (the attack class Chrome 136+ restricted).

## Solution

Replace the CLI + global port with an **in-app panel-scoped browser broker** (`src/main/panel-browser-broker.ts`) exposed as `browser_*` MCP tools on the existing task-api-server `/mcp` endpoint (the same channel every session already uses for task management):

- `browser_list_panels`, `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_press_key`, `browser_scroll`, `browser_get`, `browser_wait`, `browser_screenshot`, `browser_back`, `browser_forward`, `browser_reload`

### Safety properties

- **No debug port exists anymore** (`--remote-debugging-port=19222` removed) — nothing to enumerate or hijack.
- **The main window is unreachable by construction**: only explicitly registered canvas panels live in the broker registry; nothing else can be addressed.
- **Task↔panel authorization**: tools take `task_id`; commands bind only to panels edge-connected to that task. Ambiguity (multiple linked panels without an explicit `panel_id`) is an error, not a guess.
- **Deterministic addressing by canvas panelId** + `@eN` ref snapshots (same ergonomics agents know from agent-browser), so control always lands on the same tab.

### Implementation notes

- Built entirely on plain Electron APIs (`loadURL`, `executeJavaScript`, `capturePage`) — no debugger attachment, no CDP sockets, zero new dependencies.
- Renderer registers/unregisters each browser panel with its linked task ids via new IPC (`browser:registerBrokerPanel` / `browser:unregisterBrokerPanel`); registration refreshes on edges change and webview load events.
- Agent handoff message now points at the MCP tools instead of CLI commands.
- Kept unchanged: live shared `<webview>` UX, anti-bot mitigations, external-Chrome cookie-import auth flow, and the `will-navigate`/`did-navigate` guards as defense-in-depth.
- Removed: global CDP switch, `browser:getCdpPort`/`getTargetId`/`getCdpTargets` handlers, all positional-tab resolution code.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test:run` ✅ 161 files, **2510 passed**, incl. new `src/main/panel-browser-broker.test.ts` (authz matrix, snapshot round-trip, script builders, registry lifecycle)
- `rg "19222|getCdpPort|getCdpTargets|getTargetId|agent-browser connect" src/` → no functional references remain
- Overwrite regression reasoning: with no port and no unregistered targets, there is no interface through which an agent can enumerate or navigate the main window.

## Follow-ups (not in this PR)

- Per-task persistent profiles (`persist:panel-<taskId>` partitions) so logins survive restarts
- `browser_console` log streaming tool; shadow-DOM traversal in snapshots
- Optional cloud-browser provider behind the same tool surface
- Update seeded skill docs that still reference `agent-browser connect`