### PR TITLE
fix: canvas zoom buttons keep the screen center fixed instead of jumping

### DIFF
--- a/src/renderer/src/components/canvas/CanvasMinimap.test.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { render, cleanup } from '@testing-library/react'
+import { render, cleanup, fireEvent } from '@testing-library/react'
 import { CanvasMinimap } from './CanvasMinimap'
 import { useCanvasStore, type CanvasPanelData } from '@/stores/canvas-store'
+import { setLiveViewport } from '@/stores/canvas-live-viewport'
 import { useDrawingStore } from '@/stores/drawing-store'
 import type { DrawingObject } from './drawing/types'
 
@@ -109,5 +110,50 @@ describe('CanvasMinimap', () => {
     expect(x).toBeLessThanOrEqual(180 - 12)
     expect(y).toBeGreaterThanOrEqual(12)
     expect(y).toBeLessThanOrEqual(120 - 12)
+  })
+
+  /** Emulate InfiniteCanvas re-publishing the live viewport after a store write. */
+  const syncLiveViewport = () => setLiveViewport(useCanvasStore.getState().viewport)
+
+  it('zoom buttons zoom around the container center, keeping it fixed', () => {
+    // Pan so the canvas origin is nowhere near the container center.
+    useCanvasStore.setState({ panels: [makePanel()], viewport: { x: 120, y: 90, zoom: 1 } })
+    syncLiveViewport()
+    const { container } = render(<CanvasMinimap containerWidth={800} containerHeight={600} />)
+
+    const clickZoom = (title: string) => {
+      const btn = [...container.querySelectorAll('button')].find(
+        (b) => b.getAttribute('title') === title
+      )
+      expect(btn).toBeTruthy()
+      fireEvent.click(btn!)
+      syncLiveViewport()
+    }
+
+    clickZoom('Zoom in (Ctrl+=)')
+    let vp = useCanvasStore.getState().viewport
+    expect(vp.zoom).toBeCloseTo(1.2)
+    // The canvas point under the container center (400, 300) must not move.
+    expect((400 - vp.x) / vp.zoom).toBeCloseTo(280)
+    expect((300 - vp.y) / vp.zoom).toBeCloseTo(210)
+
+    clickZoom('Zoom out (Ctrl+-)')
+    vp = useCanvasStore.getState().viewport
+    expect(vp.zoom).toBeCloseTo(1)
+    expect((400 - vp.x) / vp.zoom).toBeCloseTo(280)
+    expect((300 - vp.y) / vp.zoom).toBeCloseTo(210)
+  })
+
+  it('zoom slider keeps the container center fixed', () => {
+    useCanvasStore.setState({ panels: [makePanel()], viewport: { x: 120, y: 90, zoom: 1 } })
+    const { container } = render(<CanvasMinimap containerWidth={800} containerHeight={600} />)
+    const slider = container.querySelector('input[type="range"]') as HTMLInputElement
+    expect(slider).toBeTruthy()
+
+    fireEvent.change(slider, { target: { value: '200' } })
+    const vp = useCanvasStore.getState().viewport
+    expect(vp.zoom).toBe(2)
+    expect((400 - vp.x) / vp.zoom).toBeCloseTo(280)
+    expect((300 - vp.y) / vp.zoom).toBeCloseTo(210)
   })
 })

--- a/src/renderer/src/components/canvas/CanvasMinimap.tsx
+++ b/src/renderer/src/components/canvas/CanvasMinimap.tsx
@@ -330,6 +330,21 @@ function CanvasMinimapComponent({
     return map
   }, [tasks])
 
+  // Zoom toward the center of the canvas container so step-zooms and slider
+  // drags keep the content the user is looking at fixed instead of anchoring
+  // the canvas to its top-left corner. Skipped before the container has been
+  // measured (0×0) — the store keeps x/y then.
+  const zoomAroundCenter = useCallback(
+    (zoom: number) => {
+      if (containerWidth > 0 && containerHeight > 0) {
+        zoomTo(zoom, containerWidth / 2, containerHeight / 2)
+      } else {
+        zoomTo(zoom)
+      }
+    },
+    [containerWidth, containerHeight, zoomTo]
+  )
+
   const zoomPercent = Math.round(viewport.zoom * 100)
 
   // Union box of the drawing figures (canvas space) — merged into the
@@ -445,7 +460,13 @@ function CanvasMinimapComponent({
           <div className="flex items-center justify-between px-1.5 py-1 border-t border-border/20">
             <button
               className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
-              onClick={(e) => { e.stopPropagation(); zoomTo(viewport.zoom / 1.2) }}
+              onClick={(e) => {
+                e.stopPropagation()
+                // Live zoom — a wheel gesture may still be in flight and not
+                // yet committed to the store.
+                const liveZoom = getLiveViewport().zoom || viewport.zoom
+                zoomAroundCenter(liveZoom / 1.2)
+              }}
               title="Zoom out (Ctrl+-)"
             >
               <Minus className="h-3 w-3" />
@@ -460,7 +481,7 @@ function CanvasMinimapComponent({
               value={viewport.zoom * 100}
               onChange={(e) => {
                 e.stopPropagation()
-                zoomTo(Number(e.target.value) / 100)
+                zoomAroundCenter(Number(e.target.value) / 100)
               }}
               className="flex-1 mx-1.5 h-1 accent-indigo-500 cursor-pointer"
               style={{ opacity: 0.5 }}
@@ -469,7 +490,11 @@ function CanvasMinimapComponent({
 
             <button
               className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
-              onClick={(e) => { e.stopPropagation(); zoomTo(viewport.zoom * 1.2) }}
+              onClick={(e) => {
+                e.stopPropagation()
+                const liveZoom = getLiveViewport().zoom || viewport.zoom
+                zoomAroundCenter(liveZoom * 1.2)
+              }}
               title="Zoom in (Ctrl+=)"
             >
               <Plus className="h-3 w-3" />

--- a/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.test.tsx
@@ -318,6 +318,81 @@ describe('InfiniteCanvas', () => {
     expect(viewport).toEqual({ x: 0, y: 0, zoom: 1 })
   })
 
+  /** ResizeObserver mock that reports an 800×600 canvas container. */
+  const mockMeasuredContainer = () => {
+    const originalResizeObserver = globalThis.ResizeObserver
+    globalThis.ResizeObserver = class {
+      private callback: ResizeObserverCallback
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback
+      }
+      observe() {
+        this.callback([{ contentRect: { width: 800, height: 600 } } as ResizeObserverEntry], this as ResizeObserver)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    return () => {
+      globalThis.ResizeObserver = originalResizeObserver
+    }
+  }
+
+  /** Canvas-space point displayed at the container center for a viewport. */
+  const canvasPointAtCenter = (vp: { x: number; y: number; zoom: number }) => ({
+    x: (400 - vp.x) / vp.zoom,
+    y: (300 - vp.y) / vp.zoom,
+  })
+
+  it('zoom buttons keep the screen center fixed instead of anchoring the top-left corner', () => {
+    const restore = mockMeasuredContainer()
+    try {
+      // Pan so the canvas origin is nowhere near the screen center.
+      useCanvasStore.getState().setViewport({ x: 120, y: 90, zoom: 1 })
+      render(<InfiniteCanvas />)
+
+      const before = useCanvasStore.getState().viewport
+      const point = canvasPointAtCenter(before)
+      expect(point).toEqual({ x: 280, y: 210 })
+
+      fireEvent.click(screen.getByTitle('Zoom in'))
+      const afterIn = useCanvasStore.getState().viewport
+      expect(afterIn.zoom).toBeCloseTo(1.2)
+      // The canvas point under the screen center must not move.
+      expect(canvasPointAtCenter(afterIn).x).toBeCloseTo(point.x)
+      expect(canvasPointAtCenter(afterIn).y).toBeCloseTo(point.y)
+
+      fireEvent.click(screen.getByTitle('Zoom out'))
+      const afterOut = useCanvasStore.getState().viewport
+      expect(afterOut.zoom).toBeCloseTo(1)
+      expect(canvasPointAtCenter(afterOut).x).toBeCloseTo(point.x)
+      expect(canvasPointAtCenter(afterOut).y).toBeCloseTo(point.y)
+    } finally {
+      restore()
+    }
+  })
+
+  it('Ctrl+= / Ctrl+- zoom around the screen center', () => {
+    const restore = mockMeasuredContainer()
+    try {
+      useCanvasStore.getState().setViewport({ x: 120, y: 90, zoom: 1 })
+      render(<InfiniteCanvas />)
+
+      fireEvent.keyDown(window, { code: 'Equal', ctrlKey: true })
+      const afterIn = useCanvasStore.getState().viewport
+      expect(afterIn.zoom).toBeCloseTo(1.2)
+      expect(canvasPointAtCenter(afterIn).x).toBeCloseTo(280)
+      expect(canvasPointAtCenter(afterIn).y).toBeCloseTo(210)
+
+      fireEvent.keyDown(window, { code: 'Minus', ctrlKey: true })
+      const afterOut = useCanvasStore.getState().viewport
+      expect(afterOut.zoom).toBeCloseTo(1)
+      expect(canvasPointAtCenter(afterOut).x).toBeCloseTo(280)
+      expect(canvasPointAtCenter(afterOut).y).toBeCloseTo(210)
+    } finally {
+      restore()
+    }
+  })
+
   it('should render panels with close buttons', () => {
     useCanvasStore.getState().addPanel({
       type: 'task',

--- a/src/renderer/src/components/canvas/InfiniteCanvas.tsx
+++ b/src/renderer/src/components/canvas/InfiniteCanvas.tsx
@@ -576,6 +576,28 @@ export function InfiniteCanvas() {
     viewportRafRef.current = requestAnimationFrame(flushViewportUpdate)
   }, [flushViewportUpdate])
 
+  /**
+   * Step-zoom in/out by `factor` around the center of the visible canvas area.
+   * Used by the HUD zoom buttons and the Ctrl/Cmd = / − shortcuts: zooming
+   * without an anchor point keeps the top-left corner fixed, which makes the
+   * content the user is looking at jump across the screen instead of zooming
+   * in place.
+   */
+  const zoomStep = useCallback(
+    (factor: number) => {
+      // Flush any in-flight wheel gesture so we zoom from what's on screen.
+      commitViewport()
+      const zoom = liveViewportRef.current.zoom * factor
+      const { width, height } = containerSize
+      if (width > 0 && height > 0) {
+        zoomTo(zoom, width / 2, height / 2)
+      } else {
+        zoomTo(zoom)
+      }
+    },
+    [commitViewport, containerSize, zoomTo]
+  )
+
   const queuePan = useCallback(
     (dx: number, dy: number) => {
       pendingPanRef.current.dx += dx
@@ -804,13 +826,11 @@ export function InfiniteCanvas() {
       // first so we zoom from the value the user is actually looking at.
       if (e.code === 'Equal' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
-        commitViewport()
-        zoomTo(liveViewportRef.current.zoom * 1.2)
+        zoomStep(1.2)
       }
       if (e.code === 'Minus' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
-        commitViewport()
-        zoomTo(liveViewportRef.current.zoom / 1.2)
+        zoomStep(1 / 1.2)
       }
       if (e.code === 'Digit0' && (e.ctrlKey || e.metaKey) && !isInputFocused) {
         e.preventDefault()
@@ -927,7 +947,7 @@ export function InfiniteCanvas() {
       window.removeEventListener('keyup', handleKeyUp)
       window.removeEventListener('blur', handleBlur)
     }
-  }, [zoomTo, resetViewport, focusedPanelIndex, commitViewport, setConnectingFromId])
+  }, [zoomStep, resetViewport, focusedPanelIndex, commitViewport, setConnectingFromId])
 
   const zoomPercent = Math.round(viewport.zoom * 100)
 
@@ -1047,7 +1067,7 @@ export function InfiniteCanvas() {
           variant="ghost"
           size="sm"
           className="h-7 w-7 p-0"
-          onClick={() => zoomTo(viewport.zoom / 1.2)}
+          onClick={() => zoomStep(1 / 1.2)}
           title="Zoom out"
         >
           <ZoomOut className="h-3.5 w-3.5" />
@@ -1059,7 +1079,7 @@ export function InfiniteCanvas() {
           variant="ghost"
           size="sm"
           className="h-7 w-7 p-0"
-          onClick={() => zoomTo(viewport.zoom * 1.2)}
+          onClick={() => zoomStep(1.2)}
           title="Zoom in"
         >
           <ZoomIn className="h-3.5 w-3.5" />


### PR DESCRIPTION
# Fix: canvas zoom buttons now keep the screen center fixed

## Problem

When using the zoom buttons on the canvas (the `−`/`+` controls at the bottom-left, the minimap zoom buttons and slider, or the `Ctrl/Cmd =` / `Ctrl/Cmd -` keyboard shortcuts), the canvas content **jumped across the screen** instead of zooming in/out in place.

## Root cause

The canvas renders content with `transform: translate(x, y) scale(zoom)` (`transformOrigin: 0 0`). The store's `zoomTo(zoom, centerX?, centerY?)` only adjusts `x`/`y` to keep an anchor point fixed when the center coordinates are passed — otherwise it keeps `x`/`y` untouched and just changes `zoom`, which anchors the **top-left corner** of the canvas.

All button/slider/keyboard zoom paths called `zoomTo` **without** an anchor point, so the canvas point the user was looking at (typically the screen center) flew off, making the zoom feel like a jump:

```tsx
// before — no anchor: top-left corner stays fixed, content jumps
onClick={() => zoomTo(viewport.zoom * 1.2)}
```

The wheel/pinch path (`zoomViewportAtPoint`) already zoomed around the cursor, and the remote `set_canvas_view` zoom command already passed `rect.width/2, rect.height/2` — only the buttons, slider and keyboard shortcuts were missing the anchor.

## Fix

Anchor all step-zoom controls to the **center of the visible canvas area**:

- **`InfiniteCanvas.tsx`** — new `zoomStep(factor)` helper: flushes any in-flight wheel gesture (`commitViewport()`), reads the live zoom, and calls `zoomTo(zoom, containerSize.width / 2, containerSize.height / 2)`. Used by the HUD zoom in/out buttons and the `Ctrl/Cmd =` / `Ctrl/Cmd -` keyboard shortcuts.
- **`CanvasMinimap.tsx`** — new `zoomAroundCenter(zoom)` helper passing `containerWidth / 2, containerHeight / 2` to `zoomTo`. Used by both minimap zoom buttons and the zoom slider. The buttons read the live zoom (`getLiveViewport()`) like the minimap pan path already did.

Math: the canvas point under the screen center `p = (center − x) / zoom` is preserved across the zoom, so what you're looking at stays put — matching the pinch-to-zoom feel.

## Tests

- `InfiniteCanvas.test.tsx`: HUD zoom in/out buttons and `Ctrl+=`/`Ctrl+-` keep the canvas point under the screen center fixed (verified the tests fail without the fix — old behavior moves the center point from 280→233.33).
- `CanvasMinimap.test.tsx`: minimap zoom buttons and the zoom slider keep the container center fixed.

Full suite: 166 files / 2623 tests passing, `typecheck`, `lint` and `build` green.
