### PR TITLE
Add Pi coding agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Most AI tools make you copy-paste context between tabs. 20x flips it: **your tas
 ## How It Works
 
 <p align="center">
-  <img src="resources/process.png" alt="20x process: Hubspot, YouTrack, Linear, Github issues, Peakflo Workflo → triage agent → Agent (Claude Code, Opencode, OpenAI Codex) → HITL review → Feedback" />
+  <img src="resources/process.png" alt="20x process: Hubspot, YouTrack, Linear, Github issues, Peakflo Workflo → triage agent → Agent (Claude Code, Opencode, OpenAI Codex, Pi) → HITL review → Feedback" />
 </p>
 
 1. **Tasks flow in** — from Linear, YouTrack, HubSpot, GitHub Issues, Notion, Peakflo Workflo, or created manually
-2. **Triage agent** — Assigns priority, coding agent (Claude Code, OpenCode, or Codex), relevant skills, and git repos
+2. **Triage agent** — Assigns priority, coding agent (Claude Code, OpenCode, Codex, or Pi), relevant skills, and git repos
 3. **Agent works the task** — reads skills, git worktrees, and MCP servers; streams output in real time
 4. **HITL review** — Agents pause for human approval before risky actions
 5. **Feedback loop** — Skills and confidence levels are automatically updated after completion
@@ -42,7 +42,7 @@ Most AI tools make you copy-paste context between tabs. 20x flips it: **your tas
 ## Features
 
 <p align="center">
-  <img src="resources/integrations.png" alt="20x integrations: Hubspot, YouTrack, Linear, Github issues, Peakflo Workflo → 20x ↔ GitLab, Github, MCP → Claude Code, Opencode, OpenAI Codex; Skills automatically improved" />
+  <img src="resources/integrations.png" alt="20x integrations: Hubspot, YouTrack, Linear, Github issues, Peakflo Workflo → 20x ↔ GitLab, Github, MCP → Claude Code, Opencode, OpenAI Codex, Pi; Skills automatically improved" />
 </p>
 
 ### 📊 Dashboard Workspace
@@ -55,6 +55,7 @@ Most AI tools make you copy-paste context between tabs. 20x flips it: **your tas
 - **Claude Code** — Anthropic's official agent SDK (Claude Sonnet 4.6)
 - **OpenCode** — Open-source coding agent
 - **Codex** — OpenAI's agent framework (GPT-5.6 Sol)
+- **Pi** — Open-source coding agent with Peakflo AI Gateway models
 - **Live transcripts** — Watch agents think and work in real time with message counts
 - **Human-in-the-loop** — Approve risky actions before execution
 - **Task progress tracking** — Real-time progress events during agent execution
@@ -268,7 +269,7 @@ We welcome contributions! Here's how:
 - ✅ Heartbeat monitoring with CI failure detection
 - ✅ Presetup wizard and dashboard templates
 - ✅ Claude Sonnet 4.6 and GPT-5.6 model family support
-- ✅ Multi-agent support (OpenCode, Claude Code, Codex)
+- ✅ Multi-agent support (OpenCode, Claude Code, Codex, Pi)
 - ✅ Skills system with auto-learning
 - ✅ Recurring tasks
 - ✅ Linear, HubSpot, Peakflo integrations

--- a/docs/mobile-api-spec.md
+++ b/docs/mobile-api-spec.md
@@ -975,7 +975,7 @@ interface Agent {
 }
 
 interface AgentConfig {
-  coding_agent?: "opencode" | "claude-code" | "codex"
+  coding_agent?: "opencode" | "claude-code" | "codex" | "cursor" | "pi"
   model?: string
   system_prompt?: string
   mcp_servers?: Array<string | AgentMcpServerEntry>

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -87,6 +87,7 @@ interface AppServerSessionForTest {
     toolName: string
     startTime?: number
     lastActivityTime?: number
+    lastActivityMonotonicTime?: number
     input?: Record<string, unknown>
   }>
   codexUseApiKey: boolean
@@ -693,13 +694,16 @@ describe('CodexAppServerAdapter', () => {
     })
 
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(456)
+    const monotonicSpy = vi.spyOn(performance, 'now').mockReturnValue(789)
     adapter.convertEventToMessageParts({
       method: 'item/commandExecution/outputDelta',
       params: { itemId: 'tool-1', delta: 'still running\n' }
     }, seenMessageIds, seenPartIds, lengths, session)
     nowSpy.mockRestore()
+    monotonicSpy.mockRestore()
 
     expect(session.runningTools.get('tool-tool-1')?.lastActivityTime).toBe(456)
+    expect(session.runningTools.get('tool-tool-1')?.lastActivityMonotonicTime).toBe(789)
 
     const completed = adapter.convertEventToMessageParts({
       method: 'item/completed',
@@ -719,7 +723,7 @@ describe('CodexAppServerAdapter', () => {
     expect(session.runningTools.has('tool-tool-1')).toBe(false)
   })
 
-  it('clears running tools after interrupting an active turn', async () => {
+  it('clears running tools on interrupt and waits for provider-confirmed idle', async () => {
     const adapterInstance = new CodexAppServerAdapter()
     const adapter = adapterPrivate(adapterInstance)
     const session = createSession()
@@ -740,6 +744,15 @@ describe('CodexAppServerAdapter', () => {
       turnId: 'turn-1'
     })
     expect(session.runningTools.size).toBe(0)
+    expect(session.activeTurnId).toBe('turn-1')
+    expect(session.status).toBe(SessionStatusType.BUSY)
+
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'thread/status/changed',
+      params: { threadId: 'thread-1', status: { type: 'idle' } }
+    })
+
     expect(session.status).toBe(SessionStatusType.IDLE)
   })
 

--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -86,6 +86,7 @@ interface AppServerSessionForTest {
     partId: string
     toolName: string
     startTime?: number
+    lastActivityTime?: number
     input?: Record<string, unknown>
   }>
   codexUseApiKey: boolean
@@ -691,6 +692,15 @@ describe('CodexAppServerAdapter', () => {
       startTime: 123
     })
 
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(456)
+    adapter.convertEventToMessageParts({
+      method: 'item/commandExecution/outputDelta',
+      params: { itemId: 'tool-1', delta: 'still running\n' }
+    }, seenMessageIds, seenPartIds, lengths, session)
+    nowSpy.mockRestore()
+
+    expect(session.runningTools.get('tool-tool-1')?.lastActivityTime).toBe(456)
+
     const completed = adapter.convertEventToMessageParts({
       method: 'item/completed',
       params: {
@@ -707,6 +717,30 @@ describe('CodexAppServerAdapter', () => {
       tool: { name: 'commandExecution', status: 'completed' }
     })
     expect(session.runningTools.has('tool-tool-1')).toBe(false)
+  })
+
+  it('clears running tools after interrupting an active turn', async () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    session.activeTurnId = 'turn-1'
+    session.status = SessionStatusType.BUSY
+    session.runningTools.set('tool-cmd-1', {
+      partId: 'tool-cmd-1',
+      toolName: 'commandExecution',
+      startTime: 123
+    })
+    adapter.sessions.set('thread-1', session)
+    adapter.sendRpcRequest = vi.fn().mockResolvedValue({})
+
+    await adapterInstance.abortPrompt('thread-1', {} as never)
+
+    expect(adapter.sendRpcRequest).toHaveBeenCalledWith(session, 'turn/interrupt', {
+      threadId: 'thread-1',
+      turnId: 'turn-1'
+    })
+    expect(session.runningTools.size).toBe(0)
+    expect(session.status).toBe(SessionStatusType.IDLE)
   })
 
   it('stores command approval requests and responds with app-server decision shape', async () => {

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -98,6 +98,7 @@ interface AppServerSession {
     toolName: string
     startTime?: number
     lastActivityTime?: number
+    lastActivityMonotonicTime?: number
     input?: Record<string, unknown>
   }>
   codexUseApiKey: boolean
@@ -522,7 +523,9 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     // An interrupted turn may never emit item/completed for its active tools.
     // Drop them here so the watchdog cannot repeatedly act on stale state.
     session.runningTools.clear()
-    session.status = SessionStatusType.IDLE
+    // Keep the session BUSY until Codex confirms settlement via turn/completed
+    // or thread/status/changed. Marking it idle here races those notifications
+    // and can make follow-up UI actions target a turn that is still settling.
   }
 
   async destroySession(sessionId: string, _config: SessionConfig): Promise<void> {
@@ -601,6 +604,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     toolName: string
     startTime?: number
     lastActivityTime?: number
+    lastActivityMonotonicTime?: number
     input?: Record<string, unknown>
   }>> {
     return Array.from(this.sessions.get(sessionId)?.runningTools.values() || [])
@@ -1308,7 +1312,10 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     const next = truncateForIpc(previous + extractText(params), MAX_IPC_TOOL_OUTPUT_CHARS)
     const update = seenPartIds.has(partId)
     const runningTool = session.runningTools.get(partId)
-    if (runningTool) runningTool.lastActivityTime = Date.now()
+    if (runningTool) {
+      runningTool.lastActivityTime = Date.now()
+      runningTool.lastActivityMonotonicTime = performance.now()
+    }
     seenPartIds.add(partId)
     session.streamedTextByItemId.set(partId, next)
     partContentLengths.set(partId, `${next.length}:${toolName}`)
@@ -1415,11 +1422,13 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       session.runningTools.delete(partId)
     } else {
       const startedAt = typeof params.startedAtMs === 'number' ? params.startedAtMs : Date.now()
+      const observedAt = performance.now()
       session.runningTools.set(partId, {
         partId,
         toolName,
         startTime: startedAt,
         lastActivityTime: Date.now(),
+        lastActivityMonotonicTime: observedAt,
         input: item
       })
     }

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -97,6 +97,7 @@ interface AppServerSession {
     partId: string
     toolName: string
     startTime?: number
+    lastActivityTime?: number
     input?: Record<string, unknown>
   }>
   codexUseApiKey: boolean
@@ -518,6 +519,9 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
       threadId: session.threadId,
       turnId: session.activeTurnId
     })
+    // An interrupted turn may never emit item/completed for its active tools.
+    // Drop them here so the watchdog cannot repeatedly act on stale state.
+    session.runningTools.clear()
     session.status = SessionStatusType.IDLE
   }
 
@@ -596,6 +600,7 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     partId: string
     toolName: string
     startTime?: number
+    lastActivityTime?: number
     input?: Record<string, unknown>
   }>> {
     return Array.from(this.sessions.get(sessionId)?.runningTools.values() || [])
@@ -1302,6 +1307,8 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     const previous = session.streamedTextByItemId.get(partId) || ''
     const next = truncateForIpc(previous + extractText(params), MAX_IPC_TOOL_OUTPUT_CHARS)
     const update = seenPartIds.has(partId)
+    const runningTool = session.runningTools.get(partId)
+    if (runningTool) runningTool.lastActivityTime = Date.now()
     seenPartIds.add(partId)
     session.streamedTextByItemId.set(partId, next)
     partContentLengths.set(partId, `${next.length}:${toolName}`)
@@ -1407,10 +1414,12 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     if (isCompleted) {
       session.runningTools.delete(partId)
     } else {
+      const startedAt = typeof params.startedAtMs === 'number' ? params.startedAtMs : Date.now()
       session.runningTools.set(partId, {
         partId,
         toolName,
-        startTime: typeof params.startedAtMs === 'number' ? params.startedAtMs : Date.now(),
+        startTime: startedAt,
+        lastActivityTime: Date.now(),
         input: item
       })
     }

--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -217,6 +217,7 @@ export interface CodingAgentAdapter {
     toolName: string
     startTime?: number // Unix ms when the tool started
     lastActivityTime?: number // Unix ms when the tool most recently produced output
+    lastActivityMonotonicTime?: number // Monotonic ms when output was last observed
     input?: Record<string, unknown> // Tool input (e.g. { filePath: "..." })
   }>>
 

--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -216,6 +216,7 @@ export interface CodingAgentAdapter {
     partId: string
     toolName: string
     startTime?: number // Unix ms when the tool started
+    lastActivityTime?: number // Unix ms when the tool most recently produced output
     input?: Record<string, unknown> // Tool input (e.g. { filePath: "..." })
   }>>
 

--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -96,6 +96,7 @@ export interface MessagePart {
     input?: unknown
     output?: unknown
     error?: string
+    requestId?: string
     questions?: unknown
     todos?: unknown
   }
@@ -248,8 +249,9 @@ export interface CodingAgentAdapter {
   respondToQuestion?(
     sessionId: string,
     answers: Record<string, string>,
-    config: SessionConfig
-  ): Promise<void>
+    config: SessionConfig,
+    requestId?: string
+  ): Promise<boolean | void>
 
   /**
    * List available providers and their models from the backend.

--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -23,6 +23,7 @@ export enum MessagePartType {
   TEXT = 'text',
   REASONING = 'reasoning',
   TOOL = 'tool',
+  QUESTION = 'question',
   IMAGE = 'image',
   ERROR = 'error',
   TASK_PROGRESS = 'task_progress'
@@ -251,7 +252,7 @@ export interface CodingAgentAdapter {
     answers: Record<string, string>,
     config: SessionConfig,
     requestId?: string
-  ): Promise<boolean | void>
+  ): Promise<boolean | void | { handled: boolean; resolutionPart?: MessagePart }>
 
   /**
    * List available providers and their models from the backend.

--- a/src/main/adapters/index.ts
+++ b/src/main/adapters/index.ts
@@ -17,6 +17,7 @@ export { ClaudeCodeAdapter } from './claude-code-adapter'
 export { CodexAdapter } from './codex-adapter'
 export { AcpAdapter, type AcpAgentType } from './acp-adapter'
 export { CodexAppServerAdapter } from './codex-app-server-adapter'
+export { PiAdapter } from './pi-adapter'
 
 // TODO: Extract OpencodeAdapter from AgentManager once ready
 // export { OpencodeAdapter } from './opencode-adapter'

--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -18,6 +18,7 @@ vi.mock('../enterprise-ai-gateway', () => ({
 }))
 
 import { PiAdapter } from './pi-adapter'
+import { MessagePartType } from './coding-agent-adapter'
 
 function fakeProcess() {
   const process = new EventEmitter() as EventEmitter & Record<string, any>
@@ -157,6 +158,39 @@ describe('PiAdapter', () => {
 
     ;(adapter as any).handleEvent(session, { type: 'agent_settled' })
     expect(session.status).toBe('idle')
+  })
+
+  it('steers an active Pi turn instead of queueing a follow-up', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const process = fakeProcess()
+    const session = fakeSession(process)
+    ;(adapter as any).sessions.set(session.id, session)
+
+    await adapter.sendPrompt(session.id, [{ type: MessagePartType.TEXT, text: 'Stop and do this instead' }], session.config)
+
+    expect(process.stdin.write).toHaveBeenCalledWith(
+      `${JSON.stringify({
+        type: 'prompt',
+        message: 'Stop and do this instead',
+        streamingBehavior: 'steer',
+      })}\n`,
+      expect.any(Function),
+    )
+  })
+
+  it('sends a normal prompt when Pi is idle', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const process = fakeProcess()
+    const session = fakeSession(process)
+    session.status = 'idle'
+    ;(adapter as any).sessions.set(session.id, session)
+
+    await adapter.sendPrompt(session.id, [{ type: MessagePartType.TEXT, text: 'Start work' }], session.config)
+
+    expect(process.stdin.write).toHaveBeenCalledWith(
+      `${JSON.stringify({ type: 'prompt', message: 'Start work' })}\n`,
+      expect.any(Function),
+    )
   })
 
   it('routes Pi confirmation requests through the approval API', async () => {

--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { EventEmitter } from 'events'
+import { StringDecoder } from 'string_decoder'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
@@ -51,11 +52,14 @@ function fakeSession(process = fakeProcess()): any {
     parts: [],
     allMessages: [],
     stdoutBuffer: '',
+    stdoutDecoder: new StringDecoder('utf8'),
     textByBlock: new Map(),
     reasoningByBlock: new Map(),
     toolParts: new Map(),
     pendingUiRequests: new Map(),
     turn: 1,
+    assistantMessageOrdinal: 0,
+    pendingTurnError: null,
     sawAgentActivity: true,
     promptMayBeCommandOnly: false,
     closing: false,
@@ -180,6 +184,16 @@ describe('PiAdapter', () => {
       expect.any(Function),
     )
     expect(adapter.getPendingApproval(session.id)).toBeNull()
+    expect(session.parts.at(-1)).toMatchObject({
+      id: 'question-request-1',
+      type: 'question',
+      update: true,
+      tool: {
+        name: 'permission',
+        status: 'completed',
+        requestId: 'request-1',
+      },
+    })
   })
 
   it('routes Pi select requests through structured questions', async () => {
@@ -251,5 +265,159 @@ describe('PiAdapter', () => {
     ).resolves.toBe(false)
     expect(process.stdin.write).not.toHaveBeenCalled()
     expect(adapter.getPendingApproval(session.id)?.requestId).toBe('current-request')
+  })
+
+  it('keeps UTF-8 JSONL frames intact across buffer boundaries', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const process = fakeProcess()
+    const session = fakeSession(process)
+    ;(adapter as any).sessions.set(session.id, session)
+    ;(adapter as any).attachProcess(session)
+
+    const line = Buffer.from(`${JSON.stringify({
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'ราคา €\u2028ok' },
+    })}\n`)
+    const euroByte = line.indexOf(Buffer.from('€'))
+    process.stdout.emit('data', line.subarray(0, euroByte + 1))
+    process.stdout.emit('data', line.subarray(euroByte + 1))
+
+    await expect(adapter.pollMessages(session.id)).resolves.toEqual([
+      expect.objectContaining({ text: 'ราคา €\u2028ok' }),
+    ])
+  })
+
+  it('uses distinct stream IDs for separate assistant messages in one run', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const session = fakeSession()
+    ;(adapter as any).sessions.set(session.id, session)
+
+    ;(adapter as any).handleEvent(session, { type: 'message_start', message: { role: 'assistant' } })
+    ;(adapter as any).handleEvent(session, {
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'First' },
+    })
+    ;(adapter as any).handleEvent(session, { type: 'message_start', message: { role: 'assistant' } })
+    ;(adapter as any).handleEvent(session, {
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'Second' },
+    })
+
+    const parts = await adapter.pollMessages(session.id)
+    expect(parts.map((part) => part.id)).toEqual(['pi-text-1:1:0', 'pi-text-1:2:0'])
+    expect(parts.map((part) => part.text)).toEqual(['First', 'Second'])
+  })
+
+  it('uses the completed assistant message as the authoritative text', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const session = fakeSession()
+    ;(adapter as any).sessions.set(session.id, session)
+
+    ;(adapter as any).handleEvent(session, { type: 'message_start', message: { role: 'assistant' } })
+    ;(adapter as any).handleEvent(session, {
+      type: 'message_update',
+      assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'Partial' },
+    })
+    ;(adapter as any).handleEvent(session, {
+      type: 'message_end',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Final text' }], stopReason: 'stop' },
+    })
+
+    expect((await adapter.pollMessages(session.id)).at(-1)).toMatchObject({
+      id: 'pi-text-1:1:0',
+      text: 'Final text',
+      update: true,
+    })
+  })
+
+  it('does not surface a transient model error when Pi retry succeeds', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const session = fakeSession()
+    ;(adapter as any).sessions.set(session.id, session)
+
+    ;(adapter as any).handleEvent(session, {
+      type: 'message_end',
+      message: { role: 'assistant', content: [], stopReason: 'error', errorMessage: 'Temporary overload' },
+    })
+    ;(adapter as any).handleEvent(session, { type: 'auto_retry_start' })
+    await expect(adapter.getStatus(session.id, session.config)).resolves.toEqual({ type: 'busy' })
+
+    ;(adapter as any).handleEvent(session, { type: 'auto_retry_end', success: true })
+    ;(adapter as any).handleEvent(session, { type: 'agent_settled' })
+    await expect(adapter.getStatus(session.id, session.config)).resolves.toEqual({ type: 'idle' })
+    expect((await adapter.pollMessages(session.id)).some((part) => part.type === 'error')).toBe(false)
+  })
+
+  it('closes timed-out dialogs when the Pi run settles', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const process = fakeProcess()
+    const session = fakeSession(process)
+    ;(adapter as any).sessions.set(session.id, session)
+
+    ;(adapter as any).handleEvent(session, {
+      type: 'extension_ui_request',
+      id: 'timed-request',
+      method: 'input',
+      title: 'Name',
+      placeholder: 'Type a name',
+      timeout: 10,
+    })
+    ;(adapter as any).handleEvent(session, { type: 'agent_settled' })
+
+    expect(session.pendingUiRequests.size).toBe(0)
+    expect((await adapter.pollMessages(session.id)).at(-1)).toMatchObject({
+      id: 'pi-question-timed-request',
+      type: 'question',
+      tool: { name: 'question', status: 'cancelled', requestId: 'timed-request' },
+    })
+    await expect(adapter.getStatus(session.id, session.config)).resolves.toEqual({ type: 'idle' })
+  })
+
+  it('includes editor prefill in the structured question', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const session = fakeSession()
+    ;(adapter as any).sessions.set(session.id, session)
+
+    ;(adapter as any).handleEvent(session, {
+      type: 'extension_ui_request',
+      id: 'editor-request',
+      method: 'editor',
+      title: 'Edit release notes',
+      prefill: 'Existing notes',
+    })
+
+    expect(session.parts[0].tool.questions[0].question).toContain('Current value:\nExisting notes')
+  })
+
+  it('clears queued messages and pending dialogs before aborting', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const process = fakeProcess()
+    const session = fakeSession(process)
+    session.pendingUiRequests.set('request-1', {
+      id: 'request-1',
+      method: 'confirm',
+      title: 'Allow bash?',
+      message: 'Run a command',
+      options: [],
+    })
+    ;(adapter as any).sessions.set(session.id, session)
+    const command = vi.spyOn(adapter as any, 'command').mockResolvedValue({
+      type: 'response',
+      command: 'abort',
+      success: true,
+    })
+
+    await adapter.abortPrompt(session.id)
+
+    expect(command.mock.calls.map((call) => call[1])).toEqual([
+      { type: 'clear_queue' },
+      { type: 'abort' },
+    ])
+    expect(process.stdin.write).toHaveBeenCalledWith(
+      `${JSON.stringify({ type: 'extension_ui_response', id: 'request-1', cancelled: true })}\n`,
+      expect.any(Function),
+    )
+    expect(session.pendingUiRequests.size).toBe(0)
+    expect(session.status).toBe('idle')
   })
 })

--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -1,0 +1,210 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { EventEmitter } from 'events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock,
+  execFile: vi.fn(),
+}))
+
+vi.mock('../enterprise-ai-gateway', () => ({
+  ENTERPRISE_AI_GATEWAY_PROVIDER_ID: 'peakflo',
+  ENTERPRISE_AI_GATEWAY_PROVIDER_NAME: 'Peakflo',
+  buildPiAiGatewayProviderConfig: vi.fn(() => ({})),
+  readEnterpriseAiGatewayConfig: vi.fn(() => null),
+}))
+
+import { PiAdapter } from './pi-adapter'
+
+function fakeProcess() {
+  const process = new EventEmitter() as EventEmitter & Record<string, any>
+  process.pid = 12345
+  process.exitCode = null
+  process.stdin = {
+    writable: true,
+    write: vi.fn((_value: string, callback?: (error?: Error | null) => void) => {
+      callback?.(null)
+      return true
+    }),
+  }
+  process.stdout = new EventEmitter()
+  process.stderr = new EventEmitter()
+  process.kill = vi.fn(() => true)
+  return process
+}
+
+function fakeSession(process = fakeProcess()): any {
+  return {
+    id: 'session-1',
+    process,
+    config: {
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      workspaceDir: '/workspace',
+      permissionMode: 'ask',
+    },
+    status: 'busy',
+    lastError: null,
+    pending: new Map(),
+    parts: [],
+    allMessages: [],
+    stdoutBuffer: '',
+    textByBlock: new Map(),
+    reasoningByBlock: new Map(),
+    toolParts: new Map(),
+    pendingUiRequests: new Map(),
+    turn: 1,
+    sawAgentActivity: true,
+    promptMayBeCommandOnly: false,
+    closing: false,
+  }
+}
+
+describe('PiAdapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the native Pi session file and applies model selection through RPC', async () => {
+    const child = fakeProcess()
+    spawnMock.mockReturnValue(child)
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    vi.spyOn(adapter as any, 'findPiExecutable').mockResolvedValue('/usr/local/bin/pi')
+    vi.spyOn(adapter as any, 'installPeakfloGateway').mockReturnValue(null)
+    vi.spyOn(adapter as any, 'buildMcpConfig').mockReturnValue(undefined)
+    vi.spyOn(adapter as any, 'installPermissionExtension').mockReturnValue('/tmp/20x-permissions.ts')
+    vi.spyOn(adapter as any, 'attachProcess').mockImplementation(() => undefined)
+    const command = vi.spyOn(adapter as any, 'command')
+      .mockResolvedValueOnce({
+        type: 'response',
+        command: 'get_state',
+        success: true,
+        data: { sessionFile: '/sessions/native-session.jsonl' },
+      })
+      .mockResolvedValueOnce({ type: 'response', command: 'set_model', success: true })
+
+    const id = await adapter.createSession({
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      workspaceDir: '/workspace',
+      model: 'peakflo/model-one',
+      permissionMode: 'ask',
+    })
+
+    expect(id).toBe('/sessions/native-session.jsonl')
+    const args = spawnMock.mock.calls[0][1] as string[]
+    expect(args).toContain('--mode')
+    expect(args).toContain('--extension')
+    expect(args).not.toContain('--session-dir')
+    expect(args).not.toContain('--provider')
+    expect(args).not.toContain('--model')
+    expect(command).toHaveBeenLastCalledWith(
+      expect.anything(),
+      { type: 'set_model', provider: 'peakflo', modelId: 'model-one' },
+    )
+  })
+
+  it('discovers the effective Pi model catalog through RPC', async () => {
+    const child = fakeProcess()
+    spawnMock.mockReturnValue(child)
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    vi.spyOn(adapter as any, 'findPiExecutable').mockResolvedValue('/usr/local/bin/pi')
+    vi.spyOn(adapter as any, 'installPeakfloGateway').mockReturnValue(null)
+    vi.spyOn(adapter as any, 'attachProcess').mockImplementation(() => undefined)
+    vi.spyOn(adapter as any, 'terminateProcess').mockResolvedValue(undefined)
+    vi.spyOn(adapter as any, 'command')
+      .mockResolvedValueOnce({
+        type: 'response',
+        command: 'get_state',
+        success: true,
+        data: { model: { provider: 'peakflo', id: 'model-one' } },
+      })
+      .mockResolvedValueOnce({
+        type: 'response',
+        command: 'get_available_models',
+        success: true,
+        data: {
+          models: [
+            { provider: 'peakflo', id: 'model-one', name: 'Model One' },
+            { provider: 'openai', id: 'model-two', name: 'Model Two' },
+          ],
+        },
+      })
+
+    await expect(adapter.getProviders(undefined, '/workspace')).resolves.toEqual({
+      providers: [
+        { id: 'peakflo', name: 'Peakflo', models: [{ id: 'model-one', name: 'Model One' }] },
+        { id: 'openai', name: 'openai', models: [{ id: 'model-two', name: 'Model Two' }] },
+      ],
+      default: { peakflo: 'model-one' },
+    })
+    expect(spawnMock.mock.calls[0][1]).toEqual(['--mode', 'rpc', '--no-session', '--approve'])
+  })
+
+  it('waits for agent_settled instead of agent_end', () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const session = fakeSession()
+
+    ;(adapter as any).handleEvent(session, { type: 'agent_end' })
+    expect(session.status).toBe('busy')
+
+    ;(adapter as any).handleEvent(session, { type: 'agent_settled' })
+    expect(session.status).toBe('idle')
+  })
+
+  it('routes Pi confirmation requests through the approval API', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const process = fakeProcess()
+    const session = fakeSession(process)
+    ;(adapter as any).sessions.set(session.id, session)
+
+    ;(adapter as any).handleEvent(session, {
+      type: 'extension_ui_request',
+      id: 'request-1',
+      method: 'confirm',
+      title: 'Allow bash?',
+      message: 'Run a command',
+    })
+
+    expect(adapter.getPendingApproval(session.id)?.question).toContain('Run a command')
+    await expect(adapter.getStatus(session.id, session.config)).resolves.toEqual({
+      type: 'waiting_approval',
+      message: 'Pi is waiting for input',
+    })
+
+    await expect(adapter.respondToApproval(session.id, true)).resolves.toBe(true)
+    expect(process.stdin.write).toHaveBeenCalledWith(
+      `${JSON.stringify({ type: 'extension_ui_response', id: 'request-1', confirmed: true })}\n`,
+      expect.any(Function),
+    )
+    expect(adapter.getPendingApproval(session.id)).toBeNull()
+  })
+
+  it('routes Pi select requests through structured questions', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const process = fakeProcess()
+    const session = fakeSession(process)
+    ;(adapter as any).sessions.set(session.id, session)
+
+    ;(adapter as any).handleEvent(session, {
+      type: 'extension_ui_request',
+      id: 'request-2',
+      method: 'select',
+      title: 'Environment',
+      message: 'Select an environment',
+      options: ['Stage', 'Production'],
+    })
+
+    expect(session.parts[0].tool.questions[0].options).toEqual([
+      { label: 'Stage', description: 'Stage' },
+      { label: 'Production', description: 'Production' },
+    ])
+    await adapter.respondToQuestion(session.id, { Environment: 'Stage' }, session.config)
+    expect(process.stdin.write).toHaveBeenCalledWith(
+      `${JSON.stringify({ type: 'extension_ui_response', id: 'request-2', value: 'Stage' })}\n`,
+      expect.any(Function),
+    )
+  })
+})

--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -60,6 +60,7 @@ function fakeSession(process = fakeProcess()): any {
     turn: 1,
     assistantMessageOrdinal: 0,
     pendingTurnError: null,
+    pendingTurnErrorMonotonicTime: null,
     sawAgentActivity: true,
     promptMayBeCommandOnly: false,
     closing: false,
@@ -346,6 +347,41 @@ describe('PiAdapter', () => {
     ;(adapter as any).handleEvent(session, { type: 'agent_settled' })
     await expect(adapter.getStatus(session.id, session.config)).resolves.toEqual({ type: 'idle' })
     expect((await adapter.pollMessages(session.id)).some((part) => part.type === 'error')).toBe(false)
+  })
+
+  it('settles a terminal model error when Pi omits agent_settled', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const session = fakeSession()
+    ;(adapter as any).sessions.set(session.id, session)
+    vi.spyOn(adapter as any, 'command').mockResolvedValue({
+      type: 'response',
+      command: 'get_state',
+      success: true,
+      data: { isStreaming: false },
+    })
+
+    const monotonicSpy = vi.spyOn(performance, 'now').mockReturnValue(100)
+    ;(adapter as any).handleEvent(session, {
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        stopReason: 'error',
+        errorMessage: 'Provider unavailable',
+      },
+    })
+    monotonicSpy.mockReturnValue(1_101)
+
+    await expect(adapter.getStatus(session.id, session.config)).resolves.toEqual({
+      type: 'error',
+      message: 'Provider unavailable',
+    })
+    expect((await adapter.pollMessages(session.id)).at(-1)).toMatchObject({
+      id: 'pi-error-1',
+      type: 'error',
+      text: 'Provider unavailable',
+    })
+    monotonicSpy.mockRestore()
   })
 
   it('closes timed-out dialogs when the Pi run settles', async () => {

--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -201,6 +201,7 @@ describe('PiAdapter', () => {
       { label: 'Stage', description: 'Stage' },
       { label: 'Production', description: 'Production' },
     ])
+    expect(session.parts[0].type).toBe('question')
     expect(session.parts[0].tool.requestId).toBe('request-2')
     await expect(
       adapter.respondToQuestion(session.id, { Environment: 'Stage' }, session.config, 'request-2'),
@@ -211,17 +212,44 @@ describe('PiAdapter', () => {
     )
 
     vi.mocked(process.stdin.write).mockClear()
-    await expect(
-      adapter.respondToQuestion(session.id, { Environment: 'Production' }, session.config, 'request-2'),
-    ).resolves.toBe(false)
+    const staleResponse = await adapter.respondToQuestion(
+      session.id,
+      { Environment: 'Production' },
+      session.config,
+      'request-2',
+    )
     expect(process.stdin.write).not.toHaveBeenCalled()
-    expect(session.parts.at(-1)).toMatchObject({
-      id: 'pi-question-request-2',
-      update: true,
-      tool: {
-        name: 'question',
-        status: 'cancelled',
+    expect(staleResponse).toMatchObject({
+      handled: false,
+      resolutionPart: {
+        id: 'pi-question-request-2',
+        update: true,
+        tool: {
+          name: 'question',
+          status: 'cancelled',
+        },
       },
     })
+  })
+
+  it('does not answer a newer confirmation with a stale request ID', async () => {
+    const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+    const process = fakeProcess()
+    const session = fakeSession(process)
+    ;(adapter as any).sessions.set(session.id, session)
+
+    ;(adapter as any).handleEvent(session, {
+      type: 'extension_ui_request',
+      id: 'current-request',
+      method: 'confirm',
+      title: 'Allow bash?',
+      message: 'Run a command',
+    })
+
+    await expect(
+      adapter.respondToApproval(session.id, true, 'approved', 'stale-request'),
+    ).resolves.toBe(false)
+    expect(process.stdin.write).not.toHaveBeenCalled()
+    expect(adapter.getPendingApproval(session.id)?.requestId).toBe('current-request')
   })
 })

--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -215,5 +215,13 @@ describe('PiAdapter', () => {
       adapter.respondToQuestion(session.id, { Environment: 'Production' }, session.config, 'request-2'),
     ).resolves.toBe(false)
     expect(process.stdin.write).not.toHaveBeenCalled()
+    expect(session.parts.at(-1)).toMatchObject({
+      id: 'pi-question-request-2',
+      update: true,
+      tool: {
+        name: 'question',
+        status: 'cancelled',
+      },
+    })
   })
 })

--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -201,10 +201,19 @@ describe('PiAdapter', () => {
       { label: 'Stage', description: 'Stage' },
       { label: 'Production', description: 'Production' },
     ])
-    await adapter.respondToQuestion(session.id, { Environment: 'Stage' }, session.config)
+    expect(session.parts[0].tool.requestId).toBe('request-2')
+    await expect(
+      adapter.respondToQuestion(session.id, { Environment: 'Stage' }, session.config, 'request-2'),
+    ).resolves.toBe(true)
     expect(process.stdin.write).toHaveBeenCalledWith(
       `${JSON.stringify({ type: 'extension_ui_response', id: 'request-2', value: 'Stage' })}\n`,
       expect.any(Function),
     )
+
+    vi.mocked(process.stdin.write).mockClear()
+    await expect(
+      adapter.respondToQuestion(session.id, { Environment: 'Production' }, session.config, 'request-2'),
+    ).resolves.toBe(false)
+    expect(process.stdin.write).not.toHaveBeenCalled()
   })
 })

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -11,6 +11,7 @@ import { randomUUID } from 'crypto'
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join } from 'path'
+import { StringDecoder } from 'string_decoder'
 import { promisify } from 'util'
 import type { DatabaseManager } from '../database'
 import {
@@ -84,11 +85,14 @@ interface PiSession {
   parts: MessagePart[]
   allMessages: SessionMessage[]
   stdoutBuffer: string
+  stdoutDecoder: StringDecoder
   textByBlock: Map<string, string>
   reasoningByBlock: Map<string, string>
   toolParts: Map<string, MessagePart>
   pendingUiRequests: Map<string, PiUiRequest>
   turn: number
+  assistantMessageOrdinal: number
+  pendingTurnError: string | null
   sawAgentActivity: boolean
   promptMayBeCommandOnly: boolean
   closing: boolean
@@ -278,11 +282,14 @@ export class PiAdapter implements CodingAgentAdapter {
       parts: [],
       allMessages: [],
       stdoutBuffer: '',
+      stdoutDecoder: new StringDecoder('utf8'),
       textByBlock: new Map(),
       reasoningByBlock: new Map(),
       toolParts: new Map(),
       pendingUiRequests: new Map(),
       turn: 0,
+      assistantMessageOrdinal: 0,
+      pendingTurnError: null,
       sawAgentActivity: false,
       promptMayBeCommandOnly: false,
       closing: false,
@@ -373,20 +380,10 @@ export class PiAdapter implements CodingAgentAdapter {
 
   private attachProcess(session: PiSession): void {
     session.process.stdout.on('data', (chunk: Buffer | string) => {
-      session.stdoutBuffer += chunk.toString()
-      while (true) {
-        const newline = session.stdoutBuffer.indexOf('\n')
-        if (newline < 0) break
-        let line = session.stdoutBuffer.slice(0, newline)
-        session.stdoutBuffer = session.stdoutBuffer.slice(newline + 1)
-        if (line.endsWith('\r')) line = line.slice(0, -1)
-        if (!line.trim()) continue
-        try {
-          this.handleEvent(session, JSON.parse(line) as Record<string, unknown>)
-        } catch (error) {
-          console.warn('[PiAdapter] Invalid RPC output:', error)
-        }
-      }
+      this.consumeStdout(session, typeof chunk === 'string' ? chunk : session.stdoutDecoder.write(chunk))
+    })
+    session.process.stdout.on('end', () => {
+      this.consumeStdout(session, session.stdoutDecoder.end(), true)
     })
     session.process.stderr.on('data', (chunk: Buffer | string) => {
       const length = chunk.toString().trim().length
@@ -406,6 +403,32 @@ export class PiAdapter implements CodingAgentAdapter {
       this.rejectPending(session, new Error(session.lastError || (session.closing ? 'Pi process closed' : 'Pi process exited')))
       this.onDataAvailable?.(session.id)
     })
+  }
+
+  private consumeStdout(session: PiSession, chunk: string, flush = false): void {
+    session.stdoutBuffer += chunk
+    while (true) {
+      const newline = session.stdoutBuffer.indexOf('\n')
+      if (newline < 0) break
+      const line = session.stdoutBuffer.slice(0, newline)
+      session.stdoutBuffer = session.stdoutBuffer.slice(newline + 1)
+      this.handleJsonlLine(session, line)
+    }
+    if (flush && session.stdoutBuffer.length > 0) {
+      const line = session.stdoutBuffer
+      session.stdoutBuffer = ''
+      this.handleJsonlLine(session, line)
+    }
+  }
+
+  private handleJsonlLine(session: PiSession, rawLine: string): void {
+    const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
+    if (!line.trim()) return
+    try {
+      this.handleEvent(session, JSON.parse(line) as Record<string, unknown>)
+    } catch (error) {
+      console.warn('[PiAdapter] Invalid RPC output:', error)
+    }
   }
 
   private rejectPending(session: PiSession, error: Error): void {
@@ -439,7 +462,10 @@ export class PiAdapter implements CodingAgentAdapter {
         && !session.sawAgentActivity
       ) {
         void this.command(session, { type: 'get_state' }).then((state) => {
-          if (state.data?.isStreaming !== true && !session.sawAgentActivity) {
+          const pendingMessageCount = typeof state.data?.pendingMessageCount === 'number'
+            ? state.data.pendingMessageCount
+            : 0
+          if (state.data?.isStreaming !== true && pendingMessageCount === 0 && !session.sawAgentActivity) {
             session.status = session.pendingUiRequests.size > 0 ? 'busy' : 'idle'
             this.onDataAvailable?.(session.id)
           }
@@ -453,22 +479,38 @@ export class PiAdapter implements CodingAgentAdapter {
       case 'agent_start':
         session.status = 'busy'
         session.lastError = null
+        session.pendingTurnError = null
         session.turn++
+        session.assistantMessageOrdinal = 0
         session.sawAgentActivity = true
         break
-      case 'agent_settled':
-        session.status = session.pendingUiRequests.size > 0 ? 'busy' : 'idle'
+      case 'agent_settled': {
+        this.cancelPendingUiRequests(session, 'This request is no longer active.')
+        if (session.pendingTurnError) {
+          session.lastError = session.pendingTurnError
+          session.parts.push({
+            id: `pi-error-${session.turn}`,
+            type: MessagePartType.ERROR,
+            text: session.pendingTurnError,
+          })
+        }
+        session.status = 'idle'
         session.promptMayBeCommandOnly = false
         break
+      }
+      case 'message_start': {
+        const message = event.message as PiMessage | undefined
+        if (message?.role === 'assistant') session.assistantMessageOrdinal++
+        break
+      }
       case 'message_update':
         this.handleMessageUpdate(session, event.assistantMessageEvent as Record<string, unknown> | undefined)
         break
       case 'message_end': {
         const message = event.message as PiMessage | undefined
+        this.reconcileAssistantMessage(session, message)
         if (message?.role === 'assistant' && message.stopReason === 'error') {
-          const text = message.errorMessage || 'Pi model request failed'
-          session.parts.push({ id: `pi-error-${session.turn}`, type: MessagePartType.ERROR, text })
-          session.lastError = text
+          session.pendingTurnError = message.errorMessage || 'Pi model request failed'
         }
         break
       }
@@ -485,8 +527,18 @@ export class PiAdapter implements CodingAgentAdapter {
         session.status = 'busy'
         break
       case 'auto_retry_end':
-        if (event.success === false) {
-          session.lastError = String(event.finalError || 'Pi retry failed')
+        session.pendingTurnError = event.success === true
+          ? null
+          : String(event.finalError || 'Pi retry failed')
+        break
+      case 'compaction_end':
+        if (event.result) session.pendingTurnError = null
+        else if (event.aborted !== true && event.errorMessage) {
+          session.parts.push({
+            id: `pi-compaction-error-${session.turn}-${randomUUID()}`,
+            type: MessagePartType.ERROR,
+            text: String(event.errorMessage),
+          })
         }
         break
       case 'extension_error':
@@ -528,7 +580,7 @@ export class PiAdapter implements CodingAgentAdapter {
       id,
       method,
       title: String(event.title || (method === 'confirm' ? 'Permission Required' : 'Input Required')),
-      message: String(event.message || event.placeholder || event.title || 'Pi needs your response'),
+      message: this.uiRequestMessage(method, event),
       options: Array.isArray(event.options) ? event.options.filter((option): option is string => typeof option === 'string') : [],
     }
 
@@ -558,20 +610,78 @@ export class PiAdapter implements CodingAgentAdapter {
     }
   }
 
+  private uiRequestMessage(method: PiUiRequest['method'], event: Record<string, unknown>): string {
+    const message = String(event.message || event.placeholder || event.title || 'Pi needs your response')
+    const prefill = method === 'editor' && typeof event.prefill === 'string'
+      ? event.prefill.slice(0, 2_000)
+      : ''
+    return prefill ? `${message}\n\nCurrent value:\n${prefill}` : message
+  }
+
+  private cancelPendingUiRequests(session: PiSession, output: string, notifyPi = false): void {
+    for (const request of session.pendingUiRequests.values()) {
+      if (notifyPi) {
+        try {
+          this.sendRecord(session, { type: 'extension_ui_response', id: request.id, cancelled: true })
+        } catch {
+          // The process may have closed while the turn was being stopped.
+        }
+      }
+      session.parts.push({
+        id: request.method === 'confirm' ? `question-${request.id}` : `pi-question-${request.id}`,
+        type: MessagePartType.QUESTION,
+        update: true,
+        tool: {
+          name: request.method === 'confirm' ? 'permission' : 'question',
+          status: 'cancelled',
+          requestId: request.id,
+          output,
+        },
+      })
+    }
+    session.pendingUiRequests.clear()
+  }
+
   private handleMessageUpdate(session: PiSession, update?: Record<string, unknown>): void {
     if (!update) return
     const index = String(update.contentIndex ?? 0)
+    const key = `${session.turn}:${session.assistantMessageOrdinal}:${index}`
     if (update.type === 'text_delta') {
-      const key = `${session.turn}:${index}`
       const text = (session.textByBlock.get(key) || '') + String(update.delta || '')
       session.textByBlock.set(key, text)
       session.parts.push({ id: `pi-text-${key}`, type: MessagePartType.TEXT, text, update: true })
+    } else if (update.type === 'text_end') {
+      const text = String(update.content ?? session.textByBlock.get(key) ?? '')
+      session.textByBlock.set(key, text)
+      session.parts.push({ id: `pi-text-${key}`, type: MessagePartType.TEXT, text, update: true })
     } else if (update.type === 'thinking_delta') {
-      const key = `${session.turn}:${index}`
       const text = (session.reasoningByBlock.get(key) || '') + String(update.delta || '')
       session.reasoningByBlock.set(key, text)
       session.parts.push({ id: `pi-reasoning-${key}`, type: MessagePartType.REASONING, text, update: true })
+    } else if (update.type === 'thinking_end') {
+      const text = String(update.content ?? update.thinking ?? session.reasoningByBlock.get(key) ?? '')
+      session.reasoningByBlock.set(key, text)
+      session.parts.push({ id: `pi-reasoning-${key}`, type: MessagePartType.REASONING, text, update: true })
     }
+  }
+
+  private reconcileAssistantMessage(session: PiSession, message?: PiMessage): void {
+    if (message?.role !== 'assistant') return
+    const blocks = typeof message.content === 'string'
+      ? [{ type: 'text', text: message.content }]
+      : Array.isArray(message.content) ? message.content : []
+    blocks.forEach((block, index) => {
+      const key = `${session.turn}:${session.assistantMessageOrdinal}:${index}`
+      if (block.type === 'text') {
+        const text = String(block.text ?? '')
+        session.textByBlock.set(key, text)
+        session.parts.push({ id: `pi-text-${key}`, type: MessagePartType.TEXT, text, update: true })
+      } else if (block.type === 'thinking') {
+        const text = String(block.thinking ?? '')
+        session.reasoningByBlock.set(key, text)
+        session.parts.push({ id: `pi-reasoning-${key}`, type: MessagePartType.REASONING, text, update: true })
+      }
+    })
   }
 
   private handleToolEvent(session: PiSession, event: Record<string, unknown>, status: string): void {
@@ -695,6 +805,17 @@ export class PiAdapter implements CodingAgentAdapter {
       confirmed: approved,
     })
     session.pendingUiRequests.delete(request.id)
+    session.parts.push({
+      id: `question-${request.id}`,
+      type: MessagePartType.QUESTION,
+      update: true,
+      tool: {
+        name: 'permission',
+        status: approved ? 'completed' : 'cancelled',
+        requestId: request.id,
+        output: approved ? 'Approved' : 'Declined',
+      },
+    })
     session.status = 'busy'
     this.onDataAvailable?.(session.id)
     return true
@@ -741,12 +862,13 @@ export class PiAdapter implements CodingAgentAdapter {
     session.pendingUiRequests.delete(request.id)
     session.parts.push({
       id: `pi-question-${request.id}`,
-      type: MessagePartType.TOOL,
+      type: MessagePartType.QUESTION,
       update: true,
       tool: {
         name: 'question',
         status: 'completed',
         title: request.title,
+        requestId: request.id,
         output: value,
       },
     })
@@ -803,6 +925,8 @@ export class PiAdapter implements CodingAgentAdapter {
   async abortPrompt(sessionId: string): Promise<void> {
     const session = this.sessions.get(sessionId)
     if (!session) return
+    this.cancelPendingUiRequests(session, 'This request was cancelled when the turn stopped.', true)
+    await this.command(session, { type: 'clear_queue' }).catch(() => undefined)
     await this.command(session, { type: 'abort' })
     session.status = 'idle'
   }

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -547,6 +547,7 @@ export class PiAdapter implements CodingAgentAdapter {
           name: 'question',
           status: 'running',
           title: request.title,
+          requestId: request.id,
           questions: [{
             header: request.title,
             question: request.message,
@@ -696,11 +697,16 @@ export class PiAdapter implements CodingAgentAdapter {
     sessionId: string,
     answers: Record<string, string>,
     _config: SessionConfig,
-  ): Promise<void> {
+    requestId?: string,
+  ): Promise<boolean> {
     const session = this.sessions.get(sessionId)
     if (!session) throw new Error(`Session not found: ${sessionId}`)
-    const request = Array.from(session.pendingUiRequests.values()).find((item) => item.method !== 'confirm')
-    if (!request) throw new Error('Pi has no pending question')
+    const request = requestId
+      ? session.pendingUiRequests.get(requestId)
+      : Array.from(session.pendingUiRequests.values()).find((item) => item.method !== 'confirm')
+    // A restored transcript or another client can submit a response after Pi
+    // has already consumed the request. Treat that response as stale.
+    if (!request || request.method === 'confirm') return false
     const value = answers[request.title] ?? answers[request.message] ?? answers.answer ?? Object.values(answers)[0] ?? ''
     this.sendRecord(session, {
       type: 'extension_ui_response',
@@ -721,6 +727,7 @@ export class PiAdapter implements CodingAgentAdapter {
     })
     session.status = 'busy'
     this.onDataAvailable?.(session.id)
+    return true
   }
 
   async getRunningTools(sessionId: string): Promise<Array<{

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -745,7 +745,11 @@ export class PiAdapter implements CodingAgentAdapter {
     this.sendRecord(session, {
       type: 'prompt',
       message,
-      ...(wasBusy ? { streamingBehavior: 'followUp' } : {}),
+      // A message sent from the task composer while Pi is already running is
+      // user steering, not deferred work. Pi delivers `steer` after the current
+      // tool finishes and before the next model call; `followUp` would wait for
+      // the whole run to settle and lets a misdirected turn continue unchecked.
+      ...(wasBusy ? { streamingBehavior: 'steer' } : {}),
     })
   }
 

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -31,6 +31,33 @@ import { MessagePartType, MessageRole, SessionStatusType } from './coding-agent-
 const execFileAsync = promisify(execFile)
 const RPC_TIMEOUT_MS = 15_000
 const MAX_BUFFERED_PARTS = 1_000
+const MINIMUM_PI_VERSION = [0, 80, 5] as const
+const PI_PERMISSION_MODE_ENV = 'TWENTYX_PI_PERMISSION_MODE'
+
+const PI_PERMISSION_EXTENSION_SOURCE = `\
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+const READ_ONLY_TOOLS = new Set(["read", "grep", "find", "ls"]);
+
+function inputSummary(input: unknown): string {
+  try {
+    return JSON.stringify(input, null, 2).slice(0, 4000);
+  } catch {
+    return String(input).slice(0, 4000);
+  }
+}
+
+export default function permissions(pi: ExtensionAPI) {
+  pi.on("tool_call", async (event, ctx) => {
+    if (process.env.${PI_PERMISSION_MODE_ENV} === "allow" || READ_ONLY_TOOLS.has(event.toolName)) return;
+    const approved = await ctx.ui.confirm(
+      \`Allow \${event.toolName}?\`,
+      inputSummary(event.input),
+    );
+    if (!approved) return { block: true, reason: \`\${event.toolName} was declined in 20x.\` };
+  });
+}
+`
 
 interface PiRpcResponse {
   id?: string
@@ -60,8 +87,20 @@ interface PiSession {
   textByBlock: Map<string, string>
   reasoningByBlock: Map<string, string>
   toolParts: Map<string, MessagePart>
+  pendingUiRequests: Map<string, PiUiRequest>
   turn: number
+  sawAgentActivity: boolean
+  promptMayBeCommandOnly: boolean
+  closing: boolean
   mcpConfigPath?: string
+}
+
+interface PiUiRequest {
+  id: string
+  method: 'confirm' | 'select' | 'input' | 'editor'
+  title: string
+  message: string
+  options: string[]
 }
 
 type PiMessage = {
@@ -193,50 +232,44 @@ export class PiAdapter implements CodingAgentAdapter {
     return path
   }
 
-  private splitModel(model?: string): { provider?: string; modelId?: string } {
-    if (!model) return {}
-    const separator = model.indexOf('/')
-    if (separator < 0) return { modelId: model }
-    return { provider: model.slice(0, separator), modelId: model.slice(separator + 1) }
+  private installPermissionExtension(): string {
+    const dir = join(homedir(), '.20x', 'pi')
+    const path = join(dir, 'permissions.ts')
+    mkdirSync(dir, { recursive: true })
+    const current = existsSync(path) ? readFileSync(path, 'utf8') : ''
+    if (current !== PI_PERMISSION_EXTENSION_SOURCE) {
+      const temporaryPath = `${path}.${process.pid}.tmp`
+      writeFileSync(temporaryPath, PI_PERMISSION_EXTENSION_SOURCE, { mode: 0o600 })
+      chmodSync(temporaryPath, 0o600)
+      renameSync(temporaryPath, path)
+    }
+    chmodSync(path, 0o600)
+    return path
   }
 
-  private async spawnSession(config: SessionConfig, resumeId?: string): Promise<PiSession> {
-    const executable = await this.findPiExecutable()
-    const gateway = this.installPeakfloGateway()
-    const mcpConfigPath = this.buildMcpConfig(config)
-    const sessionDir = join(homedir(), '.20x', 'pi-sessions')
-    mkdirSync(sessionDir, { recursive: true })
-
-    const args = ['--mode', 'rpc', '--approve', '--session-dir', sessionDir, '--name', config.taskId]
-    if (config.systemPrompt?.trim()) {
-      args.push('--append-system-prompt', config.systemPrompt.trim())
-    }
-    if (resumeId) args.push('--session', resumeId)
-    const { provider, modelId } = this.splitModel(config.model)
-    if (provider) args.push('--provider', provider)
-    if (modelId) args.push('--model', modelId)
-    if (config.reasoningEffort) args.push('--thinking', config.reasoningEffort)
-    if (mcpConfigPath) args.push('--mcp-config', mcpConfigPath)
-
+  private processEnv(
+    config: SessionConfig,
+    gateway: { apiKey: string } | null,
+  ): NodeJS.ProcessEnv {
     const env = {
       ...process.env,
       ...(config.secretEnvVars ?? {}),
       ...(gateway ? { PEAKFLO_AI_GATEWAY_API_KEY: gateway.apiKey } : {}),
+      [PI_PERMISSION_MODE_ENV]: config.permissionMode ?? 'ask',
     } as NodeJS.ProcessEnv
     delete env.AI_AGENT
     delete env.PI_CODING_AGENT
+    return env
+  }
 
-    const child = spawn(executable, args, {
-      cwd: config.workspaceDir,
-      env,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      windowsHide: true,
-      shell: process.platform === 'win32',
-    })
-
-    const tempId = resumeId || randomUUID()
-    const session: PiSession = {
-      id: tempId,
+  private createSessionState(
+    id: string,
+    child: ChildProcessWithoutNullStreams,
+    config: SessionConfig,
+    mcpConfigPath?: string,
+  ): PiSession {
+    return {
+      id,
       process: child,
       config,
       status: 'idle',
@@ -248,20 +281,81 @@ export class PiAdapter implements CodingAgentAdapter {
       textByBlock: new Map(),
       reasoningByBlock: new Map(),
       toolParts: new Map(),
+      pendingUiRequests: new Map(),
       turn: 0,
+      sawAgentActivity: false,
+      promptMayBeCommandOnly: false,
+      closing: false,
       mcpConfigPath,
     }
+  }
+
+  private splitModel(model?: string): { provider?: string; modelId?: string } {
+    if (!model) return {}
+    const separator = model.indexOf('/')
+    if (separator < 0) return { modelId: model }
+    return { provider: model.slice(0, separator), modelId: model.slice(separator + 1) }
+  }
+
+  private async applySelection(session: PiSession, config: SessionConfig): Promise<void> {
+    if (config.model && config.model !== 'default') {
+      const { provider, modelId } = this.splitModel(config.model)
+      if (!provider || !modelId) {
+        throw new Error(`Pi model must use provider/model format: ${config.model}`)
+      }
+      await this.command(session, { type: 'set_model', provider, modelId })
+    }
+    if (config.reasoningEffort) {
+      await this.command(session, { type: 'set_thinking_level', level: config.reasoningEffort })
+    }
+  }
+
+  private async spawnSession(config: SessionConfig, resumeId?: string): Promise<PiSession> {
+    const executable = await this.findPiExecutable()
+    const gateway = this.installPeakfloGateway()
+    const mcpConfigPath = this.buildMcpConfig(config)
+    const permissionExtension = this.installPermissionExtension()
+
+    const args = ['--mode', 'rpc', '--approve', '--name', config.taskId, '--extension', permissionExtension]
+    if (config.systemPrompt?.trim()) {
+      args.push('--append-system-prompt', config.systemPrompt.trim())
+    }
+    if (resumeId) args.push('--session', resumeId)
+    if (mcpConfigPath) args.push('--mcp-config', mcpConfigPath)
+
+    const child = spawn(executable, args, {
+      cwd: config.workspaceDir,
+      env: this.processEnv(config, gateway),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+      shell: process.platform === 'win32',
+      detached: process.platform !== 'win32',
+    })
+
+    const tempId = resumeId || randomUUID()
+    const session = this.createSessionState(tempId, child, config, mcpConfigPath)
     this.sessions.set(tempId, session)
     this.attachProcess(session)
 
-    const state = await this.command(session, { type: 'get_state' })
-    const realId = typeof state.data?.sessionId === 'string' ? state.data.sessionId : tempId
-    session.id = realId
-    if (realId !== tempId) {
+    try {
+      const state = await this.command(session, { type: 'get_state' })
+      const realId = typeof state.data?.sessionFile === 'string'
+        ? state.data.sessionFile
+        : typeof state.data?.sessionId === 'string' ? state.data.sessionId : tempId
+      session.id = realId
+      if (realId !== tempId) {
+        this.sessions.delete(tempId)
+        this.sessions.set(realId, session)
+      }
+      await this.applySelection(session, config)
+      return session
+    } catch (error) {
       this.sessions.delete(tempId)
-      this.sessions.set(realId, session)
+      this.sessions.delete(session.id)
+      await this.terminateProcess(session)
+      if (mcpConfigPath && existsSync(mcpConfigPath)) unlinkSync(mcpConfigPath)
+      throw error
     }
-    return session
   }
 
   async createSession(config: SessionConfig): Promise<string> {
@@ -295,8 +389,8 @@ export class PiAdapter implements CodingAgentAdapter {
       }
     })
     session.process.stderr.on('data', (chunk: Buffer | string) => {
-      const text = chunk.toString().trim()
-      if (text) console.warn(`[PiAdapter/${session.id}] ${text.slice(0, 2_000)}`)
+      const length = chunk.toString().trim().length
+      if (length > 0) console.warn(`[PiAdapter/${session.id}] Pi wrote ${length} character(s) to stderr`)
     })
     session.process.on('error', (error) => {
       session.status = 'error'
@@ -305,11 +399,11 @@ export class PiAdapter implements CodingAgentAdapter {
       this.onDataAvailable?.(session.id)
     })
     session.process.on('exit', (code, signal) => {
-      if (session.status === 'busy') {
+      if (!session.closing && session.status === 'busy') {
         session.status = 'error'
         session.lastError = `Pi exited before the turn completed (${signal || `code ${code}`})`
       }
-      this.rejectPending(session, new Error(session.lastError || 'Pi process exited'))
+      this.rejectPending(session, new Error(session.lastError || (session.closing ? 'Pi process closed' : 'Pi process exited')))
       this.onDataAvailable?.(session.id)
     })
   }
@@ -332,8 +426,26 @@ export class PiAdapter implements CodingAgentAdapter {
           session.pending.delete(response.id)
           if (response.success) pending.resolve(response)
           else pending.reject(new Error(response.error || `Pi ${response.command} failed`))
+          return
         }
       }
+      if (response.command === 'prompt' && !response.success) {
+        session.status = 'error'
+        session.lastError = response.error || 'Pi rejected the prompt'
+      } else if (
+        response.command === 'prompt'
+        && response.success
+        && session.promptMayBeCommandOnly
+        && !session.sawAgentActivity
+      ) {
+        void this.command(session, { type: 'get_state' }).then((state) => {
+          if (state.data?.isStreaming !== true && !session.sawAgentActivity) {
+            session.status = session.pendingUiRequests.size > 0 ? 'busy' : 'idle'
+            this.onDataAvailable?.(session.id)
+          }
+        }).catch(() => undefined)
+      }
+      this.onDataAvailable?.(session.id)
       return
     }
 
@@ -342,9 +454,11 @@ export class PiAdapter implements CodingAgentAdapter {
         session.status = 'busy'
         session.lastError = null
         session.turn++
+        session.sawAgentActivity = true
         break
       case 'agent_settled':
-        session.status = 'idle'
+        session.status = session.pendingUiRequests.size > 0 ? 'busy' : 'idle'
+        session.promptMayBeCommandOnly = false
         break
       case 'message_update':
         this.handleMessageUpdate(session, event.assistantMessageEvent as Record<string, unknown> | undefined)
@@ -382,12 +496,65 @@ export class PiAdapter implements CodingAgentAdapter {
           text: String(event.error || 'Pi extension failed'),
         })
         break
+      case 'extension_ui_request':
+        this.handleExtensionUiRequest(session, event)
+        break
     }
 
     if (session.parts.length > MAX_BUFFERED_PARTS) {
       session.parts.splice(0, session.parts.length - MAX_BUFFERED_PARTS)
     }
     this.onDataAvailable?.(session.id)
+  }
+
+  private handleExtensionUiRequest(session: PiSession, event: Record<string, unknown>): void {
+    const method = event.method
+    const id = event.id
+    if (method === 'notify') {
+      const message = String(event.message || event.title || 'Pi notification')
+      session.parts.push({
+        id: `pi-notify-${randomUUID()}`,
+        type: MessagePartType.TEXT,
+        text: message,
+      })
+      return
+    }
+    if (
+      typeof id !== 'string'
+      || (method !== 'confirm' && method !== 'select' && method !== 'input' && method !== 'editor')
+    ) return
+
+    const request: PiUiRequest = {
+      id,
+      method,
+      title: String(event.title || (method === 'confirm' ? 'Permission Required' : 'Input Required')),
+      message: String(event.message || event.placeholder || event.title || 'Pi needs your response'),
+      options: Array.isArray(event.options) ? event.options.filter((option): option is string => typeof option === 'string') : [],
+    }
+
+    if (method === 'confirm' && session.config.permissionMode === 'allow') {
+      this.sendRecord(session, { type: 'extension_ui_response', id, confirmed: true })
+      return
+    }
+
+    session.pendingUiRequests.set(id, request)
+    session.status = 'busy'
+    if (method !== 'confirm') {
+      session.parts.push({
+        id: `pi-question-${id}`,
+        type: MessagePartType.TOOL,
+        tool: {
+          name: 'question',
+          status: 'running',
+          title: request.title,
+          questions: [{
+            header: request.title,
+            question: request.message,
+            options: request.options.map((label) => ({ label, description: label })),
+          }],
+        },
+      })
+    }
   }
 
   private handleMessageUpdate(session: PiSession, update?: Record<string, unknown>): void {
@@ -442,6 +609,18 @@ export class PiAdapter implements CodingAgentAdapter {
     })
   }
 
+  private sendRecord(session: PiSession, record: Record<string, unknown>): void {
+    if (session.process.exitCode !== null || !session.process.stdin.writable) {
+      throw new Error('Pi process is not running')
+    }
+    session.process.stdin.write(`${JSON.stringify(record)}\n`, (error) => {
+      if (!error) return
+      session.status = 'error'
+      session.lastError = error.message
+      this.onDataAvailable?.(session.id)
+    })
+  }
+
   async sendPrompt(sessionId: string, parts: MessagePart[], _config: SessionConfig): Promise<void> {
     const session = this.sessions.get(sessionId)
     if (!session) throw new Error(`Session not found: ${sessionId}`)
@@ -449,7 +628,10 @@ export class PiAdapter implements CodingAgentAdapter {
     if (!message) throw new Error('No text content in prompt parts')
     const wasBusy = session.status === 'busy'
     session.status = 'busy'
-    await this.command(session, {
+    session.lastError = null
+    session.sawAgentActivity = false
+    session.promptMayBeCommandOnly = message.trimStart().startsWith('/')
+    this.sendRecord(session, {
       type: 'prompt',
       message,
       ...(wasBusy ? { streamingBehavior: 'followUp' } : {}),
@@ -460,6 +642,9 @@ export class PiAdapter implements CodingAgentAdapter {
     const session = this.sessions.get(sessionId)
     if (!session) return { type: SessionStatusType.ERROR, message: 'Session not found' }
     if (session.lastError) return { type: SessionStatusType.ERROR, message: session.lastError }
+    if (session.pendingUiRequests.size > 0) {
+      return { type: SessionStatusType.WAITING_APPROVAL, message: 'Pi is waiting for input' }
+    }
     return { type: session.status === 'busy' ? SessionStatusType.BUSY : SessionStatusType.IDLE }
   }
 
@@ -467,6 +652,94 @@ export class PiAdapter implements CodingAgentAdapter {
     const session = this.sessions.get(sessionId)
     if (!session) return []
     return session.parts.splice(0)
+  }
+
+  getPendingApproval(sessionId: string): {
+    requestId: string
+    toolCallId: string
+    question: string
+    options: Array<{ optionId: string; name: string; kind: string }>
+  } | null {
+    const session = this.sessions.get(sessionId)
+    const request = session
+      ? Array.from(session.pendingUiRequests.values()).find((item) => item.method === 'confirm')
+      : undefined
+    if (!request) return null
+    return {
+      requestId: request.id,
+      toolCallId: request.id,
+      question: [request.title, request.message].filter(Boolean).join('\n\n'),
+      options: [
+        { optionId: 'approved', name: 'Yes', kind: 'allow_once' },
+        { optionId: 'abort', name: 'No', kind: 'reject_once' },
+      ],
+    }
+  }
+
+  async respondToApproval(sessionId: string, approved: boolean): Promise<boolean> {
+    const session = this.sessions.get(sessionId)
+    if (!session) throw new Error(`Session not found: ${sessionId}`)
+    const request = Array.from(session.pendingUiRequests.values()).find((item) => item.method === 'confirm')
+    if (!request) return false
+    this.sendRecord(session, {
+      type: 'extension_ui_response',
+      id: request.id,
+      confirmed: approved,
+    })
+    session.pendingUiRequests.delete(request.id)
+    session.status = 'busy'
+    this.onDataAvailable?.(session.id)
+    return true
+  }
+
+  async respondToQuestion(
+    sessionId: string,
+    answers: Record<string, string>,
+    _config: SessionConfig,
+  ): Promise<void> {
+    const session = this.sessions.get(sessionId)
+    if (!session) throw new Error(`Session not found: ${sessionId}`)
+    const request = Array.from(session.pendingUiRequests.values()).find((item) => item.method !== 'confirm')
+    if (!request) throw new Error('Pi has no pending question')
+    const value = answers[request.title] ?? answers[request.message] ?? answers.answer ?? Object.values(answers)[0] ?? ''
+    this.sendRecord(session, {
+      type: 'extension_ui_response',
+      id: request.id,
+      value,
+    })
+    session.pendingUiRequests.delete(request.id)
+    session.parts.push({
+      id: `pi-question-${request.id}`,
+      type: MessagePartType.TOOL,
+      update: true,
+      tool: {
+        name: 'question',
+        status: 'completed',
+        title: request.title,
+        output: value,
+      },
+    })
+    session.status = 'busy'
+    this.onDataAvailable?.(session.id)
+  }
+
+  async getRunningTools(sessionId: string): Promise<Array<{
+    partId: string
+    toolName: string
+    input?: Record<string, unknown>
+  }>> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return []
+    return Array.from(session.toolParts.values()).flatMap((part) => {
+      if (part.tool?.status !== 'running') return []
+      return [{
+        partId: part.id || `pi-tool-${part.tool.name}`,
+        toolName: part.tool.name,
+        ...(part.tool.input && typeof part.tool.input === 'object'
+          ? { input: part.tool.input as Record<string, unknown> }
+          : {}),
+      }]
+    })
   }
 
   private convertMessages(messages: PiMessage[]): SessionMessage[] {
@@ -502,10 +775,45 @@ export class PiAdapter implements CodingAgentAdapter {
     session.status = 'idle'
   }
 
+  private async terminateProcess(session: PiSession): Promise<void> {
+    session.closing = true
+    if (session.process.exitCode !== null || !session.process.pid) return
+    if (process.platform === 'win32') {
+      await execFileAsync('taskkill', ['/PID', String(session.process.pid), '/T', '/F'], {
+        timeout: 5_000,
+        windowsHide: true,
+      }).catch(() => session.process.kill())
+      return
+    }
+
+    const processGroup = -session.process.pid
+    try {
+      process.kill(processGroup, 'SIGTERM')
+    } catch {
+      session.process.kill()
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000))
+    if (session.process.exitCode !== null) return
+    try {
+      process.kill(processGroup, 'SIGKILL')
+    } catch {
+      // The process group exited during the grace period.
+    }
+  }
+
   async destroySession(sessionId: string): Promise<void> {
     const session = this.sessions.get(sessionId)
     if (!session) return
-    session.process.kill()
+    for (const request of session.pendingUiRequests.values()) {
+      try {
+        this.sendRecord(session, { type: 'extension_ui_response', id: request.id, cancelled: true })
+      } catch {
+        break
+      }
+    }
+    session.pendingUiRequests.clear()
+    await this.terminateProcess(session)
     this.sessions.delete(sessionId)
     if (session.mcpConfigPath && existsSync(session.mcpConfigPath)) {
       unlinkSync(session.mcpConfigPath)
@@ -523,23 +831,102 @@ export class PiAdapter implements CodingAgentAdapter {
   async checkHealth(): Promise<{ available: boolean; reason?: string }> {
     try {
       const executable = await this.findPiExecutable()
-      await execFileAsync(executable, ['--version'], { timeout: 10_000, windowsHide: true })
+      const { stdout, stderr } = await execFileAsync(executable, ['--version'], {
+        timeout: 10_000,
+        windowsHide: true,
+      })
+      const match = `${stdout}\n${stderr}`.match(/(\d+)\.(\d+)\.(\d+)/)
+      if (!match) return { available: false, reason: 'Could not determine the Pi version' }
+      const installed = match.slice(1, 4).map(Number)
+      for (let index = 0; index < MINIMUM_PI_VERSION.length; index++) {
+        if (installed[index] > MINIMUM_PI_VERSION[index]) break
+        if (installed[index] < MINIMUM_PI_VERSION[index]) {
+          return {
+            available: false,
+            reason: `Pi ${MINIMUM_PI_VERSION.join('.')} or newer is required`,
+          }
+        }
+      }
       return { available: true }
     } catch (error) {
       return { available: false, reason: error instanceof Error ? error.message : String(error) }
     }
   }
 
-  async getProviders(): Promise<{ providers: Array<{ id: string; name: string; models: Array<{ id: string; name: string }> }>; default: Record<string, string> }> {
-    const gateway = readEnterpriseAiGatewayConfig(this.db)
-    if (!gateway) return { providers: [], default: {} }
-    return {
-      providers: [{
-        id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
-        name: ENTERPRISE_AI_GATEWAY_PROVIDER_NAME,
-        models: gateway.models ?? [],
-      }],
-      default: {},
+  async getProviders(
+    _serverUrl?: string,
+    directory?: string,
+  ): Promise<{ providers: Array<{ id: string; name: string; models: Array<{ id: string; name: string }> }>; default: Record<string, string> }> {
+    const executable = await this.findPiExecutable()
+    const gateway = this.installPeakfloGateway()
+    const config: SessionConfig = {
+      agentId: 'pi-discovery',
+      taskId: 'pi-discovery',
+      workspaceDir: directory || process.cwd(),
+      permissionMode: 'allow',
+    }
+    const child = spawn(executable, ['--mode', 'rpc', '--no-session', '--approve'], {
+      cwd: config.workspaceDir,
+      env: this.processEnv(config, gateway),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+      shell: process.platform === 'win32',
+      detached: process.platform !== 'win32',
+    })
+    const session = this.createSessionState(`pi-discovery-${randomUUID()}`, child, config)
+    this.attachProcess(session)
+
+    try {
+      const [state, available] = await Promise.all([
+        this.command(session, { type: 'get_state' }),
+        this.command(session, { type: 'get_available_models' }),
+      ])
+      const models = Array.isArray(available.data?.models) ? available.data.models : []
+      const providers = new Map<string, { id: string; name: string; models: Array<{ id: string; name: string }> }>()
+      for (const model of models) {
+        if (!model || typeof model !== 'object') continue
+        const record = model as Record<string, unknown>
+        if (typeof record.provider !== 'string' || typeof record.id !== 'string') continue
+        const provider = providers.get(record.provider) ?? {
+          id: record.provider,
+          name: record.provider === ENTERPRISE_AI_GATEWAY_PROVIDER_ID
+            ? ENTERPRISE_AI_GATEWAY_PROVIDER_NAME
+            : record.provider,
+          models: [],
+        }
+        if (!provider.models.some((item) => item.id === record.id)) {
+          provider.models.push({
+            id: record.id,
+            name: typeof record.name === 'string' ? record.name : record.id,
+          })
+        }
+        providers.set(record.provider, provider)
+      }
+      const defaultModel = state.data?.model
+      const defaultProvider = defaultModel && typeof defaultModel === 'object'
+        ? (defaultModel as Record<string, unknown>).provider
+        : undefined
+      const defaultModelId = defaultModel && typeof defaultModel === 'object'
+        ? (defaultModel as Record<string, unknown>).id
+        : undefined
+      return {
+        providers: Array.from(providers.values()),
+        default: typeof defaultProvider === 'string' && typeof defaultModelId === 'string'
+          ? { [defaultProvider]: defaultModelId }
+          : {},
+      }
+    } catch (error) {
+      if (!gateway) throw error
+      return {
+        providers: [{
+          id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+          name: ENTERPRISE_AI_GATEWAY_PROVIDER_NAME,
+          models: gateway.providerModels,
+        }],
+        default: {},
+      }
+    } finally {
+      await this.terminateProcess(session)
     }
   }
 }

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -1,0 +1,545 @@
+/**
+ * Pi coding-agent adapter.
+ *
+ * Pi exposes a JSONL RPC protocol over stdin/stdout. 20x keeps one Pi process
+ * per live session and converts Pi events to the shared adapter message shape.
+ */
+
+import { spawn, execFile } from 'child_process'
+import type { ChildProcessWithoutNullStreams } from 'child_process'
+import { randomUUID } from 'crypto'
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { dirname, join } from 'path'
+import { promisify } from 'util'
+import type { DatabaseManager } from '../database'
+import {
+  ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+  ENTERPRISE_AI_GATEWAY_PROVIDER_NAME,
+  buildPiAiGatewayProviderConfig,
+  readEnterpriseAiGatewayConfig,
+} from '../enterprise-ai-gateway'
+import type {
+  CodingAgentAdapter,
+  MessagePart,
+  SessionConfig,
+  SessionMessage,
+  SessionStatus,
+} from './coding-agent-adapter'
+import { MessagePartType, MessageRole, SessionStatusType } from './coding-agent-adapter'
+
+const execFileAsync = promisify(execFile)
+const RPC_TIMEOUT_MS = 15_000
+const MAX_BUFFERED_PARTS = 1_000
+
+interface PiRpcResponse {
+  id?: string
+  type: 'response'
+  command: string
+  success: boolean
+  data?: Record<string, unknown>
+  error?: string
+}
+
+interface PendingRequest {
+  resolve: (response: PiRpcResponse) => void
+  reject: (error: Error) => void
+  timer: NodeJS.Timeout
+}
+
+interface PiSession {
+  id: string
+  process: ChildProcessWithoutNullStreams
+  config: SessionConfig
+  status: 'idle' | 'busy' | 'error'
+  lastError: string | null
+  pending: Map<string, PendingRequest>
+  parts: MessagePart[]
+  allMessages: SessionMessage[]
+  stdoutBuffer: string
+  textByBlock: Map<string, string>
+  reasoningByBlock: Map<string, string>
+  toolParts: Map<string, MessagePart>
+  turn: number
+  mcpConfigPath?: string
+}
+
+type PiMessage = {
+  role?: string
+  content?: string | Array<Record<string, unknown>>
+  timestamp?: number
+  stopReason?: string
+  errorMessage?: string
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((block): block is Record<string, unknown> => !!block && typeof block === 'object')
+    .filter((block) => block.type === 'text')
+    .map((block) => String(block.text ?? ''))
+    .join('')
+}
+
+function resultText(result: unknown): string {
+  if (!result || typeof result !== 'object') return ''
+  const content = (result as { content?: unknown }).content
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((block): block is Record<string, unknown> => !!block && typeof block === 'object')
+    .map((block) => block.type === 'text' ? String(block.text ?? '') : JSON.stringify(block))
+    .join('\n')
+}
+
+export class PiAdapter implements CodingAgentAdapter {
+  private sessions = new Map<string, PiSession>()
+  private piExecutablePath: string | null = null
+  onDataAvailable?: (sessionId: string) => void
+
+  constructor(private db: Pick<DatabaseManager, 'getSetting'>) {}
+
+  async initialize(): Promise<void> {
+    await this.findPiExecutable()
+  }
+
+  private async findPiExecutable(): Promise<string> {
+    if (this.piExecutablePath) return this.piExecutablePath
+    const isWin = process.platform === 'win32'
+    try {
+      const { stdout } = await execFileAsync(isWin ? 'where' : 'which', ['pi'], {
+        timeout: 10_000,
+        windowsHide: true,
+      })
+      this.piExecutablePath = stdout.trim().split(/\r?\n/)[0]
+      return this.piExecutablePath
+    } catch {
+      const home = homedir()
+      const candidates = isWin
+        ? [
+            join(home, 'AppData', 'Roaming', 'npm', 'pi.cmd'),
+            join(home, 'AppData', 'Roaming', 'npm', 'pi.exe'),
+          ]
+        : [
+            '/opt/homebrew/bin/pi',
+            '/usr/local/bin/pi',
+            join(home, '.local', 'bin', 'pi'),
+            join(home, '.npm-global', 'bin', 'pi'),
+            join(home, '.volta', 'bin', 'pi'),
+          ]
+      const found = candidates.find(existsSync)
+      if (!found) {
+        throw new Error('Pi CLI not found. Install it with: npm install -g --ignore-scripts @earendil-works/pi-coding-agent')
+      }
+      this.piExecutablePath = found
+      return found
+    }
+  }
+
+  /**
+   * Install or update the Peakflo provider in Pi's normal models file. The key
+   * remains an environment reference; 20x supplies the decrypted value only to
+   * the child process.
+   */
+  private installPeakfloGateway(): { apiKey: string; providerModels: Array<{ id: string; name: string }> } | null {
+    const gateway = readEnterpriseAiGatewayConfig(this.db)
+    if (!gateway) return null
+
+    const agentDir = process.env.PI_CODING_AGENT_DIR || join(homedir(), '.pi', 'agent')
+    const modelsPath = join(agentDir, 'models.json')
+    mkdirSync(dirname(modelsPath), { recursive: true })
+
+    let root: { providers?: Record<string, unknown> } = {}
+    if (existsSync(modelsPath)) {
+      try {
+        root = JSON.parse(readFileSync(modelsPath, 'utf8')) as { providers?: Record<string, unknown> }
+      } catch (error) {
+        throw new Error(`Pi models file is not valid JSON: ${error instanceof Error ? error.message : String(error)}`)
+      }
+    }
+
+    const providers = { ...(root.providers ?? {}) }
+    providers[ENTERPRISE_AI_GATEWAY_PROVIDER_ID] = buildPiAiGatewayProviderConfig(gateway)
+
+    const temporaryPath = `${modelsPath}.20x-${process.pid}.tmp`
+    writeFileSync(temporaryPath, `${JSON.stringify({ ...root, providers }, null, 2)}\n`, { mode: 0o600 })
+    chmodSync(temporaryPath, 0o600)
+    renameSync(temporaryPath, modelsPath)
+    chmodSync(modelsPath, 0o600)
+
+    return { apiKey: gateway.apiKey, providerModels: gateway.models ?? [] }
+  }
+
+  private buildMcpConfig(config: SessionConfig): string | undefined {
+    if (!config.mcpServers || Object.keys(config.mcpServers).length === 0) return undefined
+    const dir = join(homedir(), '.20x', 'pi-mcp')
+    mkdirSync(dir, { recursive: true })
+    const path = join(dir, `${config.taskId}-${randomUUID()}.json`)
+    const mcpServers = Object.fromEntries(Object.entries(config.mcpServers).map(([name, server]) => {
+      if (server.type === 'stdio') {
+        return [name, {
+          command: server.command,
+          args: server.args ?? [],
+          env: server.env ?? {},
+        }]
+      }
+      return [name, {
+        url: server.url,
+        headers: server.headers ?? {},
+      }]
+    }))
+    writeFileSync(path, `${JSON.stringify({ mcpServers }, null, 2)}\n`, { mode: 0o600 })
+    chmodSync(path, 0o600)
+    return path
+  }
+
+  private splitModel(model?: string): { provider?: string; modelId?: string } {
+    if (!model) return {}
+    const separator = model.indexOf('/')
+    if (separator < 0) return { modelId: model }
+    return { provider: model.slice(0, separator), modelId: model.slice(separator + 1) }
+  }
+
+  private async spawnSession(config: SessionConfig, resumeId?: string): Promise<PiSession> {
+    const executable = await this.findPiExecutable()
+    const gateway = this.installPeakfloGateway()
+    const mcpConfigPath = this.buildMcpConfig(config)
+    const sessionDir = join(homedir(), '.20x', 'pi-sessions')
+    mkdirSync(sessionDir, { recursive: true })
+
+    const args = ['--mode', 'rpc', '--approve', '--session-dir', sessionDir, '--name', config.taskId]
+    if (config.systemPrompt?.trim()) {
+      args.push('--append-system-prompt', config.systemPrompt.trim())
+    }
+    if (resumeId) args.push('--session', resumeId)
+    const { provider, modelId } = this.splitModel(config.model)
+    if (provider) args.push('--provider', provider)
+    if (modelId) args.push('--model', modelId)
+    if (config.reasoningEffort) args.push('--thinking', config.reasoningEffort)
+    if (mcpConfigPath) args.push('--mcp-config', mcpConfigPath)
+
+    const env = {
+      ...process.env,
+      ...(config.secretEnvVars ?? {}),
+      ...(gateway ? { PEAKFLO_AI_GATEWAY_API_KEY: gateway.apiKey } : {}),
+    } as NodeJS.ProcessEnv
+    delete env.AI_AGENT
+    delete env.PI_CODING_AGENT
+
+    const child = spawn(executable, args, {
+      cwd: config.workspaceDir,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+      shell: process.platform === 'win32',
+    })
+
+    const tempId = resumeId || randomUUID()
+    const session: PiSession = {
+      id: tempId,
+      process: child,
+      config,
+      status: 'idle',
+      lastError: null,
+      pending: new Map(),
+      parts: [],
+      allMessages: [],
+      stdoutBuffer: '',
+      textByBlock: new Map(),
+      reasoningByBlock: new Map(),
+      toolParts: new Map(),
+      turn: 0,
+      mcpConfigPath,
+    }
+    this.sessions.set(tempId, session)
+    this.attachProcess(session)
+
+    const state = await this.command(session, { type: 'get_state' })
+    const realId = typeof state.data?.sessionId === 'string' ? state.data.sessionId : tempId
+    session.id = realId
+    if (realId !== tempId) {
+      this.sessions.delete(tempId)
+      this.sessions.set(realId, session)
+    }
+    return session
+  }
+
+  async createSession(config: SessionConfig): Promise<string> {
+    const session = await this.spawnSession(config)
+    return session.id
+  }
+
+  async resumeSession(sessionId: string, config: SessionConfig): Promise<SessionMessage[]> {
+    const session = await this.spawnSession(config, sessionId)
+    const response = await this.command(session, { type: 'get_messages' })
+    const messages = Array.isArray(response.data?.messages) ? response.data.messages as PiMessage[] : []
+    session.allMessages = this.convertMessages(messages)
+    return session.allMessages
+  }
+
+  private attachProcess(session: PiSession): void {
+    session.process.stdout.on('data', (chunk: Buffer | string) => {
+      session.stdoutBuffer += chunk.toString()
+      while (true) {
+        const newline = session.stdoutBuffer.indexOf('\n')
+        if (newline < 0) break
+        let line = session.stdoutBuffer.slice(0, newline)
+        session.stdoutBuffer = session.stdoutBuffer.slice(newline + 1)
+        if (line.endsWith('\r')) line = line.slice(0, -1)
+        if (!line.trim()) continue
+        try {
+          this.handleEvent(session, JSON.parse(line) as Record<string, unknown>)
+        } catch (error) {
+          console.warn('[PiAdapter] Invalid RPC output:', error)
+        }
+      }
+    })
+    session.process.stderr.on('data', (chunk: Buffer | string) => {
+      const text = chunk.toString().trim()
+      if (text) console.warn(`[PiAdapter/${session.id}] ${text.slice(0, 2_000)}`)
+    })
+    session.process.on('error', (error) => {
+      session.status = 'error'
+      session.lastError = error.message
+      this.rejectPending(session, error)
+      this.onDataAvailable?.(session.id)
+    })
+    session.process.on('exit', (code, signal) => {
+      if (session.status === 'busy') {
+        session.status = 'error'
+        session.lastError = `Pi exited before the turn completed (${signal || `code ${code}`})`
+      }
+      this.rejectPending(session, new Error(session.lastError || 'Pi process exited'))
+      this.onDataAvailable?.(session.id)
+    })
+  }
+
+  private rejectPending(session: PiSession, error: Error): void {
+    for (const request of session.pending.values()) {
+      clearTimeout(request.timer)
+      request.reject(error)
+    }
+    session.pending.clear()
+  }
+
+  private handleEvent(session: PiSession, event: Record<string, unknown>): void {
+    if (event.type === 'response') {
+      const response = event as unknown as PiRpcResponse
+      if (response.id) {
+        const pending = session.pending.get(response.id)
+        if (pending) {
+          clearTimeout(pending.timer)
+          session.pending.delete(response.id)
+          if (response.success) pending.resolve(response)
+          else pending.reject(new Error(response.error || `Pi ${response.command} failed`))
+        }
+      }
+      return
+    }
+
+    switch (event.type) {
+      case 'agent_start':
+        session.status = 'busy'
+        session.lastError = null
+        session.turn++
+        break
+      case 'agent_settled':
+        session.status = 'idle'
+        break
+      case 'message_update':
+        this.handleMessageUpdate(session, event.assistantMessageEvent as Record<string, unknown> | undefined)
+        break
+      case 'message_end': {
+        const message = event.message as PiMessage | undefined
+        if (message?.role === 'assistant' && message.stopReason === 'error') {
+          const text = message.errorMessage || 'Pi model request failed'
+          session.parts.push({ id: `pi-error-${session.turn}`, type: MessagePartType.ERROR, text })
+          session.lastError = text
+        }
+        break
+      }
+      case 'tool_execution_start':
+        this.handleToolEvent(session, event, 'running')
+        break
+      case 'tool_execution_update':
+        this.handleToolEvent(session, event, 'running')
+        break
+      case 'tool_execution_end':
+        this.handleToolEvent(session, event, event.isError ? 'error' : 'completed')
+        break
+      case 'auto_retry_start':
+        session.status = 'busy'
+        break
+      case 'auto_retry_end':
+        if (event.success === false) {
+          session.lastError = String(event.finalError || 'Pi retry failed')
+        }
+        break
+      case 'extension_error':
+        session.parts.push({
+          id: `pi-extension-error-${randomUUID()}`,
+          type: MessagePartType.ERROR,
+          text: String(event.error || 'Pi extension failed'),
+        })
+        break
+    }
+
+    if (session.parts.length > MAX_BUFFERED_PARTS) {
+      session.parts.splice(0, session.parts.length - MAX_BUFFERED_PARTS)
+    }
+    this.onDataAvailable?.(session.id)
+  }
+
+  private handleMessageUpdate(session: PiSession, update?: Record<string, unknown>): void {
+    if (!update) return
+    const index = String(update.contentIndex ?? 0)
+    if (update.type === 'text_delta') {
+      const key = `${session.turn}:${index}`
+      const text = (session.textByBlock.get(key) || '') + String(update.delta || '')
+      session.textByBlock.set(key, text)
+      session.parts.push({ id: `pi-text-${key}`, type: MessagePartType.TEXT, text, update: true })
+    } else if (update.type === 'thinking_delta') {
+      const key = `${session.turn}:${index}`
+      const text = (session.reasoningByBlock.get(key) || '') + String(update.delta || '')
+      session.reasoningByBlock.set(key, text)
+      session.parts.push({ id: `pi-reasoning-${key}`, type: MessagePartType.REASONING, text, update: true })
+    }
+  }
+
+  private handleToolEvent(session: PiSession, event: Record<string, unknown>, status: string): void {
+    const id = String(event.toolCallId || randomUUID())
+    const existing = session.toolParts.get(id)
+    const output = resultText(event.result ?? event.partialResult)
+    const tool: NonNullable<MessagePart['tool']> = {
+      name: String(event.toolName || existing?.tool?.name || 'tool'),
+      status,
+      input: event.args ?? existing?.tool?.input,
+      output: output || existing?.tool?.output,
+      error: status === 'error' ? output || 'Tool failed' : undefined,
+    }
+    const part: MessagePart = { id: `pi-tool-${id}`, type: MessagePartType.TOOL, tool, update: !!existing }
+    session.toolParts.set(id, part)
+    session.parts.push(part)
+  }
+
+  private command(session: PiSession, command: Record<string, unknown>): Promise<PiRpcResponse> {
+    if (session.process.exitCode !== null || !session.process.stdin.writable) {
+      return Promise.reject(new Error('Pi process is not running'))
+    }
+    const id = randomUUID()
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        session.pending.delete(id)
+        reject(new Error(`Pi RPC command timed out: ${String(command.type)}`))
+      }, RPC_TIMEOUT_MS)
+      session.pending.set(id, { resolve, reject, timer })
+      session.process.stdin.write(`${JSON.stringify({ ...command, id })}\n`, (error) => {
+        if (!error) return
+        clearTimeout(timer)
+        session.pending.delete(id)
+        reject(error)
+      })
+    })
+  }
+
+  async sendPrompt(sessionId: string, parts: MessagePart[], _config: SessionConfig): Promise<void> {
+    const session = this.sessions.get(sessionId)
+    if (!session) throw new Error(`Session not found: ${sessionId}`)
+    const message = parts.filter((part) => part.type === MessagePartType.TEXT && part.text).map((part) => part.text).join('\n')
+    if (!message) throw new Error('No text content in prompt parts')
+    const wasBusy = session.status === 'busy'
+    session.status = 'busy'
+    await this.command(session, {
+      type: 'prompt',
+      message,
+      ...(wasBusy ? { streamingBehavior: 'followUp' } : {}),
+    })
+  }
+
+  async getStatus(sessionId: string, _config: SessionConfig): Promise<SessionStatus> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return { type: SessionStatusType.ERROR, message: 'Session not found' }
+    if (session.lastError) return { type: SessionStatusType.ERROR, message: session.lastError }
+    return { type: session.status === 'busy' ? SessionStatusType.BUSY : SessionStatusType.IDLE }
+  }
+
+  async pollMessages(sessionId: string): Promise<MessagePart[]> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return []
+    return session.parts.splice(0)
+  }
+
+  private convertMessages(messages: PiMessage[]): SessionMessage[] {
+    return messages.flatMap((message, index) => {
+      if (message.role !== 'user' && message.role !== 'assistant') return []
+      const text = textFromContent(message.content)
+      if (!text) return []
+      return [{
+        id: `pi-history-${message.timestamp ?? index}`,
+        role: message.role === 'user' ? MessageRole.USER : MessageRole.ASSISTANT,
+        parts: [{ id: `pi-history-part-${message.timestamp ?? index}`, type: MessagePartType.TEXT, text }],
+      }]
+    })
+  }
+
+  async getAllMessages(sessionId: string): Promise<SessionMessage[]> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return []
+    try {
+      const response = await this.command(session, { type: 'get_messages' })
+      const messages = Array.isArray(response.data?.messages) ? response.data.messages as PiMessage[] : []
+      session.allMessages = this.convertMessages(messages)
+    } catch {
+      // Use the last successful snapshot when the process has already ended.
+    }
+    return session.allMessages
+  }
+
+  async abortPrompt(sessionId: string): Promise<void> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return
+    await this.command(session, { type: 'abort' })
+    session.status = 'idle'
+  }
+
+  async destroySession(sessionId: string): Promise<void> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return
+    session.process.kill()
+    this.sessions.delete(sessionId)
+    if (session.mcpConfigPath && existsSync(session.mcpConfigPath)) {
+      unlinkSync(session.mcpConfigPath)
+    }
+  }
+
+  async registerMcpServer(
+    _serverName: string,
+    _mcpConfig: { type: 'local' | 'remote'; command?: string[]; args?: string[]; url?: string; headers?: Record<string, string>; environment?: Record<string, string> },
+    _workspaceDir?: string,
+  ): Promise<void> {
+    // MCP servers are supplied per process through pi-mcp-adapter.
+  }
+
+  async checkHealth(): Promise<{ available: boolean; reason?: string }> {
+    try {
+      const executable = await this.findPiExecutable()
+      await execFileAsync(executable, ['--version'], { timeout: 10_000, windowsHide: true })
+      return { available: true }
+    } catch (error) {
+      return { available: false, reason: error instanceof Error ? error.message : String(error) }
+    }
+  }
+
+  async getProviders(): Promise<{ providers: Array<{ id: string; name: string; models: Array<{ id: string; name: string }> }>; default: Record<string, string> }> {
+    const gateway = readEnterpriseAiGatewayConfig(this.db)
+    if (!gateway) return { providers: [], default: {} }
+    return {
+      providers: [{
+        id: ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
+        name: ENTERPRISE_AI_GATEWAY_PROVIDER_NAME,
+        models: gateway.models ?? [],
+      }],
+      default: {},
+    }
+  }
+}

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -542,7 +542,7 @@ export class PiAdapter implements CodingAgentAdapter {
     if (method !== 'confirm') {
       session.parts.push({
         id: `pi-question-${id}`,
-        type: MessagePartType.TOOL,
+        type: MessagePartType.QUESTION,
         tool: {
           name: 'question',
           status: 'running',
@@ -677,11 +677,18 @@ export class PiAdapter implements CodingAgentAdapter {
     }
   }
 
-  async respondToApproval(sessionId: string, approved: boolean): Promise<boolean> {
+  async respondToApproval(
+    sessionId: string,
+    approved: boolean,
+    _optionId?: string,
+    requestId?: string,
+  ): Promise<boolean> {
     const session = this.sessions.get(sessionId)
     if (!session) throw new Error(`Session not found: ${sessionId}`)
-    const request = Array.from(session.pendingUiRequests.values()).find((item) => item.method === 'confirm')
-    if (!request) return false
+    const request = requestId
+      ? session.pendingUiRequests.get(requestId)
+      : Array.from(session.pendingUiRequests.values()).find((item) => item.method === 'confirm')
+    if (request?.method !== 'confirm') return false
     this.sendRecord(session, {
       type: 'extension_ui_response',
       id: request.id,
@@ -698,7 +705,7 @@ export class PiAdapter implements CodingAgentAdapter {
     answers: Record<string, string>,
     _config: SessionConfig,
     requestId?: string,
-  ): Promise<boolean> {
+  ): Promise<boolean | { handled: false; resolutionPart: MessagePart }> {
     const session = this.sessions.get(sessionId)
     if (!session) throw new Error(`Session not found: ${sessionId}`)
     const request = requestId
@@ -708,17 +715,20 @@ export class PiAdapter implements CodingAgentAdapter {
     // has already consumed the request. Treat that response as stale.
     if (!request || request.method === 'confirm') {
       if (!request && requestId) {
-        session.parts.push({
-          id: `pi-question-${requestId}`,
-          type: MessagePartType.TOOL,
-          update: true,
-          tool: {
-            name: 'question',
-            status: 'cancelled',
-            output: 'This Pi question expired when the session ended.',
+        return {
+          handled: false,
+          resolutionPart: {
+            id: `pi-question-${requestId}`,
+            type: MessagePartType.QUESTION,
+            update: true,
+            tool: {
+              name: 'question',
+              status: 'cancelled',
+              requestId,
+              output: 'This request expired when the session ended. Restart the turn to continue.',
+            },
           },
-        })
-        this.onDataAvailable?.(session.id)
+        }
       }
       return false
     }

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -34,6 +34,7 @@ const RPC_TIMEOUT_MS = 15_000
 const MAX_BUFFERED_PARTS = 1_000
 const MINIMUM_PI_VERSION = [0, 80, 5] as const
 const PI_PERMISSION_MODE_ENV = 'TWENTYX_PI_PERMISSION_MODE'
+const TERMINAL_ERROR_SETTLE_GRACE_MS = 1_000
 
 const PI_PERMISSION_EXTENSION_SOURCE = `\
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -93,6 +94,7 @@ interface PiSession {
   turn: number
   assistantMessageOrdinal: number
   pendingTurnError: string | null
+  pendingTurnErrorMonotonicTime: number | null
   sawAgentActivity: boolean
   promptMayBeCommandOnly: boolean
   closing: boolean
@@ -290,6 +292,7 @@ export class PiAdapter implements CodingAgentAdapter {
       turn: 0,
       assistantMessageOrdinal: 0,
       pendingTurnError: null,
+      pendingTurnErrorMonotonicTime: null,
       sawAgentActivity: false,
       promptMayBeCommandOnly: false,
       closing: false,
@@ -480,21 +483,15 @@ export class PiAdapter implements CodingAgentAdapter {
         session.status = 'busy'
         session.lastError = null
         session.pendingTurnError = null
+        session.pendingTurnErrorMonotonicTime = null
         session.turn++
         session.assistantMessageOrdinal = 0
         session.sawAgentActivity = true
         break
       case 'agent_settled': {
         this.cancelPendingUiRequests(session, 'This request is no longer active.')
-        if (session.pendingTurnError) {
-          session.lastError = session.pendingTurnError
-          session.parts.push({
-            id: `pi-error-${session.turn}`,
-            type: MessagePartType.ERROR,
-            text: session.pendingTurnError,
-          })
-        }
-        session.status = 'idle'
+        if (session.pendingTurnError) this.settlePendingTurnError(session)
+        else session.status = 'idle'
         session.promptMayBeCommandOnly = false
         break
       }
@@ -511,6 +508,7 @@ export class PiAdapter implements CodingAgentAdapter {
         this.reconcileAssistantMessage(session, message)
         if (message?.role === 'assistant' && message.stopReason === 'error') {
           session.pendingTurnError = message.errorMessage || 'Pi model request failed'
+          session.pendingTurnErrorMonotonicTime = performance.now()
         }
         break
       }
@@ -525,11 +523,13 @@ export class PiAdapter implements CodingAgentAdapter {
         break
       case 'auto_retry_start':
         session.status = 'busy'
+        session.pendingTurnErrorMonotonicTime = null
         break
       case 'auto_retry_end':
         session.pendingTurnError = event.success === true
           ? null
           : String(event.finalError || 'Pi retry failed')
+        session.pendingTurnErrorMonotonicTime = event.success === true ? null : performance.now()
         break
       case 'compaction_end':
         if (event.result) session.pendingTurnError = null
@@ -752,11 +752,47 @@ export class PiAdapter implements CodingAgentAdapter {
   async getStatus(sessionId: string, _config: SessionConfig): Promise<SessionStatus> {
     const session = this.sessions.get(sessionId)
     if (!session) return { type: SessionStatusType.ERROR, message: 'Session not found' }
+    // Some providers end the model stream with stopReason=error but omit the
+    // final agent_settled event. Confirm Pi is no longer streaming so that a
+    // terminal provider error cannot leave the task BUSY forever. A retry keeps
+    // isStreaming=true (and auto_retry_start clears/replaces the pending error).
+    if (
+      session.pendingTurnError
+      && session.pendingTurnErrorMonotonicTime !== null
+      && performance.now() - session.pendingTurnErrorMonotonicTime >= TERMINAL_ERROR_SETTLE_GRACE_MS
+      && session.status === 'busy'
+    ) {
+      try {
+        const state = await this.command(session, { type: 'get_state' })
+        const pendingMessageCount = typeof state.data?.pendingMessageCount === 'number'
+          ? state.data.pendingMessageCount
+          : 0
+        if (state.data?.isStreaming !== true && pendingMessageCount === 0) {
+          this.settlePendingTurnError(session)
+        }
+      } catch {
+        // Keep polling; process exit/error handling remains authoritative.
+      }
+    }
     if (session.lastError) return { type: SessionStatusType.ERROR, message: session.lastError }
     if (session.pendingUiRequests.size > 0) {
       return { type: SessionStatusType.WAITING_APPROVAL, message: 'Pi is waiting for input' }
     }
     return { type: session.status === 'busy' ? SessionStatusType.BUSY : SessionStatusType.IDLE }
+  }
+
+  private settlePendingTurnError(session: PiSession): void {
+    if (!session.pendingTurnError) return
+    const error = session.pendingTurnError
+    session.pendingTurnError = null
+    session.pendingTurnErrorMonotonicTime = null
+    session.lastError = error
+    session.status = 'error'
+    session.parts.push({
+      id: `pi-error-${session.turn}`,
+      type: MessagePartType.ERROR,
+      text: error,
+    })
   }
 
   async pollMessages(sessionId: string): Promise<MessagePart[]> {

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -706,7 +706,22 @@ export class PiAdapter implements CodingAgentAdapter {
       : Array.from(session.pendingUiRequests.values()).find((item) => item.method !== 'confirm')
     // A restored transcript or another client can submit a response after Pi
     // has already consumed the request. Treat that response as stale.
-    if (!request || request.method === 'confirm') return false
+    if (!request || request.method === 'confirm') {
+      if (!request && requestId) {
+        session.parts.push({
+          id: `pi-question-${requestId}`,
+          type: MessagePartType.TOOL,
+          update: true,
+          tool: {
+            name: 'question',
+            status: 'cancelled',
+            output: 'This Pi question expired when the session ended.',
+          },
+        })
+        this.onDataAvailable?.(session.id)
+      }
+      return false
+    }
     const value = answers[request.title] ?? answers[request.message] ?? answers.answer ?? Object.values(answers)[0] ?? ''
     this.sendRecord(session, {
       type: 'extension_ui_response',

--- a/src/main/agent-installer/detect.js
+++ b/src/main/agent-installer/detect.js
@@ -65,7 +65,7 @@ export async function detectInstalledAgents() {
   }
 
   // Run all probes in parallel — shell:true on Windows resolves .cmd automatically
-  const [nodejs, npm, pnpm, git, gh, glab, claudeCode, opencode, codex, cursor] = await Promise.all([
+  const [nodejs, npm, pnpm, git, gh, glab, claudeCode, opencode, codex, cursor, pi] = await Promise.all([
     probe('node', ['--version']),
     probe('npm', ['--version']),
     probe('pnpm', ['--version']),
@@ -75,8 +75,9 @@ export async function detectInstalledAgents() {
     probe('claude', ['--version']),
     probe('opencode', ['--version']),
     probe('codex', ['--version']),
-    probe('cursor-agent', ['--version'])
+    probe('cursor-agent', ['--version']),
+    probe('pi', ['--version'])
   ])
 
-  return { nodejs, npm, pnpm, git, gh, glab, claudeCode, opencode, codex, cursor }
+  return { nodejs, npm, pnpm, git, gh, glab, claudeCode, opencode, codex, cursor, pi }
 }

--- a/src/main/agent-installer/detect.js
+++ b/src/main/agent-installer/detect.js
@@ -1,10 +1,73 @@
 import { execFile } from 'child_process'
 import { promisify } from 'util'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import { homedir } from 'os'
 import { existsSync } from 'fs'
 
 const execFileAsync = promisify(execFile)
+export const MINIMUM_PI_VERSION = '0.80.5'
+
+function unique(items) {
+  return [...new Set(items.filter(Boolean))]
+}
+
+function ensurePathDirectory(dir) {
+  const sep = process.platform === 'win32' ? ';' : ':'
+  const segments = (process.env.PATH || '').split(sep)
+  if (!dir || segments.includes(dir) || segments.includes(`${dir}/`)) return false
+  process.env.PATH = `${dir}${sep}${process.env.PATH || ''}`
+  return true
+}
+
+/** Return common locations used by global npm and Node version managers. */
+export async function getPiCommandCandidates() {
+  const home = homedir()
+  const candidates = process.platform === 'win32'
+    ? [
+        'pi.cmd',
+        'pi.exe',
+        join(home, 'AppData', 'Roaming', 'npm', 'pi.cmd'),
+        join(home, 'AppData', 'Roaming', 'npm', 'pi.exe')
+      ]
+    : [
+        'pi',
+        '/opt/homebrew/bin/pi',
+        '/usr/local/bin/pi',
+        join(home, '.local', 'bin', 'pi'),
+        join(home, '.npm-global', 'bin', 'pi'),
+        join(home, '.volta', 'bin', 'pi')
+      ]
+
+  try {
+    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    const { stdout } = await execFileAsync(npmCommand, ['prefix', '-g'], {
+      timeout: 5000,
+      shell: process.platform === 'win32',
+      windowsHide: true
+    })
+    const prefix = stdout.trim()
+    if (prefix) {
+      candidates.push(process.platform === 'win32'
+        ? join(prefix, 'pi.cmd')
+        : join(prefix, 'bin', 'pi'))
+    }
+  } catch {
+    // npm is optional during detection.
+  }
+
+  return unique(candidates)
+}
+
+export function isVersionAtLeast(version, minimum) {
+  const current = String(version || '').split('.').map((part) => Number.parseInt(part, 10) || 0)
+  const required = String(minimum || '').split('.').map((part) => Number.parseInt(part, 10) || 0)
+  const length = Math.max(current.length, required.length)
+  for (let index = 0; index < length; index++) {
+    if ((current[index] || 0) > (required[index] || 0)) return true
+    if ((current[index] || 0) < (required[index] || 0)) return false
+  }
+  return true
+}
 
 /**
  * Ensure well-known agent install directories are on the running process's
@@ -12,9 +75,6 @@ const execFileAsync = promisify(execFile)
  */
 function ensureAgentPaths() {
   const home = homedir()
-  const sep = process.platform === 'win32' ? ';' : ':'
-  const pathEnv = process.env.PATH || ''
-  const segments = pathEnv.split(sep)
 
   const knownDirs = [
     join(home, '.opencode', 'bin'),  // OpenCode standalone installer
@@ -23,10 +83,7 @@ function ensureAgentPaths() {
 
   let modified = false
   for (const dir of knownDirs) {
-    if (existsSync(dir) && !segments.includes(dir) && !segments.includes(`${dir}/`)) {
-      process.env.PATH = `${dir}${sep}${process.env.PATH}`
-      modified = true
-    }
+    if (existsSync(dir) && ensurePathDirectory(dir)) modified = true
   }
   return modified
 }
@@ -50,18 +107,39 @@ export async function detectInstalledAgents() {
    */
   async function probe(cmd, args) {
     try {
-      const { stdout } = await execFileAsync(cmd, args, {
+      const { stdout, stderr } = await execFileAsync(cmd, args, {
         timeout: 10000,
         shell: isWin,
         windowsHide: true
       })
-      const raw = stdout.trim()
+      const raw = `${stdout}\n${stderr}`.trim()
       // Extract version-like string (e.g. "v22.1.0", "2.44.0", "1.0.3")
       const match = raw.match(/(\d+\.\d+[\w.\-]*)/)
       return { installed: true, version: match ? match[1] : raw.split('\n')[0] }
     } catch {
       return { installed: false, version: null }
     }
+  }
+
+  async function probePi() {
+    for (const command of await getPiCommandCandidates()) {
+      const status = await probe(command, ['--version'])
+      if (!status.installed) continue
+      if (existsSync(command)) ensurePathDirectory(dirname(command))
+      const supported = status.version
+        ? isVersionAtLeast(status.version, MINIMUM_PI_VERSION)
+        : false
+      return {
+        ...status,
+        supported,
+        reason: supported
+          ? null
+          : status.version
+            ? `Pi ${status.version} is unsupported. Update to ${MINIMUM_PI_VERSION} or newer.`
+            : `Could not determine the Pi version. Pi ${MINIMUM_PI_VERSION} or newer is required.`
+      }
+    }
+    return { installed: false, version: null, supported: false, reason: 'Pi CLI is not installed.' }
   }
 
   // Run all probes in parallel — shell:true on Windows resolves .cmd automatically
@@ -76,7 +154,7 @@ export async function detectInstalledAgents() {
     probe('opencode', ['--version']),
     probe('codex', ['--version']),
     probe('cursor-agent', ['--version']),
-    probe('pi', ['--version'])
+    probePi()
   ])
 
   return { nodejs, npm, pnpm, git, gh, glab, claudeCode, opencode, codex, cursor, pi }

--- a/src/main/agent-installer/detect.test.ts
+++ b/src/main/agent-installer/detect.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { isVersionAtLeast, MINIMUM_PI_VERSION } from './detect.js'
+
+describe('Pi version support', () => {
+  it('accepts the minimum and newer versions', () => {
+    expect(isVersionAtLeast(MINIMUM_PI_VERSION, MINIMUM_PI_VERSION)).toBe(true)
+    expect(isVersionAtLeast('0.84.3', MINIMUM_PI_VERSION)).toBe(true)
+    expect(isVersionAtLeast('1.0.0', MINIMUM_PI_VERSION)).toBe(true)
+  })
+
+  it('rejects versions older than the supported RPC runtime', () => {
+    expect(isVersionAtLeast('0.80.4', MINIMUM_PI_VERSION)).toBe(false)
+    expect(isVersionAtLeast('0.79.9', MINIMUM_PI_VERSION)).toBe(false)
+  })
+})

--- a/src/main/agent-installer/install.js
+++ b/src/main/agent-installer/install.js
@@ -2,7 +2,7 @@ import { spawn, execFile } from 'child_process'
 import { createWriteStream, mkdirSync, existsSync, unlinkSync, rmSync, symlinkSync, copyFileSync, chmodSync } from 'fs'
 import { join } from 'path'
 import { tmpdir, homedir } from 'os'
-import { detectInstalledAgents } from './detect.js'
+import { detectInstalledAgents, getPiCommandCandidates } from './detect.js'
 
 /**
  * Ensure a directory is on the running process's PATH so subsequently
@@ -752,7 +752,15 @@ export async function installAgent(agentName, onProgress) {
     )
     if (!piResult.success) return piResult
 
-    const piCommand = isWin ? 'pi.cmd' : 'pi'
+    const piStatus = await detectInstalledAgents()
+    if (!piStatus.pi?.installed) {
+      const error = 'Pi was installed, but the Pi executable could not be found.'
+      onProgress({ stage: 'error', output: `${error}\n`, percent: 100 })
+      return { success: false, error, newStatus: piStatus }
+    }
+
+    const piCandidates = await getPiCommandCandidates()
+    const piCommand = piCandidates.find((candidate) => existsSync(candidate)) || (isWin ? 'pi.cmd' : 'pi')
     return spawnInstall(
       piCommand,
       ['install', 'npm:pi-mcp-adapter'],

--- a/src/main/agent-installer/install.js
+++ b/src/main/agent-installer/install.js
@@ -26,6 +26,7 @@ const INSTALL_COMMANDS = {
   claudeCode: { cmd: 'npm', args: ['install', '-g', '@anthropic-ai/claude-code'] },
   opencode: { cmd: 'npm', args: ['install', '-g', 'opencode-ai'] },
   codex: { cmd: 'npm', args: ['install', '-g', '@openai/codex'] },
+  pi: { cmd: 'npm', args: ['install', '-g', '--ignore-scripts', '@earendil-works/pi-coding-agent'] },
   pnpm: { cmd: 'npm', args: ['install', '-g', 'pnpm'] },
   gh: null,
   glab: null,
@@ -65,6 +66,9 @@ export function getInstallCommand(agentName) {
     if (isMac) return 'Triggers Xcode Command Line Tools install (includes Git)'
     if (isLinux) return 'Installs git via system package manager (admin prompt)'
     return 'Install Git from https://git-scm.com/'
+  }
+  if (agentName === 'pi') {
+    return 'npm install -g --ignore-scripts @earendil-works/pi-coding-agent && pi install npm:pi-mcp-adapter'
   }
   const info = INSTALL_COMMANDS[agentName]
   if (!info) return `Unknown agent: ${agentName}`
@@ -632,7 +636,7 @@ async function installGit(onProgress) {
 
 /**
  * Install an agent CLI tool.
- * @param {string} agentName - One of 'claudeCode', 'opencode', 'codex', 'pnpm', 'gh', 'nodejs', 'git'
+ * @param {string} agentName - One of 'claudeCode', 'opencode', 'codex', 'pi', 'pnpm', 'gh', 'nodejs', 'git'
  * @param {(progress: { stage: string, output: string, percent: number }) => void} onProgress
  * @returns {Promise<{ success: boolean, error: string | null, newStatus: object }>}
  */
@@ -736,6 +740,25 @@ export async function installAgent(agentName, onProgress) {
       successMsg: 'Codex installed successfully!\n',
       detectKey: 'codex'
     }, onProgress)
+  }
+
+  if (agentName === 'pi') {
+    const npmCommand = isWin ? 'npm.cmd' : 'npm'
+    const piResult = await spawnInstall(
+      npmCommand,
+      ['install', '-g', '--ignore-scripts', '@earendil-works/pi-coding-agent'],
+      agentName,
+      (progress) => onProgress({ ...progress, percent: Math.min(70, Math.round(progress.percent * 0.7)) })
+    )
+    if (!piResult.success) return piResult
+
+    const piCommand = isWin ? 'pi.cmd' : 'pi'
+    return spawnInstall(
+      piCommand,
+      ['install', 'npm:pi-mcp-adapter'],
+      agentName,
+      (progress) => onProgress({ ...progress, percent: Math.min(100, 70 + Math.round(progress.percent * 0.3)) })
+    )
   }
 
   const info = INSTALL_COMMANDS[agentName]

--- a/src/main/agent-installer/install.test.ts
+++ b/src/main/agent-installer/install.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
-import { getNodejsAssetName, selectGhMacAsset } from './install.js'
+import { getInstallCommand, getNodejsAssetName, selectGhMacAsset } from './install.js'
+
+describe('getInstallCommand', () => {
+  it('installs Pi and its MCP adapter', () => {
+    expect(getInstallCommand('pi')).toBe(
+      'npm install -g --ignore-scripts @earendil-works/pi-coding-agent && pi install npm:pi-mcp-adapter'
+    )
+  })
+})
 
 describe('getNodejsAssetName', () => {
   it('uses the universal macOS pkg name without an arch suffix', () => {

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -50,6 +50,7 @@ vi.mock('./adapters/opencode-adapter', () => ({ OpencodeAdapter: vi.fn() }))
 vi.mock('./adapters/claude-code-adapter', () => ({ ClaudeCodeAdapter: vi.fn() }))
 vi.mock('./adapters/acp-adapter', () => ({ AcpAdapter: vi.fn() }))
 vi.mock('./adapters/codex-app-server-adapter', () => ({ CodexAppServerAdapter: vi.fn() }))
+vi.mock('./adapters/pi-adapter', () => ({ PiAdapter: vi.fn() }))
 vi.mock('./task-api-server', () => ({ getTaskApiPort: vi.fn(), waitForTaskApiServer: vi.fn() }))
 vi.mock('./secret-broker', () => ({
   registerSecretSession: vi.fn(),
@@ -62,6 +63,7 @@ import { mkdir as mkdirAsync, writeFile as writeFileAsync } from 'fs/promises'
 import { existsSync, copyFileSync, mkdirSync, readFileSync } from 'fs'
 import { AcpAdapter } from './adapters/acp-adapter'
 import { CodexAppServerAdapter } from './adapters/codex-app-server-adapter'
+import { PiAdapter } from './adapters/pi-adapter'
 import { getTaskApiPort } from './task-api-server'
 
 const mockedMkdirAsync = vi.mocked(mkdirAsync)
@@ -165,6 +167,16 @@ describe('AgentManager skill file paths', () => {
 
       expect(adapter).toBeInstanceOf(AcpAdapter)
       expect(AcpAdapter).toHaveBeenCalledWith('cursor')
+    })
+
+    it('uses the Pi RPC adapter for Pi agents', () => {
+      const mockDb = createMockDb({ coding_agent: 'pi' })
+      manager = new AgentManager(mockDb)
+
+      const adapter = (manager as any).getAdapter('agent-1')
+
+      expect(adapter).toBeInstanceOf(PiAdapter)
+      expect(PiAdapter).toHaveBeenCalledOnce()
     })
   })
 

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -3269,6 +3269,31 @@ describe('AgentManager delegation-aware watchdogs', () => {
     expect(entry.watchdogFired).toBe(true)
   })
 
+  it('stuck-tool detector allows a long-running tool with recent output', async () => {
+    const { mgr } = buildManager()
+    const adapter = {
+      pollMessages: vi.fn(async () => []),
+      getStatus: vi.fn(async () => ({ type: SessionStatusType.BUSY })),
+      getRunningTools: vi.fn(async () => [
+        {
+          partId: 'p1',
+          toolName: 'commandExecution',
+          startTime: Date.now() - 10 * 60_000,
+          lastActivityTime: Date.now() - 1_000,
+        },
+      ]),
+      abortPrompt: vi.fn(async () => undefined),
+    }
+    const { entry } = buildBusySession(mgr, adapter)
+    entry.createdAt = Date.now() - 60_000
+    entry.lastPartReceivedAt = Date.now() - 1_000
+
+    await (mgr as any).pollSingleSession(entry)
+
+    expect(adapter.abortPrompt).not.toHaveBeenCalled()
+    expect(entry.watchdogFired).toBeFalsy()
+  })
+
   it('stuck-session watchdog stands down while a delegation tool is running', async () => {
     const { mgr } = buildManager()
     const adapter = {

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -2006,7 +2006,9 @@ describe('AgentManager session ID re-keying redirect', () => {
       respondToQuestion: vi.fn(async () => false),
     }
     ;(session as any).adapter = adapter
+    session.pollingStarted = false
     const sendToRenderer = vi.spyOn(mgr as any, 'sendToRenderer')
+    const startAdapterPolling = vi.spyOn(mgr as any, 'startAdapterPolling').mockImplementation(() => undefined)
     vi.spyOn(mgr as any, 'getAdapter').mockReturnValue(adapter)
     vi.spyOn(mgr as any, 'buildSessionConfig').mockResolvedValue({ workspaceDir: '/tmp/ws' })
 
@@ -2019,6 +2021,11 @@ describe('AgentManager session ID re-keying redirect', () => {
       'stale-request'
     )
     expect(sendToRenderer).not.toHaveBeenCalled()
+    expect(startAdapterPolling).toHaveBeenCalledWith(
+      'temp-id',
+      adapter,
+      { workspaceDir: '/tmp/ws' }
+    )
   })
 
   it('abortSession resolves re-keyed session via redirect map', async () => {

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1995,20 +1995,59 @@ describe('AgentManager session ID re-keying redirect', () => {
 
     await mgr.respondToPermission('temp-id', true, 'Yes')
 
-    expect(dualAdapter.respondToApproval).toHaveBeenCalledWith('temp-id', true, 'approved')
+    expect(dualAdapter.respondToApproval).toHaveBeenCalledWith('temp-id', true, 'approved', undefined)
     expect(dualAdapter.respondToQuestion).not.toHaveBeenCalled()
+  })
+
+  it('closes a stale request-scoped approval without sending a continuation', async () => {
+    const { mgr, session } = createManagerWithSession()
+    const dualAdapter = {
+      ...session.adapter,
+      respondToQuestion: vi.fn(async () => undefined),
+      respondToApproval: vi.fn(async () => false),
+    }
+    session.adapter = dualAdapter
+    const sendToRenderer = vi.spyOn(mgr as any, 'sendToRenderer')
+    const doSendAdapterMessage = vi.spyOn(mgr as any, 'doSendAdapterMessage')
+    vi.spyOn(mgr as any, 'getAdapter').mockReturnValue(dualAdapter)
+
+    await mgr.respondToPermission('temp-id', true, 'Yes', undefined, 'permission', 'stale-request')
+
+    expect(dualAdapter.respondToApproval).toHaveBeenCalledWith(
+      'temp-id',
+      true,
+      'approved',
+      'stale-request'
+    )
+    expect(sendToRenderer).toHaveBeenCalledWith('agent:output', expect.objectContaining({
+      data: expect.objectContaining({
+        id: 'question-stale-request',
+        partType: 'question',
+        update: true,
+        tool: expect.objectContaining({
+          name: 'permission',
+          status: 'cancelled',
+          requestId: 'stale-request'
+        })
+      })
+    }))
+    expect(doSendAdapterMessage).not.toHaveBeenCalled()
   })
 
   it('does not publish an answer when the adapter rejects a stale question request', async () => {
     const { mgr, session } = createManagerWithSession()
+    const resolutionPart = {
+      id: 'pi-question-stale-request',
+      type: 'tool',
+      update: true,
+      tool: { name: 'question', status: 'cancelled' },
+    }
     const adapter = {
       ...session.adapter,
-      respondToQuestion: vi.fn(async () => false),
+      respondToQuestion: vi.fn(async () => ({ handled: false, resolutionPart })),
     }
     ;(session as any).adapter = adapter
-    session.pollingStarted = false
     const sendToRenderer = vi.spyOn(mgr as any, 'sendToRenderer')
-    const startAdapterPolling = vi.spyOn(mgr as any, 'startAdapterPolling').mockImplementation(() => undefined)
     vi.spyOn(mgr as any, 'getAdapter').mockReturnValue(adapter)
     vi.spyOn(mgr as any, 'buildSessionConfig').mockResolvedValue({ workspaceDir: '/tmp/ws' })
 
@@ -2020,12 +2059,19 @@ describe('AgentManager session ID re-keying redirect', () => {
       { workspaceDir: '/tmp/ws' },
       'stale-request'
     )
-    expect(sendToRenderer).not.toHaveBeenCalled()
-    expect(startAdapterPolling).toHaveBeenCalledWith(
-      'temp-id',
-      adapter,
-      { workspaceDir: '/tmp/ws' }
-    )
+    expect(sendToRenderer).toHaveBeenCalledWith('agent:output', {
+      sessionId: 'temp-id',
+      taskId: 'task-1',
+      type: 'message',
+      data: {
+        id: 'pi-question-stale-request',
+        role: 'assistant',
+        content: '',
+        partType: 'tool',
+        tool: { name: 'question', status: 'cancelled' },
+        update: true,
+      },
+    })
   })
 
   it('abortSession resolves re-keyed session via redirect map', async () => {

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1999,6 +1999,28 @@ describe('AgentManager session ID re-keying redirect', () => {
     expect(dualAdapter.respondToQuestion).not.toHaveBeenCalled()
   })
 
+  it('does not publish an answer when the adapter rejects a stale question request', async () => {
+    const { mgr, session } = createManagerWithSession()
+    const adapter = {
+      ...session.adapter,
+      respondToQuestion: vi.fn(async () => false),
+    }
+    ;(session as any).adapter = adapter
+    const sendToRenderer = vi.spyOn(mgr as any, 'sendToRenderer')
+    vi.spyOn(mgr as any, 'getAdapter').mockReturnValue(adapter)
+    vi.spyOn(mgr as any, 'buildSessionConfig').mockResolvedValue({ workspaceDir: '/tmp/ws' })
+
+    await mgr.respondToPermission('temp-id', true, 'Yes', undefined, 'question', 'stale-request')
+
+    expect(adapter.respondToQuestion).toHaveBeenCalledWith(
+      'temp-id',
+      { answer: 'Yes' },
+      { workspaceDir: '/tmp/ws' },
+      'stale-request'
+    )
+    expect(sendToRenderer).not.toHaveBeenCalled()
+  })
+
   it('abortSession resolves re-keyed session via redirect map', async () => {
     const { mgr, session } = createManagerWithSession()
 

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -2583,7 +2583,7 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
 
   it('does not spam auto-abort messages when a stuck running tool remains visible after polling restarts', async () => {
     const mgr = buildManager()
-    const startedAt = Date.now() - 240_000
+    const startedAt = Date.now() - 31 * 60_000
     const abortPrompt = vi.fn(async () => undefined)
     const adapter = {
       pollMessages: vi.fn(async () => [] as any[]),
@@ -2662,7 +2662,7 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
       getRunningTools: vi.fn(async () => [{
         partId: 'tool-call-1',
         toolName: 'commandExecution',
-        startTime: Date.now() - 240_000,
+        startTime: Date.now() - 31 * 60_000,
         input: {}
       }]),
       abortPrompt,
@@ -3287,6 +3287,52 @@ describe('AgentManager delegation-aware watchdogs', () => {
     const { entry } = buildBusySession(mgr, adapter)
     entry.createdAt = Date.now() - 60_000
     entry.lastPartReceivedAt = Date.now() - 1_000
+
+    await (mgr as any).pollSingleSession(entry)
+
+    expect(adapter.abortPrompt).not.toHaveBeenCalled()
+    expect(entry.watchdogFired).toBeFalsy()
+  })
+
+  it('uses monotonic activity when the wall clock timestamp is stale', async () => {
+    const { mgr } = buildManager()
+    const monotonicNow = performance.now()
+    const adapter = {
+      pollMessages: vi.fn(async () => []),
+      getStatus: vi.fn(async () => ({ type: SessionStatusType.BUSY })),
+      getRunningTools: vi.fn(async () => [{
+        partId: 'p1',
+        toolName: 'commandExecution',
+        startTime: Date.now() - 10 * 60_000,
+        lastActivityTime: Date.now() - 10 * 60_000,
+        lastActivityMonotonicTime: monotonicNow - 1_000,
+      }]),
+      abortPrompt: vi.fn(async () => undefined),
+    }
+    const { entry } = buildBusySession(mgr, adapter)
+    entry.lastPartReceivedAt = Date.now() - 1_000
+
+    await (mgr as any).pollSingleSession(entry)
+
+    expect(adapter.abortPrompt).not.toHaveBeenCalled()
+  })
+
+  it('does not apply the session timeout while a command is actively running', async () => {
+    const { mgr } = buildManager()
+    const adapter = {
+      pollMessages: vi.fn(async () => []),
+      getStatus: vi.fn(async () => ({ type: SessionStatusType.BUSY })),
+      getRunningTools: vi.fn(async () => [{
+        partId: 'p1',
+        toolName: 'commandExecution',
+        startTime: Date.now() - 10 * 60_000,
+        lastActivityTime: Date.now() - 10 * 60_000,
+      }]),
+      abortPrompt: vi.fn(async () => undefined),
+    }
+    const { entry } = buildBusySession(mgr, adapter)
+    entry.createdAt = Date.now() - 10 * 60_000
+    entry.lastPartReceivedAt = Date.now() - 6 * 60_000
 
     await (mgr as any).pollSingleSession(entry)
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -4413,6 +4413,10 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         : await adapter.respondToQuestion(sessionId, answers, adapterConfig)
       if (handled === false) {
         console.log(`[AgentManager] Ignored stale question response for session ${sessionId}`)
+        if (!session.pollingStarted && session.adapter) {
+          session.pollingStarted = true
+          this.startAdapterPolling(sessionId, session.adapter, adapterConfig)
+        }
         return
       }
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -4349,7 +4349,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     approved: boolean,
     message?: string,
     optionId?: string,
-    responseType?: 'permission' | 'question'
+    responseType?: 'permission' | 'question',
+    requestId?: string
   ): Promise<void> {
     let session = this.sessions.get(sessionId)
 
@@ -4404,9 +4405,18 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         }
       }
 
-      console.log(`[AgentManager] Responding to question via adapter for session ${sessionId}:`, answers)
+      console.log(`[AgentManager] Responding to question via adapter for session ${sessionId}`)
 
-      // Update session and task state before sending
+      const adapterConfig = await this.buildSessionConfig(session.agentId, session.taskId, session.workspaceDir)
+      const handled = requestId
+        ? await adapter.respondToQuestion(sessionId, answers, adapterConfig, requestId)
+        : await adapter.respondToQuestion(sessionId, answers, adapterConfig)
+      if (handled === false) {
+        console.log(`[AgentManager] Ignored stale question response for session ${sessionId}`)
+        return
+      }
+
+      // Update session and task state after the adapter accepts the response.
       session.status = 'working'
       const currentTask = this.db.getTask(session.taskId)
       if (currentTask?.status !== TaskStatus.AgentLearning) {
@@ -4430,9 +4440,6 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           }
         })
       }
-
-      const adapterConfig = await this.buildSessionConfig(session.agentId, session.taskId, session.workspaceDir)
-      await adapter.respondToQuestion(sessionId, answers, adapterConfig)
 
       // Restart polling if it was stopped (session may have gone idle before answer)
       if (!session.pollingStarted && session.adapter) {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -242,11 +242,15 @@ export class AgentManager extends EventEmitter {
    *  the agent process (20x is just a spectator on the HTTP prompt call). */
   private static readonly STUCK_SESSION_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
-  /** Maximum time (ms) a single tool can stay in "running" state before it's
-   *  considered stuck. This is much shorter than the session watchdog because
-   *  a single hung tool (e.g. cross-workspace file read that OpenCode silently
-   *  blocks) should be aborted quickly so the agent can recover. */
+  /** Fast inactivity deadline for known local read operations. These should
+   *  complete quickly; a blocked cross-workspace read should recover without
+   *  waiting for the longer active-tool deadline. */
   private static readonly STUCK_TOOL_TIMEOUT_MS = 90 * 1000 // 90 seconds
+
+  /** Long-running tools can legitimately remain quiet while an external
+   * command works. Give them a separate inactivity deadline; the 90-second
+   * detector remains only for known fast local operations such as file reads. */
+  private static readonly ACTIVE_TOOL_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
 
   /** Tool names that delegate work to subagents or block on subtask progress.
    *  These are long-running BY DESIGN (a coordinator waiting on child agents can
@@ -2493,7 +2497,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
 
           // Fetch currently running tools once — shared by the stuck-tool
           // detector and the stuck-session watchdog's delegation check below.
-          let runningTools: Array<{ partId: string; toolName: string; startTime?: number; lastActivityTime?: number; input?: Record<string, unknown> }> = []
+          let runningTools: Array<{ partId: string; toolName: string; startTime?: number; lastActivityTime?: number; lastActivityMonotonicTime?: number; input?: Record<string, unknown> }> = []
           if ('getRunningTools' in adapter && typeof adapter.getRunningTools === 'function') {
             try {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2517,12 +2521,19 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           if (!peBusy.watchdogFired && runningTools.length > 0) {
             try {
               const now = Date.now()
+              const monotonicNow = performance.now()
               for (const tool of runningTools) {
                 if (!tool.startTime) continue
                 if (AgentManager.isDelegationTool(tool.toolName)) continue
                 const elapsed = now - tool.startTime
-                const inactiveFor = now - (tool.lastActivityTime ?? tool.startTime)
-                if (inactiveFor > AgentManager.STUCK_TOOL_TIMEOUT_MS) {
+                const inactiveFor = tool.lastActivityMonotonicTime !== undefined
+                  ? monotonicNow - tool.lastActivityMonotonicTime
+                  : now - (tool.lastActivityTime ?? tool.startTime)
+                const normalizedToolName = tool.toolName.toLowerCase().replace(/[^a-z]/g, '')
+                const timeout = normalizedToolName === 'read' || normalizedToolName === 'readfile'
+                  ? AgentManager.STUCK_TOOL_TIMEOUT_MS
+                  : AgentManager.ACTIVE_TOOL_INACTIVITY_TIMEOUT_MS
+                if (inactiveFor > timeout) {
                   // Build a descriptive reason
                   let reason = `Tool "${tool.toolName}" has been running for ${Math.round(elapsed / 1000)}s with no activity for ${Math.round(inactiveFor / 1000)}s`
                   const filePath = tool.input?.filePath as string | undefined
@@ -2626,6 +2637,10 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
             } else if (hasActiveDelegation) {
               console.log(
                 `[AgentManager] Session ${sessionId} BUSY for ${Math.round(silentDuration / 1000)}s but has active delegation (subagents/subtasks in progress) — not aborting`
+              )
+            } else if (runningTools.length > 0) {
+              console.log(
+                `[AgentManager] Session ${sessionId} BUSY for ${Math.round(silentDuration / 1000)}s but has an active tool — using the tool-specific inactivity deadline`
               )
             } else {
               // Mark the watchdog as fired BEFORE sending the message/abort.

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -14,6 +14,7 @@ import { OpencodeAdapter } from './adapters/opencode-adapter'
 import { ClaudeCodeAdapter } from './adapters/claude-code-adapter'
 import { AcpAdapter } from './adapters/acp-adapter'
 import { CodexAppServerAdapter } from './adapters/codex-app-server-adapter'
+import { PiAdapter } from './adapters/pi-adapter'
 import type { CodingAgentAdapter, SessionConfig, MessagePart, SessionMessage, McpServerConfig } from './adapters/coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './adapters/coding-agent-adapter'
 import { getTaskApiPort, waitForTaskApiServer } from './task-api-server'
@@ -31,7 +32,8 @@ enum CodingAgentType {
   OPENCODE = 'opencode',
   CLAUDE_CODE = 'claude-code',
   CODEX = 'codex',
-  CURSOR = 'cursor'
+  CURSOR = 'cursor',
+  PI = 'pi'
 }
 
 const ARTIFACT_WORKSPACE_INSTRUCTIONS = `
@@ -676,6 +678,10 @@ export class AgentManager extends EventEmitter {
       case CodingAgentType.CURSOR:
         console.log('[AgentManager] Creating new AcpAdapter for Cursor')
         adapter = new AcpAdapter('cursor')
+        break
+      case CodingAgentType.PI:
+        console.log('[AgentManager] Creating new PiAdapter')
+        adapter = new PiAdapter(this.db)
         break
       default:
         console.warn(`[AgentManager] Unknown coding agent type: ${backendType}`)
@@ -4731,9 +4737,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         return (defaultAgent?.config?.coding_agent as string) || CodingAgentType.OPENCODE
       })()
 
-      // Only the OpenCode adapter exposes configurable providers/models.
-      // For other backends (claude-code, codex), provider listing isn't supported.
-      if (resolvedBackend !== CodingAgentType.OPENCODE) {
+      // OpenCode and Pi expose configurable providers/models.
+      if (resolvedBackend !== CodingAgentType.OPENCODE && resolvedBackend !== CodingAgentType.PI) {
         console.log(`[AgentManager] Backend "${resolvedBackend}" does not support provider listing, skipping`)
         return null
       }
@@ -4792,6 +4797,9 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         break
       case CodingAgentType.CLAUDE_CODE:
         adapter = new ClaudeCodeAdapter()
+        break
+      case CodingAgentType.PI:
+        adapter = new PiAdapter(this.db)
         break
     }
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -2347,6 +2347,8 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
             partType: 'question',
             tool: {
               name: 'permission',
+              status: 'running',
+              requestId: approval.requestId,
               questions: [{
                 header: 'Permission Required',
                 question: approval.question,
@@ -4408,14 +4410,27 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       console.log(`[AgentManager] Responding to question via adapter for session ${sessionId}`)
 
       const adapterConfig = await this.buildSessionConfig(session.agentId, session.taskId, session.workspaceDir)
-      const handled = requestId
+      const response = requestId
         ? await adapter.respondToQuestion(sessionId, answers, adapterConfig, requestId)
         : await adapter.respondToQuestion(sessionId, answers, adapterConfig)
+      const handled = typeof response === 'object' ? response.handled : response
       if (handled === false) {
         console.log(`[AgentManager] Ignored stale question response for session ${sessionId}`)
-        if (!session.pollingStarted && session.adapter) {
-          session.pollingStarted = true
-          this.startAdapterPolling(sessionId, session.adapter, adapterConfig)
+        if (typeof response === 'object' && response.resolutionPart) {
+          const part = response.resolutionPart
+          this.sendToRenderer('agent:output', {
+            sessionId,
+            taskId: session.taskId,
+            type: 'message',
+            data: {
+              id: part.id,
+              role: part.role || 'assistant',
+              content: part.content || part.text || '',
+              partType: part.type,
+              tool: part.tool,
+              update: part.update,
+            },
+          })
         }
         return
       }
@@ -4469,7 +4484,35 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       console.log(`[AgentManager] Responding to ACP adapter approval with: ${selectedOption}`)
       // OpenCode adapter returns boolean (true=handled, false=no permission found).
       // AcpAdapter returns void. Cast to boolean|void to handle both.
-      const handled = await (adapter as unknown as { respondToApproval: (sid: string, approved: boolean, opt?: string) => Promise<boolean | void> }).respondToApproval(sessionId, approved, selectedOption)
+      const handled = await (adapter as unknown as {
+        respondToApproval: (sid: string, approved: boolean, opt?: string, requestId?: string) => Promise<boolean | void>
+      }).respondToApproval(sessionId, approved, selectedOption, requestId)
+
+      // Provider callbacks do not survive a restored session. Resolve the old
+      // card immediately instead of approving a newer request or sending a
+      // continuation into a session that is already idle.
+      if (handled === false && requestId) {
+        console.log(`[AgentManager] Ignored stale approval response for session ${sessionId}`)
+        this.sendToRenderer('agent:output', {
+          sessionId,
+          taskId: session.taskId,
+          type: 'message',
+          data: {
+            id: `question-${requestId}`,
+            role: 'assistant',
+            content: '',
+            partType: 'question',
+            tool: {
+              name: 'permission',
+              status: 'cancelled',
+              requestId,
+              output: 'This request expired when the session ended. Restart the turn to continue.'
+            },
+            update: true
+          }
+        })
+        return
+      }
 
       // If no pending permission was found (stale prompt after watchdog abort
       // or app restart), send a continuation message so the session recovers.

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -2243,10 +2243,10 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       if (newParts.length > 0) {
         entry.lastPartReceivedAt = Date.now()
         activeSession.lastActivityAt = Date.now()
-        // Reset watchdog flag — new data means the session is alive again.
-        // If a follow-up message also gets stuck, the watchdog can re-fire.
+        // Reset the polling-entry watchdog because new data means this polling
+        // cycle is alive. Keep the session-level one-shot guard intact: late
+        // output from an interrupted turn must not re-arm the same abort.
         entry.watchdogFired = false
-        activeSession.autoAbortNotified = false
       }
 
       // ── Garbled output detection ──
@@ -2493,7 +2493,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
 
           // Fetch currently running tools once — shared by the stuck-tool
           // detector and the stuck-session watchdog's delegation check below.
-          let runningTools: Array<{ partId: string; toolName: string; startTime?: number; input?: Record<string, unknown> }> = []
+          let runningTools: Array<{ partId: string; toolName: string; startTime?: number; lastActivityTime?: number; input?: Record<string, unknown> }> = []
           if ('getRunningTools' in adapter && typeof adapter.getRunningTools === 'function') {
             try {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2508,7 +2508,9 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           // Some tools (notably `read` on cross-workspace files) silently hang
           // without producing any output or asking for permission. The general
           // watchdog below waits 5 minutes, which is far too long for a single
-          // tool. Here we check for tools stuck in "running" state for >90s.
+          // tool. Here we check for tools that have produced no activity for
+          // >90s. Total runtime alone is not a hang signal: commands such as
+          // test and CI watchers can legitimately stream output for minutes.
           //
           // Delegation tools (subagent spawns, subtask waits) are exempt: they
           // run for minutes by design, and aborting them kills the child work.
@@ -2519,9 +2521,10 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
                 if (!tool.startTime) continue
                 if (AgentManager.isDelegationTool(tool.toolName)) continue
                 const elapsed = now - tool.startTime
-                if (elapsed > AgentManager.STUCK_TOOL_TIMEOUT_MS) {
+                const inactiveFor = now - (tool.lastActivityTime ?? tool.startTime)
+                if (inactiveFor > AgentManager.STUCK_TOOL_TIMEOUT_MS) {
                   // Build a descriptive reason
-                  let reason = `Tool "${tool.toolName}" has been running for ${Math.round(elapsed / 1000)}s with no output`
+                  let reason = `Tool "${tool.toolName}" has been running for ${Math.round(elapsed / 1000)}s with no activity for ${Math.round(inactiveFor / 1000)}s`
                   const filePath = tool.input?.filePath as string | undefined
                   if (filePath && config.workspaceDir && !filePath.startsWith(config.workspaceDir)) {
                     reason = `Tool "${tool.toolName}" stuck trying to access file outside workspace: ${filePath}`

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -33,7 +33,7 @@ export interface AgentMcpServerEntry {
 }
 
 export interface AgentConfigRecord {
-  coding_agent?: 'opencode' | 'claude-code' | 'codex' | 'cursor'
+  coding_agent?: 'opencode' | 'claude-code' | 'codex' | 'cursor' | 'pi'
   model?: string
   reasoning_effort?: ReasoningEffort
   auth_method?: 'subscription' | 'api_key'

--- a/src/main/enterprise-ai-gateway.test.ts
+++ b/src/main/enterprise-ai-gateway.test.ts
@@ -86,7 +86,11 @@ describe('enterprise AI gateway helpers', () => {
       baseUrl: 'https://litellm.example.com/v1',
       api: 'openai-completions',
       apiKey: '$PEAKFLO_AI_GATEWAY_API_KEY',
-      models: [{ id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra' }]
+      models: [{
+        id: 'gpt-5.6-terra',
+        name: 'GPT-5.6 Terra',
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }
+      }]
     })
     expect(JSON.stringify(provider)).not.toContain('sk-virtual-must-not-be-written')
   })

--- a/src/main/enterprise-ai-gateway.test.ts
+++ b/src/main/enterprise-ai-gateway.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildEnterpriseAiGatewayProviderConfig,
+  buildPiAiGatewayProviderConfig,
   ENTERPRISE_AI_GATEWAY_PROVIDER_ID,
   readEnterpriseAiGatewayConfig,
   storeEnterpriseAiGatewayConfig
@@ -71,5 +72,22 @@ describe('enterprise AI gateway helpers', () => {
         }
       }
     })
+  })
+
+  it('builds a Pi provider without writing the virtual key', () => {
+    const provider = buildPiAiGatewayProviderConfig({
+      apiKey: 'sk-virtual-must-not-be-written',
+      baseUrl: 'https://litellm.example.com/v1',
+      models: [{ id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra' }]
+    })
+
+    expect(provider).toMatchObject({
+      name: 'Peakflo',
+      baseUrl: 'https://litellm.example.com/v1',
+      api: 'openai-completions',
+      apiKey: '$PEAKFLO_AI_GATEWAY_API_KEY',
+      models: [{ id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra' }]
+    })
+    expect(JSON.stringify(provider)).not.toContain('sk-virtual-must-not-be-written')
   })
 })

--- a/src/main/enterprise-ai-gateway.ts
+++ b/src/main/enterprise-ai-gateway.ts
@@ -140,6 +140,7 @@ export function buildPiAiGatewayProviderConfig(
       // unsupported reasoning_effort field.
       reasoning: false,
       input: ['text', 'image'],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: 200000,
       maxTokens: 32768
     }))

--- a/src/main/enterprise-ai-gateway.ts
+++ b/src/main/enterprise-ai-gateway.ts
@@ -120,3 +120,28 @@ export function buildEnterpriseAiGatewayProviderConfig(
     }
   }
 }
+
+/** Build the equivalent provider entry for Pi's ~/.pi/agent/models.json. */
+export function buildPiAiGatewayProviderConfig(
+  stored: StoredEnterpriseAiGatewayConfig
+): Record<string, unknown> {
+  return {
+    name: ENTERPRISE_AI_GATEWAY_PROVIDER_NAME,
+    baseUrl: stored.baseUrl,
+    api: 'openai-completions',
+    // Keep the virtual key out of models.json. Pi resolves this value from the
+    // environment of the child process for every request.
+    apiKey: '$PEAKFLO_AI_GATEWAY_API_KEY',
+    models: (stored.models ?? []).map((model) => ({
+      id: model.id,
+      name: model.name,
+      // The LiteLLM catalog does not expose reasoning-parameter support. Keep
+      // the compatible default so OpenRouter-backed models do not reject an
+      // unsupported reasoning_effort field.
+      reasoning: false,
+      input: ['text', 'image'],
+      contextWindow: 200000,
+      maxTokens: 32768
+    }))
+  }
+}

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -449,8 +449,8 @@ export function registerIpcHandlers(
     }
   )
 
-  ipcMain.handle('agentSession:approve', async (_, sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question') => {
-    await agentManager.respondToPermission(sessionId, approved, message, undefined, responseType)
+  ipcMain.handle('agentSession:approve', async (_, sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question', requestId?: string) => {
+    await agentManager.respondToPermission(sessionId, approved, message, undefined, responseType, requestId)
     return { success: true }
   })
 

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -805,13 +805,14 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
   const approveMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/approve$/)
   if (approveMatch) {
     const sessionId = approveMatch[1]
-    const { approved, message, responseType } = params as {
+    const { approved, message, responseType, requestId } = params as {
       approved: boolean
       message?: string
       responseType?: 'permission' | 'question'
+      requestId?: string
     }
     if (typeof approved !== 'boolean') throw Object.assign(new Error('approved (boolean) is required'), { status: 400 })
-    await agent.respondToPermission(sessionId, approved, message, undefined, responseType)
+    await agent.respondToPermission(sessionId, approved, message, undefined, responseType, requestId)
     return { success: true }
   }
 

--- a/src/mobile/api/client.ts
+++ b/src/mobile/api/client.ts
@@ -108,8 +108,8 @@ export const api = {
       post<{ sessionId: string }>(`/api/sessions/${encodeURIComponent(sessionId)}/resume`, { agentId, taskId }),
     send: (sessionId: string, message: string, taskId?: string, agentId?: string, attachments?: Array<{ id: string; filename: string; size: number; mime_type: string }>) =>
       post<{ success: boolean; newSessionId?: string }>(`/api/sessions/${encodeURIComponent(sessionId)}/send`, { message, taskId, agentId, attachments }),
-    approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question') =>
-      post<{ success: boolean }>(`/api/sessions/${encodeURIComponent(sessionId)}/approve`, { approved, message, responseType }),
+    approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question', requestId?: string) =>
+      post<{ success: boolean }>(`/api/sessions/${encodeURIComponent(sessionId)}/approve`, { approved, message, responseType, requestId }),
     sync: (sessionId: string) =>
       post<{ success: boolean; status: string }>(`/api/sessions/${encodeURIComponent(sessionId)}/sync`),
     abort: (sessionId: string) =>

--- a/src/mobile/pages/ConversationPage.tsx
+++ b/src/mobile/pages/ConversationPage.tsx
@@ -232,8 +232,9 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
       if (!currentSession?.sessionId) return
       try {
         if (isQuestion) {
-          const requestId = currentSession.messages.find((item) => item.id === activeQuestionId)?.tool?.requestId
-          await api.sessions.approve(currentSession.sessionId, true, message, 'question', requestId)
+          const activeQuestion = currentSession.messages.find((item) => item.id === activeQuestionId)
+          const responseType = activeQuestion?.tool?.name === 'permission' ? 'permission' : 'question'
+          await api.sessions.approve(currentSession.sessionId, true, message, responseType, activeQuestion?.tool?.requestId)
           captureAnalyticsEvent('agent_approval_responded', {
             task_id: taskId,
             agent_id: currentSession.agentId,
@@ -282,8 +283,9 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
       const currentSession = useAgentStore.getState().sessions.get(taskId)
       if (!currentSession?.sessionId || !activeQuestionId) return
       try {
-        const requestId = currentSession.messages.find((item) => item.id === activeQuestionId)?.tool?.requestId
-        await api.sessions.approve(currentSession.sessionId, true, answer, 'question', requestId)
+        const activeQuestion = currentSession.messages.find((item) => item.id === activeQuestionId)
+        const responseType = activeQuestion?.tool?.name === 'permission' ? 'permission' : 'question'
+        await api.sessions.approve(currentSession.sessionId, true, answer, responseType, activeQuestion?.tool?.requestId)
         captureAnalyticsEvent('agent_approval_responded', {
           task_id: taskId,
           agent_id: currentSession.agentId,

--- a/src/mobile/pages/ConversationPage.tsx
+++ b/src/mobile/pages/ConversationPage.tsx
@@ -232,7 +232,8 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
       if (!currentSession?.sessionId) return
       try {
         if (isQuestion) {
-          await api.sessions.approve(currentSession.sessionId, true, message, 'question')
+          const requestId = currentSession.messages.find((item) => item.id === activeQuestionId)?.tool?.requestId
+          await api.sessions.approve(currentSession.sessionId, true, message, 'question', requestId)
           captureAnalyticsEvent('agent_approval_responded', {
             task_id: taskId,
             agent_id: currentSession.agentId,
@@ -271,7 +272,7 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
         endSend(taskId)
       }
     },
-    [taskId, isQuestion, initSession, beginSend, endSend]
+    [taskId, isQuestion, activeQuestionId, initSession, beginSend, endSend]
   )
 
   // Handle question answer from QuestionMessage options
@@ -281,7 +282,8 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
       const currentSession = useAgentStore.getState().sessions.get(taskId)
       if (!currentSession?.sessionId || !activeQuestionId) return
       try {
-        await api.sessions.approve(currentSession.sessionId, true, answer, 'question')
+        const requestId = currentSession.messages.find((item) => item.id === activeQuestionId)?.tool?.requestId
+        await api.sessions.approve(currentSession.sessionId, true, answer, 'question', requestId)
         captureAnalyticsEvent('agent_approval_responded', {
           task_id: taskId,
           agent_id: currentSession.agentId,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -111,10 +111,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('agentSession:send', sessionId, message, taskId, agentId, attachments),
     sendByTaskId: (taskId: string, message: string, attachments?: Array<{ id: string; filename: string; size: number; mime_type: string }>): Promise<{ success: boolean; sessionId: string | null; newSessionId?: string }> =>
       ipcRenderer.invoke('agentSession:sendByTaskId', taskId, message, attachments),
-    approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question'): Promise<{ success: boolean }> =>
-      responseType
-        ? ipcRenderer.invoke('agentSession:approve', sessionId, approved, message, responseType)
-        : ipcRenderer.invoke('agentSession:approve', sessionId, approved, message),
+    approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question', requestId?: string): Promise<{ success: boolean }> =>
+      requestId
+        ? ipcRenderer.invoke('agentSession:approve', sessionId, approved, message, responseType, requestId)
+        : responseType
+          ? ipcRenderer.invoke('agentSession:approve', sessionId, approved, message, responseType)
+          : ipcRenderer.invoke('agentSession:approve', sessionId, approved, message),
     syncSkills: (sessionId: string): Promise<{ created: string[]; updated: string[]; unchanged: string[] }> =>
       ipcRenderer.invoke('agentSession:syncSkills', sessionId),
     syncSkillsForTask: (taskId: string): Promise<{ created: string[]; updated: string[]; unchanged: string[] }> =>

--- a/src/renderer/src/components/agents/AgentForm.tsx
+++ b/src/renderer/src/components/agents/AgentForm.tsx
@@ -379,7 +379,7 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
         </select>
       </div>
 
-      {(codingAgent === CodingAgentType.OPENCODE || codingAgent === CodingAgentType.CLAUDE_CODE || codingAgent === CodingAgentType.CODEX || codingAgent === CodingAgentType.CURSOR) && (
+      {(codingAgent === CodingAgentType.OPENCODE || codingAgent === CodingAgentType.CLAUDE_CODE || codingAgent === CodingAgentType.CODEX || codingAgent === CodingAgentType.CURSOR || codingAgent === CodingAgentType.PI) && (
         <>
           <div className="space-y-1.5">
             <Label htmlFor="agent-permission-mode">Permissions</Label>
@@ -393,8 +393,8 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
               <option value="allow">Allow automatically</option>
             </select>
             <p className="text-xs text-muted-foreground">
-              {codingAgent === CodingAgentType.CODEX || codingAgent === CodingAgentType.CURSOR
-                ? `Allow automatically auto-approves ${codingAgent === CodingAgentType.CURSOR ? 'Cursor' : 'Codex'} permission requests for this agent.`
+              {codingAgent === CodingAgentType.CODEX || codingAgent === CodingAgentType.CURSOR || codingAgent === CodingAgentType.PI
+                ? `Allow automatically auto-approves ${codingAgent === CodingAgentType.CURSOR ? 'Cursor' : codingAgent === CodingAgentType.PI ? 'Pi' : 'Codex'} permission requests for this agent.`
                 : 'Controls how this agent handles tool and command approval prompts.'}
             </p>
           </div>

--- a/src/renderer/src/components/agents/AgentForm.tsx
+++ b/src/renderer/src/components/agents/AgentForm.tsx
@@ -121,6 +121,8 @@ export function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
     } else if (codingAgent === CodingAgentType.CURSOR) {
       setAvailableModels(CURSOR_MODELS)
       setModel(CURSOR_MODELS[0].id)
+    } else if (codingAgent === CodingAgentType.PI) {
+      fetchModels()
     } else {
       setAvailableModels([])
       setModel('')

--- a/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { AgentTranscriptPanel } from '@/components/agents/AgentTranscriptPanel'
 import { useAgentSession } from '@/hooks/use-agent-session'
 import { useAgentStore, SessionStatus } from '@/stores/agent-store'
@@ -21,6 +21,7 @@ export function TranscriptPanelContent({ taskId }: TranscriptPanelContentProps) 
   // delta of every task's session.
   const removeSession = useAgentStore((s) => s.removeSession)
   const task = useTaskStore((s) => s.tasks.find((t) => t.id === taskId))
+  const submittedQuestionIdsRef = useRef(new Set<string>())
 
   const messages = session?.messages ?? []
   const status = session?.status ?? SessionStatus.IDLE
@@ -71,9 +72,22 @@ export function TranscriptPanelContent({ taskId }: TranscriptPanelContentProps) 
         questionIndex >= 0 &&
         !currentMessages.slice(questionIndex + 1).some((m) => m.role === 'user')
       if (hasActiveQuestion) {
-        const readySessionId = await ensureChatSession()
-        if (!readySessionId) return
-        await approve(true, message, 'question', currentMessages[questionIndex].tool?.requestId)
+        const question = currentMessages[questionIndex]
+        const questionKey = question.tool?.requestId || question.id
+        if (submittedQuestionIdsRef.current.has(questionKey)) return
+        submittedQuestionIdsRef.current.add(questionKey)
+        try {
+          const readySessionId = await ensureChatSession()
+          if (!readySessionId) {
+            submittedQuestionIdsRef.current.delete(questionKey)
+            return
+          }
+          const responseType = question.tool?.name === 'permission' ? 'permission' : 'question'
+          await approve(true, message, responseType, question.tool?.requestId)
+        } catch (error) {
+          submittedQuestionIdsRef.current.delete(questionKey)
+          throw error
+        }
         return
       }
 

--- a/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
@@ -15,7 +15,7 @@ interface TranscriptPanelContentProps {
  * full stop/restart/send capabilities.
  */
 export function TranscriptPanelContent({ taskId }: TranscriptPanelContentProps) {
-  const { session, stop, start, sendMessage, approve } = useAgentSession(taskId)
+  const { session, stop, start, resume, sendMessage, approve } = useAgentSession(taskId)
   // Select the single action instead of subscribing to the whole store — a
   // selector-less useAgentStore() re-renders this panel on every streamed
   // delta of every task's session.
@@ -44,6 +44,14 @@ export function TranscriptPanelContent({ taskId }: TranscriptPanelContentProps) 
     }
   }, [task?.agent_id, session?.sessionId, stop, removeSession, taskId, start])
 
+  const ensureChatSession = useCallback(async (): Promise<string | null> => {
+    if (!task?.agent_id) return null
+    const currentSession = useAgentStore.getState().sessions.get(taskId)
+    if (currentSession?.sessionId) return currentSession.sessionId
+    if (task.session_id) return resume(task.agent_id, taskId, task.session_id)
+    return start(task.agent_id, taskId)
+  }, [resume, start, task?.agent_id, task?.session_id, taskId])
+
   const handleSend = useCallback(
     async (message: string) => {
       // Read messages from the store at call time instead of closing over the
@@ -63,13 +71,15 @@ export function TranscriptPanelContent({ taskId }: TranscriptPanelContentProps) 
         questionIndex >= 0 &&
         !currentMessages.slice(questionIndex + 1).some((m) => m.role === 'user')
       if (hasActiveQuestion) {
+        const readySessionId = await ensureChatSession()
+        if (!readySessionId) return
         await approve(true, message, 'question', currentMessages[questionIndex].tool?.requestId)
         return
       }
 
       await sendMessage(message)
     },
-    [taskId, approve, sendMessage]
+    [taskId, approve, ensureChatSession, sendMessage]
   )
 
   if (!session || (status === SessionStatus.IDLE && messages.length === 0)) {

--- a/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TranscriptPanelContent.tsx
@@ -63,7 +63,7 @@ export function TranscriptPanelContent({ taskId }: TranscriptPanelContentProps) 
         questionIndex >= 0 &&
         !currentMessages.slice(questionIndex + 1).some((m) => m.role === 'user')
       if (hasActiveQuestion) {
-        await approve(true, message, 'question')
+        await approve(true, message, 'question', currentMessages[questionIndex].tool?.requestId)
         return
       }
 

--- a/src/renderer/src/components/dashboard/TaskBoard.tsx
+++ b/src/renderer/src/components/dashboard/TaskBoard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback, memo } from 'react'
 import { Clock, AlertCircle, CheckCircle2, ExternalLink, Bot, Terminal } from 'lucide-react'
 import { Badge } from '@/components/ui/Badge'
-import { OpenCodeLogo, AnthropicLogo, OpenAILogo } from '@/components/icons/AgentLogos'
+import { OpenCodeLogo, AnthropicLogo, OpenAILogo, PiLogo } from '@/components/icons/AgentLogos'
 import { useTaskStore } from '@/stores/task-store'
 import { useAgentStore } from '@/stores/agent-store'
 import { useUIStore } from '@/stores/ui-store'
@@ -163,7 +163,7 @@ function getAgentDisplay(agent: Agent | undefined): { name: string; Logo: React.
     case CodingAgentType.CURSOR:
       return { name, Logo: Terminal }
     case CodingAgentType.PI:
-      return { name, Logo: Terminal }
+      return { name, Logo: PiLogo }
     default:
       return { name, Logo: ({ className }: { className?: string }) => <Bot className={className} /> }
   }

--- a/src/renderer/src/components/dashboard/TaskBoard.tsx
+++ b/src/renderer/src/components/dashboard/TaskBoard.tsx
@@ -162,6 +162,8 @@ function getAgentDisplay(agent: Agent | undefined): { name: string; Logo: React.
       return { name, Logo: OpenAILogo }
     case CodingAgentType.CURSOR:
       return { name, Logo: Terminal }
+    case CodingAgentType.PI:
+      return { name, Logo: Terminal }
     default:
       return { name, Logo: ({ className }: { className?: string }) => <Bot className={className} /> }
   }

--- a/src/renderer/src/components/icons/AgentLogos.tsx
+++ b/src/renderer/src/components/icons/AgentLogos.tsx
@@ -22,3 +22,16 @@ export function OpenAILogo({ className }: { className?: string }) {
     </svg>
   )
 }
+
+export function PiLogo({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 800 800" width="100%" height="100%" className={className} xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"
+      />
+      <path fill="currentColor" d="M517.36 400H634.72V634.72H517.36Z" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/onboarding/OnboardingWizard.test.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { OnboardingWizard, shouldShowOnboarding, isForceOnboarding } from './OnboardingWizard'
+import { CodingAgentType } from '@/types'
 
 // Access mock electronAPI from test/setup-renderer.ts
 const mockAgentInstaller = window.electronAPI.agentInstaller as unknown as {
@@ -79,6 +80,8 @@ describe('isForceOnboarding', () => {
 })
 
 describe('OnboardingWizard', () => {
+  afterEach(() => cleanup())
+
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
@@ -90,7 +93,15 @@ describe('OnboardingWizard', () => {
       claudeCode: { installed: true, version: '1.0.0' },
       opencode: { installed: false, version: null },
       codex: { installed: false, version: null },
-      cursor: { installed: false, version: null }
+      cursor: { installed: false, version: null },
+      pi: { installed: false, version: null, supported: false, reason: 'Pi CLI is not installed.' }
+    })
+    mockAgentInstaller.install.mockResolvedValue({
+      success: true,
+      error: null,
+      newStatus: {
+        pi: { installed: true, version: '0.84.3', supported: true, reason: null }
+      }
     })
     mockAgentInstaller.onProgress.mockImplementation(() => vi.fn())
     mockAgents.getAll.mockResolvedValue([])
@@ -120,11 +131,12 @@ describe('OnboardingWizard', () => {
     expect(screen.getAllByText(/Managed agents, workflows/i).length).toBeGreaterThan(0)
   })
 
-  it('should display all three BYO coding agent options', () => {
+  it('should display all BYO coding agent options', () => {
     render(<OnboardingWizard open={true} onOpenChange={vi.fn()} />)
     expect(screen.getAllByText('Claude Code').length).toBeGreaterThan(0)
     expect(screen.getAllByText('OpenCode').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Codex').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Pi').length).toBeGreaterThan(0)
   })
 
   it('should show button disabled when no agent is selected', () => {
@@ -152,6 +164,24 @@ describe('OnboardingWizard', () => {
       // Button contains "Get Started" text alongside icon elements
       const btns = screen.getAllByText('Get Started')
       expect(btns.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('installs Pi before creating the selected agent', async () => {
+    const onOpenChange = vi.fn()
+    render(<OnboardingWizard open={true} onOpenChange={onOpenChange} />)
+
+    await screen.findAllByText('Not installed')
+    const piTaglines = screen.getAllByText('Open-source coding agent')
+    fireEvent.click(piTaglines[piTaglines.length - 1].closest('button')!)
+    fireEvent.click(await screen.findByRole('button', { name: /install & get started/i }))
+
+    await waitFor(() => {
+      expect(mockAgentInstaller.install).toHaveBeenCalledWith('pi')
+      expect(mockAgents.create).toHaveBeenCalledWith(expect.objectContaining({
+        config: expect.objectContaining({ coding_agent: CodingAgentType.PI })
+      }))
+      expect(onOpenChange).toHaveBeenCalledWith(false)
     })
   })
 

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -6,8 +6,7 @@ import {
   ArrowRight,
   Download,
   Sparkles,
-  Zap,
-  Terminal
+  Zap
 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import {
@@ -28,7 +27,7 @@ import { PresetupWizard } from '@/components/dashboard/PresetupWizard'
 import { CodingAgentType, CLAUDE_MODELS, CODEX_MODELS, CURSOR_MODELS } from '@/types'
 import { VoiceRuntimeRow } from '@/components/voice/VoiceRuntimeRow'
 import { agentConfigApi } from '@/lib/ipc-client'
-import { AnthropicLogo, OpenCodeLogo, OpenAILogo } from '@/components/icons/AgentLogos'
+import { AnthropicLogo, OpenCodeLogo, OpenAILogo, PiLogo } from '@/components/icons/AgentLogos'
 import type { ToolStatus } from '@/types/electron'
 import type { PresetupTemplate } from '@/stores/dashboard-store'
 
@@ -119,7 +118,7 @@ const AGENT_OPTIONS: AgentOption[] = [
     type: CodingAgentType.PI,
     label: 'Pi',
     tagline: 'Open-source coding agent',
-    Logo: Terminal
+    Logo: PiLogo
   }
 ]
 

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -6,7 +6,8 @@ import {
   ArrowRight,
   Download,
   Sparkles,
-  Zap
+  Zap,
+  Terminal
 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import {
@@ -47,6 +48,7 @@ enum DetectKey {
   OPENCODE = 'opencode',
   CODEX = 'codex',
   CURSOR = 'cursor',
+  PI = 'pi',
   GH = 'gh',
   GLAB = 'glab'
 }
@@ -112,6 +114,12 @@ const AGENT_OPTIONS: AgentOption[] = [
     label: 'Codex',
     tagline: 'OpenAI',
     Logo: OpenAILogo
+  },
+  {
+    type: CodingAgentType.PI,
+    label: 'Pi',
+    tagline: 'Open-source coding agent',
+    Logo: Terminal
   }
 ]
 
@@ -127,6 +135,8 @@ function getAgentToolKey(type: CodingAgentType): DetectKey {
       return DetectKey.CODEX
     case CodingAgentType.CURSOR:
       return DetectKey.CURSOR
+    case CodingAgentType.PI:
+      return DetectKey.PI
   }
 }
 
@@ -176,9 +186,9 @@ async function getDefaultModel(type: CodingAgentType): Promise<string> {
   if (type === CodingAgentType.CURSOR) {
     return CURSOR_MODELS[0]?.id || ''
   }
-  // OpenCode — try to fetch providers, prefer Peakflo gateway if authenticated
+  // OpenCode and Pi — prefer the Peakflo gateway when it is available.
   try {
-    const result = await agentConfigApi.getProviders(undefined, CodingAgentType.OPENCODE)
+    const result = await agentConfigApi.getProviders(undefined, type)
     if (result?.providers) {
       const providers = Array.isArray(result.providers) ? result.providers : []
 
@@ -648,7 +658,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
               <p className="text-xs text-muted-foreground mb-2">
                 Or bring your own agent:
               </p>
-              <div className="grid grid-cols-3 gap-2.5">
+              <div className="grid grid-cols-4 gap-2.5">
                 {AGENT_OPTIONS.map((agent) => {
                   const isSelected = selectedAgent === agent.type
                   const toolKey = getAgentToolKey(agent.type as CodingAgentType)

--- a/src/renderer/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingWizard.tsx
@@ -356,6 +356,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
   }, [open])
 
   const handleInstall = useCallback(async (toolKey: string) => {
+    setError(null)
     setInstalling(toolKey)
     try {
       const result = (await window.electronAPI.agentInstaller.install(toolKey)) as {
@@ -369,9 +370,21 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
         const fresh = await window.electronAPI.agentInstaller.detect()
         setToolStatus(fresh)
       }
+      if (!result?.success) {
+        setError(result?.error || 'Installation failed. Try again or install the agent manually.')
+        return false
+      }
+      const status = result.newStatus?.[toolKey]
+      if (!status?.installed || status.supported === false) {
+        setError(status?.reason || 'The agent executable is not ready after installation.')
+        return false
+      }
+      return true
     } catch {
       const fresh = await window.electronAPI.agentInstaller.detect()
       setToolStatus(fresh)
+      setError('Installation failed. Try again or install the agent manually.')
+      return false
     } finally {
       setInstalling(null)
     }
@@ -519,13 +532,20 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
       return
     }
 
-    // BYO agent path — create default agent and close
+    // BYO agent path — install or update the selected runtime before creating
+    // an agent that depends on it.
     setCreating(true)
     try {
+      const toolKey = getAgentToolKey(selectedAgent)
+      const status = toolStatus?.[toolKey]
+      if (status && (!status.installed || status.supported === false)) {
+        const ready = await handleInstall(toolKey)
+        if (!ready) return
+      }
       await createDefaultAgent(selectedAgent)
       onOpenChange(false)
-    } catch {
-      setError('Failed to set up agent. You can configure it later in Settings.')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to set up agent. You can configure it later in Settings.')
     } finally {
       setCreating(false)
     }
@@ -547,10 +567,13 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
   const selectedCodingAgent =
     selectedAgent && selectedAgent !== AgentChoiceType.PEAKFLO ? selectedAgent : null
 
-  const agentInstalled =
+  const selectedAgentStatus =
     selectedCodingAgent && toolStatus
-      ? toolStatus[getAgentToolKey(selectedCodingAgent)]?.installed
+      ? toolStatus[getAgentToolKey(selectedCodingAgent)]
       : null
+  const agentReady = selectedAgentStatus
+    ? selectedAgentStatus.installed && selectedAgentStatus.supported !== false
+    : null
 
   /* ─── Render: Templates screen ─── */
 
@@ -664,6 +687,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
                   const toolKey = getAgentToolKey(agent.type as CodingAgentType)
                   const detected = toolStatus?.[toolKey]
                   const isInstalled = detected?.installed === true
+                  const isReady = isInstalled && detected.supported !== false
                   return (
                     <button
                       key={agent.type}
@@ -691,13 +715,15 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
                       {/* Detected status */}
                       {toolStatus && (
                         <span className={`text-[10px] flex items-center gap-0.5 ${
-                          isInstalled ? 'text-emerald-400' : 'text-muted-foreground/50'
+                          isReady ? 'text-emerald-400' : detected?.supported === false ? 'text-amber-400' : 'text-muted-foreground/50'
                         }`}>
-                          {isInstalled ? (
+                          {isReady ? (
                             <>
                               <Check className="size-2.5" />
                               {detected?.version ? `v${detected.version}` : 'Installed'}
                             </>
+                          ) : isInstalled ? (
+                            'Update required'
                           ) : (
                             'Not installed'
                           )}
@@ -727,11 +753,11 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
             <VoiceRuntimeRow variant="compact" />
 
             {/* ── Install prompt (only when selected agent is not installed) ── */}
-            {toolStatus && selectedCodingAgent && agentInstalled === false && (
+            {toolStatus && selectedCodingAgent && agentReady === false && (
               <div className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-border bg-muted/20 text-xs">
                 <AlertTriangle className="size-4 text-amber-400 shrink-0" />
                 <span className="text-muted-foreground flex-1">
-                  {AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} will be installed automatically
+                  {selectedAgentStatus?.reason || `${AGENT_OPTIONS.find((a) => a.type === selectedCodingAgent)?.label} will be installed automatically`}
                 </span>
                 <Button
                   size="sm"
@@ -771,7 +797,7 @@ export function OnboardingWizard({ open, onOpenChange }: OnboardingWizardProps) 
                 )}
                 {selectedAgent === AgentChoiceType.PEAKFLO
                   ? (isAuthenticated ? 'Get Started' : 'Sign up / Log in')
-                  : 'Get Started'}
+                  : agentReady === false ? 'Install & Get Started' : 'Get Started'}
                 {!creating && <ArrowRight className="size-4 ml-1.5" />}
               </Button>
               <Button

--- a/src/renderer/src/components/settings/tabs/AgentsSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/AgentsSettings.tsx
@@ -145,7 +145,8 @@ export function AgentsSettings() {
               const isClaudeCode = agent.config.coding_agent === CodingAgentType.CLAUDE_CODE
               const isCodex = agent.config.coding_agent === CodingAgentType.CODEX
               const isCursor = agent.config.coding_agent === CodingAgentType.CURSOR
-              const isCliAgent = isClaudeCode || isCodex || isCursor
+              const isPi = agent.config.coding_agent === CodingAgentType.PI
+              const isCliAgent = isClaudeCode || isCodex || isCursor || isPi
 
               return (
                 <div key={agent.id} className="rounded-lg border border-border bg-card overflow-hidden">
@@ -179,6 +180,11 @@ export function AgentsSettings() {
                         )}
                         {isCursor && (
                           <span title="Cursor">
+                            <Terminal className="h-3.5 w-3.5 text-violet-300/80" />
+                          </span>
+                        )}
+                        {isPi && (
+                          <span title="Pi">
                             <Terminal className="h-3.5 w-3.5 text-violet-300/80" />
                           </span>
                         )}

--- a/src/renderer/src/components/settings/tabs/AgentsSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/AgentsSettings.tsx
@@ -3,7 +3,7 @@ import { Plus, Loader2, Wifi, WifiOff, RefreshCw, Edit3, Trash2, Terminal } from
 import { Button } from '@/components/ui/Button'
 import { SettingsSection } from '../SettingsSection'
 import { AgentFormDialog } from '../forms/AgentFormDialog'
-import { OpenCodeLogo, AnthropicLogo, OpenAILogo } from '@/components/icons/AgentLogos'
+import { OpenCodeLogo, AnthropicLogo, OpenAILogo, PiLogo } from '@/components/icons/AgentLogos'
 import { useAgentStore } from '@/stores/agent-store'
 import { agentConfigApi } from '@/lib/ipc-client'
 import { CLAUDE_MODELS, CODEX_MODELS, CURSOR_MODELS, CodingAgentType } from '@/types'
@@ -185,7 +185,7 @@ export function AgentsSettings() {
                         )}
                         {isPi && (
                           <span title="Pi">
-                            <Terminal className="h-3.5 w-3.5 text-violet-300/80" />
+                            <PiLogo className="h-3.5 w-3.5 text-foreground/80" />
                           </span>
                         )}
                       </div>

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -504,10 +504,12 @@ function TaskDetailViewComponent({ task, agents, onEdit, onDelete, onUpdateAttac
                     const agentName = codingAgent === CodingAgentType.CLAUDE_CODE ? 'Claude Code' :
                                      codingAgent === CodingAgentType.OPENCODE ? 'OpenCode' :
                                      codingAgent === CodingAgentType.CURSOR ? 'Cursor' :
+                                     codingAgent === CodingAgentType.PI ? 'Pi' :
                                      'Codex'
                     const LogoComponent = codingAgent === CodingAgentType.CLAUDE_CODE ? AnthropicLogo :
                                          codingAgent === CodingAgentType.OPENCODE ? OpenCodeLogo :
                                          codingAgent === CodingAgentType.CURSOR ? Terminal :
+                                         codingAgent === CodingAgentType.PI ? Terminal :
                                          OpenAILogo
                     return (
                       <div

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -16,7 +16,7 @@ import { useSkillStore } from '@/stores/skill-store'
 import { AssigneeSelect } from './AssigneeSelect'
 import { TaskStatus, CodingAgentType } from '@/types'
 import type { WorkfloTask, FileAttachment, OutputField, Agent, RecurrencePattern, RecurrencePatternObject } from '@/types'
-import { AnthropicLogo, OpenCodeLogo, OpenAILogo } from '@/components/icons/AgentLogos'
+import { AnthropicLogo, OpenCodeLogo, OpenAILogo, PiLogo } from '@/components/icons/AgentLogos'
 import { HeartbeatSection } from './HeartbeatSection'
 import { useUIStore } from '@/stores/ui-store'
 import { isAgentConfigured, getAgentConfigIssue } from '@shared/agent-utils'
@@ -509,7 +509,7 @@ function TaskDetailViewComponent({ task, agents, onEdit, onDelete, onUpdateAttac
                     const LogoComponent = codingAgent === CodingAgentType.CLAUDE_CODE ? AnthropicLogo :
                                          codingAgent === CodingAgentType.OPENCODE ? OpenCodeLogo :
                                          codingAgent === CodingAgentType.CURSOR ? Terminal :
-                                         codingAgent === CodingAgentType.PI ? Terminal :
+                                         codingAgent === CodingAgentType.PI ? PiLogo :
                                          OpenAILogo
                     return (
                       <div

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -303,16 +303,18 @@ describe('TaskWorkspace – stale triage session cleanup', () => {
     renderWorkspace(task)
 
     fireEvent.click(screen.getByTestId('mock-send'))
+    fireEvent.click(screen.getByTestId('mock-send'))
 
     await waitFor(() => {
       expect(window.electronAPI.agentSession.approve).toHaveBeenCalledWith(
         'session-1',
         true,
         'approved',
-        'question',
+        'permission',
         'pi-request-1'
       )
     })
+    expect(window.electronAPI.agentSession.approve).toHaveBeenCalledTimes(1)
     expect(window.electronAPI.agentSession.send).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -316,6 +316,58 @@ describe('TaskWorkspace – stale triage session cleanup', () => {
     expect(window.electronAPI.agentSession.send).not.toHaveBeenCalled()
   })
 
+  it('resumes a lost session before it answers a persisted Pi question', async () => {
+    const taskId = 'task-1'
+    const agentId = 'agent-1'
+    useAgentStore.setState({
+      sessions: new Map([[taskId, {
+        sessionId: null,
+        agentId,
+        taskId,
+        status: SessionStatus.IDLE,
+        messages: [{
+          id: 'pi-question-request-3',
+          role: 'assistant',
+          content: 'Choose an environment',
+          timestamp: new Date(),
+          partType: 'question',
+          tool: {
+            name: 'question',
+            status: 'running',
+            requestId: 'request-3',
+            questions: [{
+              header: 'Environment',
+              question: 'Choose an environment',
+              options: [{ label: 'Stage', description: 'Stage' }]
+            }]
+          }
+        }],
+        pendingApproval: null
+      }]])
+    })
+    vi.mocked(window.electronAPI.agentSession.resume).mockResolvedValue({ sessionId: 'resumed-session-3' })
+    const task = makeRendererTask({
+      id: taskId,
+      status: TaskStatus.AgentWorking,
+      agent_id: agentId,
+      session_id: 'persisted-session-3'
+    })
+
+    renderWorkspace(task)
+    fireEvent.click(screen.getByTestId('mock-send'))
+
+    await waitFor(() => {
+      expect(window.electronAPI.agentSession.resume).toHaveBeenCalledWith(agentId, taskId, 'persisted-session-3')
+      expect(window.electronAPI.agentSession.approve).toHaveBeenCalledWith(
+        'resumed-session-3',
+        true,
+        'approved',
+        'question',
+        'request-3'
+      )
+    })
+  })
+
   it('resumes a persisted session before sending a follow-up message', async () => {
     const taskId = 'task-1'
     const agentId = 'agent-1'

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -284,6 +284,7 @@ describe('TaskWorkspace – stale triage session cleanup', () => {
               tool: {
                 name: 'permission',
                 status: 'pending',
+                requestId: 'pi-request-1',
                 questions: [
                   {
                     header: 'Permission',
@@ -304,7 +305,13 @@ describe('TaskWorkspace – stale triage session cleanup', () => {
     fireEvent.click(screen.getByTestId('mock-send'))
 
     await waitFor(() => {
-      expect(window.electronAPI.agentSession.approve).toHaveBeenCalledWith('session-1', true, 'approved', 'question')
+      expect(window.electronAPI.agentSession.approve).toHaveBeenCalledWith(
+        'session-1',
+        true,
+        'approved',
+        'question',
+        'pi-request-1'
+      )
     })
     expect(window.electronAPI.agentSession.send).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -540,7 +540,7 @@ function TaskWorkspaceComponent({
       const hasActiveQuestion = questionIndex >= 0
         && !messages.slice(questionIndex + 1).some((m) => m.role === 'user')
       if (hasActiveQuestion) {
-        await approve(true, message, 'question')
+        await approve(true, message, 'question', messages[questionIndex].tool?.requestId)
         return
       }
 

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -540,6 +540,8 @@ function TaskWorkspaceComponent({
       const hasActiveQuestion = questionIndex >= 0
         && !messages.slice(questionIndex + 1).some((m) => m.role === 'user')
       if (hasActiveQuestion) {
+        const readySessionId = await ensureChatSession()
+        if (!readySessionId) return
         await approve(true, message, 'question', messages[questionIndex].tool?.requestId)
         return
       }

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -113,6 +113,7 @@ function TaskWorkspaceComponent({
   const [incompatibleSessionError, setIncompatibleSessionError] = useState<string>()
   const [parentTask, setParentTask] = useState<WorkfloTask | null>(null)
   const startingRef = useRef(false)
+  const submittedQuestionIdsRef = useRef(new Set<string>())
   const workspaceBodyRef = useRef<HTMLDivElement>(null)
   const resizingRef = useRef(false)
   const [transcriptWidth, setTranscriptWidth] = useState(() => {
@@ -540,9 +541,22 @@ function TaskWorkspaceComponent({
       const hasActiveQuestion = questionIndex >= 0
         && !messages.slice(questionIndex + 1).some((m) => m.role === 'user')
       if (hasActiveQuestion) {
-        const readySessionId = await ensureChatSession()
-        if (!readySessionId) return
-        await approve(true, message, 'question', messages[questionIndex].tool?.requestId)
+        const question = messages[questionIndex]
+        const questionKey = question.tool?.requestId || question.id
+        if (submittedQuestionIdsRef.current.has(questionKey)) return
+        submittedQuestionIdsRef.current.add(questionKey)
+        try {
+          const readySessionId = await ensureChatSession()
+          if (!readySessionId) {
+            submittedQuestionIdsRef.current.delete(questionKey)
+            return
+          }
+          const responseType = question.tool?.name === 'permission' ? 'permission' : 'question'
+          await approve(true, message, responseType, question.tool?.requestId)
+        } catch (error) {
+          submittedQuestionIdsRef.current.delete(questionKey)
+          throw error
+        }
         return
       }
 

--- a/src/renderer/src/hooks/use-agent-session.ts
+++ b/src/renderer/src/hooks/use-agent-session.ts
@@ -214,10 +214,10 @@ export function useAgentSession(taskId: string | undefined) {
   )
 
   const approve = useCallback(
-    async (approved: boolean, message?: string, responseType?: 'permission' | 'question') => {
+    async (approved: boolean, message?: string, responseType?: 'permission' | 'question', requestId?: string) => {
       const currentSession = useAgentStore.getState().sessions.get(taskId!)
       if (!currentSession?.sessionId) throw new Error('No active session')
-      await agentSessionApi.approve(currentSession.sessionId, approved, message, responseType)
+      await agentSessionApi.approve(currentSession.sessionId, approved, message, responseType, requestId)
       captureAnalyticsEvent('agent_approval_responded', {
         task_id: taskId,
         agent_id: currentSession.agentId,

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -154,10 +154,10 @@ export const agentSessionApi = {
     return window.electronAPI.agentSession.sendByTaskId(taskId, message, attachments)
   },
 
-  approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question'): Promise<{ success: boolean }> => {
-    return responseType
-      ? window.electronAPI.agentSession.approve(sessionId, approved, message, responseType)
-      : window.electronAPI.agentSession.approve(sessionId, approved, message)
+  approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question', requestId?: string): Promise<{ success: boolean }> => {
+    if (requestId) return window.electronAPI.agentSession.approve(sessionId, approved, message, responseType, requestId)
+    if (responseType) return window.electronAPI.agentSession.approve(sessionId, approved, message, responseType)
+    return window.electronAPI.agentSession.approve(sessionId, approved, message)
   },
 
   syncSkills: (sessionId: string): Promise<SkillSyncResult> => {

--- a/src/renderer/src/stores/agent-store.ts
+++ b/src/renderer/src/stores/agent-store.ts
@@ -36,6 +36,7 @@ export interface AgentMessage {
     input?: string
     output?: string
     error?: string
+    requestId?: string
     questions?: Array<{
       header: string
       question: string

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -255,7 +255,7 @@ interface ElectronAPI {
     stopByTaskId: (taskId: string) => Promise<AgentSessionSuccessResult & { sessionId: string | null }>
     send: (sessionId: string, message: string, taskId?: string, agentId?: string, attachments?: AgentMessageAttachment[]) => Promise<AgentSessionSuccessResult & { newSessionId?: string }>
     sendByTaskId: (taskId: string, message: string, attachments?: AgentMessageAttachment[]) => Promise<AgentSessionSuccessResult & { sessionId: string | null; newSessionId?: string }>
-    approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question') => Promise<AgentSessionSuccessResult>
+    approve: (sessionId: string, approved: boolean, message?: string, responseType?: 'permission' | 'question', requestId?: string) => Promise<AgentSessionSuccessResult>
     syncSkills: (sessionId: string) => Promise<SkillSyncResult>
     syncSkillsForTask: (taskId: string) => Promise<SkillSyncResult>
     learnFromSession: (sessionId: string, message: string) => Promise<SkillSyncResult>

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -202,6 +202,7 @@ export interface DepsStatus {
   opencode: ToolStatus
   codex: ToolStatus
   cursor: ToolStatus
+  pi: ToolStatus
 }
 
 export interface GlabCliStatus {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -189,6 +189,8 @@ export interface WorkspaceCleanupProgressEvent {
 export interface ToolStatus {
   installed: boolean
   version: string | null
+  supported?: boolean
+  reason?: string | null
 }
 
 export interface DepsStatus {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -32,7 +32,8 @@ export enum CodingAgentType {
   OPENCODE = 'opencode',
   CLAUDE_CODE = 'claude-code',
   CODEX = 'codex',
-  CURSOR = 'cursor'
+  CURSOR = 'cursor',
+  PI = 'pi'
 }
 
 export type AgentPermissionMode = 'ask' | 'allow'
@@ -44,7 +45,8 @@ export const CODING_AGENTS: { value: CodingAgentType; label: string }[] = [
   { value: CodingAgentType.OPENCODE, label: 'OpenCode' },
   { value: CodingAgentType.CLAUDE_CODE, label: 'Claude Code' },
   { value: CodingAgentType.CODEX, label: 'Codex' },
-  { value: CodingAgentType.CURSOR, label: 'Cursor' }
+  { value: CodingAgentType.CURSOR, label: 'Cursor' },
+  { value: CodingAgentType.PI, label: 'Pi' }
 ]
 
 export const CURSOR_MODELS: { id: string; name: string }[] = [


### PR DESCRIPTION
## Summary

- Add Pi as a coding agent in setup, agent forms, task views, and settings.
- Use the supplied Pi brand mark in onboarding, agent settings, task cards, and task details.
- Detect Pi across PATH, common global install locations, and the active npm global prefix.
- Require Pi 0.80.5 or newer and show ready, not installed, or update required in the setup wizard.
- Install or update Pi and its MCP adapter before the wizard creates a Pi agent.
- Run Pi as a native JSONL RPC process with Pi-owned session files and runtime model selection.
- Discover the effective Pi model catalog through RPC.
- Route Pi extension confirmations and questions through the existing desktop and mobile approval APIs.
- Preserve user and project Pi configuration while adding 20x permission enforcement and MCP support.
- Install the Peakflo AI Gateway provider without writing its key to the Pi model file.

## Verification

- Type check passed.
- Lint and JavaScript syntax checks passed for changed files.
- 183 focused integration tests and 55 related UI tests passed.
- Local detection found supported Pi 0.84.3.
- Pi 0.84.3 and pi-mcp-adapter are installed locally.
- A live Pi request through the Peakflo AI Gateway returned the expected response.
- An isolated mobile API end-to-end test paired a client, created a task, started a Pi session through `POST /api/sessions/start`, and received the expected model response.
- The Pi model file has mode 0600 and contains only an environment-variable reference for the key.

## Release note

The pull request runs the Verify workflow. A merge does not make a release because the release workflow needs a version tag.
