### PR TITLE
G1 · Honour the per-agent permission mode in the Claude Code adapter

### DIFF
--- a/src/main/adapters/claude-code-adapter.test.ts
+++ b/src/main/adapters/claude-code-adapter.test.ts
@@ -13,6 +13,9 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
 vi.mock('child_process', () => ({ execFile: vi.fn() }))
 vi.mock('fs', () => ({ existsSync: vi.fn(() => false) }))
 
+// Same mocked `query` the adapter resolves through its dynamic import, so tests
+// can inspect exactly what the adapter handed the SDK.
+import { query } from '@anthropic-ai/claude-agent-sdk'
 import { ClaudeCodeAdapter, ClaudeSystemSubtype } from './claude-code-adapter'
 import { MessagePartType } from './coding-agent-adapter'
 
@@ -1285,5 +1288,127 @@ describe('ClaudeCodeAdapter abort classification (regression)', () => {
 
     expect(session.status).toBe('error')
     expect(session.lastError).toBe('socket hang up')
+  })
+})
+
+/**
+ * DEFECT G1 — the adapter must ACTUALLY CONSULT `claudeCodePermissionMode`.
+ *
+ * `permission-mode.test.ts` pins the pure function, but a pure function nobody
+ * calls fixes nothing: the defect was a hardcoded
+ *
+ *     permissionMode: 'bypassPermissions',
+ *     allowDangerouslySkipPermissions: true,
+ *
+ * sitting in `sendPrompt`'s options object. So these tests drive the REAL
+ * `adapter.sendPrompt(...)` and assert on the options the SDK's `query` was
+ * actually handed. Re-introducing the hardcode fails all four of them.
+ *
+ * Deliberately NOT the shape used by 'sendPrompt session continuation mode'
+ * above, which re-implements the adapter's branching inside the test body and
+ * then asserts on its own local object — that can never fail for a change made
+ * in the adapter.
+ */
+describe('sendPrompt permission mode (defect G1)', () => {
+  /**
+   * Runs the real `sendPrompt` against the mocked SDK and returns the `options`
+   * object `query` received.
+   *
+   * Nothing private is stubbed. The one piece of pre-set state is
+   * `claudeExecutablePath`, the adapter's OWN memoised result for
+   * `findClaudeExecutable()`; priming that cache is what stops the lookup from
+   * shelling out to `which claude` (whose `child_process.execFile` is mocked
+   * file-wide to a `vi.fn()` that never invokes its callback, so the promise
+   * would hang forever). The permission-mode code under test runs untouched.
+   */
+  async function captureQueryOptions(config: any): Promise<any> {
+    const queryMock = vi.mocked(query) as any
+    queryMock.mockClear()
+    // An async-iterable that ends immediately, so consumeStream drains and the
+    // stream task settles without a real Claude Code process.
+    queryMock.mockImplementation(() => ({
+      async *[Symbol.asyncIterator]() {
+        // no messages: the turn ends the moment it starts
+      },
+    }))
+
+    const adapter = new ClaudeCodeAdapter()
+    await (adapter as any).ensureSDKLoaded()
+    ;(adapter as any).claudeExecutablePath = '/usr/local/bin/claude'
+
+    const session: any = {
+      sessionId: '',
+      queryIterator: null,
+      abortController: null,
+      status: 'idle',
+      messageBuffer: [],
+      messageCursor: 0,
+      streamTask: null,
+      lastError: null,
+      config,
+      isResumed: false,
+      backgroundTasks: new Map(),
+      sawResult: false,
+      enqueuePrompt: null,
+      releasePrompt: null,
+    }
+    ;(adapter as any).sessions.set('s1', session)
+
+    await adapter.sendPrompt('s1', [{ type: MessagePartType.TEXT, text: 'hello' }] as any, config)
+    await session.streamTask
+
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    return queryMock.mock.calls[0][0].options
+  }
+
+  it("passes 'default' and NO bypass flag for permissionMode 'ask'", async () => {
+    const options = await captureQueryOptions({
+      agentId: 'a',
+      taskId: 't',
+      workspaceDir: '/tmp/ws',
+      permissionMode: 'ask',
+    })
+
+    expect(options.permissionMode).toBe('default')
+    // The flag must be ABSENT, not merely falsy: the SDK treats its presence as
+    // consent, so a hardcoded `true` here would make the mode decorative.
+    expect(options.allowDangerouslySkipPermissions).toBeUndefined()
+    expect(Object.prototype.hasOwnProperty.call(options, 'allowDangerouslySkipPermissions')).toBe(false)
+  })
+
+  it("passes 'bypassPermissions' WITH the bypass flag for permissionMode 'allow'", async () => {
+    const options = await captureQueryOptions({
+      agentId: 'a',
+      taskId: 't',
+      workspaceDir: '/tmp/ws',
+      permissionMode: 'allow',
+    })
+
+    expect(options.permissionMode).toBe('bypassPermissions')
+    expect(options.allowDangerouslySkipPermissions).toBe(true)
+  })
+
+  it("passes 'plan' for permissionMode 'ask' with a read-only sandbox", async () => {
+    const options = await captureQueryOptions({
+      agentId: 'a',
+      taskId: 't',
+      workspaceDir: '/tmp/ws',
+      permissionMode: 'ask',
+      sandboxMode: 'read-only',
+    })
+
+    expect(options.permissionMode).toBe('plan')
+    expect(options.allowDangerouslySkipPermissions).toBeUndefined()
+  })
+
+  it("never reaches 'bypassPermissions' from a config that sets no permission mode", async () => {
+    // THE ANTI-REGRESSION ASSERTION. Omission is exactly the pre-G1 state; it
+    // must resolve to Claude Code's own asking mode, never back to the bypass.
+    const options = await captureQueryOptions({ agentId: 'a', taskId: 't', workspaceDir: '/tmp/ws' })
+
+    expect(options.permissionMode).toBe('default')
+    expect(options.permissionMode).not.toBe('bypassPermissions')
+    expect(options.allowDangerouslySkipPermissions).toBeUndefined()
+    expect(Object.prototype.hasOwnProperty.call(options, 'allowDangerouslySkipPermissions')).toBe(false)
   })
 })

--- a/src/main/adapters/claude-code-adapter.ts
+++ b/src/main/adapters/claude-code-adapter.ts
@@ -17,6 +17,7 @@ import type {
   MessagePart,
 } from './coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './coding-agent-adapter'
+import { claudeCodePermissionMode } from './permission-mode'
 
 type ClaudeSDK = typeof import('@anthropic-ai/claude-agent-sdk')
 type Query = import('@anthropic-ai/claude-agent-sdk').Query
@@ -752,6 +753,8 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
     // Build options
     const secretHooks = this.buildSecretHooks(config)
     const effort = config.reasoningEffort === 'minimal' ? undefined : config.reasoningEffort
+    const claudePermissionMode = claudeCodePermissionMode(config)
+
     const options: Options = {
       cwd: config.workspaceDir,
       pathToClaudeCodeExecutable: claudePath,
@@ -761,8 +764,38 @@ export class ClaudeCodeAdapter implements CodingAgentAdapter {
       effort,
       systemPrompt: config.systemPrompt,
       abortController,
-      permissionMode: 'bypassPermissions', // Auto-approve all actions (user has already chosen to run agent)
-      allowDangerouslySkipPermissions: true, // Required for bypassPermissions mode
+      /*
+       * DEFECT G1 WAS BORN ON THIS LINE.
+       *
+       * It used to read:
+       *     permissionMode: 'bypassPermissions', // Auto-approve all actions
+       *     allowDangerouslySkipPermissions: true,
+       *
+       * — a hardcode, with the per-agent `permission_mode` sitting unread in
+       * the config that was passed in. Every agent ran fully unrestricted no
+       * matter what the user chose, while the UI showed them their choice.
+       *
+       * The comment justified it with "the user has already chosen to run
+       * agent". That was true of 20x's ORIGINAL shape, where the agent ran on
+       * the user's own laptop with the user watching. It stopped being true the
+       * moment the same adapter ran unattended in a cloud sandbox with a real
+       * filesystem, which is the whole point of the sandbox.
+       *
+       * `claudeCodePermissionMode` reconstructs the user's original four-valued
+       * choice from the (permissionMode, sandboxMode) pair the runner mapped it
+       * onto — see ./permission-mode.ts for the table. Claude Code is the one
+       * backend that takes all four natively, so nothing is lost here.
+       *
+       * A config with NO permissionMode maps to 'default', NOT to
+       * 'bypassPermissions'. That is deliberate: the old behaviour must not be
+       * reachable by omission, or every caller that forgets the field silently
+       * restores the defect.
+       */
+      permissionMode: claudePermissionMode,
+      // ONLY for the mode that actually asks for it. The SDK requires this flag
+      // to honour 'bypassPermissions'; passing it unconditionally would make
+      // the mode above decorative in exactly the way G1 was.
+      ...(claudePermissionMode === 'bypassPermissions' ? { allowDangerouslySkipPermissions: true } : {}),
       ...(secretHooks ? { hooks: secretHooks } : {}),
     }
 

--- a/src/main/adapters/permission-mode.test.ts
+++ b/src/main/adapters/permission-mode.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { claudeCodePermissionMode } from './permission-mode'
+
+/**
+ * DEFECT G1 IN 20x: `claude-code-adapter.ts` hardcoded
+ * `permissionMode: 'bypassPermissions'` and `allowDangerouslySkipPermissions: true`,
+ * so every Claude Code session ran fully unrestricted no matter what the user
+ * had chosen — while `agent-manager.ts` had been passing the real per-agent
+ * setting into the config all along, at three separate call sites.
+ *
+ * These tests pin the resolution that replaced the hardcode.
+ */
+describe('claudeCodePermissionMode', () => {
+  it('resolves an explicit allow to a real bypass', () => {
+    expect(claudeCodePermissionMode({ permissionMode: 'allow' })).toBe('bypassPermissions')
+    // sandboxMode must not be able to talk it out of the user's explicit choice.
+    expect(claudeCodePermissionMode({ permissionMode: 'allow', sandboxMode: 'read-only' })).toBe(
+      'bypassPermissions'
+    )
+  })
+
+  it('resolves ask + read-only to plan, and ask + workspace-write to default', () => {
+    expect(claudeCodePermissionMode({ permissionMode: 'ask', sandboxMode: 'read-only' })).toBe('plan')
+    expect(claudeCodePermissionMode({ permissionMode: 'ask', sandboxMode: 'workspace-write' })).toBe(
+      'default'
+    )
+  })
+
+  /**
+   * THE ASSERTION THAT MATTERS MOST.
+   *
+   * If an absent mode resolved back to `bypassPermissions`, then every caller
+   * that forgot to set the field would silently restore the defect — and the
+   * restoration would be invisible, because the observable behaviour would be
+   * identical to the code we just deleted.
+   */
+  it('NEVER resolves an absent mode to a bypass', () => {
+    expect(claudeCodePermissionMode({})).toBe('default')
+    expect(claudeCodePermissionMode({ permissionMode: 'ask' })).toBe('default')
+    expect(claudeCodePermissionMode({ sandboxMode: 'workspace-write' })).toBe('default')
+    expect(claudeCodePermissionMode({ sandboxMode: 'danger-full-access' })).toBe('default')
+  })
+
+  it('is total — every input yields a defined mode, and only allow yields a bypass', () => {
+    const inputs = [
+      {},
+      { permissionMode: 'ask' as const },
+      { permissionMode: 'allow' as const },
+      { sandboxMode: 'read-only' as const },
+      { sandboxMode: 'workspace-write' as const },
+      { sandboxMode: 'danger-full-access' as const },
+      { permissionMode: 'ask' as const, sandboxMode: 'danger-full-access' as const }
+    ]
+    for (const input of inputs) {
+      const resolved = claudeCodePermissionMode(input)
+      expect(resolved).toBeTruthy()
+      // The one-way door: a bypass is reachable ONLY from an explicit allow.
+      if (resolved === 'bypassPermissions') {
+        expect(input).toHaveProperty('permissionMode', 'allow')
+      }
+    }
+  })
+})

--- a/src/main/adapters/permission-mode.ts
+++ b/src/main/adapters/permission-mode.ts
@@ -1,0 +1,91 @@
+/**
+ * THE PERMISSION-MODE MAPPING — defect G1's other half, in 20x.
+ *
+ * READ THIS BEFORE COMPARING WITH THE WORKFLOW-BUILDER COPY. The two files are
+ * deliberately close but the STORY IS NOT THE SAME in the two products, and an
+ * earlier draft of this file carried workflow-builder's version of it, which
+ * was simply untrue here.
+ *
+ * WHAT WAS ACTUALLY WRONG IN 20x. `SessionConfig.permissionMode` was populated
+ * correctly all along — `agent-manager.ts` sets it from the per-agent
+ * `permission_mode` at three separate call sites (:844, :1568, :2829), and
+ * OpenCode, Codex, ACP and Pi all honour it. Only ONE adapter ignored it:
+ * `claude-code-adapter.ts` hardcoded `permissionMode: 'bypassPermissions'` with
+ * `allowDangerouslySkipPermissions: true`. So the value travelled the whole way
+ * and was dropped at the last step, by one backend.
+ *
+ * (In workflow-builder the failure is one step earlier — the runner never put
+ * the value into the config at all. Same defect id, different missing wire.)
+ *
+ * WHY ONLY THE INVERSE FUNCTION LIVES HERE. 20x stores the two-valued form
+ * DIRECTLY: `AgentConfigRecord.permission_mode` is `'ask' | 'allow'`
+ * (database.ts:40) and the agent form offers exactly those. There is no
+ * four-valued vocabulary in this product, so a four-to-two mapping would have
+ * no caller — dead code that reads as though something used it. The four-valued
+ * side belongs to the control plane, and it lives in
+ * `workflow-builder/packages/agent-harness/src/runtime/permission-mode.ts`,
+ * where the lease actually carries those values.
+ *
+ * THE RULE BOTH COPIES OBEY: **a mode may resolve to something STRICTER than
+ * the user asked for, never to something looser.** `'bypassPermissions'` is
+ * reachable from exactly one input, an explicit `'allow'`, and from nothing
+ * else — including from an ABSENT mode, which is the pre-G1 state and must
+ * never silently become a bypass again.
+ *
+ * ---------------------------------------------------------------------------
+ * THE TABLE THIS FILE IMPLEMENTS
+ * ---------------------------------------------------------------------------
+ *
+ *  permissionMode | sandboxMode        | Claude Code mode
+ *  ---------------|--------------------|------------------
+ *  'allow'        | (any)              | 'bypassPermissions'
+ *  'ask'          | 'read-only'        | 'plan'
+ *  'ask'          | 'workspace-write'  | 'default'
+ *  'ask'          | (absent)           | 'default'
+ *  (absent)       | (absent)           | 'default'      <-- NOT bypass
+ *
+ * Claude Code is the one backend whose SDK takes all four values natively, so
+ * nothing is collapsed here. On OpenCode there is a permission prompt or there
+ * is none, which is why 20x's own stored vocabulary is two-valued in the first
+ * place.
+ */
+
+/** Claude Code's own four-valued vocabulary — the RESULT of the resolution. */
+export type LeasePermissionMode = 'default' | 'plan' | 'acceptEdits' | 'bypassPermissions'
+
+/** What 20x stores and what the shared adapter contract accepts. */
+export type AdapterPermissionMode = 'ask' | 'allow'
+
+export type AdapterSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access'
+
+/**
+ * Resolve the adapter's own two-valued permission setting — plus `sandboxMode`,
+ * which carries the part `'ask' | 'allow'` cannot — into the four-valued
+ * vocabulary Claude Code's SDK actually accepts.
+ *
+ * TOTAL BY DESIGN. Every input, including nonsense and absence, yields a
+ * defined mode, and only an explicit `'allow'` yields `'bypassPermissions'`.
+ * Absent `permissionMode` means the caller never set one: that is exactly the
+ * pre-G1 state, so it maps to `'default'` — Claude Code's own asking mode — and
+ * NOT back to the bypass that was the defect. If omission restored the old
+ * behaviour, every caller that forgot the field would silently reintroduce G1
+ * and no test would notice.
+ */
+export function claudeCodePermissionMode(config: {
+  permissionMode?: AdapterPermissionMode
+  sandboxMode?: AdapterSandboxMode
+}): LeasePermissionMode {
+  if (config.permissionMode === 'allow') {
+    return 'bypassPermissions'
+  }
+  if (config.sandboxMode === 'read-only') {
+    return 'plan'
+  }
+  if (config.sandboxMode === 'workspace-write') {
+    // `acceptEdits` and `default` share a sandbox mode, so this direction
+    // cannot tell them apart on its own. `default` is the stricter of the two
+    // and therefore the right answer when in doubt.
+    return 'default'
+  }
+  return 'default'
+}


### PR DESCRIPTION
`claude-code-adapter.ts` hardcoded `permissionMode: 'bypassPermissions'` with `allowDangerouslySkipPermissions: true`, so **every Claude Code session ran fully unrestricted no matter what the user chose** in the agent form.

Companion to [workflow-builder#1602](https://github.com/peakflo/workflow-builder/pull/1602), which fixes the same defect id on the cloud runner.

## The value was there all along

`agent-manager.ts` sets `permissionMode` from the agent's `permission_mode` at **three** call sites (`:844`, `:1568`, `:2829`), and OpenCode, Codex, ACP and Pi all honour it. **Claude Code was the only adapter that ignored it** — the setting travelled the whole way and was dropped at the last step, by one backend.

(The same defect in workflow-builder is a *different* missing wire: there the runner never put the value into the config at all.)

## The fix

`permission-mode.ts` resolves the adapter's two-valued setting — plus `sandboxMode`, which carries what `'ask' | 'allow'` cannot — into the four-valued vocabulary Claude Code's own SDK accepts, so **nothing is collapsed for this backend**:

| permissionMode | sandboxMode | Claude Code mode |
|---|---|---|
| `'allow'` | any | `bypassPermissions` |
| `'ask'` | `read-only` | `plan` |
| `'ask'` | `workspace-write` | `default` |
| absent | absent | `default` — **not** bypass |

That last row is the point. If omission restored the old behaviour, every caller that forgot the field would silently reintroduce the defect and no test would notice.

## Why the old comment stopped being true

It justified the hardcode with *"the user has already chosen to run agent"*. That was true of the desktop-only shape, where the agent ran on the user's laptop with the user watching. It stopped being true when the same adapter began running unattended in a cloud sandbox with a real filesystem.

## Tests

- A unit suite for the resolution, including the anti-regression case above.
- **A discriminating adapter test** that drives the real `sendPrompt` and inspects the options the mocked SDK actually received. Restoring the hardcode **fails three of its four assertions**; a subtler mutation (spreading `allowDangerouslySkipPermissions` unconditionally) fails three more.
  - Note: this deliberately does **not** follow the existing `sendPrompt session continuation mode` block, which re-implements the adapter's if/else in the test body and asserts on its own local variable.
- `src/main/adapters`: **249 passed**, up from 245. `typecheck` and `eslint` clean.

## Deliberately NOT done here — a decision for the owner

workflow-builder needed a fifth wire: **telling OpenCode to raise permission events at all.** Measured there against a real `opencode serve` — only `external_directory` defaults to `"ask"`; `bash`, `edit` and `webfetch` default to allow, so the adapter's whole approval path is unreachable.

The same is true in this repo. I did not change it, because on the desktop it would **start prompting on every bash call for existing agents whose `permission_mode` is unset**, which could stall unattended task runs. That is a product decision, not a silent behaviour change to make in passing.

Also unchanged: 20x stores `permission_mode` as `'ask' | 'allow'` already, so there is no four-valued vocabulary here and no four-to-two mapping to port — only the inverse function, which has a real caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)