### PR TITLE
fix: wake parent coordinator when a subtask is reviewed from the UI or mobile

### DIFF
--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -149,3 +149,71 @@ describe('registerIpcHandlers', () => {
     expect(mockChildKill).toHaveBeenCalledWith('SIGTERM')
   })
 })
+
+describe('db:updateTask coordinator wake-up', () => {
+  function setup(existing: Record<string, unknown>, updated: Record<string, unknown>) {
+    const notifyParent = vi.fn().mockResolvedValue(undefined)
+    const agentManager = { notifyParentOfSubtaskCompletion: notifyParent } as unknown as Parameters<typeof registerIpcHandlers>[1]
+    const db = {
+      getTask: vi.fn(() => existing),
+      updateTask: vi.fn(() => updated)
+    } as unknown as Parameters<typeof registerIpcHandlers>[0]
+
+    registerIpcHandlers(db, agentManager, {} as never, {} as never, {} as never, {} as never)
+
+    const handleCalls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls as [string, (...args: unknown[]) => unknown][]
+    const updateHandler = handleCalls.filter((call) => call[0] === 'db:updateTask').pop()?.[1]
+    expect(updateHandler).toBeDefined()
+    return { notifyParent, updateHandler: updateHandler! }
+  }
+
+  it('wakes the parent coordinator when a subtask is moved to a terminal state from the UI', () => {
+    const existing = { id: 'sub-1', parent_task_id: 'parent-1', status: 'agent_working' }
+    const updated = { ...existing, status: 'ready_for_review' }
+    const { notifyParent, updateHandler } = setup(existing, updated)
+
+    updateHandler({}, 'sub-1', { status: 'ready_for_review' })
+
+    expect(notifyParent).toHaveBeenCalledWith('parent-1', 'sub-1')
+  })
+
+  it('wakes the parent when a UI completion closes a subtask', () => {
+    const existing = { id: 'sub-2', parent_task_id: 'parent-1', status: 'ready_for_review' }
+    const updated = { ...existing, status: 'completed' }
+    const { notifyParent, updateHandler } = setup(existing, updated)
+
+    updateHandler({}, 'sub-2', { status: 'completed' })
+
+    expect(notifyParent).toHaveBeenCalledWith('parent-1', 'sub-2')
+  })
+
+  it('does not wake the parent for a non-terminal status change', () => {
+    const existing = { id: 'sub-3', parent_task_id: 'parent-1', status: 'not_started' }
+    const updated = { ...existing, status: 'agent_working' }
+    const { notifyParent, updateHandler } = setup(existing, updated)
+
+    updateHandler({}, 'sub-3', { status: 'agent_working' })
+
+    expect(notifyParent).not.toHaveBeenCalled()
+  })
+
+  it('does not wake the parent when the status did not change', () => {
+    const existing = { id: 'sub-4', parent_task_id: 'parent-1', status: 'ready_for_review' }
+    const updated = { ...existing, title: 'rename only path' }
+    const { notifyParent, updateHandler } = setup(existing, updated)
+
+    updateHandler({}, 'sub-4', { title: 'rename only path' })
+
+    expect(notifyParent).not.toHaveBeenCalled()
+  })
+
+  it('does not wake anything for a top-level task', () => {
+    const existing = { id: 'top-1', parent_task_id: null, status: 'agent_working' }
+    const updated = { ...existing, status: 'ready_for_review' }
+    const { notifyParent, updateHandler } = setup(existing, updated)
+
+    updateHandler({}, 'top-1', { status: 'ready_for_review' })
+
+    expect(notifyParent).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -185,6 +185,24 @@ export function registerIpcHandlers(
       void taskAutomationScheduler?.runNow()
     }
 
+    // Event-driven coordinator wake-up: a subtask moved into a terminal state
+    // from the UI (Kanban drag, status dropdown, feedback dialog) must wake its
+    // parent coordinator exactly like the agent / MCP / auto-complete routes do.
+    // Without this, a coordinator reviewing children never learns that the last
+    // one was reviewed from the board and sits idle until a human nudges it.
+    if (
+      updated &&
+      updated.parent_task_id &&
+      previousStatus !== undefined &&
+      (data.status === TaskStatus.ReadyForReview || data.status === TaskStatus.Completed)
+    ) {
+      agentManager
+        .notifyParentOfSubtaskCompletion(updated.parent_task_id, id)
+        .catch((err) => {
+          console.error(`[IPC] Failed to wake parent ${updated.parent_task_id} after subtask ${id} update:`, err)
+        })
+    }
+
     // Record feedback event for enterprise sync
     if (enterpriseStateSync && data.feedback_rating && updated) {
       enterpriseStateSync.recordFeedbackSubmitted(updated, data.feedback_rating)

--- a/src/main/mobile-api-server.test.ts
+++ b/src/main/mobile-api-server.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createHash } from 'crypto'
 import { createTestDb } from '../../test/helpers/db-test-helper'
 import { makeTask } from '../../test/helpers/task-fixtures'
 import type { DatabaseManager } from './database'
@@ -138,5 +139,77 @@ describe('mobile-api-server: auth', () => {
 
     const logs = logSpy.mock.calls.map((call) => call.map(String).join(' ')).join('\n')
     expect(logs).toContain('[MobileAPI] Started on port')
+  })
+})
+
+describe('mobile-api-server: POST /api/tasks/:id coordinator wake-up', () => {
+  afterEach(() => {
+    stopMobileApiServer()
+    vi.restoreAllMocks()
+  })
+
+  function startServer(agentManager: unknown) {
+    const { db } = createTestDb()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    // The server resolves the requested port, so pick a free-ish high port
+    // instead of 0 (which would make the caller resolve port 0).
+    const port = 21000 + Math.floor(Math.random() * 40000)
+    return { db, logSpy, portPromise: startMobileApiServer(db, agentManager as never, {} as never, port) }
+  }
+
+  function pairToken(db: DatabaseManager): string {
+    const token = 'test-pairing-token'
+    const hash = createHash('sha256').update(token).digest('hex')
+    db.createMobileSession('sess-1', hash, 'test-device')
+    return token
+  }
+
+  it('wakes the parent coordinator when a phone moves a subtask to ready_for_review', async () => {
+    const notifyParent = vi.fn().mockResolvedValue(undefined)
+    const agentManager = { notifyParentOfSubtaskCompletion: notifyParent }
+    const { db, portPromise } = startServer(agentManager)
+    const port = await portPromise
+
+    const parent = db.createTask(makeTask({ title: 'Parent' }))!
+    const subtask = db.createTask(makeTask({ title: 'Child', parent_task_id: parent.id }))!
+    db.updateTask(subtask.id, { status: 'agent_working' })
+
+    const token = pairToken(db)
+    const res = await fetch(`http://127.0.0.1:${port}/api/tasks/${subtask.id}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'ready_for_review' })
+    })
+    expect(res.status).toBe(200)
+
+    expect(notifyParent).toHaveBeenCalledWith(parent.id, subtask.id)
+  })
+
+  it('does not wake the parent for a non-terminal or unchanged status from a phone', async () => {
+    const notifyParent = vi.fn().mockResolvedValue(undefined)
+    const agentManager = { notifyParentOfSubtaskCompletion: notifyParent }
+    const { db, portPromise } = startServer(agentManager)
+    const port = await portPromise
+
+    const parent = db.createTask(makeTask({ title: 'Parent' }))!
+    const subtask = db.createTask(makeTask({ title: 'Child', parent_task_id: parent.id }))!
+
+    const token = pairToken(db)
+
+    // Non-terminal transition
+    await fetch(`http://127.0.0.1:${port}/api/tasks/${subtask.id}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'agent_working' })
+    })
+    expect(notifyParent).not.toHaveBeenCalled()
+
+    // Title-only update
+    await fetch(`http://127.0.0.1:${port}/api/tasks/${subtask.id}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'renamed' })
+    })
+    expect(notifyParent).not.toHaveBeenCalled()
   })
 })

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -19,6 +19,7 @@ import type { PluginRegistry } from './plugins/registry'
 import { listTaskArtifactEntries, readTaskArtifact } from './artifacts'
 import type { Artifact, ArtifactFileEntry } from '../shared/artifacts'
 import { MOBILE_VOICE_CAPABILITIES } from '../shared/voice'
+import { TaskStatus } from '../shared/constants'
 import { guardStream } from './child-stream-guards'
 
 // ── State ────────────────────────────────────────────────────
@@ -763,6 +764,18 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
         changed.auto_complete_without_review !== undefined
       ) {
         triggerTaskAutomation()
+      }
+      // Event-driven coordinator wake-up: a subtask moved into a terminal state
+      // from a phone must wake its parent coordinator, same as every other
+      // status-changing route.
+      if (
+        updated.parent_task_id &&
+        existing.status !== updated.status &&
+        (updated.status === TaskStatus.ReadyForReview || updated.status === TaskStatus.Completed)
+      ) {
+        agent.notifyParentOfSubtaskCompletion(updated.parent_task_id, taskId).catch((err) => {
+          console.error(`[MobileAPI] Failed to wake parent ${updated.parent_task_id} after subtask ${taskId} update:`, err)
+        })
       }
     }
     return updated


### PR DESCRIPTION
## Problem

A parent (coordinator) task was not always woken when its children finished. Observed on the parent task "bring coding agents to workflow-builder UI": the first agent-driven wake-up arrived correctly, but when the last active child flipped to `ready_for_review` through a **UI route**, no second wake-up fired and the coordinator sat idle until a human nudged it with a manual message.

## Root cause

Five routes can move a subtask into a terminal state (`ready_for_review` / `completed`), but only three woke the parent:

| Route | Woke parent |
|---|---|
| Agent idle transition (`transitionToIdle`) | ✅ |
| Auto-complete-without-review (`completeTaskWithoutReview`) | ✅ |
| MCP `update_task` (task-api-server) | ✅ |
| Desktop UI — `db:updateTask` IPC (Kanban drag, status dropdown, feedback dialog) | ❌ |
| Mobile — `POST /api/tasks/:id` | ❌ |

A UI-driven flip (the child's agent session had no activity since days earlier, yet its status changed) therefore produced no coordinator wake-up.

## Fix

- `ipc-handlers.ts` — `db:updateTask` now calls `agentManager.notifyParentOfSubtaskCompletion(parent, taskId)` when a subtask's status **actually changes** into `ready_for_review` or `completed` (guarded by the already-captured `previousStatus`).
- `mobile-api-server.ts` — `POST /api/tasks/:id` does the same (`existing.status !== updated.status`).

No extra dedupe was needed: the built-in guards inside `notifyParentOfSubtaskCompletion` (wake dedupe set, skip while the parent session is actively working, defer while any sibling is `agent_working`/`triaging`) already prevent duplicate or noisy wakes.

## Tests

- 5 new IPC tests: wake on `ready_for_review`, wake on UI completion, no wake for non-terminal transitions, no wake when status didn't change, no wake for top-level tasks.
- 2 new end-to-end mobile tests: authenticated `POST /api/tasks/:id` wake on terminal transition + negatives.
- Full suite green (166 files / 2634 tests), `tsc` clean, eslint clean on touched files.