### PR TITLE
fix: stop a deliberate Claude Code abort being reported as a session error

### DIFF
--- a/src/main/adapters/claude-code-adapter.test.ts
+++ b/src/main/adapters/claude-code-adapter.test.ts
@@ -4,6 +4,9 @@ import { describe, it, expect, vi } from 'vitest'
 // Mock the SDK before importing the adapter
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   query: vi.fn(),
+  // The real module exports this; the adapter uses it to tell a deliberate
+  // abort apart from a genuine stream failure.
+  AbortError: class AbortError extends Error {},
 }))
 
 // Mock child_process and fs to avoid real filesystem operations
@@ -1204,5 +1207,83 @@ describe('ClaudeCodeAdapter background-task system messages', () => {
     })
 
     expect(session.backgroundTasks.get('a').startedAt).toBe(oldStart)
+  })
+})
+
+describe('ClaudeCodeAdapter abort classification (regression)', () => {
+  /**
+   * The agent SDK declares `class AbortError extends Error {}` with no `name`
+   * override, so a deliberate abort surfaces as `name: 'Error'` /
+   * `message: 'Operation aborted'`. The old classifier matched neither, so a
+   * normal stop was recorded as a session error.
+   */
+  function sessionThatThrows(err: unknown, opts?: { aborted?: boolean }) {
+    const abortController = new AbortController()
+    if (opts?.aborted !== false) abortController.abort()
+    return {
+      sessionId: 's1',
+      queryIterator: {
+        [Symbol.asyncIterator]() { return this },
+        async next() { throw err },
+      },
+      backgroundTasks: new Map(),
+      sawResult: false,
+      releasePrompt: null,
+      enqueuePrompt: null,
+      abortController,
+      status: 'busy',
+      messageBuffer: [],
+      messageCursor: 0,
+      streamTask: null,
+      lastError: null,
+      config: {} as any,
+      isResumed: false,
+    } as any
+  }
+
+  it('treats the SDK "Operation aborted" error as a normal abort, not a session error', async () => {
+    const adapter = new ClaudeCodeAdapter()
+    const err = new Error('Operation aborted') // name stays 'Error', as the SDK emits it
+    const session = sessionThatThrows(err)
+    ;(adapter as any).sessions.set('s1', session)
+
+    await (adapter as any).consumeStream('s1', session)
+
+    expect(session.status).toBe('idle')
+    expect(session.lastError).toBeNull()
+  })
+
+  it('keeps getStatus IDLE after an abort so polling and the task are not failed', async () => {
+    const adapter = new ClaudeCodeAdapter()
+    const session = sessionThatThrows(new Error('Operation aborted'))
+    ;(adapter as any).sessions.set('s1', session)
+
+    await (adapter as any).consumeStream('s1', session)
+    const status = await adapter.getStatus('s1', {} as any)
+
+    expect(status.type).toBe('idle')
+  })
+
+  it('classifies any stream failure as an abort once the signal is aborted', async () => {
+    const adapter = new ClaudeCodeAdapter()
+    // waitForExit can also reject with the process-exit error during teardown.
+    const session = sessionThatThrows(new Error('Claude Code process terminated by signal SIGTERM'))
+    ;(adapter as any).sessions.set('s1', session)
+
+    await (adapter as any).consumeStream('s1', session)
+
+    expect(session.status).toBe('idle')
+    expect(session.lastError).toBeNull()
+  })
+
+  it('still records a real failure when no abort was requested', async () => {
+    const adapter = new ClaudeCodeAdapter()
+    const session = sessionThatThrows(new Error('socket hang up'), { aborted: false })
+    ;(adapter as any).sessions.set('s1', session)
+
+    await (adapter as any).consumeStream('s1', session)
+
+    expect(session.status).toBe('error')
+    expect(session.lastError).toBe('socket hang up')
   })
 })

--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -1151,6 +1151,41 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
   }
 
   /**
+   * Tells a deliberate abort apart from a real stream failure.
+   *
+   * The SDK's own abort error is `class AbortError extends Error {}` with **no
+   * `name` override**, so `error.name` is the plain string `'Error'`, and the
+   * message it throws from `waitForExit()` is `'Operation aborted'` — neither
+   * `name === 'AbortError'` nor `message.includes('aborted by user')` matches it.
+   * Every user stop, watchdog abort and session teardown therefore fell through
+   * to the generic branch, which set `lastError` and made `getStatus()` report
+   * ERROR forever: the transcript showed a red "Operation aborted" message, the
+   * task flipped to `error`, polling stopped and a false "agent run failed"
+   * event was recorded.
+   *
+   * The signal is the authoritative source: if we asked for the abort, the
+   * failure is expected. The constructor and string checks stay as a safety net
+   * for the case where a new query already replaced the controller.
+   */
+  private isAbortError(error: unknown, session: ClaudeSession): boolean {
+    if (session.abortController?.signal.aborted) return true
+
+    let AbortErrorCtor: (new (msg?: string) => Error) | undefined
+    try {
+      AbortErrorCtor = (ClaudeAgentSDK as { AbortError?: new (msg?: string) => Error } | null)
+        ?.AbortError
+    } catch {
+      // Older SDK builds do not export the class; fall through to the string checks.
+      AbortErrorCtor = undefined
+    }
+    if (AbortErrorCtor && error instanceof AbortErrorCtor) return true
+
+    if (!(error instanceof Error)) return false
+    if (error.name === 'AbortError') return true
+    return error.message.includes('aborted by user') || error.message.includes('Operation aborted')
+  }
+
+  /**
    * Consumes the query stream in the background and buffers messages
    */
   private async consumeStream(sessionId: string, session: ClaudeSession): Promise<void> {
@@ -1321,10 +1356,9 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
       }
       console.log('[ClaudeCodeAdapter] Stream consumption completed normally')
     } catch (error: unknown) {
-      const errName = error instanceof Error ? error.name : ''
       const errMsg = error instanceof Error ? error.message : String(error)
       const errStack = error instanceof Error ? error.stack : undefined
-      if (errName === 'AbortError' || errMsg.includes('aborted by user')) {
+      if (this.isAbortError(error, session)) {
         console.log('[ClaudeCodeAdapter] Stream aborted by user')
         // Don't set error status - this is normal when sending a new message
       } else if (errMsg.includes('INCOMPATIBLE_SESSION_ID')) {


### PR DESCRIPTION
## Problem

Reported from the logs:

```
[ClaudeCodeAdapter] Stream error: ot [Error]: Operation aborted
    at ChildProcess.r (…/@anthropic-ai/claude-agent-sdk/sdk.mjs:60:11661)
```

`ot` is the SDK's `AbortError`. It is **not** a failure — it is what the SDK throws when *we* abort the query.

## Root cause

The SDK declares the class with no `name` override:

```js
class ot extends Error {}          // sdk.mjs
export { …, ot as AbortError }
```

so `error.name` is the plain string `'Error'`. And `ProcessTransport.waitForExit()` rejects with:

```js
if (this.abortController.signal.aborted) { t(new ot("Operation aborted")); return }
```

The classifier in `consumeStream()` tested for neither shape:

```ts
if (errName === 'AbortError' || errMsg.includes('aborted by user')) { … }
```

`'Error' !== 'AbortError'`, and `'Operation aborted'` does not contain `'aborted by user'`. So **every** deliberate abort fell through to the generic `else` branch and set `session.status = 'error'` / `session.lastError = 'Operation aborted'`.

## Why that hurts

`getStatus()` returns ERROR whenever `lastError` is set — before it looks at `session.status`:

```ts
if (session.lastError) return { type: SessionStatusType.ERROR, message: session.lastError }
```

`abortPrompt()` sets the status back to `'idle'` but never clears `lastError`, so the wrong verdict is sticky until the next prompt. On the next poll, `agent-manager`:

- pushes a red `Operation aborted` system message into the transcript,
- sets the session to `error` and emits `agent:status → error`,
- calls `stopAdapterPolling(sessionId)`,
- records an enterprise sync event with `success: false`.

Every abort path is affected: the user stop button, the garbled-output watchdog, the stuck-session watchdog, the idle reaper, and the legacy recovery path in `sendPrompt()` — the path from #446.

## Fix

Classify from the abort signal, which is authoritative: if we asked for the abort, the failure is expected. An `instanceof AbortError` check (the class is exported at runtime) and the two original string checks stay as a safety net for the case where a new query already replaced the controller.

## Tests

Four regression tests in `claude-code-adapter.test.ts`. Three of them fail on `main` and pass with this change; the fourth guards the other direction — a stream failure with no abort requested is still recorded as an error.

```
Tests  57 passed (57)        # with the fix
Tests   3 failed | 54 passed # without it
```

`tsc --noEmit -p tsconfig.node.json` and `eslint` are both clean. The DB test files fail in this workspace for an unrelated reason (`better-sqlite3` bindings are not built here).

## Relation to #446

Adjacent, not the same. #446 is about the abort *killing background subagents*; this is about the abort being *reported as a failure*. #446 remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
