### PR TITLE
fix: reap processes left running inside a task workspace (EMFILE / leaked watchers)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,7 +30,7 @@ import { TaskAutomationScheduler } from './task-automation-scheduler'
 import { WorkspaceCleanupScheduler } from './workspace-cleanup-scheduler'
 import { ClaudePluginManager } from './claude-plugin-manager'
 import { parseProcessTable, selectKillableMcpPids } from './mcp-process-cleanup'
-import { buildWorkspaceStates, sweepLeakedWorkspaceProcesses, WORKSPACE_COUNT_WARN_THRESHOLD } from './workspace-process-cleanup'
+import { buildWorkspaceStates, sweepLeakedWorkspaceProcesses, SHUTDOWN_GRACE_MS, WORKSPACE_COUNT_WARN_THRESHOLD } from './workspace-process-cleanup'
 import { WORKSPACES_DIR, listWorkspaceDirs } from './workspace-paths'
 import { EnterpriseHeartbeat } from './enterprise-heartbeat'
 import { EnterpriseStateSync } from './enterprise-state-sync'
@@ -232,7 +232,7 @@ function sweepLeakedMcpProcesses(): void {
  * The boot call is the one that matters. These orphans reparent to launchd, so
  * a shutdown hook alone never sees a machine that was force-quit or rebooted.
  */
-async function sweepLeakedWorkspaces(): Promise<void> {
+async function sweepLeakedWorkspaces(graceMs?: number): Promise<void> {
   try {
     // A workspace with no task row is as leaked as a finished one, so the two
     // sources are paired rather than either alone.
@@ -241,7 +241,8 @@ async function sweepLeakedWorkspaces(): Promise<void> {
     const states = buildWorkspaceStates(tasks, dirs)
     await sweepLeakedWorkspaceProcesses({
       workspacesRoot: WORKSPACES_DIR,
-      workspaceState: (workspaceId) => states.get(workspaceId) ?? { exists: false }
+      workspaceState: (workspaceId) => states.get(workspaceId) ?? { exists: false },
+      graceMs
     })
 
     // Nothing bounds the workspace count today. Report it, so the disk and
@@ -273,7 +274,9 @@ async function shutdownAppServices(): Promise<void> {
   stopTaskApiServer()
 
   sweepLeakedMcpProcesses()
-  await sweepLeakedWorkspaces()
+  // A short grace here: quitting must stay quick, and anything that ignores
+  // SIGTERM is collected by the boot sweep on the next start.
+  await sweepLeakedWorkspaces(SHUTDOWN_GRACE_MS)
 
   db?.close()
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -232,17 +232,32 @@ function sweepLeakedMcpProcesses(): void {
  * The boot call is the one that matters. These orphans reparent to launchd, so
  * a shutdown hook alone never sees a machine that was force-quit or rebooted.
  */
-async function sweepLeakedWorkspaces(graceMs?: number): Promise<void> {
+async function sweepLeakedWorkspaces(graceMs?: number, orphansIgnoreTaskState = false): Promise<void> {
   try {
     // A workspace with no task row is as leaked as a finished one, so the two
-    // sources are paired rather than either alone.
+    // sources are paired rather than either alone. BOTH must be trustworthy: a
+    // failed read of either one would classify healthy workspaces as leaked, so
+    // each is checked and the sweep declines rather than guesses.
     const dirs = listWorkspaceDirs()
+    if (dirs === null) {
+      console.warn('[Cleanup] Skipping the workspace sweep: the workspaces directory could not be read.')
+      return
+    }
     const tasks = db ? db.getTasks().map((task) => ({ id: task.id, status: String(task.status) })) : []
+    if (tasks.length === 0 && dirs.length > 0) {
+      // Not credible: workspaces exist but the task table is empty. Far more
+      // likely a closed or damaged database than a genuinely empty one — and
+      // believing it would mark every workspace "no task for this workspace"
+      // and kill everything in all of them.
+      console.warn(`[Cleanup] Skipping the workspace sweep: ${dirs.length} workspaces on disk but no tasks in the database.`)
+      return
+    }
     const states = buildWorkspaceStates(tasks, dirs)
     await sweepLeakedWorkspaceProcesses({
       workspacesRoot: WORKSPACES_DIR,
       workspaceState: (workspaceId) => states.get(workspaceId) ?? { exists: false },
-      graceMs
+      graceMs,
+      orphansIgnoreTaskState
     })
 
     // Nothing bounds the workspace count today. Report it, so the disk and
@@ -934,7 +949,12 @@ app.whenReady().then(async () => {
   // that was force-quit or rebooted: those orphans reparent to launchd, so no
   // shutdown hook ever sees them. Awaited — on a machine that has hit EMFILE
   // the descriptors must come back before this instance opens its own.
-  await sweepLeakedWorkspaces()
+  // `orphansIgnoreTaskState` is true HERE AND ONLY HERE. Task status is
+  // deliberately preserved across a quit and nothing repairs it at startup, so
+  // a force-quit task stays `agent_working` forever — and without this the
+  // watcher it leaked would be vetoed by its own stale status on every boot,
+  // making the reported case the one case that could never be collected.
+  await sweepLeakedWorkspaces(undefined, true)
   analytics.record('server.boot.heartbeat', {
     taskCount: db.getTasks().length,
     agentCount: db.getAgents().length

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,6 +30,8 @@ import { TaskAutomationScheduler } from './task-automation-scheduler'
 import { WorkspaceCleanupScheduler } from './workspace-cleanup-scheduler'
 import { ClaudePluginManager } from './claude-plugin-manager'
 import { parseProcessTable, selectKillableMcpPids } from './mcp-process-cleanup'
+import { buildWorkspaceStates, sweepLeakedWorkspaceProcesses, WORKSPACE_COUNT_WARN_THRESHOLD } from './workspace-process-cleanup'
+import { WORKSPACES_DIR, listWorkspaceDirs } from './workspace-paths'
 import { EnterpriseHeartbeat } from './enterprise-heartbeat'
 import { EnterpriseStateSync } from './enterprise-state-sync'
 import { handleRoute, setTaskApiAgentController, setTaskApiNotifier, setTaskApiUiState, setTaskAutomationTrigger, setTranscriptProvider, stopTaskApiServer } from './task-api-server'
@@ -215,6 +217,43 @@ function sweepLeakedMcpProcesses(): void {
   }
 }
 
+/**
+ * Kills processes still running inside a task workspace that nobody is driving.
+ *
+ * The same defect as the MCP sweep above, one level out: a watcher started by
+ * `pnpm dev` inside a workspace survives its parents, is reparented to launchd,
+ * and goes on watching several thousand files for days. Two such processes were
+ * measured holding 43% of every open file descriptor on the owner's machine.
+ *
+ * Selection is by CWD AND TASK STATE, never by process name — `node`, `tsx` and
+ * `next` are also how the user runs their own work, and a name match would kill
+ * a dev server running in their own checkout.
+ *
+ * The boot call is the one that matters. These orphans reparent to launchd, so
+ * a shutdown hook alone never sees a machine that was force-quit or rebooted.
+ */
+async function sweepLeakedWorkspaces(): Promise<void> {
+  try {
+    // A workspace with no task row is as leaked as a finished one, so the two
+    // sources are paired rather than either alone.
+    const dirs = listWorkspaceDirs()
+    const tasks = db ? db.getTasks().map((task) => ({ id: task.id, status: String(task.status) })) : []
+    const states = buildWorkspaceStates(tasks, dirs)
+    await sweepLeakedWorkspaceProcesses({
+      workspacesRoot: WORKSPACES_DIR,
+      workspaceState: (workspaceId) => states.get(workspaceId) ?? { exists: false }
+    })
+
+    // Nothing bounds the workspace count today. Report it, so the disk and
+    // inode cost of one clone per agent run is visible before it bites.
+    if (dirs.length >= WORKSPACE_COUNT_WARN_THRESHOLD) {
+      console.warn(`[Cleanup] ${dirs.length} task workspaces on disk, each with its own node_modules. Enable workspace auto-cleanup in Settings.`)
+    }
+  } catch (err) {
+    console.warn('[Cleanup] Could not sweep leaked workspace processes:', err)
+  }
+}
+
 async function shutdownAppServices(): Promise<void> {
   voiceSessionManager?.shutdown()
   enterpriseHeartbeatInstance?.stop()
@@ -234,6 +273,7 @@ async function shutdownAppServices(): Promise<void> {
   stopTaskApiServer()
 
   sweepLeakedMcpProcesses()
+  await sweepLeakedWorkspaces()
 
   db?.close()
 
@@ -884,6 +924,14 @@ app.whenReady().then(async () => {
 
   db = new DatabaseManager()
   db.initialize()
+
+  // The BOOT sweep for workspace processes. It runs here rather than beside the
+  // MCP sweep above because it needs the task table to tell a leaked workspace
+  // from one an agent is working in. This is the call that catches a machine
+  // that was force-quit or rebooted: those orphans reparent to launchd, so no
+  // shutdown hook ever sees them. Awaited — on a machine that has hit EMFILE
+  // the descriptors must come back before this instance opens its own.
+  await sweepLeakedWorkspaces()
   analytics.record('server.boot.heartbeat', {
     taskCount: db.getTasks().length,
     agentCount: db.getAgents().length

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,7 +30,7 @@ import { TaskAutomationScheduler } from './task-automation-scheduler'
 import { WorkspaceCleanupScheduler } from './workspace-cleanup-scheduler'
 import { ClaudePluginManager } from './claude-plugin-manager'
 import { parseProcessTable, selectKillableMcpPids } from './mcp-process-cleanup'
-import { buildWorkspaceStates, sweepLeakedWorkspaceProcesses, SHUTDOWN_GRACE_MS, WORKSPACE_COUNT_WARN_THRESHOLD } from './workspace-process-cleanup'
+import { buildWorkspaceStates, sweepLeakedWorkspaceProcesses, readDiskSpace, workspacePressureWarning, SHUTDOWN_GRACE_MS } from './workspace-process-cleanup'
 import { WORKSPACES_DIR, listWorkspaceDirs } from './workspace-paths'
 import { EnterpriseHeartbeat } from './enterprise-heartbeat'
 import { EnterpriseStateSync } from './enterprise-state-sync'
@@ -260,11 +260,11 @@ async function sweepLeakedWorkspaces(graceMs?: number, orphansIgnoreTaskState = 
       orphansIgnoreTaskState
     })
 
-    // Nothing bounds the workspace count today. Report it, so the disk and
-    // inode cost of one clone per agent run is visible before it bites.
-    if (dirs.length >= WORKSPACE_COUNT_WARN_THRESHOLD) {
-      console.warn(`[Cleanup] ${dirs.length} task workspaces on disk, each with its own node_modules. Enable workspace auto-cleanup in Settings.`)
-    }
+    // Nothing bounds the workspace count today. Report it with the free space
+    // beside it, so the disk cost of one clone per agent run is visible before
+    // it bites — the count alone does not say whether the next run will fit.
+    const pressure = workspacePressureWarning({ count: dirs.length, disk: readDiskSpace(WORKSPACES_DIR) })
+    if (pressure) console.warn(`[Cleanup] ${pressure}`)
   } catch (err) {
     console.warn('[Cleanup] Could not sweep leaked workspace processes:', err)
   }

--- a/src/main/workspace-cleanup-scheduler.ts
+++ b/src/main/workspace-cleanup-scheduler.ts
@@ -1,11 +1,11 @@
-import { BrowserWindow, app } from 'electron'
+import { BrowserWindow } from 'electron'
 import { existsSync, readdirSync, statSync, rmSync } from 'fs'
 import { join } from 'path'
 import type { DatabaseManager } from './database'
 import type { WorktreeManager } from './worktree-manager'
 import { TaskStatus } from '../shared/constants'
-
-const WORKSPACES_DIR = join(app.getPath('userData'), 'workspaces')
+import { WORKSPACES_DIR, listWorkspaceDirs } from './workspace-paths'
+import { terminateProcessesInWorkspaces, WORKSPACE_COUNT_WARN_THRESHOLD } from './workspace-process-cleanup'
 
 /**
  * WorkspaceCleanupScheduler - Automatic cleanup of old completed task workspaces
@@ -168,6 +168,27 @@ export class WorkspaceCleanupScheduler {
     const total = eligibleTasks.length + orphanDirs.length
     let processed = 0
 
+    // A process must not outlive its workspace. Removing the directory under a
+    // running watcher leaves it holding several thousand descriptors on files
+    // that no longer exist — the exact leak this cleanup is supposed to end.
+    // Killed BEFORE any removal, and by cwd only, so a watcher the user started
+    // in their own checkout is never a candidate.
+    if (total > 0) {
+      try {
+        const killed = await terminateProcessesInWorkspaces({
+          workspacesRoot: WORKSPACES_DIR,
+          workspaceIds: [...eligibleTasks.map((t) => t.id), ...orphanDirs]
+        })
+        if (killed.length > 0) {
+          console.log(`[WorkspaceCleanup] Terminated ${killed.length} process(es) rooted in workspaces being removed`)
+        }
+      } catch (err) {
+        const message = `Failed to terminate processes in workspaces being removed: ${err instanceof Error ? err.message : String(err)}`
+        console.warn(`[WorkspaceCleanup] ${message}`)
+        errors.push(message)
+      }
+    }
+
     if (reportProgress) {
       this.sendToRenderer('workspace:cleanup-progress', {
         phase: 'scanning',
@@ -236,7 +257,23 @@ export class WorkspaceCleanupScheduler {
       processed++
     }
 
+    this.reportWorkspaceCount()
+
     return { cleaned, errors }
+  }
+
+  /**
+   * Reports how many workspaces are left. Nothing bounds this count: every agent
+   * run makes another clone with its own `node_modules`. On the machine the
+   * process leak was diagnosed on there were 397 of them holding 313 GB, which
+   * is a disk and inode problem in its own right. Counting it is the smallest
+   * honest thing to do about it.
+   */
+  private reportWorkspaceCount(): void {
+    const count = listWorkspaceDirs().length
+    if (count < WORKSPACE_COUNT_WARN_THRESHOLD) return
+    console.warn(`[WorkspaceCleanup] ${count} task workspaces remain on disk (threshold ${WORKSPACE_COUNT_WARN_THRESHOLD}).`)
+    this.sendToRenderer('workspace:count-warning', { count, threshold: WORKSPACE_COUNT_WARN_THRESHOLD })
   }
 
   private getRetentionDays(): number {

--- a/src/main/workspace-cleanup-scheduler.ts
+++ b/src/main/workspace-cleanup-scheduler.ts
@@ -5,7 +5,7 @@ import type { DatabaseManager } from './database'
 import type { WorktreeManager } from './worktree-manager'
 import { TaskStatus } from '../shared/constants'
 import { WORKSPACES_DIR, listWorkspaceDirs } from './workspace-paths'
-import { terminateProcessesInWorkspaces, WORKSPACE_COUNT_WARN_THRESHOLD } from './workspace-process-cleanup'
+import { terminateProcessesInWorkspaces, readDiskSpace, workspacePressureWarning } from './workspace-process-cleanup'
 
 /**
  * WorkspaceCleanupScheduler - Automatic cleanup of old completed task workspaces
@@ -278,14 +278,16 @@ export class WorkspaceCleanupScheduler {
    */
   private reportWorkspaceCount(): void {
     const dirs = listWorkspaceDirs()
-    if (dirs === null || dirs.length < WORKSPACE_COUNT_WARN_THRESHOLD) return
+    if (dirs === null) return
+    const pressure = workspacePressureWarning({ count: dirs.length, disk: readDiskSpace(WORKSPACES_DIR) })
+    if (!pressure) return
     // Console only. An earlier version also sent `workspace:count-warning` to
     // the renderer, which was dead code: no preload bridge carries it and no
     // component listens, so it reached nobody while looking like it reached
     // someone. Surfacing this in the UI is a real change — a preload channel, a
     // component, and a decision about how insistent it should be — and it wants
     // to be made deliberately rather than smuggled in with a process fix.
-    console.warn(`[WorkspaceCleanup] ${dirs.length} task workspaces remain on disk (threshold ${WORKSPACE_COUNT_WARN_THRESHOLD}). Enable workspace auto-cleanup in Settings.`)
+    console.warn(`[WorkspaceCleanup] ${pressure}`)
   }
 
   private getRetentionDays(): number {

--- a/src/main/workspace-cleanup-scheduler.ts
+++ b/src/main/workspace-cleanup-scheduler.ts
@@ -92,7 +92,14 @@ export class WorkspaceCleanupScheduler {
     try {
       // Check if auto-cleanup is enabled
       const enabled = this.dbManager.getSetting('workspace_autocleanup_enabled')
-      if (enabled !== 'true') return
+      if (enabled !== 'true') {
+        // Auto-cleanup defaults to OFF, and that is exactly the machine where
+        // the count grows without bound — 397 workspaces holding 313 GB on the
+        // one this was found on. Reporting it only inside `doCleanup` would
+        // mean the warning never reached the person who needs it.
+        this.reportWorkspaceCount()
+        return
+      }
 
       // Check if we already ran today
       const lastRun = this.dbManager.getSetting('workspace_autocleanup_last_run')

--- a/src/main/workspace-cleanup-scheduler.ts
+++ b/src/main/workspace-cleanup-scheduler.ts
@@ -277,10 +277,15 @@ export class WorkspaceCleanupScheduler {
    * honest thing to do about it.
    */
   private reportWorkspaceCount(): void {
-    const count = listWorkspaceDirs().length
-    if (count < WORKSPACE_COUNT_WARN_THRESHOLD) return
-    console.warn(`[WorkspaceCleanup] ${count} task workspaces remain on disk (threshold ${WORKSPACE_COUNT_WARN_THRESHOLD}).`)
-    this.sendToRenderer('workspace:count-warning', { count, threshold: WORKSPACE_COUNT_WARN_THRESHOLD })
+    const dirs = listWorkspaceDirs()
+    if (dirs === null || dirs.length < WORKSPACE_COUNT_WARN_THRESHOLD) return
+    // Console only. An earlier version also sent `workspace:count-warning` to
+    // the renderer, which was dead code: no preload bridge carries it and no
+    // component listens, so it reached nobody while looking like it reached
+    // someone. Surfacing this in the UI is a real change — a preload channel, a
+    // component, and a decision about how insistent it should be — and it wants
+    // to be made deliberately rather than smuggled in with a process fix.
+    console.warn(`[WorkspaceCleanup] ${dirs.length} task workspaces remain on disk (threshold ${WORKSPACE_COUNT_WARN_THRESHOLD}). Enable workspace auto-cleanup in Settings.`)
   }
 
   private getRetentionDays(): number {

--- a/src/main/workspace-paths.ts
+++ b/src/main/workspace-paths.ts
@@ -1,0 +1,25 @@
+import { app } from 'electron'
+import { existsSync, readdirSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * The root every agent task workspace lives under.
+ *
+ * One definition, because two consumers now decide whether a path is inside it:
+ * `workspace-cleanup-scheduler.ts`, which removes the directories, and
+ * `workspace-process-cleanup.ts`, which kills what is still running in them. A
+ * second copy that drifted would make a process look un-leaked and keep it.
+ */
+export const WORKSPACES_DIR = join(app.getPath('userData'), 'workspaces')
+
+/** The workspace directory names present on disk right now. */
+export function listWorkspaceDirs(): string[] {
+  try {
+    if (!existsSync(WORKSPACES_DIR)) return []
+    return readdirSync(WORKSPACES_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+  } catch {
+    return []
+  }
+}

--- a/src/main/workspace-paths.ts
+++ b/src/main/workspace-paths.ts
@@ -12,14 +12,29 @@ import { join } from 'path'
  */
 export const WORKSPACES_DIR = join(app.getPath('userData'), 'workspaces')
 
-/** The workspace directory names present on disk right now. */
-export function listWorkspaceDirs(): string[] {
+/**
+ * The workspace directory names present on disk right now, or NULL when the
+ * directory could not be read.
+ *
+ * The difference is load-bearing and this used to swallow it. `readdirSync`
+ * needs a directory descriptor, so it is one of the first things to fail under
+ * EMFILE — the exact condition the process sweep exists to relieve. Returning
+ * `[]` there told the caller "no workspace exists", which marks EVERY task's
+ * workspace as removed and switches off the guard that protects a task an agent
+ * is working on right now. The sweep would have been at its most destructive on
+ * precisely the machine it was written for. EACCES and a transient rename did
+ * the same thing.
+ *
+ * An absent root is still `[]` — that is a real, readable answer.
+ */
+export function listWorkspaceDirs(): string[] | null {
   try {
     if (!existsSync(WORKSPACES_DIR)) return []
     return readdirSync(WORKSPACES_DIR, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name)
-  } catch {
-    return []
+  } catch (err) {
+    console.warn('[WorkspaceCleanup] Could not list the workspaces directory:', err)
+    return null
   }
 }

--- a/src/main/workspace-process-cleanup.e2e.test.ts
+++ b/src/main/workspace-process-cleanup.e2e.test.ts
@@ -16,6 +16,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
+  collectAncestorPids,
   readProcessSnapshot,
   selectLeakedWorkspacePids,
   selectPidsRootedInWorkspaces,
@@ -87,6 +88,36 @@ async function settle(ms = 400): Promise<void> {
   await new Promise((done) => setTimeout(done, ms))
 }
 
+/**
+ * Starts a watcher in `cwd` through a launcher that is then SIGKILLed, so the
+ * watcher survives with no parent — the force-quit shape, and a process this
+ * test process does NOT own.
+ */
+async function startOrphanedWatcher(root: string, script: string, cwd: string): Promise<number> {
+  const launcherPath = join(root, `launcher-${cwd.length}-${spawned.length}.cjs`)
+  writeFileSync(launcherPath, LAUNCHER)
+  const launcher = spawn(process.execPath, [launcherPath, script, cwd], { cwd: root, stdio: ['ignore', 'pipe', 'ignore'] })
+  spawned.push(launcher)
+
+  const watcherPid = await new Promise<number>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('launcher never reported')), 20000)
+    let buffer = ''
+    launcher.stdout!.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString()
+      const match = /launched (\d+)/.exec(buffer)
+      if (match && buffer.includes('ready')) {
+        clearTimeout(timer)
+        resolve(Number(match[1]))
+      }
+    })
+    launcher.on('error', reject)
+  })
+
+  process.kill(launcher.pid!, 'SIGKILL')
+  await settle(1500)
+  return watcherPid
+}
+
 afterEach(() => {
   for (const child of spawned.splice(0)) {
     try {
@@ -155,48 +186,26 @@ describe.skipIf(!canReadProcessCwd())('workspace process cleanup, end to end', (
     // survives and launchd adopts it. A shutdown hook never runs in this case,
     // so only a boot sweep can ever collect it.
     const fx = fixture()
-    const workDir = fx.workspaceDir('task_force_quit')
-    const launcherPath = join(fx.root, 'launcher.cjs')
-    writeFileSync(launcherPath, LAUNCHER)
-
-    const launcher = spawn(process.execPath, [launcherPath, fx.script, workDir], {
-      cwd: fx.root,
-      stdio: ['ignore', 'pipe', 'ignore']
-    })
-    spawned.push(launcher)
-
-    const watcherPid = await new Promise<number>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('launcher never reported')), 20000)
-      let buffer = ''
-      launcher.stdout!.on('data', (chunk: Buffer) => {
-        buffer += chunk.toString()
-        const match = /launched (\d+)/.exec(buffer)
-        if (match && buffer.includes('ready')) {
-          clearTimeout(timer)
-          resolve(Number(match[1]))
-        }
-      })
-      launcher.on('error', reject)
-    })
-
     // Force-quit the parent, the way SIGKILL on 20x kills `pnpm` and `turbo`.
-    process.kill(launcher.pid!, 'SIGKILL')
-    await settle(1500)
+    const watcherPid = await startOrphanedWatcher(fx.root, fx.script, fx.workspaceDir('task_force_quit'))
 
     // BEFORE: the watcher is alive and has lost its parent.
     expect(alive(watcherPid), 'the watcher survives its parent').toBe(true)
     const before = readProcessSnapshot()
     const orphan = before.rows.find((row) => row.pid === watcherPid)
     expect(orphan, 'the watcher is still in the process table').toBeDefined()
-    expect(orphan!.ppid, 'its parent is really gone').not.toBe(launcher.pid)
+    // Its launcher is dead, so its parent must now be either init or a
+    // subreaper — and a subreaper is by definition one of OUR ancestors. Any
+    // third answer would mean it is still owned by a live process, and the
+    // whole premise of the test would be wrong.
+    const reparentedToInit = orphan!.ppid === 1
+    const adopters = collectAncestorPids(before.rows, process.pid)
+    expect(reparentedToInit || adopters.has(orphan!.ppid) || orphan!.ppid === process.pid, `unexpected new parent ${orphan!.ppid}`).toBe(true)
 
     // macOS and an ordinary Linux session reparent to pid 1, which is the case
     // the sweep is built for. A Linux host with a subreaper in the session
-    // (systemd --user, a container init) hands the child to that instead — and
-    // a subreaper is by definition one of OUR ancestors, so the same process is
-    // then caught by the descendant branch. Both are asserted; which one
-    // applies is the host's business, not this test's.
-    const reparentedToInit = orphan!.ppid === 1
+    // hands the child to that instead, and it is then caught by the descendant
+    // branch. Both are asserted; which one applies is the host's business.
     console.log(`watcher ${watcherPid} reparented to ppid ${orphan!.ppid}`)
 
     // The boot sweep, as `app.whenReady` runs it.
@@ -237,10 +246,13 @@ describe.skipIf(!canReadProcessCwd())('workspace process cleanup, end to end', (
 
   it('EXIT TEST 3 — removing a workspace takes the process rooted in it', async () => {
     const fx = fixture()
-    const workDir = fx.workspaceDir('task_to_remove')
-    const child = await startWatcher(workDir, fx.script)
-    child.unref()
-    const pid = child.pid!
+    // Orphaned first, deliberately. This path protects our OWN descendants —
+    // a dev build of 20x lives inside a workspace and every child of it
+    // inherits that cwd, so killing our own tree here would take the running
+    // app's live agent sessions with it. What this path is for is a process
+    // nobody owns, left in a directory that is about to be deleted.
+    const pid = await startOrphanedWatcher(fx.root, fx.script, fx.workspaceDir('task_to_remove'))
+    expect(alive(pid)).toBe(true)
 
     const killed = await terminateProcessesInWorkspaces({
       workspacesRoot: fx.workspaces,

--- a/src/main/workspace-process-cleanup.e2e.test.ts
+++ b/src/main/workspace-process-cleanup.e2e.test.ts
@@ -188,7 +188,16 @@ describe.skipIf(!canReadProcessCwd())('workspace process cleanup, end to end', (
     const before = readProcessSnapshot()
     const orphan = before.rows.find((row) => row.pid === watcherPid)
     expect(orphan, 'the watcher is still in the process table').toBeDefined()
-    expect(orphan!.ppid, 'reparented to launchd').toBe(1)
+    expect(orphan!.ppid, 'its parent is really gone').not.toBe(launcher.pid)
+
+    // macOS and an ordinary Linux session reparent to pid 1, which is the case
+    // the sweep is built for. A Linux host with a subreaper in the session
+    // (systemd --user, a container init) hands the child to that instead — and
+    // a subreaper is by definition one of OUR ancestors, so the same process is
+    // then caught by the descendant branch. Both are asserted; which one
+    // applies is the host's business, not this test's.
+    const reparentedToInit = orphan!.ppid === 1
+    console.log(`watcher ${watcherPid} reparented to ppid ${orphan!.ppid}`)
 
     // The boot sweep, as `app.whenReady` runs it.
     const swept = await sweepLeakedWorkspaceProcesses({
@@ -199,7 +208,7 @@ describe.skipIf(!canReadProcessCwd())('workspace process cleanup, end to end', (
     // AFTER: selected as an orphan, and gone.
     const leak = swept.find((entry) => entry.pid === watcherPid)
     expect(leak, 'selected by the sweep').toBeDefined()
-    expect(leak!.reason).toContain('orphaned (ppid 1)')
+    expect(leak!.reason).toContain(reparentedToInit ? 'orphaned (ppid 1)' : 'our descendant')
     await settle()
     expect(alive(watcherPid), 'the watcher is gone after the boot sweep').toBe(false)
     expect(readProcessSnapshot().rows.some((row) => row.pid === watcherPid)).toBe(false)

--- a/src/main/workspace-process-cleanup.e2e.test.ts
+++ b/src/main/workspace-process-cleanup.e2e.test.ts
@@ -1,0 +1,275 @@
+/**
+ * The exit tests, run against REAL processes and the REAL process table.
+ *
+ * Nothing here is mocked. Watchers are spawned for real, orphaned for real by
+ * killing their parent, and the sweep reads the machine's own `ps` and cwd
+ * table to decide. The point is the one the unit tests cannot make: that the
+ * selection still holds when the input is the operating system rather than a
+ * fixture.
+ *
+ * Hermetic: every process it spawns lives under a temporary workspaces root of
+ * its own, and it can only ever select processes rooted there.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawn, type ChildProcess } from 'child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  readProcessSnapshot,
+  selectLeakedWorkspacePids,
+  selectPidsRootedInWorkspaces,
+  sweepLeakedWorkspaceProcesses,
+  terminateProcessesInWorkspaces,
+  canReadProcessCwd,
+  type WorkspaceState
+} from './workspace-process-cleanup'
+
+/** A watcher of the shape that leaks: it holds file descriptors and never exits. */
+const WATCHER = `
+const fs = require('fs')
+const path = process.argv[2]
+const held = []
+for (let i = 0; i < 200; i++) {
+  const file = path + '/watched-' + i + '.txt'
+  fs.writeFileSync(file, 'x')
+  held.push(fs.openSync(file, 'r'))
+}
+process.stdout.write('ready\\n')
+setInterval(() => {}, 1000)
+`
+
+/**
+ * Stands in for the `pnpm`/`turbo` layer that dies with 20x. It starts the
+ * watcher and then does nothing, so SIGKILLing it reparents the watcher to
+ * launchd — the exact shape a force-quit leaves behind.
+ */
+const LAUNCHER = `
+const { spawn } = require('child_process')
+const child = spawn(process.execPath, [process.argv[2], process.argv[3]], {
+  cwd: process.argv[3], stdio: ['ignore', 'inherit', 'ignore'], detached: true
+})
+child.unref()
+process.stdout.write('launched ' + child.pid + '\\n')
+setInterval(() => {}, 1000)
+`
+
+const spawned: ChildProcess[] = []
+const tempRoots: string[] = []
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Spawns the watcher in `cwd` and waits until it has really opened its files. */
+async function startWatcher(cwd: string, scriptPath: string): Promise<ChildProcess> {
+  const child = spawn(process.execPath, [scriptPath, cwd], { cwd, stdio: ['ignore', 'pipe', 'ignore'], detached: true })
+  spawned.push(child)
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('watcher did not report ready')), 15000)
+    child.stdout!.on('data', (chunk: Buffer) => {
+      if (chunk.toString().includes('ready')) {
+        clearTimeout(timer)
+        resolve()
+      }
+    })
+    child.on('error', reject)
+  })
+  return child
+}
+
+async function settle(ms = 400): Promise<void> {
+  await new Promise((done) => setTimeout(done, ms))
+}
+
+afterEach(() => {
+  for (const child of spawned.splice(0)) {
+    try {
+      if (child.pid) process.kill(child.pid, 'SIGKILL')
+    } catch {
+      // already gone
+    }
+  }
+  for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe.skipIf(!canReadProcessCwd())('workspace process cleanup, end to end', () => {
+  function fixture(): { root: string; workspaces: string; script: string; workspaceDir: (id: string) => string } {
+    const root = mkdtempSync(join(tmpdir(), '20x-sweep-'))
+    tempRoots.push(root)
+    const workspaces = join(root, 'workspaces')
+    mkdirSync(workspaces, { recursive: true })
+    const script = join(root, 'watcher.cjs')
+    writeFileSync(script, WATCHER)
+    return {
+      root,
+      workspaces,
+      script,
+      workspaceDir: (id: string) => {
+        const dir = join(workspaces, id, 'repo', 'packages', 'workflow-api')
+        mkdirSync(dir, { recursive: true })
+        return dir
+      }
+    }
+  }
+
+  it('EXIT TEST 1+2 — kills the orphan in a finished workspace, leaves the user\'s own watcher running', async () => {
+    const fx = fixture()
+
+    // The leaked one: a watcher inside a task workspace, orphaned the way a
+    // SIGKILLed 20x orphans it — its parent dies and launchd adopts it.
+    const inside = await startWatcher(fx.workspaceDir('task_finished'), fx.script)
+    inside.unref()
+
+    // The user's own work: same executable, same script, OUTSIDE the root.
+    const outsideDir = join(fx.root, 'user-checkout', 'packages', 'workflow-api')
+    mkdirSync(outsideDir, { recursive: true })
+    const outside = await startWatcher(outsideDir, fx.script)
+    outside.unref()
+
+    const insidePid = inside.pid!
+    const outsidePid = outside.pid!
+    expect(alive(insidePid)).toBe(true)
+    expect(alive(outsidePid)).toBe(true)
+
+    const states: Record<string, WorkspaceState> = { task_finished: { status: 'completed', exists: true } }
+    const swept = await sweepLeakedWorkspaceProcesses({
+      workspacesRoot: fx.workspaces,
+      workspaceState: (id) => states[id] ?? { exists: false }
+    })
+
+    expect(swept.map((leak) => leak.pid)).toContain(insidePid)
+    expect(swept.map((leak) => leak.pid)).not.toContain(outsidePid)
+    await settle()
+    expect(alive(insidePid), 'the leaked watcher must be gone').toBe(false)
+    expect(alive(outsidePid), "the user's own watcher must be untouched").toBe(true)
+  }, 60000)
+
+  it('EXIT TEST 1 — a watcher orphaned by a SIGKILLed parent is gone after the boot sweep', async () => {
+    // The exact reported mechanism: the top of the tree dies, the GRANDCHILD
+    // survives and launchd adopts it. A shutdown hook never runs in this case,
+    // so only a boot sweep can ever collect it.
+    const fx = fixture()
+    const workDir = fx.workspaceDir('task_force_quit')
+    const launcherPath = join(fx.root, 'launcher.cjs')
+    writeFileSync(launcherPath, LAUNCHER)
+
+    const launcher = spawn(process.execPath, [launcherPath, fx.script, workDir], {
+      cwd: fx.root,
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    spawned.push(launcher)
+
+    const watcherPid = await new Promise<number>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('launcher never reported')), 20000)
+      let buffer = ''
+      launcher.stdout!.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString()
+        const match = /launched (\d+)/.exec(buffer)
+        if (match && buffer.includes('ready')) {
+          clearTimeout(timer)
+          resolve(Number(match[1]))
+        }
+      })
+      launcher.on('error', reject)
+    })
+
+    // Force-quit the parent, the way SIGKILL on 20x kills `pnpm` and `turbo`.
+    process.kill(launcher.pid!, 'SIGKILL')
+    await settle(1500)
+
+    // BEFORE: the watcher is alive and has lost its parent.
+    expect(alive(watcherPid), 'the watcher survives its parent').toBe(true)
+    const before = readProcessSnapshot()
+    const orphan = before.rows.find((row) => row.pid === watcherPid)
+    expect(orphan, 'the watcher is still in the process table').toBeDefined()
+    expect(orphan!.ppid, 'reparented to launchd').toBe(1)
+
+    // The boot sweep, as `app.whenReady` runs it.
+    const swept = await sweepLeakedWorkspaceProcesses({
+      workspacesRoot: fx.workspaces,
+      workspaceState: (id) => (id === 'task_force_quit' ? { status: 'completed', exists: true } : { exists: false })
+    })
+
+    // AFTER: selected as an orphan, and gone.
+    const leak = swept.find((entry) => entry.pid === watcherPid)
+    expect(leak, 'selected by the sweep').toBeDefined()
+    expect(leak!.reason).toContain('orphaned (ppid 1)')
+    await settle()
+    expect(alive(watcherPid), 'the watcher is gone after the boot sweep').toBe(false)
+    expect(readProcessSnapshot().rows.some((row) => row.pid === watcherPid)).toBe(false)
+  }, 90000)
+
+  it('EXIT TEST 2 (again, at the selection) — an identical command line outside the root is never selected', async () => {
+    const fx = fixture()
+    const outsideDir = join(fx.root, 'user-checkout')
+    mkdirSync(outsideDir, { recursive: true })
+    const outside = await startWatcher(outsideDir, fx.script)
+    outside.unref()
+
+    const { rows, cwdRows } = readProcessSnapshot()
+    const selected = selectLeakedWorkspacePids({
+      rows,
+      cwdRows,
+      workspacesRoot: fx.workspaces,
+      ownPid: process.pid,
+      // Deliberately the most permissive answer possible: every workspace is
+      // declared leaked. Even then the cwd keeps this process out.
+      workspaceState: () => ({ status: 'completed', exists: true })
+    })
+    expect(selected).not.toContain(outside.pid)
+    expect(alive(outside.pid!)).toBe(true)
+  }, 60000)
+
+  it('EXIT TEST 3 — removing a workspace takes the process rooted in it', async () => {
+    const fx = fixture()
+    const workDir = fx.workspaceDir('task_to_remove')
+    const child = await startWatcher(workDir, fx.script)
+    child.unref()
+    const pid = child.pid!
+
+    const killed = await terminateProcessesInWorkspaces({
+      workspacesRoot: fx.workspaces,
+      workspaceIds: ['task_to_remove']
+    })
+    expect(killed).toContain(pid)
+    await settle()
+    expect(alive(pid)).toBe(false)
+
+    // Only now is the directory safe to remove.
+    rmSync(join(fx.workspaces, 'task_to_remove'), { recursive: true, force: true })
+  }, 60000)
+
+  it('leaves a watcher alone while its task is still being worked on', async () => {
+    const fx = fixture()
+    const child = await startWatcher(fx.workspaceDir('task_live'), fx.script)
+    child.unref()
+    const pid = child.pid!
+
+    const swept = await sweepLeakedWorkspaceProcesses({
+      workspacesRoot: fx.workspaces,
+      workspaceState: () => ({ status: 'agent_working', exists: true })
+    })
+    expect(swept.map((leak) => leak.pid)).not.toContain(pid)
+    await settle()
+    expect(alive(pid)).toBe(true)
+  }, 60000)
+
+  it('never selects this process, though its own cwd is inside the root it is given', async () => {
+    // The dev build of 20x is normally checked out into a task workspace.
+    const { rows, cwdRows } = readProcessSnapshot()
+    const parentOfCwd = join(process.cwd(), '..')
+    for (const selected of [
+      selectLeakedWorkspacePids({ rows, cwdRows, workspacesRoot: parentOfCwd, ownPid: process.pid, workspaceState: () => ({ status: 'completed', exists: true }) }),
+      selectPidsRootedInWorkspaces({ rows, cwdRows, workspacesRoot: parentOfCwd, ownPid: process.pid, workspaceIds: [process.cwd().split(/[\\/]/).pop()!] })
+    ]) {
+      expect(selected).not.toContain(process.pid)
+      expect(selected).not.toContain(process.ppid)
+    }
+  }, 60000)
+})

--- a/src/main/workspace-process-cleanup.test.ts
+++ b/src/main/workspace-process-cleanup.test.ts
@@ -164,9 +164,23 @@ describe('selectLeakedWorkspaceRoots', () => {
     const input = base(
       [' 10 1 20x-main', ' 500 1 ' + TSX_WATCH],
       cwds([[500, WS('task_gone', '/repo')]]),
-      { task_gone: { status: 'agent_working', exists: false } }
+      { task_gone: { status: 'completed', exists: false } }
     )
     expect(selectLeakedWorkspaceRoots(input)[0].reason).toContain('workspace directory removed')
+  })
+
+  it('but a missing directory does NOT override an active task', () => {
+    // This assertion is the reverse of what this file first said. A missing
+    // directory is far more often a failed listing than a deleted workspace —
+    // `readdirSync` needs a descriptor and so fails early under EMFILE, the
+    // very condition this feature relieves. Letting it outrank the active-task
+    // guard made the sweep most destructive on exactly the machine it is for.
+    const input = base(
+      [' 10 1 20x-main', ' 500 1 ' + TSX_WATCH],
+      cwds([[500, WS('task_live', '/repo')]]),
+      { task_live: { status: 'agent_working', exists: false } }
+    )
+    expect(selectLeakedWorkspaceRoots(input)).toEqual([])
   })
 
   it('keeps a workspace process held by ANOTHER live 20x instance', () => {
@@ -206,6 +220,83 @@ describe('selectLeakedWorkspaceRoots', () => {
   })
 })
 
+describe('descendants of a leaked root', () => {
+  const rows = parseProcessTable(
+    [' 10 1 20x-main', ' 900 1 tmux-server', ' 901 900 nvim', ' 902 900 ' + USER_TSX_WATCH, ' 903 900 node'].join('\n')
+  )
+  const input = {
+    rows,
+    cwdRows: cwds([
+      [900, WS('task_done')],
+      [901, '/Users/dev/Documents/mynotes'],
+      [902, '/Users/dev/Documents/codes/peakflo/sources/other/pf-workflo/packages/workflow-api'],
+      [903, WS('task_done', '/repo')]
+    ]),
+    workspacesRoot: ROOT,
+    ownPid: 10,
+    workspaceState: () => ({ status: 'completed', exists: true })
+  }
+
+  it('takes a descendant that is itself inside the workspace', () => {
+    // The measured shape: the matched orphan held 49 descriptors, the browser
+    // it started held 449. Stopping at the root leaves the leak behind.
+    expect(selectLeakedWorkspacePids(input)).toContain(903)
+  })
+
+  it("NEVER takes a descendant whose own cwd is outside the root", () => {
+    // A `tmux` or `screen` server started inside a workspace is ppid 1 by
+    // DESIGN, so a finished task selects it. Its panes are its descendants and
+    // their cwds are wherever the user put them. Without this rule one finished
+    // task took down the user's editor and their dev server in their own
+    // checkout — the catastrophe this module exists to avoid, from the other
+    // direction.
+    const selected = selectLeakedWorkspacePids(input)
+    expect(selected).not.toContain(901)
+    expect(selected).not.toContain(902)
+    expect(selected).toEqual([900, 903])
+  })
+
+  it('leaves a descendant with no readable cwd alone — not readable is not leaked', () => {
+    const noCwd = { ...input, cwdRows: cwds([[900, WS('task_done')]]) }
+    expect(selectLeakedWorkspacePids(noCwd)).toEqual([900])
+  })
+})
+
+describe('an active task is an absolute veto', () => {
+  const base = (ppid: number, state: { status?: string; exists: boolean }, orphansIgnoreTaskState = false) => ({
+    rows: parseProcessTable([' 10 1 20x-main', ` 500 ${ppid} ` + TSX_WATCH].join('\n')),
+    cwdRows: cwds([[500, WS('task_A', '/repo')]]),
+    workspacesRoot: ROOT,
+    ownPid: 10,
+    workspaceState: () => state,
+    orphansIgnoreTaskState
+  })
+
+  it('outranks a missing directory, which is far more likely a failed listing', () => {
+    // If this loses, one unreadable directory listing kills the workspace of
+    // every task an agent is working on right now.
+    expect(selectLeakedWorkspaceRoots(base(1, { status: 'agent_working', exists: false }))).toEqual([])
+  })
+
+  it('protects our own descendant even at boot', () => {
+    expect(selectLeakedWorkspaceRoots(base(10, { status: 'agent_working', exists: true }, true))).toEqual([])
+  })
+
+  it('does NOT protect a parentless process at boot — the force-quit case', () => {
+    // `stopAllSessions` preserves task status across a quit and nothing repairs
+    // it at startup, so a force-quit task stays `agent_working` forever. If the
+    // status wins here, the leaked watcher is vetoed on every boot from then on
+    // and the reported bug is never fixed.
+    const leaked = selectLeakedWorkspaceRoots(base(1, { status: 'agent_working', exists: true }, true))
+    expect(leaked.map((entry) => entry.pid)).toEqual([500])
+    expect(leaked[0].reason).toContain('parentless at startup')
+  })
+
+  it('still protects a parentless process when that flag is off — the shutdown sweep', () => {
+    expect(selectLeakedWorkspaceRoots(base(1, { status: 'agent_working', exists: true }, false))).toEqual([])
+  })
+})
+
 describe('selectLeakedWorkspacePids', () => {
   it('takes the whole tree, because the descendants hold the descriptors', () => {
     // Measured shape: a 49-fd orphaned `node` whose `firefox` child held 449 more.
@@ -233,8 +324,12 @@ describe('selectPidsRootedInWorkspaces', () => {
     [42, '/Users/dev/Documents/codes/peakflo/sources/other/pf-workflo']
   ])
 
-  it('takes every process in the workspace whatever its parent, because the directory is going', () => {
-    expect(selectPidsRootedInWorkspaces({ rows, cwdRows, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_A'] })).toEqual([12, 21])
+  it("takes a process held by ANOTHER instance, because that directory is going", () => {
+    // The scope rule does not apply on this path and must not: the directory is
+    // being deleted, so a process still running in it cannot be left behind,
+    // and whose child it is does not change that. pid 12 is OUR child and is
+    // excluded — the sweep owns what we own, judged on task state.
+    expect(selectPidsRootedInWorkspaces({ rows, cwdRows, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_A'] })).toEqual([21])
   })
 
   it('still leaves a process outside the root alone', () => {
@@ -245,9 +340,24 @@ describe('selectPidsRootedInWorkspaces', () => {
     expect(selectPidsRootedInWorkspaces({ rows, cwdRows, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_B'] })).toEqual([])
   })
 
-  it('never selects itself or an ancestor', () => {
-    const own = parseProcessTable([' 5 1 shell', ' 10 5 20x-dev', ' 12 10 child'].join('\n'))
-    const ownCwds = cwds([[5, WS('task_A')], [10, WS('task_A')], [12, WS('task_A')]])
-    expect(selectPidsRootedInWorkspaces({ rows: own, cwdRows: ownCwds, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_A'] })).toEqual([12])
+  it('never selects itself, an ancestor, OR ANY OF OUR OWN CHILDREN', () => {
+    // A dev build of 20x lives inside a task workspace, so the main process's
+    // cwd IS that workspace and every child inherits it — `opencode serve`, the
+    // stdio MCP children, git. Protecting only self and ancestors meant that
+    // once that task passed the retention window the daily cleanup killed the
+    // running app's whole subprocess tree, every live agent session with it,
+    // and then deleted the directory underneath.
+    const own = parseProcessTable(
+      [' 5 1 shell', ' 10 5 20x-dev', ' 12 10 opencode-serve', ' 13 12 mcp-child', ' 99 1 stranger'].join('\n')
+    )
+    const ownCwds = cwds([[5, WS('task_A')], [10, WS('task_A')], [12, WS('task_A')], [13, WS('task_A')], [99, WS('task_A')]])
+    const selected = selectPidsRootedInWorkspaces({ rows: own, cwdRows: ownCwds, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_A'] })
+    expect(selected).toEqual([99])
+  })
+
+  it('does not follow a tree out of the workspaces root', () => {
+    const tree = parseProcessTable([' 10 1 20x-main', ' 900 1 tmux', ' 901 900 nvim'].join('\n'))
+    const treeCwds = cwds([[900, WS('task_A')], [901, '/Users/dev/Documents/mynotes']])
+    expect(selectPidsRootedInWorkspaces({ rows: tree, cwdRows: treeCwds, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_A'] })).toEqual([900])
   })
 })

--- a/src/main/workspace-process-cleanup.test.ts
+++ b/src/main/workspace-process-cleanup.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest'
+import { parseProcessTable } from './mcp-process-cleanup'
+import {
+  parseLsofCwd,
+  workspaceIdForCwd,
+  collectAncestorPids,
+  buildWorkspaceStates,
+  selectLeakedWorkspaceRoots,
+  selectLeakedWorkspacePids,
+  selectPidsRootedInWorkspaces,
+  ACTIVE_TASK_STATUSES,
+  type CwdRow
+} from './workspace-process-cleanup'
+
+const ROOT = '/Users/dev/Library/Application Support/20x/workspaces'
+const WS = (id: string, tail = '') => `${ROOT}/${id}${tail}`
+
+/** The real command line of the two processes measured holding 20,341 descriptors. */
+const TSX_WATCH =
+  'node /Users/dev/Library/Application Support/20x/workspaces/task_A/workflow-builder/packages/workflow-api/node_modules/.bin/tsx watch src/index.ts'
+/** The owner's own work, outside the workspaces root, with a near-identical command. */
+const USER_TSX_WATCH =
+  'node /Users/dev/Documents/codes/peakflo/sources/other/pf-workflo/packages/workflow-api/node_modules/.bin/tsx watch src/index.ts'
+
+function cwds(pairs: [number, string][]): CwdRow[] {
+  return pairs.map(([pid, cwd]) => ({ pid, cwd }))
+}
+
+describe('parseLsofCwd', () => {
+  it('pairs each p line with its own n line', () => {
+    expect(parseLsofCwd(['p101', 'n/tmp/a', 'p102', 'n/tmp/b'].join('\n'))).toEqual([
+      { pid: 101, cwd: '/tmp/a' },
+      { pid: 102, cwd: '/tmp/b' }
+    ])
+  })
+
+  it('drops a p line with no path instead of pairing it with the next process', () => {
+    // A process that exits mid-scan prints no n line. Carrying the pid forward
+    // would attribute another process's directory to it — and that directory
+    // decides whether it is killed.
+    expect(parseLsofCwd(['p101', 'p102', 'n/tmp/b'].join('\n'))).toEqual([{ pid: 102, cwd: '/tmp/b' }])
+  })
+
+  it('takes one cwd per process, not a second row from a stray extra n line', () => {
+    // A process has exactly one cwd. A second `n` line under the same `p` is
+    // not a second process, and inventing one would put a pid into the kill
+    // list under a directory it is not running in.
+    expect(parseLsofCwd(['p101', 'n/tmp/a', 'n/tmp/b'].join('\n'))).toEqual([{ pid: 101, cwd: '/tmp/a' }])
+  })
+
+  it('ignores an unparseable pid', () => {
+    expect(parseLsofCwd(['pnot-a-number', 'n/tmp/a'].join('\n'))).toEqual([])
+  })
+})
+
+describe('workspaceIdForCwd', () => {
+  it('returns the workspace directory name for a path inside it', () => {
+    expect(workspaceIdForCwd(WS('task_A', '/repo/packages/api'), ROOT)).toBe('task_A')
+    expect(workspaceIdForCwd(WS('task_A'), ROOT)).toBe('task_A')
+  })
+
+  it('returns null for a path outside the root — the regression that matters most', () => {
+    expect(workspaceIdForCwd('/Users/dev/Documents/codes/peakflo/sources/other/pf-workflo', ROOT)).toBeNull()
+  })
+
+  it('returns null for a sibling directory that merely shares the prefix', () => {
+    // `startsWith` on the raw string would match this and kill a process in it.
+    expect(workspaceIdForCwd(`${ROOT}-backup/task_A/repo`, ROOT)).toBeNull()
+    expect(workspaceIdForCwd(`${ROOT}2/task_A`, ROOT)).toBeNull()
+  })
+
+  it('returns null for the root itself — a shell there is in no task workspace', () => {
+    // Measured on the machine: one zsh sat in exactly this directory. It is in
+    // no task workspace, so no task state can ever declare it leaked.
+    expect(workspaceIdForCwd(ROOT, ROOT)).toBeNull()
+    expect(workspaceIdForCwd(`${ROOT}/`, ROOT)).toBeNull()
+    expect(workspaceIdForCwd(`${ROOT}/.`, ROOT)).toBeNull()
+  })
+
+  it('resolves .. before deciding, so a path cannot climb out and still match', () => {
+    expect(workspaceIdForCwd(`${ROOT}/task_A/../../elsewhere`, ROOT)).toBeNull()
+  })
+
+  it('returns null for a relative path', () => {
+    expect(workspaceIdForCwd('task_A/repo', ROOT)).toBeNull()
+  })
+})
+
+describe('collectAncestorPids', () => {
+  it('walks up to the top and stops at launchd', () => {
+    const rows = parseProcessTable([' 10 1 launched-app', ' 11 10 shell', ' 12 11 me'].join('\n'))
+    expect(collectAncestorPids(rows, 12)).toEqual(new Set([11, 10]))
+  })
+
+  it('terminates on a parent cycle', () => {
+    const rows = parseProcessTable([' 10 11 a', ' 11 10 b'].join('\n'))
+    expect(collectAncestorPids(rows, 10)).toEqual(new Set([11, 10]))
+  })
+})
+
+describe('buildWorkspaceStates', () => {
+  it('marks a directory with no task as unowned, and a task with no directory as gone', () => {
+    const states = buildWorkspaceStates(
+      [{ id: 'task_A', status: 'agent_working' }, { id: 'task_gone', status: 'completed' }],
+      ['task_A', 'orphan_dir']
+    )
+    expect(states.get('task_A')).toEqual({ status: 'agent_working', exists: true })
+    expect(states.get('orphan_dir')).toEqual({ exists: true })
+    expect(states.get('task_gone')).toEqual({ status: 'completed', exists: false })
+  })
+})
+
+describe('selectLeakedWorkspaceRoots', () => {
+  const base = (rows: string[], cwdRows: CwdRow[], states: Record<string, { status?: string; exists: boolean }>) => ({
+    rows: parseProcessTable(rows.join('\n')),
+    cwdRows,
+    workspacesRoot: ROOT,
+    ownPid: 10,
+    workspaceState: (id: string) => states[id] ?? { exists: false }
+  })
+
+  it('kills an orphaned watcher rooted in a finished task workspace', () => {
+    const input = base(
+      [' 10 1 20x-main', ' 77531 1 ' + TSX_WATCH],
+      cwds([[77531, WS('task_A', '/workflow-builder/packages/workflow-api')]]),
+      { task_A: { status: 'completed', exists: true } }
+    )
+    expect(selectLeakedWorkspaceRoots(input).map((leak) => leak.pid)).toEqual([77531])
+  })
+
+  it("LEAVES the user's own watcher alone, though its command line is near-identical", () => {
+    // This is the regression that destroys running work. The command matches
+    // `tsx watch` exactly; only the cwd differs, and only the cwd decides.
+    const input = base(
+      [' 10 1 20x-main', ' 4242 1 ' + USER_TSX_WATCH],
+      cwds([[4242, '/Users/dev/Documents/codes/peakflo/sources/other/pf-workflo/packages/workflow-api']]),
+      {}
+    )
+    expect(selectLeakedWorkspaceRoots(input)).toEqual([])
+    expect(selectLeakedWorkspacePids(input)).toEqual([])
+  })
+
+  it('leaves a watcher in a workspace whose task is still being worked on', () => {
+    for (const status of ACTIVE_TASK_STATUSES) {
+      const input = base(
+        [' 10 1 20x-main', ' 500 1 ' + TSX_WATCH],
+        cwds([[500, WS('task_A', '/repo')]]),
+        { task_A: { status, exists: true } }
+      )
+      expect(selectLeakedWorkspaceRoots(input), `status ${status}`).toEqual([])
+    }
+  })
+
+  it('kills a workspace process for a task in ready_for_review — nobody is driving it', () => {
+    const input = base(
+      [' 10 1 20x-main', ' 500 1 ' + TSX_WATCH],
+      cwds([[500, WS('task_A', '/repo')]]),
+      { task_A: { status: 'ready_for_review', exists: true } }
+    )
+    expect(selectLeakedWorkspaceRoots(input).map((leak) => leak.pid)).toEqual([500])
+  })
+
+  it('kills a process whose workspace directory has already been removed', () => {
+    const input = base(
+      [' 10 1 20x-main', ' 500 1 ' + TSX_WATCH],
+      cwds([[500, WS('task_gone', '/repo')]]),
+      { task_gone: { status: 'agent_working', exists: false } }
+    )
+    expect(selectLeakedWorkspaceRoots(input)[0].reason).toContain('workspace directory removed')
+  })
+
+  it('keeps a workspace process held by ANOTHER live 20x instance', () => {
+    // pid 20 is a second instance with a running agent. Its child must survive
+    // our shutdown — the regression the blind pkill caused for MCP servers.
+    const input = base(
+      [' 10 1 20x-ours', ' 20 1 20x-theirs', ' 21 20 ' + TSX_WATCH],
+      cwds([[21, WS('task_A', '/repo')]]),
+      { task_A: { status: 'completed', exists: true } }
+    )
+    expect(selectLeakedWorkspaceRoots(input)).toEqual([])
+  })
+
+  it('kills its own descendant at shutdown, even though the parent is alive', () => {
+    const input = base(
+      [' 10 1 20x-ours', ' 11 10 pnpm', ' 12 11 ' + TSX_WATCH],
+      cwds([[12, WS('task_A', '/repo')]]),
+      { task_A: { status: 'completed', exists: true } }
+    )
+    expect(selectLeakedWorkspaceRoots(input).map((leak) => leak.pid)).toEqual([12])
+  })
+
+  it('never selects itself or an ancestor, even when 20x runs from inside a workspace', () => {
+    // A dev build of 20x is normally checked out into a task workspace, so its
+    // own cwd is under the root. Killing itself or its launcher would be fatal.
+    const input = base(
+      [' 5 1 terminal', ' 10 5 20x-dev-build'],
+      cwds([[5, WS('task_A', '/20x')], [10, WS('task_A', '/20x')]]),
+      { task_A: { status: 'completed', exists: true } }
+    )
+    expect(selectLeakedWorkspaceRoots(input)).toEqual([])
+  })
+
+  it('ignores a process with no readable cwd', () => {
+    const input = base([' 10 1 20x-main', ' 500 1 ' + TSX_WATCH], [], { task_A: { status: 'completed', exists: true } })
+    expect(selectLeakedWorkspaceRoots(input)).toEqual([])
+  })
+})
+
+describe('selectLeakedWorkspacePids', () => {
+  it('takes the whole tree, because the descendants hold the descriptors', () => {
+    // Measured shape: a 49-fd orphaned `node` whose `firefox` child held 449 more.
+    const rows = parseProcessTable(
+      [' 10 1 20x-main', ' 18999 1 node', ' 19102 18999 firefox', ' 19284 19102 plugin-container'].join('\n')
+    )
+    const pids = selectLeakedWorkspacePids({
+      rows,
+      cwdRows: cwds([[18999, WS('task_A', '/cp')], [19102, WS('task_A', '/cp')], [19284, WS('task_A', '/cp')]]),
+      workspacesRoot: ROOT,
+      ownPid: 10,
+      workspaceState: () => ({ status: 'completed', exists: true })
+    })
+    expect(pids).toEqual([18999, 19102, 19284])
+  })
+})
+
+describe('selectPidsRootedInWorkspaces', () => {
+  const rows = parseProcessTable(
+    [' 10 1 20x-main', ' 11 10 pnpm', ' 12 11 ' + TSX_WATCH, ' 20 1 20x-theirs', ' 21 20 ' + TSX_WATCH, ' 42 1 ' + USER_TSX_WATCH].join('\n')
+  )
+  const cwdRows = cwds([
+    [12, WS('task_A', '/repo')],
+    [21, WS('task_A', '/repo')],
+    [42, '/Users/dev/Documents/codes/peakflo/sources/other/pf-workflo']
+  ])
+
+  it('takes every process in the workspace whatever its parent, because the directory is going', () => {
+    expect(selectPidsRootedInWorkspaces({ rows, cwdRows, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_A'] })).toEqual([12, 21])
+  })
+
+  it('still leaves a process outside the root alone', () => {
+    expect(selectPidsRootedInWorkspaces({ rows, cwdRows, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_A'] })).not.toContain(42)
+  })
+
+  it('takes nothing for a workspace that is not being removed', () => {
+    expect(selectPidsRootedInWorkspaces({ rows, cwdRows, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_B'] })).toEqual([])
+  })
+
+  it('never selects itself or an ancestor', () => {
+    const own = parseProcessTable([' 5 1 shell', ' 10 5 20x-dev', ' 12 10 child'].join('\n'))
+    const ownCwds = cwds([[5, WS('task_A')], [10, WS('task_A')], [12, WS('task_A')]])
+    expect(selectPidsRootedInWorkspaces({ rows: own, cwdRows: ownCwds, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_A'] })).toEqual([12])
+  })
+})

--- a/src/main/workspace-process-cleanup.test.ts
+++ b/src/main/workspace-process-cleanup.test.ts
@@ -5,6 +5,8 @@ import {
   workspaceIdForCwd,
   collectAncestorPids,
   buildWorkspaceStates,
+  workspacePressureWarning,
+  WORKSPACE_COUNT_WARN_THRESHOLD,
   selectLeakedWorkspaceRoots,
   selectLeakedWorkspacePids,
   selectPidsRootedInWorkspaces,
@@ -359,5 +361,55 @@ describe('selectPidsRootedInWorkspaces', () => {
     const tree = parseProcessTable([' 10 1 20x-main', ' 900 1 tmux', ' 901 900 nvim'].join('\n'))
     const treeCwds = cwds([[900, WS('task_A')], [901, '/Users/dev/Documents/mynotes']])
     expect(selectPidsRootedInWorkspaces({ rows: tree, cwdRows: treeCwds, workspacesRoot: ROOT, ownPid: 10, workspaceIds: ['task_A'] })).toEqual([900])
+  })
+})
+
+
+describe('workspacePressureWarning', () => {
+  const GiB = 1024 ** 3
+  const roomy = { freeBytes: 500 * GiB, totalBytes: 926 * GiB }
+  // The affected machine on 28 Aug: 39 GiB free of 926 GiB, 96% full.
+  const nearlyFull = { freeBytes: 39 * GiB, totalBytes: 926 * GiB }
+
+  it('says nothing when the count is low and the disk is roomy', () => {
+    expect(workspacePressureWarning({ count: 3, disk: roomy })).toBeNull()
+  })
+
+  it('warns on the count alone, even with plenty of space', () => {
+    const message = workspacePressureWarning({ count: WORKSPACE_COUNT_WARN_THRESHOLD, disk: roomy })
+    expect(message).toContain('100 task workspaces')
+    expect(message).not.toContain('DISK NEARLY FULL')
+  })
+
+  it('warns on low free space even when the count is small', () => {
+    // The count is a weak signal on its own: a handful of very large checkouts
+    // fills a disk just as well as four hundred small ones.
+    const message = workspacePressureWarning({ count: 4, disk: nearlyFull })
+    expect(message).toContain('DISK NEARLY FULL')
+  })
+
+  it('reports the free space beside the count, because the count alone does not say whether the next run fits', () => {
+    const message = workspacePressureWarning({ count: 398, disk: nearlyFull })
+    expect(message).toContain('398 task workspaces')
+    expect(message).toContain('39.0 GiB free of 926.0 GiB (4%)')
+    expect(message).toContain('DISK NEARLY FULL')
+  })
+
+  it('still warns on the count when the disk could not be read', () => {
+    const message = workspacePressureWarning({ count: 398 })
+    expect(message).toContain('398 task workspaces')
+    expect(message).not.toContain('GiB')
+  })
+
+  it('never prints NaN when the volume reports nothing', () => {
+    // My first version of this asserted a low count with a zero total returns
+    // null — which it does whatever the code says, because 0/0 is NaN and the
+    // comparison is false either way. It passed against a deliberately broken
+    // version, so it was replaced with the case that can actually go wrong: a
+    // high count, where the message IS built and must not contain "NaN%".
+    const message = workspacePressureWarning({ count: 398, disk: { freeBytes: 0, totalBytes: 0 } })
+    expect(message).toContain('398 task workspaces')
+    expect(message).not.toContain('NaN')
+    expect(message).not.toContain('DISK NEARLY FULL')
   })
 })

--- a/src/main/workspace-process-cleanup.ts
+++ b/src/main/workspace-process-cleanup.ts
@@ -36,7 +36,7 @@
  */
 
 import { execFileSync } from 'child_process'
-import { existsSync, readlinkSync, realpathSync } from 'fs'
+import { existsSync, readlinkSync, realpathSync, statfsSync } from 'fs'
 import { isAbsolute, normalize, resolve, sep } from 'path'
 import { collectDescendantPids, parseProcessTable, type ProcessRow } from './mcp-process-cleanup'
 
@@ -452,6 +452,17 @@ export function resolveWorkspacesRoot(workspacesRoot: string): string {
   }
 }
 
+/** Free and total bytes on the volume holding `path`, or undefined if unreadable. */
+export function readDiskSpace(path: string): DiskSpace | undefined {
+  try {
+    const stats = statfsSync(path)
+    return { freeBytes: stats.bsize * stats.bavail, totalBytes: stats.bsize * stats.blocks }
+  } catch {
+    // A missing directory or an unsupported filesystem. The count still warns.
+    return undefined
+  }
+}
+
 /** True on platforms where a process's cwd can be read. Windows has no cheap query. */
 export function canReadProcessCwd(): boolean {
   return process.platform !== 'win32'
@@ -538,3 +549,49 @@ export function buildWorkspaceStates(
  * own right, independent of the process leak.
  */
 export const WORKSPACE_COUNT_WARN_THRESHOLD = 100
+
+/**
+ * Warn below this share of the volume free, whatever the workspace count says.
+ *
+ * A count is a weak signal on its own. Measured on the affected machine over
+ * one day: 397 workspaces / 313 GB, then 398 / 315 GB — roughly 2 GB per agent
+ * run, against 39 GiB free on a 926 GiB volume, 96% full. "398 workspaces" does
+ * not convey that; "39 GiB free, 4% of the volume" does, and it is the number
+ * that decides whether the next run succeeds.
+ */
+export const WORKSPACE_FREE_SPACE_WARN_FRACTION = 0.1
+
+/** Volume capacity, when it could be read. */
+export type DiskSpace = { freeBytes: number; totalBytes: number }
+
+function formatGiB(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(1)} GiB`
+}
+
+/**
+ * The line to log about workspace pressure, or null when there is nothing to
+ * say. Pure, so the thresholds are testable without a filesystem.
+ *
+ * Deliberately REPORTS and does not BOUND. Bounding means deleting a user's
+ * checkouts on a rule nobody chose; the retention setting that already exists
+ * (`workspace_autocleanup_enabled`) is the place for that decision, and it
+ * defaults to off. Turning it on silently is not this change's to make.
+ */
+export function workspacePressureWarning(input: { count: number; disk?: DiskSpace }): string | null {
+  const { count, disk } = input
+  const countHigh = count >= WORKSPACE_COUNT_WARN_THRESHOLD
+  // No zero-guard needed on the division: 0/0 is NaN and x/0 is Infinity, and
+  // neither is `< WORKSPACE_FREE_SPACE_WARN_FRACTION`. A guard here would be
+  // dead code that reads as a guard. The one in the message body below is NOT
+  // dead — without it an unreadable volume prints "NaN%".
+  const spaceLow = disk !== undefined && disk.freeBytes / disk.totalBytes < WORKSPACE_FREE_SPACE_WARN_FRACTION
+  if (!countHigh && !spaceLow) return null
+
+  const parts = [`${count} task workspaces on disk, each with its own node_modules`]
+  if (disk !== undefined && disk.totalBytes > 0) {
+    const percent = ((disk.freeBytes / disk.totalBytes) * 100).toFixed(0)
+    parts.push(`${formatGiB(disk.freeBytes)} free of ${formatGiB(disk.totalBytes)} (${percent}%)`)
+  }
+  parts.push('Enable workspace auto-cleanup in Settings')
+  return `${spaceLow ? 'DISK NEARLY FULL. ' : ''}${parts.join('. ')}.`
+}

--- a/src/main/workspace-process-cleanup.ts
+++ b/src/main/workspace-process-cleanup.ts
@@ -188,10 +188,14 @@ export function selectLeakedWorkspaceRoots(input: LeakSelection): LeakedProcess[
   return leaked
 }
 
+/** Adds the descendants of already-selected roots, keeping the same guards. */
+export function expandToProcessTrees(rows: ProcessRow[], roots: readonly number[], ownPid: number): number[] {
+  return withDescendants(rows, roots, protectedPids(rows, ownPid))
+}
+
 /** Every pid to kill: the leaked roots plus their descendants. */
 export function selectLeakedWorkspacePids(input: LeakSelection): number[] {
-  const roots = selectLeakedWorkspaceRoots(input)
-  return withDescendants(input.rows, roots.map((leak) => leak.pid), protectedPids(input.rows, input.ownPid))
+  return expandToProcessTrees(input.rows, selectLeakedWorkspaceRoots(input).map((leak) => leak.pid), input.ownPid)
 }
 
 /**
@@ -278,12 +282,23 @@ export function readProcessSnapshot(): { rows: ProcessRow[]; cwdRows: CwdRow[] }
   return { rows, cwdRows }
 }
 
+/** How long a process gets to honour SIGTERM before SIGKILL. */
+export const DEFAULT_GRACE_MS = 1500
+
+/**
+ * The grace used while quitting. Shorter, because quit latency is visible to
+ * the user and the BOOT sweep is the backstop: anything that ignores SIGTERM
+ * here is collected on the next start, which is the path that has to work
+ * anyway for a force-quit.
+ */
+export const SHUTDOWN_GRACE_MS = 300
+
 /**
  * SIGTERM, a short grace period, then SIGKILL for whatever ignored it.
  * A watcher that traps SIGTERM and keeps its file descriptors is exactly the
  * process this whole module exists to remove.
  */
-export async function terminateProcessTree(pids: readonly number[], graceMs = 2000): Promise<void> {
+export async function terminateProcessTree(pids: readonly number[], graceMs = DEFAULT_GRACE_MS): Promise<void> {
   if (pids.length === 0) return
   for (const pid of pids) {
     try {
@@ -339,6 +354,7 @@ export async function sweepLeakedWorkspaceProcesses(input: {
   workspacesRoot: string
   workspaceState: (workspaceId: string) => WorkspaceState
   ownPid?: number
+  graceMs?: number
 }): Promise<LeakedProcess[]> {
   if (!canReadProcessCwd()) return []
   const ownPid = input.ownPid ?? process.pid
@@ -348,11 +364,11 @@ export async function sweepLeakedWorkspaceProcesses(input: {
   const leaked = selectLeakedWorkspaceRoots(selection)
   if (leaked.length === 0) return []
 
-  const pids = selectLeakedWorkspacePids(selection)
+  const pids = expandToProcessTrees(rows, leaked.map((leak) => leak.pid), ownPid)
   for (const leak of leaked) {
     console.log(`[WorkspaceProcessCleanup] Killing pid ${leak.pid} in workspace ${leak.workspaceId} — ${leak.reason}: ${leak.command.slice(0, 160)}`)
   }
-  await terminateProcessTree(pids)
+  await terminateProcessTree(pids, input.graceMs)
   console.log(`[WorkspaceProcessCleanup] Terminated ${pids.length} process(es) across ${leaked.length} leaked workspace root(s)`)
   return leaked
 }

--- a/src/main/workspace-process-cleanup.ts
+++ b/src/main/workspace-process-cleanup.ts
@@ -1,0 +1,402 @@
+/**
+ * Cleanup of processes left running inside an agent task workspace.
+ *
+ * This is the same defect `mcp-process-cleanup.ts` already fixes for stdio MCP
+ * children, one level further out. A task runs `pnpm dev` (or any long-lived
+ * watcher) inside its workspace. When the session ends, the user stops it, or
+ * 20x is force-quit, the top of the tree dies — `pnpm`, `turbo` — but a
+ * GRANDCHILD such as `tsx watch` survives, is reparented to launchd, and keeps
+ * watching several thousand files for days. Measured on the owner's machine:
+ * two such processes held 20,341 file descriptors, 43% of everything open, and
+ * `next dev` in another repo died with
+ * `Watchpack Error (watcher): Error: EMFILE: too many open files`.
+ *
+ * WHAT MAKES A PROCESS LEAKED — the cwd and the task's state, NEVER the name.
+ * `node`, `tsx` and `next` are also how the user runs their own work. Matching
+ * on the command would kill a developer's own dev server. So the selection here
+ * is:
+ *
+ *   1. the process's cwd is inside a TASK WORKSPACE directory, and
+ *   2. that workspace belongs to a task that is not being worked on, or to no
+ *      task at all, or to a directory that has already been removed, and
+ *   3. the process is either a descendant of THIS 20x instance (so no other
+ *      instance can be using it) or has already lost its parent (ppid 1).
+ *
+ * Rule 3 is copied from `selectKillableMcpPids` for the same reason: two 20x
+ * instances on one machine (a packaged app and a dev build) are normal, and
+ * quitting one must not kill the live children of the other.
+ */
+
+import { execFileSync } from 'child_process'
+import { existsSync, readlinkSync, realpathSync } from 'fs'
+import { isAbsolute, normalize, resolve, sep } from 'path'
+import { collectDescendantPids, parseProcessTable, type ProcessRow } from './mcp-process-cleanup'
+
+export type { ProcessRow }
+
+/** One process and the directory it is running in. */
+export type CwdRow = { pid: number; cwd: string }
+
+/**
+ * Task statuses in which an agent may legitimately be running a process inside
+ * its workspace. Every other status — including `ready_for_review` and
+ * `completed` — means nobody is driving that workspace any more.
+ *
+ * Kept as plain strings so this module stays free of Electron and of the
+ * renderer's constants, and can be unit-tested on its own.
+ */
+export const ACTIVE_TASK_STATUSES: readonly string[] = ['triaging', 'agent_working', 'agent_learning']
+
+/**
+ * Parses `lsof -a -d cwd -n -P -w -F pn` output.
+ *
+ * The field format emits one `p<pid>` line followed by one `n<path>` line per
+ * process. A `p` line with no `n` line (the process exited mid-scan) is
+ * dropped rather than paired with the next process's path.
+ */
+export function parseLsofCwd(lsofOutput: string): CwdRow[] {
+  const rows: CwdRow[] = []
+  let pid: number | null = null
+  for (const line of lsofOutput.split('\n')) {
+    if (line.startsWith('p')) {
+      const parsed = Number(line.slice(1))
+      pid = Number.isInteger(parsed) && parsed > 0 ? parsed : null
+    } else if (line.startsWith('n')) {
+      const path = line.slice(1)
+      if (pid !== null && path.length > 0) rows.push({ pid, cwd: path })
+      pid = null
+    }
+  }
+  return rows
+}
+
+/**
+ * The workspace directory name a cwd sits in, or null when the cwd is not
+ * inside the workspaces root.
+ *
+ * Compared on PATH SEGMENTS, never as a string prefix. `startsWith` would make
+ * `<root>-backup/repo` look like a workspace, and the root itself has no
+ * workspace id — a shell sitting in `<root>` is not rooted in any task.
+ */
+export function workspaceIdForCwd(cwd: string, workspacesRoot: string): string | null {
+  if (!cwd || !workspacesRoot || !isAbsolute(cwd) || !isAbsolute(workspacesRoot)) return null
+
+  const root = normalize(resolve(workspacesRoot))
+  const path = normalize(resolve(cwd))
+  const prefix = root.endsWith(sep) ? root : root + sep
+  if (!path.startsWith(prefix)) return null
+
+  // `resolve` has already collapsed `.` and `..`, and a path equal to the root
+  // failed the prefix check above, so the first segment is always a real name.
+  return path.slice(prefix.length).split(sep)[0]
+}
+
+/** Every ancestor of `pid`, up to the top of the table. */
+export function collectAncestorPids(rows: ProcessRow[], pid: number): Set<number> {
+  const parentOf = new Map<number, number>()
+  for (const row of rows) parentOf.set(row.pid, row.ppid)
+
+  const ancestors = new Set<number>()
+  let current = parentOf.get(pid)
+  while (current !== undefined && current > 1 && !ancestors.has(current)) {
+    ancestors.add(current)
+    current = parentOf.get(current)
+  }
+  return ancestors
+}
+
+/** The pids that must never be signalled: this process and everything above it. */
+function protectedPids(rows: ProcessRow[], ownPid: number): Set<number> {
+  const guarded = collectAncestorPids(rows, ownPid)
+  guarded.add(ownPid)
+  guarded.add(0)
+  guarded.add(1)
+  return guarded
+}
+
+/**
+ * Adds every descendant of each selected pid, so a whole leaked tree goes.
+ *
+ * This matters more than it reads: the orphan measured on the machine was a
+ * 49-fd `node`, but the `firefox` it had spawned held 449 more. Killing only
+ * the matched process leaves the file descriptors behind.
+ */
+function withDescendants(rows: ProcessRow[], roots: Iterable<number>, guarded: Set<number>): number[] {
+  const selected = new Set<number>()
+  for (const root of roots) {
+    if (guarded.has(root)) continue
+    selected.add(root)
+    for (const child of collectDescendantPids(rows, root)) {
+      if (!guarded.has(child)) selected.add(child)
+    }
+  }
+  return [...selected].sort((a, b) => a - b)
+}
+
+/** How the caller answers "is this workspace still in use?". */
+export type WorkspaceState = {
+  /** The task's status, or undefined when no task row matches the directory. */
+  status?: string
+  /** False when the workspace directory itself is gone. */
+  exists: boolean
+}
+
+export type LeakSelection = {
+  rows: ProcessRow[]
+  cwdRows: CwdRow[]
+  workspacesRoot: string
+  ownPid: number
+  /** Looks up the task behind a workspace directory name. */
+  workspaceState: (workspaceId: string) => WorkspaceState
+}
+
+/** A leaked process, kept with its reason so the log can say why it went. */
+export type LeakedProcess = { pid: number; workspaceId: string; reason: string; command: string }
+
+/**
+ * The leaked roots — matched processes only, before their descendants are
+ * added. Exported so a caller can report exactly what it matched and why.
+ */
+export function selectLeakedWorkspaceRoots(input: LeakSelection): LeakedProcess[] {
+  const { rows, cwdRows, workspacesRoot, ownPid, workspaceState } = input
+  const guarded = protectedPids(rows, ownPid)
+  const ourDescendants = collectDescendantPids(rows, ownPid)
+  const cwdByPid = new Map(cwdRows.map((row) => [row.pid, row.cwd]))
+
+  const leaked: LeakedProcess[] = []
+  for (const row of rows) {
+    if (guarded.has(row.pid)) continue
+
+    // Scope: only what this instance owns, or what has already lost its owner.
+    const ours = ourDescendants.has(row.pid)
+    if (!ours && row.ppid !== 1) continue
+
+    const cwd = cwdByPid.get(row.pid)
+    if (!cwd) continue
+    const workspaceId = workspaceIdForCwd(cwd, workspacesRoot)
+    if (!workspaceId) continue
+
+    const state = workspaceState(workspaceId)
+    let reason: string | null = null
+    if (!state.exists) reason = 'workspace directory removed'
+    else if (state.status === undefined) reason = 'no task for this workspace'
+    else if (!ACTIVE_TASK_STATUSES.includes(state.status)) reason = `task ${state.status}`
+    if (!reason) continue
+
+    leaked.push({ pid: row.pid, workspaceId, reason: `${reason}, ${ours ? 'our descendant' : 'orphaned (ppid 1)'}`, command: row.command })
+  }
+  return leaked
+}
+
+/** Every pid to kill: the leaked roots plus their descendants. */
+export function selectLeakedWorkspacePids(input: LeakSelection): number[] {
+  const roots = selectLeakedWorkspaceRoots(input)
+  return withDescendants(input.rows, roots.map((leak) => leak.pid), protectedPids(input.rows, input.ownPid))
+}
+
+/**
+ * Every process rooted in one of `workspaceIds`, whoever its parent is.
+ *
+ * Used when a workspace DIRECTORY is about to be deleted. There the scope rule
+ * above does not apply and must not: the directory is going, so a process still
+ * running in it cannot be left behind, and its parent's identity is irrelevant.
+ * A process must not outlive its workspace.
+ */
+export function selectPidsRootedInWorkspaces(input: {
+  rows: ProcessRow[]
+  cwdRows: CwdRow[]
+  workspacesRoot: string
+  ownPid: number
+  workspaceIds: readonly string[]
+}): number[] {
+  const wanted = new Set(input.workspaceIds)
+  const guarded = protectedPids(input.rows, input.ownPid)
+  const known = new Set(input.rows.map((row) => row.pid))
+
+  const roots: number[] = []
+  for (const { pid, cwd } of input.cwdRows) {
+    if (guarded.has(pid) || !known.has(pid)) continue
+    const workspaceId = workspaceIdForCwd(cwd, input.workspacesRoot)
+    if (workspaceId && wanted.has(workspaceId)) roots.push(pid)
+  }
+  return withDescendants(input.rows, roots, guarded)
+}
+
+// ── Runtime ─────────────────────────────────────────────────
+//
+// Everything above is pure and unit-tested. Below is the thin layer that reads
+// the real process table and signals. It is deliberately free of Electron so
+// the module can be imported from the scheduler and from `index.ts` alike.
+
+/**
+ * lsof is not on the PATH Electron inherits on every machine, so the usual
+ * install locations are tried in turn rather than assumed.
+ */
+const LSOF_CANDIDATES = ['/usr/sbin/lsof', '/usr/bin/lsof', 'lsof'] as const
+
+function readCwdsWithLsof(): CwdRow[] {
+  // `-w` suppresses the warnings lsof prints for directories it cannot read;
+  // without it an ordinary permission notice looks like a failure. `-n` and
+  // `-P` skip DNS and service lookups.
+  const args = ['-a', '-d', 'cwd', '-n', '-P', '-w', '-F', 'pn']
+  let lastError: unknown = new Error('lsof not found')
+  for (const binary of LSOF_CANDIDATES) {
+    try {
+      return parseLsofCwd(execFileSync(binary, args, { encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024 }))
+    } catch (err) {
+      // lsof exits non-zero when any process refused inspection, but still
+      // prints everything it could read. Use that rather than losing the scan.
+      const output = (err as { stdout?: string }).stdout
+      if (typeof output === 'string' && output.length > 0) return parseLsofCwd(output)
+      lastError = err
+    }
+  }
+  throw lastError
+}
+
+/** On Linux the kernel answers directly, with no lsof and no subprocess. */
+function readCwdsFromProc(pids: readonly number[]): CwdRow[] {
+  const rows: CwdRow[] = []
+  for (const pid of pids) {
+    try {
+      rows.push({ pid, cwd: readlinkSync(`/proc/${pid}/cwd`) })
+    } catch {
+      // Exited mid-scan, or owned by another user. Not readable is not leaked.
+    }
+  }
+  return rows
+}
+
+/** Both tables, read once. A full cwd scan measures at ~0.7 s via lsof on macOS. */
+export function readProcessSnapshot(): { rows: ProcessRow[]; cwdRows: CwdRow[] } {
+  const ps = execFileSync('ps', ['-eo', 'pid=,ppid=,command='], {
+    encoding: 'utf-8',
+    maxBuffer: 16 * 1024 * 1024
+  })
+  const rows = parseProcessTable(ps)
+  const cwdRows = existsSync('/proc/self/cwd') ? readCwdsFromProc(rows.map((row) => row.pid)) : readCwdsWithLsof()
+  return { rows, cwdRows }
+}
+
+/**
+ * SIGTERM, a short grace period, then SIGKILL for whatever ignored it.
+ * A watcher that traps SIGTERM and keeps its file descriptors is exactly the
+ * process this whole module exists to remove.
+ */
+export async function terminateProcessTree(pids: readonly number[], graceMs = 2000): Promise<void> {
+  if (pids.length === 0) return
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 'SIGTERM')
+    } catch {
+      // Already gone between the listing and the signal.
+    }
+  }
+  await new Promise((done) => setTimeout(done, graceMs))
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 0) // throws when the process is gone
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      // Gone, which is the outcome we wanted.
+    }
+  }
+}
+
+/**
+ * The workspaces root as the KERNEL spells it.
+ *
+ * Both `lsof` and `/proc/<pid>/cwd` report a cwd with every symlink already
+ * resolved, and the configured root need not be — on macOS `os.tmpdir()` is
+ * `/var/folders/...` while the kernel says `/private/var/folders/...`, and a
+ * home directory can be a symlink too. Comparing the two forms makes every
+ * workspace look OUTSIDE the root, so the sweep finds nothing and reports
+ * success. Found exactly that way: the end-to-end test selected zero processes
+ * while its watcher was plainly running in the workspace it had been given.
+ *
+ * Falls back to the path as given when it does not exist yet — there is then
+ * nothing under it to sweep either way.
+ */
+export function resolveWorkspacesRoot(workspacesRoot: string): string {
+  try {
+    return realpathSync(workspacesRoot)
+  } catch {
+    return workspacesRoot
+  }
+}
+
+/** True on platforms where a process's cwd can be read. Windows has no cheap query. */
+export function canReadProcessCwd(): boolean {
+  return process.platform !== 'win32'
+}
+
+/**
+ * The boot and shutdown sweep. Boot is the important one: these orphans
+ * reparent to launchd, so a shutdown hook alone never sees a machine that was
+ * force-quit or rebooted.
+ */
+export async function sweepLeakedWorkspaceProcesses(input: {
+  workspacesRoot: string
+  workspaceState: (workspaceId: string) => WorkspaceState
+  ownPid?: number
+}): Promise<LeakedProcess[]> {
+  if (!canReadProcessCwd()) return []
+  const ownPid = input.ownPid ?? process.pid
+  const { rows, cwdRows } = readProcessSnapshot()
+  const selection: LeakSelection = { rows, cwdRows, workspacesRoot: resolveWorkspacesRoot(input.workspacesRoot), ownPid, workspaceState: input.workspaceState }
+
+  const leaked = selectLeakedWorkspaceRoots(selection)
+  if (leaked.length === 0) return []
+
+  const pids = selectLeakedWorkspacePids(selection)
+  for (const leak of leaked) {
+    console.log(`[WorkspaceProcessCleanup] Killing pid ${leak.pid} in workspace ${leak.workspaceId} — ${leak.reason}: ${leak.command.slice(0, 160)}`)
+  }
+  await terminateProcessTree(pids)
+  console.log(`[WorkspaceProcessCleanup] Terminated ${pids.length} process(es) across ${leaked.length} leaked workspace root(s)`)
+  return leaked
+}
+
+/** Kills everything rooted in the given workspaces, before their directories go. */
+export async function terminateProcessesInWorkspaces(input: {
+  workspacesRoot: string
+  workspaceIds: readonly string[]
+  ownPid?: number
+}): Promise<number[]> {
+  if (!canReadProcessCwd() || input.workspaceIds.length === 0) return []
+  const ownPid = input.ownPid ?? process.pid
+  const { rows, cwdRows } = readProcessSnapshot()
+  const pids = selectPidsRootedInWorkspaces({ rows, cwdRows, workspacesRoot: resolveWorkspacesRoot(input.workspacesRoot), ownPid, workspaceIds: input.workspaceIds })
+  if (pids.length === 0) return []
+  console.log(`[WorkspaceProcessCleanup] ${pids.length} process(es) still rooted in ${input.workspaceIds.length} workspace(s) being removed: ${pids.join(', ')}`)
+  await terminateProcessTree(pids)
+  return pids
+}
+
+/**
+ * Pairs the workspace directories on disk with the tasks that own them.
+ *
+ * A directory with no task is reported with `status: undefined` (nothing owns
+ * it), and a task whose directory is gone with `exists: false` — both are
+ * leaked states, and a process rooted in either has nothing left to serve.
+ */
+export function buildWorkspaceStates(
+  tasks: readonly { id: string; status: string }[],
+  workspaceDirs: readonly string[]
+): Map<string, WorkspaceState> {
+  const onDisk = new Set(workspaceDirs)
+  const states = new Map<string, WorkspaceState>()
+  for (const dir of onDisk) states.set(dir, { exists: true })
+  for (const task of tasks) {
+    states.set(task.id, { status: task.status, exists: onDisk.has(task.id) })
+  }
+  return states
+}
+
+/**
+ * How many workspaces exist, so an unbounded count is visible rather than
+ * merely felt. Each carries its own `node_modules`; the machine this was found
+ * on had 397 of them holding 313 GB, which is a disk and inode problem in its
+ * own right, independent of the process leak.
+ */
+export const WORKSPACE_COUNT_WARN_THRESHOLD = 100

--- a/src/main/workspace-process-cleanup.ts
+++ b/src/main/workspace-process-cleanup.ts
@@ -123,22 +123,49 @@ function protectedPids(rows: ProcessRow[], ownPid: number): Set<number> {
 }
 
 /**
- * Adds every descendant of each selected pid, so a whole leaked tree goes.
+ * Adds the descendants of each selected pid THAT ARE THEMSELVES ROOTED IN THE
+ * WORKSPACES ROOT, so a whole leaked tree goes but nothing else does.
  *
- * This matters more than it reads: the orphan measured on the machine was a
- * 49-fd `node`, but the `firefox` it had spawned held 449 more. Killing only
- * the matched process leaves the file descriptors behind.
+ * Taking the descendants matters: the orphan measured on the machine was a
+ * 49-fd `node`, but the `firefox` it had spawned held 449 more, and killing
+ * only the matched process leaves 90% of the leak behind.
+ *
+ * Requiring the descendant's OWN cwd to be in the root matters just as much,
+ * and this originally did not. A `tmux` or `screen` server started once inside
+ * a workspace is `ppid 1` by design and is selected when that task finishes —
+ * but its panes are its descendants, and their cwds are wherever the user put
+ * them. Without this check, one finished task took down the user's editor,
+ * their dev server in their own checkout, and any 20x instance launched from
+ * that session, with its running agents. That is the exact catastrophe this
+ * module exists to avoid, arrived at from the other direction.
+ *
+ * A descendant with no readable cwd is left alone: not readable is not leaked.
  */
-function withDescendants(rows: ProcessRow[], roots: Iterable<number>, guarded: Set<number>): number[] {
+function withDescendants(
+  rows: ProcessRow[],
+  roots: Iterable<number>,
+  guarded: Set<number>,
+  isRootedInWorkspaces: (pid: number) => boolean
+): number[] {
   const selected = new Set<number>()
   for (const root of roots) {
     if (guarded.has(root)) continue
     selected.add(root)
     for (const child of collectDescendantPids(rows, root)) {
-      if (!guarded.has(child)) selected.add(child)
+      if (guarded.has(child) || !isRootedInWorkspaces(child)) continue
+      selected.add(child)
     }
   }
   return [...selected].sort((a, b) => a - b)
+}
+
+/** "Is this pid's cwd inside the workspaces root?", as a reusable predicate. */
+function rootedInWorkspaces(cwdRows: readonly CwdRow[], workspacesRoot: string): (pid: number) => boolean {
+  const cwdByPid = new Map(cwdRows.map((row) => [row.pid, row.cwd]))
+  return (pid) => {
+    const cwd = cwdByPid.get(pid)
+    return cwd !== undefined && workspaceIdForCwd(cwd, workspacesRoot) !== null
+  }
 }
 
 /** How the caller answers "is this workspace still in use?". */
@@ -156,6 +183,24 @@ export type LeakSelection = {
   ownPid: number
   /** Looks up the task behind a workspace directory name. */
   workspaceState: (workspaceId: string) => WorkspaceState
+  /**
+   * Whether a parentless process is leaked WHATEVER its task's status says.
+   *
+   * True only for the BOOT sweep, and it is what makes the reported bug
+   * actually get fixed. `stopAllSessions` deliberately preserves task status
+   * across a quit (`agent-manager.ts`: "Don't reset task status during app
+   * shutdown"), and nothing repairs it at startup — so a task that was
+   * force-quit mid-run stays `agent_working` in SQLite FOREVER. Without this,
+   * the watcher it leaked is vetoed by its own stale status on every boot from
+   * then on, and the headline case — "20x is force-quit" — is the one case the
+   * sweep could never collect.
+   *
+   * Sound only at boot, and only for `ppid 1`: this instance has no descendants
+   * yet, so no agent of ours can own the process; and another live instance's
+   * agent children are parented to that instance, not to launchd. Our own
+   * descendants are still judged on task state, so a live session is safe.
+   */
+  orphansIgnoreTaskState?: boolean
 }
 
 /** A leaked process, kept with its reason so the log can say why it went. */
@@ -185,10 +230,18 @@ export function selectLeakedWorkspaceRoots(input: LeakSelection): LeakedProcess[
     if (!workspaceId) continue
 
     const state = workspaceState(workspaceId)
+    const active = state.status !== undefined && ACTIVE_TASK_STATUSES.includes(state.status)
+
     let reason: string | null = null
-    if (!state.exists) reason = 'workspace directory removed'
+    if (active) {
+      // An agent is working here. Nothing else may override that — including a
+      // missing directory, which is far more likely to be a failed listing than
+      // a deleted workspace. The one exception is a parentless process at boot,
+      // where the status itself cannot be trusted (see `orphansIgnoreTaskState`).
+      if (!ours && input.orphansIgnoreTaskState) reason = `task ${state.status} but parentless at startup`
+    } else if (!state.exists) reason = 'workspace directory removed'
     else if (state.status === undefined) reason = 'no task for this workspace'
-    else if (!ACTIVE_TASK_STATUSES.includes(state.status)) reason = `task ${state.status}`
+    else reason = `task ${state.status}`
     if (!reason) continue
 
     leaked.push({ pid: row.pid, workspaceId, reason: `${reason}, ${ours ? 'our descendant' : 'orphaned (ppid 1)'}`, command: row.command })
@@ -197,13 +250,20 @@ export function selectLeakedWorkspaceRoots(input: LeakSelection): LeakedProcess[
 }
 
 /** Adds the descendants of already-selected roots, keeping the same guards. */
-export function expandToProcessTrees(rows: ProcessRow[], roots: readonly number[], ownPid: number): number[] {
-  return withDescendants(rows, roots, protectedPids(rows, ownPid))
+export function expandToProcessTrees(
+  rows: ProcessRow[],
+  cwdRows: readonly CwdRow[],
+  workspacesRoot: string,
+  roots: readonly number[],
+  ownPid: number
+): number[] {
+  return withDescendants(rows, roots, protectedPids(rows, ownPid), rootedInWorkspaces(cwdRows, workspacesRoot))
 }
 
 /** Every pid to kill: the leaked roots plus their descendants. */
 export function selectLeakedWorkspacePids(input: LeakSelection): number[] {
-  return expandToProcessTrees(input.rows, selectLeakedWorkspaceRoots(input).map((leak) => leak.pid), input.ownPid)
+  const roots = selectLeakedWorkspaceRoots(input).map((leak) => leak.pid)
+  return expandToProcessTrees(input.rows, input.cwdRows, input.workspacesRoot, roots, input.ownPid)
 }
 
 /**
@@ -223,6 +283,16 @@ export function selectPidsRootedInWorkspaces(input: {
 }): number[] {
   const wanted = new Set(input.workspaceIds)
   const guarded = protectedPids(input.rows, input.ownPid)
+  // OUR OWN DESCENDANTS ARE PROTECTED HERE, and that is not a detail.
+  // A dev build of 20x is normally checked out INSIDE a task workspace, so the
+  // main process's cwd is that workspace and every child inherits it — the
+  // shared `opencode serve`, the stdio MCP children, git. Protecting only self
+  // and ancestors meant that when that task finally passed the retention
+  // window, the daily cleanup killed the running app's entire subprocess tree,
+  // every live agent session with it, and then deleted the directory underneath.
+  // Whatever we own is the sweep's business, judged on task state; this path
+  // exists for processes we do NOT own.
+  for (const pid of collectDescendantPids(input.rows, input.ownPid)) guarded.add(pid)
   const known = new Set(input.rows.map((row) => row.pid))
 
   const roots: number[] = []
@@ -231,7 +301,7 @@ export function selectPidsRootedInWorkspaces(input: {
     const workspaceId = workspaceIdForCwd(cwd, input.workspacesRoot)
     if (workspaceId && wanted.has(workspaceId)) roots.push(pid)
   }
-  return withDescendants(input.rows, roots, guarded)
+  return withDescendants(input.rows, roots, guarded, rootedInWorkspaces(input.cwdRows, input.workspacesRoot))
 }
 
 // ── Runtime ─────────────────────────────────────────────────
@@ -246,6 +316,16 @@ export function selectPidsRootedInWorkspaces(input: {
  */
 const LSOF_CANDIDATES = ['/usr/sbin/lsof', '/usr/bin/lsof', 'lsof'] as const
 
+/**
+ * Both reads are bounded. The boot sweep is awaited BEFORE the window is
+ * created and the shutdown sweep runs inside a `preventDefault`ed `before-quit`,
+ * so a hang means an app that never appears or never exits. `lsof` in
+ * particular blocks on an unresponsive network mount; `-w` suppresses its
+ * warnings, it does not bound its time. A `try/catch` catches a throw, never a
+ * hang. Healthy cost measured on the affected machine: 0.34 s.
+ */
+const SUBPROCESS_TIMEOUT_MS = 20_000
+
 function readCwdsWithLsof(): CwdRow[] {
   // `-w` suppresses the warnings lsof prints for directories it cannot read;
   // without it an ordinary permission notice looks like a failure. `-n` and
@@ -254,7 +334,7 @@ function readCwdsWithLsof(): CwdRow[] {
   let lastError: unknown = new Error('lsof not found')
   for (const binary of LSOF_CANDIDATES) {
     try {
-      return parseLsofCwd(execFileSync(binary, args, { encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024 }))
+      return parseLsofCwd(execFileSync(binary, args, { encoding: 'utf-8', maxBuffer: 16 * 1024 * 1024, timeout: SUBPROCESS_TIMEOUT_MS }))
     } catch (err) {
       // lsof exits non-zero when any process refused inspection, but still
       // prints everything it could read. Use that rather than losing the scan.
@@ -283,10 +363,26 @@ function readCwdsFromProc(pids: readonly number[]): CwdRow[] {
 export function readProcessSnapshot(): { rows: ProcessRow[]; cwdRows: CwdRow[] } {
   const ps = execFileSync('ps', ['-eo', 'pid=,ppid=,command='], {
     encoding: 'utf-8',
-    maxBuffer: 16 * 1024 * 1024
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: SUBPROCESS_TIMEOUT_MS
   })
   const rows = parseProcessTable(ps)
-  const cwdRows = existsSync('/proc/self/cwd') ? readCwdsFromProc(rows.map((row) => row.pid)) : readCwdsWithLsof()
+  // On Linux `/proc` answers directly. But `hidepid=2`, a container, or another
+  // uid can make every entry unreadable, and an EMPTY cwd table is
+  // indistinguishable from "nothing is leaked" — the sweep would report success
+  // having looked at nothing. Fall back to lsof, and say so if both come back
+  // empty against a non-empty process table.
+  let cwdRows = existsSync('/proc/self/cwd') ? readCwdsFromProc(rows.map((row) => row.pid)) : []
+  if (cwdRows.length === 0) {
+    try {
+      cwdRows = readCwdsWithLsof()
+    } catch (err) {
+      console.warn('[WorkspaceProcessCleanup] Could not read any process cwd:', err)
+    }
+  }
+  if (cwdRows.length === 0 && rows.length > 0) {
+    console.warn(`[WorkspaceProcessCleanup] Read ${rows.length} processes but no cwd for any of them — the sweep can see nothing and is a no-op.`)
+  }
   return { rows, cwdRows }
 }
 
@@ -371,16 +467,26 @@ export async function sweepLeakedWorkspaceProcesses(input: {
   workspaceState: (workspaceId: string) => WorkspaceState
   ownPid?: number
   graceMs?: number
+  /** See `LeakSelection.orphansIgnoreTaskState`. Boot sweep only. */
+  orphansIgnoreTaskState?: boolean
 }): Promise<LeakedProcess[]> {
   if (!canReadProcessCwd()) return []
   const ownPid = input.ownPid ?? process.pid
   const { rows, cwdRows } = readProcessSnapshot()
-  const selection: LeakSelection = { rows, cwdRows, workspacesRoot: resolveWorkspacesRoot(input.workspacesRoot), ownPid, workspaceState: input.workspaceState }
+  const workspacesRoot = resolveWorkspacesRoot(input.workspacesRoot)
+  const selection: LeakSelection = {
+    rows,
+    cwdRows,
+    workspacesRoot,
+    ownPid,
+    workspaceState: input.workspaceState,
+    orphansIgnoreTaskState: input.orphansIgnoreTaskState
+  }
 
   const leaked = selectLeakedWorkspaceRoots(selection)
   if (leaked.length === 0) return []
 
-  const pids = expandToProcessTrees(rows, leaked.map((leak) => leak.pid), ownPid)
+  const pids = expandToProcessTrees(rows, cwdRows, workspacesRoot, leaked.map((leak) => leak.pid), ownPid)
   for (const leak of leaked) {
     console.log(`[WorkspaceProcessCleanup] Killing pid ${leak.pid} in workspace ${leak.workspaceId} — ${leak.reason}: ${leak.command.slice(0, 160)}`)
   }

--- a/src/main/workspace-process-cleanup.ts
+++ b/src/main/workspace-process-cleanup.ts
@@ -25,6 +25,14 @@
  * Rule 3 is copied from `selectKillableMcpPids` for the same reason: two 20x
  * instances on one machine (a packaged app and a dev build) are normal, and
  * quitting one must not kill the live children of the other.
+ *
+ * ONE CONSEQUENCE, STATED SO IT IS NOT A SURPRISE: some processes are `ppid 1`
+ * BY DESIGN, `screen -dm` and `tmux` among them. One started inside a task
+ * workspace whose task has finished is selected. That is intended and follows
+ * from a policy that already exists — 20x deletes those directories on a
+ * schedule, so a service living in one was going to lose its files anyway. This
+ * only makes the process policy agree with the directory policy. A long-lived
+ * service belongs outside the workspaces root.
  */
 
 import { execFileSync } from 'child_process'
@@ -297,6 +305,14 @@ export const SHUTDOWN_GRACE_MS = 300
  * SIGTERM, a short grace period, then SIGKILL for whatever ignored it.
  * A watcher that traps SIGTERM and keeps its file descriptors is exactly the
  * process this whole module exists to remove.
+ *
+ * There is a pid-reuse window of roughly a second between reading the table and
+ * signalling: a selected process could exit and its number be handed to
+ * something else. `kill(pid, 0)` proves a process exists, never that it is the
+ * same one. The exposure is identical to the MCP sweep this copies, it is not
+ * closable without a pidfd (Linux) or a kqueue handle per process, and a second
+ * of window against days of leaked descriptors is the right trade. Written down
+ * rather than engineered around.
  */
 export async function terminateProcessTree(pids: readonly number[], graceMs = DEFAULT_GRACE_MS): Promise<void> {
   if (pids.length === 0) return


### PR DESCRIPTION
## The defect

An agent task runs `pnpm dev` (or any long-lived watcher) inside its workspace. When the session ends, the user stops it, or 20x is force-quit, the top of the tree dies — `pnpm`, `turbo` — but the **grandchild `tsx watch` survives**, launchd adopts it (`ppid = 1`), and it goes on watching ~3,800 files forever. Nothing ever reaped it.

Measured on the owner's machine on 27 Aug:

| pid | started | ppid | open fds | files watched |
|---|---|---|---|---|
| 77531 | Sat 22 Aug 22:34 — **five days earlier** | **1** | 10,161 | 3,816 |
| 74417 | Thu 27 Aug 11:09 | **1** | 10,180 | 3,823 |

**20,341 file descriptors — 43% of everything open on the machine — held by two processes nobody was using.** `next dev` in another repo died with `Watchpack Error (watcher): Error: EMFILE: too many open files`. Killing exactly those two took the machine from 47,800 to 28,307 open files and the errors stopped.

`src/main/mcp-process-cleanup.ts` already fixes this exact shape for stdio MCP children. `workspace-cleanup-scheduler.ts` removes workspace *directories* but never the processes running in them. That gap is the bug, and the fix copies the existing shape rather than inventing one.

## What changed

- **`workspace-process-cleanup.ts`** (new) — pure selection logic plus a thin runtime layer. A process is leaked when **all** of:
  1. its **cwd** is inside a task workspace,
  2. that workspace has **no task**, a task **not being worked on**, or **no directory left**, and
  3. it is **this instance's descendant** or has **already lost its parent** (`ppid 1`) — rule 3 lifted verbatim from `selectKillableMcpPids`, so a second 20x instance keeps the children of its running agents.
- **Boot sweep** (`index.ts`, right after the database opens). **This is the one that matters** — the orphans reparent to launchd, so a shutdown hook alone never sees a machine that was force-quit or rebooted.
- **Shutdown sweep**, beside the MCP one.
- **Workspace cleanup** kills what is rooted in a directory *before* removing it. A process must not outlive its workspace.
- **The workspace count is reported.** 397 clones holding **313 GB** on this machine, each with its own `node_modules`.
- **`workspace-paths.ts`** (new) — one definition of the workspaces root, because two consumers now decide whether a path is inside it. A second copy that drifted would make a process look un-leaked and keep it.

## NEVER by process name

`node`, `tsx` and `next` are also how the user runs their own work — the owner had `pnpm dev` running in `~/Documents/codes/peakflo/sources/other/pf-workflo` throughout. **The cwd and the task's state are what make a process leaked.** Path comparison is on **segments**, never a string prefix: `startsWith` would make `<root>-backup/repo` look like a workspace.

## Three defects found in this code before review

- **A symlinked root silently swept NOTHING.** `lsof` and `/proc/<pid>/cwd` report a cwd with symlinks already resolved; the configured root need not be (`/var/folders/...` vs `/private/var/folders/...`, and a home directory can be a symlink). Comparing the two forms puts *every* workspace outside the root — so the sweep finds nothing and **reports success**. Found only by running it: the end-to-end test selected zero while its watcher was plainly in the workspace it had been given. Closed by `resolveWorkspacesRoot`.
- **A `.`/`..` guard in `workspaceIdForCwd` was unreachable dead code that read as a guard** — `resolve()` had already collapsed both. Removed rather than left to look load-bearing.
- **One parser test passed against a deliberately broken parser.** Replaced with one that discriminates.

## Verification

- **27 unit tests.** Every negative assertion was mutation-tested: **10 of 10 mutations killed** (plain-prefix matching, dropped scope guard, dropped self/ancestor guard, no descendant expansion, last-segment instead of first, ignored active-status list, ignored the wanted set, and three more).
- **6 end-to-end tests against REAL processes and the REAL process table**, nothing mocked — including a watcher **orphaned by a SIGKILLed parent** and then collected by the boot sweep, its `ppid` asserted to be 1 before and its absence from the process table asserted after.
- **A live run on the owner's machine**: 40,317 → 39,023 open files, **18 orphaned processes and 1,294 descriptors reclaimed**, zero survivors — while all **37** of the owner's own `pf-workflo` processes stayed up, one of them also an orphan (`ppid 1`) with a `node dist/cli.js start` command line. Under the most permissive selection possible — all 397 workspaces declared leaked — **zero** of the owner's processes are selected.

`tsc --build --noEmit` clean, `eslint` clean.

**Pre-existing and unrelated:** 9 suites fail locally on `better-sqlite3` bindings that cannot compile in this workspace. Verified pre-existing by stashing every change and re-running — the same suite fails identically on a clean tree.

## One judgement call left to the owner

The rule treats `ready_for_review` as "nobody is driving this", which the reported evidence requires. On the live machine that also selects a `screen -dmS rivetplane-telegram` started by another agent — `screen -dm` is `ppid 1` **by design**. **I held that one back from the live run rather than decide it in passing.** The consequence is worth stating plainly: a long-lived service must not live in a task workspace, because 20x already deletes those directories on a schedule; this change only makes the process policy consistent with the directory policy that already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)