### PR TITLE
feat: hard refresh for browser panels — MCP field and UI dropdown

### DIFF
--- a/src/main/mcp-servers/task-management-core.ts
+++ b/src/main/mcp-servers/task-management-core.ts
@@ -643,7 +643,15 @@ const browserTools: Tool[] = [
   {
     name: 'browser_reload',
     description: 'Reload a browser panel page.',
-    inputSchema: { type: 'object', properties: { task_id: taskParam, panel_id: panelIdParam }, required: ['task_id'] }
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: taskParam,
+        hard: { type: 'boolean', description: 'Hard refresh: bypass the cache and refetch everything from the network (default false = normal reload).' },
+        panel_id: panelIdParam
+      },
+      required: ['task_id']
+    }
   }
 ]
 

--- a/src/main/mcp-servers/task-management-mcp-schema.test.ts
+++ b/src/main/mcp-servers/task-management-mcp-schema.test.ts
@@ -111,6 +111,21 @@ describe('tool sets per scope', () => {
   })
 })
 
+describe('browser_reload schema', () => {
+  it('exposes an optional hard-refresh flag for both scopes', () => {
+    for (const scope of [FULL_ACCESS_SCOPE, SCOPED]) {
+      const hard = propertiesOf(scope, 'browser_reload').hard as { type?: string } | undefined
+      expect(hard, 'browser_reload must accept a hard flag').toBeDefined()
+      expect(hard!.type).toBe('boolean')
+    }
+  })
+
+  it('keeps hard optional and task_id required', () => {
+    const tool = toolByName(FULL_ACCESS_SCOPE, 'browser_reload')
+    expect(tool!.inputSchema.required).toEqual(['task_id'])
+  })
+})
+
 describe('subtask status ceiling', () => {
   it('refuses a self-completion and points at ready_for_review', async () => {
     const invoke = async (): Promise<unknown> => ({ ok: true })

--- a/src/main/panel-browser-broker.test.ts
+++ b/src/main/panel-browser-broker.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 
 // The broker only touches Electron APIs inside its command methods; the pure
-// helpers under test here need nothing from it.
+// helpers under test here need nothing from it. `fromId` is configurable so
+// reload/navigation tests can hand the broker a fake WebContents.
+const electronMocks = vi.hoisted(() => ({ fromId: vi.fn((): unknown => null) }))
+
 vi.mock('electron', () => ({
   app: {},
-  webContents: { fromId: () => null }
+  webContents: { fromId: electronMocks.fromId }
 }))
 
 import {
@@ -159,5 +162,53 @@ describe('registry lifecycle', () => {
     expect(panelBrowserBroker.unregisterPanel('px')).toBe(true)
     expect(panelBrowserBroker.unregisterPanel('px')).toBe(false)
     panelBrowserBroker.stopAll()
+  })
+})
+
+describe('reload hard flag', () => {
+  function fakeWebContents(url: string) {
+    let settle: (() => void) | null = null
+    const settleSoon = (): void => {
+      queueMicrotask(() => settle?.())
+    }
+    const wc = {
+      reload: vi.fn(settleSoon),
+      reloadIgnoringCache: vi.fn(settleSoon),
+      isDestroyed: vi.fn(() => false),
+      once: vi.fn((_event: string, cb: () => void) => {
+        settle = cb
+      }),
+      removeListener: vi.fn(),
+      getURL: vi.fn(() => url)
+    }
+    return wc
+  }
+
+  it('bypasses the cache when hard is set', async () => {
+    const wc = fakeWebContents('https://x.io/after-hard')
+    electronMocks.fromId.mockReturnValue(wc)
+    panelBrowserBroker.registerPanel('p-hard', 42, ['task-hard'])
+    try {
+      const result = await panelBrowserBroker.reload('task-hard', 'p-hard', true)
+      expect(wc.reloadIgnoringCache).toHaveBeenCalledTimes(1)
+      expect(wc.reload).not.toHaveBeenCalled()
+      expect(result).toEqual({ ok: true, url: 'https://x.io/after-hard' })
+    } finally {
+      panelBrowserBroker.unregisterPanel('p-hard')
+    }
+  })
+
+  it('defaults to a normal cached reload', async () => {
+    const wc = fakeWebContents('https://x.io/after-soft')
+    electronMocks.fromId.mockReturnValue(wc)
+    panelBrowserBroker.registerPanel('p-soft', 43, ['task-soft'])
+    try {
+      const result = await panelBrowserBroker.reload('task-soft', 'p-soft')
+      expect(wc.reload).toHaveBeenCalledTimes(1)
+      expect(wc.reloadIgnoringCache).not.toHaveBeenCalled()
+      expect(result).toEqual({ ok: true, url: 'https://x.io/after-soft' })
+    } finally {
+      panelBrowserBroker.unregisterPanel('p-soft')
+    }
   })
 })

--- a/src/main/panel-browser-broker.ts
+++ b/src/main/panel-browser-broker.ts
@@ -445,8 +445,8 @@ export class PanelBrowserBroker {
     return this.historyStep(taskId, (wc) => wc.goForward(), panelId)
   }
 
-  reload(taskId: string, panelId?: string | null): Promise<Record<string, unknown>> {
-    return this.historyStep(taskId, (wc) => wc.reload(), panelId)
+  reload(taskId: string, panelId?: string | null, hard = false): Promise<Record<string, unknown>> {
+    return this.historyStep(taskId, (wc) => (hard ? wc.reloadIgnoringCache() : wc.reload()), panelId)
   }
 
   async snapshot(taskId: string, panelId?: string | null): Promise<Record<string, unknown>> {

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -1207,7 +1207,7 @@ export async function handleRoute(db: DatabaseManager, route: string, params: Re
       const panelId = str(params.panel_id)
       if (route === '/browser_back') return panelBrowserBroker.back(taskId, panelId)
       if (route === '/browser_forward') return panelBrowserBroker.forward(taskId, panelId)
-      return panelBrowserBroker.reload(taskId, panelId)
+      return panelBrowserBroker.reload(taskId, panelId, params.hard === true)
     }
 
     default:

--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   Globe,
   RefreshCw,
+  ChevronDown,
   ArrowLeft,
   ArrowRight,
   Loader2,
@@ -312,6 +313,12 @@ export function BrowserPanelContent({
     webviewRef.current?.reload()
   }, [])
 
+  // Hard refresh — bypasses the HTTP cache and refetches everything from the
+  // network (same as Electron's webContents.reloadIgnoringCache / Cmd+Shift+R).
+  const handleHardRefresh = useCallback(() => {
+    webviewRef.current?.reloadIgnoringCache()
+  }, [])
+
   const handleOpenInBrowser = useCallback(async () => {
     if (!blockedUrl) return
 
@@ -358,6 +365,7 @@ export function BrowserPanelContent({
         onBack={handleBack}
         onForward={handleForward}
         onRefresh={handleRefresh}
+        onHardRefresh={handleHardRefresh}
         connectedTaskName={connectedTaskName}
       />
 
@@ -414,6 +422,7 @@ function BrowserUrlBar({
   onBack,
   onForward,
   onRefresh,
+  onHardRefresh,
   connectedTaskName,
   autoFocus,
 }: {
@@ -426,9 +435,11 @@ function BrowserUrlBar({
   onBack: () => void
   onForward: () => void
   onRefresh: () => void
+  onHardRefresh: () => void
   connectedTaskName?: string | null
   autoFocus?: boolean
 }) {
+  const [refreshMenuOpen, setRefreshMenuOpen] = useState(false)
   return (
     <form
       onSubmit={onSubmit}
@@ -453,18 +464,63 @@ function BrowserUrlBar({
       >
         <ArrowRight className="h-3 w-3" />
       </button>
-      <button
-        type="button"
-        onClick={onRefresh}
-        className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
-        title="Refresh"
-      >
-        {isLoading ? (
-          <Loader2 className="h-3 w-3 animate-spin" />
-        ) : (
-          <RefreshCw className="h-3 w-3" />
+      {/* Refresh + refresh-mode dropdown */}
+      <div className="relative flex-shrink-0">
+        <div className="flex items-center">
+          <button
+            type="button"
+            onClick={onRefresh}
+            className="h-5 w-5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+            title="Refresh"
+          >
+            {isLoading ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => setRefreshMenuOpen((o) => !o)}
+            className="h-5 w-2.5 rounded flex items-center justify-center text-muted-foreground/40 hover:text-muted-foreground hover:bg-white/5 transition-colors"
+            title="Refresh options"
+          >
+            <ChevronDown className="h-2 w-2" />
+          </button>
+        </div>
+        {refreshMenuOpen && (
+          <>
+            {/* Invisible backdrop to close the menu on outside click */}
+            <div className="fixed inset-0 z-40" onClick={() => setRefreshMenuOpen(false)} />
+            <div className="absolute left-0 top-full mt-1 z-50 w-44 rounded-md border border-border/40 bg-[#161b22] shadow-lg py-1">
+              <button
+                type="button"
+                onClick={() => {
+                  setRefreshMenuOpen(false)
+                  onRefresh()
+                }}
+                className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[11px] text-foreground hover:bg-white/5 text-left transition-colors"
+              >
+                <RefreshCw className="h-3 w-3 text-muted-foreground" />
+                Refresh
+                <span className="ml-auto text-[9px] text-muted-foreground/50">cache OK</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setRefreshMenuOpen(false)
+                  onHardRefresh()
+                }}
+                className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[11px] text-foreground hover:bg-white/5 text-left transition-colors"
+              >
+                <Zap className="h-3 w-3 text-orange-400" />
+                Hard refresh
+                <span className="ml-auto text-[9px] text-muted-foreground/50">ignore cache</span>
+              </button>
+            </div>
+          </>
         )}
-      </button>
+      </div>
 
       {/* URL input */}
       <div className="flex-1 flex items-center gap-1.5 bg-[var(--canvas-panel)] rounded-md px-2 py-1 border border-border/20 focus-within:border-orange-500/30 transition-colors">


### PR DESCRIPTION
## Summary

Adds a **hard refresh** (cache-bypassing reload) for canvas Agent Browser panels, in both the agent-facing MCP tool and the user-facing UI.

### MCP tool field (task management server)
- `browser_reload` gains an optional `hard: boolean` field. When set, the panel broker calls `webContents.reloadIgnoringCache()` instead of the default cache-honoring `reload()`.

### UI dropdown (canvas Agent Browser panel)
- The URL bar now has a small chevron next to the refresh button that opens a dropdown with **Refresh** (normal, cache OK) and **Hard refresh** (ignore cache) options. Hard refresh uses the webview's `reloadIgnoringCache()`. Outside click closes the menu; selecting an option runs the corresponding reload.

### Changes
- `src/main/panel-browser-broker.ts` — `reload(taskId, panelId, hard)` routes to `reloadIgnoringCache` when `hard` is set
- `src/main/task-api-server.ts` — `/browser_reload` route passes `params.hard === true` through
- `src/main/mcp-servers/task-management-core.ts` — `hard` field added to the `browser_reload` schema
- `src/renderer/src/components/canvas/BrowserPanelContent.tsx` — refresh dropdown + `reloadIgnoringCache` handler

### Tests
- Broker: hard reload uses `reloadIgnoringCache`, default uses `reload`
- MCP schema: `hard` exposed as optional boolean for both scopes, `task_id` stays the only required field
- Full suite green (166 files / 2627 tests), typecheck and lint clean