### PR TITLE
fix: Write a message... placeholder and 60/40 workspace split default

### DIFF
--- a/src/mobile/components/ChatInput.test.tsx
+++ b/src/mobile/components/ChatInput.test.tsx
@@ -13,7 +13,7 @@ describe('ChatInput attachments', () => {
 
     render(<ChatInput onSend={onSend} attachments={attachments} />)
 
-    fireEvent.change(screen.getByPlaceholderText('Send a message...'), { target: { value: 'Please review' } })
+    fireEvent.change(screen.getByPlaceholderText('Write a message...'), { target: { value: 'Please review' } })
     fireEvent.click(screen.getByLabelText('Send message'))
 
     expect(onSend).toHaveBeenCalledWith('Please review', { attachments })

--- a/src/mobile/components/ChatInput.tsx
+++ b/src/mobile/components/ChatInput.tsx
@@ -27,7 +27,7 @@ function formatFileSize(bytes: number): string {
 export function ChatInput({
   onSend,
   disabled,
-  placeholder = 'Send a message...',
+  placeholder = 'Write a message...',
   attachments = [],
   onRemoveAttachment,
   onOpenAttachmentPicker

--- a/src/mobile/pages/ConversationPage.tsx
+++ b/src/mobile/pages/ConversationPage.tsx
@@ -221,7 +221,7 @@ export function ConversationPage({ taskId, onNavigate }: { taskId: string; onNav
     if (isStarting) return 'Starting agent…'
     if (isQuestion) return 'Type your answer...'
     if (isWaitingApproval) return 'Approve or provide feedback...'
-    return 'Send a message... (Shift+Enter for new line)'
+    return 'Write a message...'
   }, [hasSession, isStarting, isQuestion, isWaitingApproval])
 
   // Smart send handler — mirrors desktop TaskWorkspace.handleSend logic

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.test.tsx
@@ -69,7 +69,7 @@ describe('AgentTranscriptPanel drag and drop attachments', () => {
     })
     expect(await screen.findByText('spec.md')).toBeInTheDocument()
 
-    fireEvent.change(screen.getByPlaceholderText('Send a message... (Shift+Enter for new line)'), {
+    fireEvent.change(screen.getByPlaceholderText('Write a message...'), {
       target: { value: 'Please use this file' }
     })
     fireEvent.click(screen.getByLabelText('Send message'))

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -1458,7 +1458,7 @@ export function AgentTranscriptPanel({
                 ref={inputRef}
                 rows={1}
                 disabled={isStarting}
-                placeholder={isStarting ? 'Starting agent…' : 'Send a message... (Shift+Enter for new line)'}
+                placeholder={isStarting ? 'Starting agent…' : 'Write a message...'}
                 className="flex-1 bg-input border border-border rounded-lg px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/30 resize-none overflow-hidden max-h-32 min-h-[32px] disabled:opacity-60"
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && !e.shiftKey) {

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -135,6 +135,74 @@ describe('clampTranscriptWidth', () => {
   })
 })
 
+describe('TaskWorkspace – artifacts/details sidebar default width', () => {
+  const LEGACY_KEY = '20x:task:transcriptWidth'
+  const V2_KEY = '20x:task:transcriptWidth:v2'
+
+  beforeEach(() => {
+    window.localStorage.removeItem(LEGACY_KEY)
+    window.localStorage.removeItem(V2_KEY)
+    // jsdom reports zero-sized rects; give the workspace body a fixed width so
+    // the layout effect's applyWidth() computes a deterministic default split.
+    vi.spyOn(HTMLDivElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 1_000, height: 800, top: 0, left: 0, bottom: 800, right: 1_000, x: 0, y: 0,
+      toJSON: () => ({})
+    } as DOMRect)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const renderWorkingTask = () => {
+    const task = makeRendererTask({
+      status: TaskStatus.AgentWorking,
+      session_id: 'persisted-session-1'
+    })
+    renderWorkspace(task)
+  }
+
+  const openDetailsPanel = () => {
+    fireEvent.click(screen.getAllByRole('button', { name: 'Details' })[0])
+  }
+
+  it('gives the artifacts/details sidebar ~40% of the workspace by default', () => {
+    renderWorkingTask()
+    openDetailsPanel()
+
+    // 60% of the 1000px workspace body goes to the transcript; the remaining
+    // ~396px (minus the resizer) is the artifacts/details sidebar.
+    expect(screen.getByTestId('transcript-pane').style.width).toBe('600px')
+  })
+
+  it('ignores stale widths persisted under the legacy storage key', () => {
+    window.localStorage.setItem(LEGACY_KEY, '340')
+    renderWorkingTask()
+    openDetailsPanel()
+
+    expect(screen.getByTestId('transcript-pane').style.width).toBe('600px')
+  })
+
+  it('respects a user-dragged width persisted under the v2 key', () => {
+    window.localStorage.setItem(V2_KEY, '340')
+    renderWorkingTask()
+    openDetailsPanel()
+
+    expect(screen.getByTestId('transcript-pane').style.width).toBe('340px')
+  })
+
+  it('does not persist system clamps back to storage as user preferences', () => {
+    // Width far beyond the 1000px container must be clamped on screen...
+    window.localStorage.setItem(V2_KEY, '1200')
+    renderWorkingTask()
+    openDetailsPanel()
+
+    expect(screen.getByTestId('transcript-pane').style.width).toBe('676px')
+    // ...but the stored preference keeps its original value.
+    expect(window.localStorage.getItem(V2_KEY)).toBe('1200')
+  })
+})
+
 describe('TaskWorkspace – stale triage session cleanup', () => {
   it('sets up worktrees when adding repos to a task with only a persisted session_id', async () => {
     ;(window.electronAPI.github.checkCli as ReturnType<typeof vi.fn>).mockResolvedValue({ installed: true, authenticated: true })

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -41,10 +41,26 @@ const EMPTY_ARTIFACTS: Artifact[] = []
 const DEFAULT_ARTIFACT_UI: ArtifactUIState = { open: false, activeTabId: null, railExpanded: false }
 const MIN_WORKSPACE_PANE_WIDTH = 320
 const WORKSPACE_RESIZER_WIDTH = 4
+/** Fraction of the workspace body given to the transcript by default. Leaves ~40% for the artifacts/details sidebar. */
+const DEFAULT_TRANSCRIPT_WIDTH_FRACTION = 0.6
+// v2 key: the legacy key stored widths derived from transient window sizes, which
+// permanently shrank the transcript and blew the details sidebar up to ~70%.
+const TRANSCRIPT_WIDTH_STORAGE_KEY = '20x:task:transcriptWidth:v2'
 
 export function clampTranscriptWidth(width: number, containerWidth: number): number {
   const maximum = Math.max(MIN_WORKSPACE_PANE_WIDTH, containerWidth - MIN_WORKSPACE_PANE_WIDTH - WORKSPACE_RESIZER_WIDTH)
   return Math.min(Math.max(MIN_WORKSPACE_PANE_WIDTH, width), maximum)
+}
+
+/** User-persisted transcript width, or null when the default 60/40 split should apply. */
+function readStoredTranscriptWidth(): number | null {
+  const stored = Number(window.localStorage.getItem(TRANSCRIPT_WIDTH_STORAGE_KEY))
+  return Number.isFinite(stored) && stored >= MIN_WORKSPACE_PANE_WIDTH ? stored : null
+}
+
+/** Default split: transcript takes its fraction of the actual workspace body. */
+function defaultTranscriptWidth(containerWidth: number): number {
+  return clampTranscriptWidth(Math.round(containerWidth * DEFAULT_TRANSCRIPT_WIDTH_FRACTION), containerWidth)
 }
 
 /** Controls which columns are visible in the TaskWorkspace grid */
@@ -117,12 +133,12 @@ function TaskWorkspaceComponent({
   const workspaceBodyRef = useRef<HTMLDivElement>(null)
   const resizingRef = useRef(false)
   const [transcriptWidth, setTranscriptWidth] = useState(() => {
-    const stored = Number(window.localStorage.getItem('20x:task:transcriptWidth'))
-    const preferred = Number.isFinite(stored) && stored >= MIN_WORKSPACE_PANE_WIDTH
-      ? stored
-      : Math.max(MIN_WORKSPACE_PANE_WIDTH, Math.round(window.innerWidth * 0.44))
-    return clampTranscriptWidth(preferred, window.innerWidth)
+    const stored = readStoredTranscriptWidth()
+    return stored ?? Math.max(MIN_WORKSPACE_PANE_WIDTH, Math.round(window.innerWidth * DEFAULT_TRANSCRIPT_WIDTH_FRACTION))
   })
+  // Whether the user actively resized the panes. While false, the transcript
+  // tracks the default 60/40 split as the workspace resizes.
+  const hasCustomTranscriptWidthRef = useRef(readStoredTranscriptWidth() !== null)
   const openTaskOnCanvas = useUIStore((s) => s.openTaskOnCanvas)
   const artifacts = useArtifactStore((s) => task?.id ? (s.artifactsByTask[task.id] || EMPTY_ARTIFACTS) : EMPTY_ARTIFACTS)
   const artifactUI = useArtifactStore((s) => task?.id ? (s.uiByTask[task.id] || DEFAULT_ARTIFACT_UI) : DEFAULT_ARTIFACT_UI)
@@ -166,18 +182,20 @@ function TaskWorkspaceComponent({
   useLayoutEffect(() => {
     if (!artifactUI.open || !workspaceBodyRef.current) return
     const container = workspaceBodyRef.current
-    const clampToContainer = () => {
+    const applyWidth = () => {
       const containerWidth = container.getBoundingClientRect().width
       if (containerWidth <= 0) return
       setTranscriptWidth((current) => {
-        const next = clampTranscriptWidth(current, containerWidth)
-        if (next !== current) window.localStorage.setItem('20x:task:transcriptWidth', String(next))
-        return next
+        // Default mode keeps the artifacts/details sidebar at ~40% of the
+        // workspace as it resizes; once the user drags, their width wins
+        // (clamped only, never persisted as a system-side effect).
+        if (!hasCustomTranscriptWidthRef.current) return defaultTranscriptWidth(containerWidth)
+        return clampTranscriptWidth(current, containerWidth)
       })
     }
-    clampToContainer()
+    applyWidth()
     if (typeof ResizeObserver === 'undefined') return
-    const observer = new ResizeObserver(clampToContainer)
+    const observer = new ResizeObserver(applyWidth)
     observer.observe(container)
     return () => observer.disconnect()
   }, [artifactUI.open])
@@ -186,6 +204,7 @@ function TaskWorkspaceComponent({
     if (!resizingRef.current || !workspaceBodyRef.current) return
     const rect = workspaceBodyRef.current.getBoundingClientRect()
     const next = clampTranscriptWidth(event.clientX - rect.left, rect.width)
+    hasCustomTranscriptWidthRef.current = true
     setTranscriptWidth(next)
   }, [])
 
@@ -193,7 +212,7 @@ function TaskWorkspaceComponent({
     if (!resizingRef.current) return
     resizingRef.current = false
     event.currentTarget.releasePointerCapture?.(event.pointerId)
-    window.localStorage.setItem('20x:task:transcriptWidth', String(transcriptWidth))
+    window.localStorage.setItem(TRANSCRIPT_WIDTH_STORAGE_KEY, String(transcriptWidth))
   }, [transcriptWidth])
 
   // Fetch settings on mount
@@ -1026,7 +1045,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
             <div className="min-h-0 min-w-0 flex-1">{transcriptView}</div>
           ) : (
             <>
-              <div className="min-h-0 min-w-0 shrink-0" style={{ width: artifactUI.open ? transcriptWidth : 'auto', flex: artifactUI.open ? undefined : 1 }}>
+              <div data-testid="transcript-pane" className="min-h-0 min-w-0 shrink-0" style={{ width: artifactUI.open ? transcriptWidth : 'auto', flex: artifactUI.open ? undefined : 1 }}>
                 {transcriptView}
               </div>
               {artifactUI.open ? (


### PR DESCRIPTION
## Summary

Two UI fixes, desktop + mobile kept in sync:

### 1. Message placeholder
Replaces `Send a message... (Shift+Enter for new line)` with just **`Write a message...`** in:
- Desktop: `AgentTranscriptPanel.tsx`
- Mobile: `ConversationPage.tsx` and the `ChatInput` default placeholder

(The MCP tool description for the same wording in `task-management-core.ts` is intentionally untouched — it is not user-facing UI.)

### 2. Artifacts/details sidebar defaults to ~40% of the workspace
The workspace split between transcript and the artifacts/details sidebar (Details / Changes / Output) had two bugs that made the details sidebar balloon to ~70%:

- **Default width was computed from `window.innerWidth`, not the actual workspace body**, and before layout — so the transcript's share (44% of the window) ignored the left sidebar and resizer geometry.
- **System-side width clamps were persisted to localStorage** as if the user had dragged the resizer. Transient window sizes (e.g. briefly resizing a window) got permanently baked in as a tiny stored transcript width, blowing the details sidebar up to ~70% with no way to reset it.

Changes in `TaskWorkspace.tsx`:
- Default split is now **60% transcript / ~40% artifacts-details**, computed against the *actual workspace body* and re-tracked on container resize (sidebar collapse, orchestrator drawer, window resize) until the user takes control.
- Width clamps are no longer persisted; only a real user drag writes to storage (on drag end).
- Storage key bumped to `20x:task:transcriptWidth:v2` so existing stale widths are ignored — users hit by the bug get the new default immediately.
- User-dragged widths are still respected (clamped to keep both panes >= 320px).

## Testing
- New tests in `TaskWorkspace.test.tsx` cover: default 60/40 split, legacy-key staleness (ignored), user-dragged width respected, and system clamps not persisted back to storage.
- Full suite: 2638 passed | 4 skipped.
- `pnpm typecheck` and `eslint` clean on all touched files.
