### PR TITLE
fix: skip electron-builder in-packager rebuild so Electron 44 releases package

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,6 @@
       "include": "resources/installer.nsh"
     },
     "nativeRebuilder": "sequential",
-    "npmRebuild": true
+    "npmRebuild": false
   }
 }


### PR DESCRIPTION
## Summary
- Releases v0.0.138 and v0.0.139 failed on **all four platform jobs** at the "Package for <os>" step: `⨯ Could not detect abi for version 44.0.0 and runtime electron` thrown by `node-abi@3.87.0` (via the `@electron/rebuild@3.6.1` bundled inside `electron-builder@25.1.8`). node-abi 3.87.0 predates Electron 44 and has no ABI entry for it.
- The repo already rebuilds native modules for the exact Electron version in **postinstall** (`scripts/rebuild-native.mjs`) — added precisely because the electron-builder rebuild path is unreliable under pnpm's hardlink structure. CI logs of the failed run prove postinstall rebuilt better-sqlite3 and node-pty for Electron 44.0.0 successfully on linux, windows, mac x64 and mac arm64 **before** packaging crashed.
- Fix: `npmRebuild: false` in the electron-builder config — packaging now uses the already-correct binaries instead of re-running electron-builder's redundant (and broken-for-Electron-44) rebuild. No dependency or lockfile changes; the packaging pipeline that shipped v0.0.137 and earlier is otherwise untouched.

## Repro / verification (local, macOS arm64)
- Reproduced the CI failure exactly: `electron-builder --dir --mac --config.npmRebuild=true` → same "Could not detect abi" crash, exit 1.
- With this fix: `electron-builder --dir --mac` → packaging completes, exit 0.
- Loaded the packaged `better-sqlite3` from `app.asar.unpacked` under the Electron 44.0.0 runtime (Node 24.18.1): full create/insert/select round-trip works; node-pty binding loads (process spawn itself is sandbox-blocked locally, unrelated).
- Note: better-sqlite3@13 ships NAPI prebuilds that are runtime-agnostic; the packaging config's `asarUnpack` glob covers them.

## Follow-up (not in this PR)
- Bumping `electron-builder` 25 → 26 (uses `@electron/rebuild` 4.x / node-abi 4.x with Electron 44 support) is the upstream-proper path, but it is a packaging-major change and does not belong in a release-blocker hotfix.
- The unused `@electron/rebuild` devDependency can be dropped (electron-builder itself warns about it); it has no effect under pnpm's strict resolution.

## Test plan
- [x] Reproduced the failing packaging step locally (exit 1, same error as CI)
- [x] Packaging succeeds with the fix (exit 0)
- [x] Packaged native modules load and function under the Electron 44 runtime
- [ ] Release workflow on the next tag goes green end-to-end

Generated with [Claude Code](https://claude.com/claude-code)