### PR TITLE
fix: transcript width computed in layout px inside scaled canvas panels

### DIFF
--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -136,21 +136,53 @@ describe('clampTranscriptWidth', () => {
 })
 
 describe('TaskWorkspace – artifacts/details sidebar default width', () => {
-  const LEGACY_KEY = '20x:task:transcriptWidth'
-  const V2_KEY = '20x:task:transcriptWidth:v2'
+  // Keys older than the current one must all be ignored as stale.
+  const STALE_KEYS = [
+    '20x:task:transcriptWidth', // v1: pre-redesign widths
+    '20x:task:transcriptWidth:v2' // v2: poisoned by scaled-canvas drags
+  ]
+  const V3_KEY = '20x:task:transcriptWidth:v3'
+
+  let layoutWidth: number
+  let screenScale: number
 
   beforeEach(() => {
-    window.localStorage.removeItem(LEGACY_KEY)
-    window.localStorage.removeItem(V2_KEY)
-    // jsdom reports zero-sized rects; give the workspace body a fixed width so
-    // the layout effect's applyWidth() computes a deterministic default split.
-    vi.spyOn(HTMLDivElement.prototype, 'getBoundingClientRect').mockReturnValue({
-      width: 1_000, height: 800, top: 0, left: 0, bottom: 800, right: 1_000, x: 0, y: 0,
+    STALE_KEYS.forEach((key) => window.localStorage.removeItem(key))
+    window.localStorage.removeItem(V3_KEY)
+    // jsdom reports zero-sized rects and offsetWidth 0; give the workspace
+    // body a deterministic layout width, optionally scaled by a canvas-style
+    // ancestor transform: offsetWidth is LAYOUT px, getBoundingClientRect()
+    // is SCREEN px (scaled) — exactly how canvas task panels behave.
+    // offsetWidth lives on Element.prototype in jsdom, so shadow it directly
+    // on HTMLDivElement.prototype rather than spyOn.
+    layoutWidth = 1_000
+    screenScale = 1
+    Object.defineProperty(HTMLDivElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get: () => layoutWidth
+    })
+    vi.spyOn(HTMLDivElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
+      width: layoutWidth * screenScale, height: 800, top: 0, left: 0,
+      bottom: 800, right: layoutWidth * screenScale, x: 0, y: 0,
       toJSON: () => ({})
-    } as DOMRect)
+    } as DOMRect))
+    // jsdom may throw "no active pointer" on pointer capture; the drag tests
+    // only need the pointermove/pointerup handlers to fire. Define the stubs
+    // (rather than spyOn) since this jsdom build may not implement them.
+    for (const capture of ['setPointerCapture', 'releasePointerCapture'] as const) {
+      Object.defineProperty(HTMLDivElement.prototype, capture, {
+        configurable: true,
+        writable: true,
+        value: vi.fn()
+      })
+    }
   })
 
   afterEach(() => {
+    delete (HTMLDivElement.prototype as unknown as Record<string, unknown>).offsetWidth
+    for (const capture of ['setPointerCapture', 'releasePointerCapture'] as const) {
+      delete (HTMLDivElement.prototype as unknown as Record<string, unknown>)[capture]
+    }
     vi.restoreAllMocks()
   })
 
@@ -175,16 +207,16 @@ describe('TaskWorkspace – artifacts/details sidebar default width', () => {
     expect(screen.getByTestId('transcript-pane').style.width).toBe('600px')
   })
 
-  it('ignores stale widths persisted under the legacy storage key', () => {
-    window.localStorage.setItem(LEGACY_KEY, '340')
+  it('ignores stale widths persisted under legacy storage keys', () => {
+    STALE_KEYS.forEach((key) => window.localStorage.setItem(key, '340'))
     renderWorkingTask()
     openDetailsPanel()
 
     expect(screen.getByTestId('transcript-pane').style.width).toBe('600px')
   })
 
-  it('respects a user-dragged width persisted under the v2 key', () => {
-    window.localStorage.setItem(V2_KEY, '340')
+  it('respects a user-dragged width persisted under the current key', () => {
+    window.localStorage.setItem(V3_KEY, '340')
     renderWorkingTask()
     openDetailsPanel()
 
@@ -193,13 +225,44 @@ describe('TaskWorkspace – artifacts/details sidebar default width', () => {
 
   it('does not persist system clamps back to storage as user preferences', () => {
     // Width far beyond the 1000px container must be clamped on screen...
-    window.localStorage.setItem(V2_KEY, '1200')
+    window.localStorage.setItem(V3_KEY, '1200')
     renderWorkingTask()
     openDetailsPanel()
 
     expect(screen.getByTestId('transcript-pane').style.width).toBe('676px')
     // ...but the stored preference keeps its original value.
-    expect(window.localStorage.getItem(V2_KEY)).toBe('1200')
+    expect(window.localStorage.getItem(V3_KEY)).toBe('1200')
+  })
+
+  it('computes the default split in layout px inside scaled canvas panels', () => {
+    // Canvas task panels render under scale(zoom): rect measurements come
+    // back scaled while width styles apply in local px. A 1020px panel at
+    // zoom 0.5 must default to 60% of its LOCAL width (612px), not collapse
+    // to the 320px floor and leave the sidebar at ~70%.
+    layoutWidth = 1_020
+    screenScale = 0.5
+    renderWorkingTask()
+    openDetailsPanel()
+
+    expect(screen.getByTestId('transcript-pane').style.width).toBe('612px')
+  })
+
+  it('converts drag positions to layout px so the sidebar can shrink in scaled panels', () => {
+    layoutWidth = 1_020
+    screenScale = 0.5
+    renderWorkingTask()
+    openDetailsPanel()
+
+    const resizer = screen.getByRole('separator', { name: 'Resize transcript' })
+    fireEvent.pointerDown(resizer, { pointerId: 1, clientX: 300 })
+    // Pointer at screen x=400 → local x=800 (scale 0.5) → clamped to 696.
+    // The sidebar can now go down to ~31% instead of being stuck at ~70%.
+    fireEvent.pointerMove(resizer, { pointerId: 1, clientX: 400 })
+    fireEvent.pointerUp(resizer, { pointerId: 1 })
+
+    expect(screen.getByTestId('transcript-pane').style.width).toBe('696px')
+    // The drag persists a LOCAL px value under the current key.
+    expect(window.localStorage.getItem(V3_KEY)).toBe('696')
   })
 })
 

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -43,9 +43,10 @@ const MIN_WORKSPACE_PANE_WIDTH = 320
 const WORKSPACE_RESIZER_WIDTH = 4
 /** Fraction of the workspace body given to the transcript by default. Leaves ~40% for the artifacts/details sidebar. */
 const DEFAULT_TRANSCRIPT_WIDTH_FRACTION = 0.6
-// v2 key: the legacy key stored widths derived from transient window sizes, which
-// permanently shrank the transcript and blew the details sidebar up to ~70%.
-const TRANSCRIPT_WIDTH_STORAGE_KEY = '20x:task:transcriptWidth:v2'
+// v3 key: v2 values could be poisoned by drags performed inside scaled canvas
+// panels (screen px persisted as if they were local px), pinning the details
+// sidebar at ~70% until re-dragged. Bump to give everyone a clean default.
+const TRANSCRIPT_WIDTH_STORAGE_KEY = '20x:task:transcriptWidth:v3'
 
 export function clampTranscriptWidth(width: number, containerWidth: number): number {
   const maximum = Math.max(MIN_WORKSPACE_PANE_WIDTH, containerWidth - MIN_WORKSPACE_PANE_WIDTH - WORKSPACE_RESIZER_WIDTH)
@@ -183,7 +184,11 @@ function TaskWorkspaceComponent({
     if (!artifactUI.open || !workspaceBodyRef.current) return
     const container = workspaceBodyRef.current
     const applyWidth = () => {
-      const containerWidth = container.getBoundingClientRect().width
+      // offsetWidth is the LAYOUT width in local px. getBoundingClientRect()
+      // would return scaled screen px on the canvas, where task panels render
+      // under a scale(zoom) transform — mixing the two spaces is what pinned
+      // the details sidebar at ~70% regardless of dragging.
+      const containerWidth = container.offsetWidth
       if (containerWidth <= 0) return
       setTranscriptWidth((current) => {
         // Default mode keeps the artifacts/details sidebar at ~40% of the
@@ -202,8 +207,15 @@ function TaskWorkspaceComponent({
 
   const handleResizeMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (!resizingRef.current || !workspaceBodyRef.current) return
-    const rect = workspaceBodyRef.current.getBoundingClientRect()
-    const next = clampTranscriptWidth(event.clientX - rect.left, rect.width)
+    const container = workspaceBodyRef.current
+    // clientX/rect are in screen px and include any ancestor transform scale
+    // (canvas zoom); the width style is applied in layout px. Convert the
+    // pointer position to local px so the pane tracks the cursor and the
+    // clamp operates in the same space as the applied width.
+    const rect = container.getBoundingClientRect()
+    const layoutWidth = container.offsetWidth
+    const scale = rect.width > 0 && layoutWidth > 0 ? rect.width / layoutWidth : 1
+    const next = clampTranscriptWidth((event.clientX - rect.left) / scale, layoutWidth)
     hasCustomTranscriptWidthRef.current = true
     setTranscriptWidth(next)
   }, [])


### PR DESCRIPTION
## Problem

After #490, the artifacts/details sidebar in the **task workspace on the canvas** was stuck at ~70% minimum:

1. **Default split wrong in canvas panels.** Canvas task panels render under a `translate(x,y) scale(zoom)` CSS transform (`InfiniteCanvas`). `getBoundingClientRect()` returns *screen* px (scaled), while `transcriptWidth` applies via `style.width` in *local* px. At a zoomed-out canvas (e.g. zoom 0.5), a 1020px panel measures 510px, so the default snap clamped to the 320px floor in local px → sidebar ≈ 68–70%.
2. **Sidebar couldn't be dragged below ~70% in canvas panels.** The drag clamp max was computed in scaled screen px, which floored at the 320px local minimum no matter how far you dragged.
3. **The poisoned value spread everywhere.** Any drag (even a click jitter) on a canvas-panel resizer persisted the clamped ~320px width under the v2 storage key, pinning the transcript to 320px in the main workspace too.

## Fix

- `applyWidth` now measures the workspace container with `offsetWidth` (layout px, immune to CSS transforms).
- `handleResizeMove` converts pointer positions to local px via `scale = rect.width / offsetWidth`, so drags clamp correctly in scaled panels — the sidebar can now be dragged down to ~31% inside canvas panels.
- Storage key bumped `20x:task:transcriptWidth:v2` → `v3` so poisoned v2 values are discarded (both v1 and v2 are now treated as stale/ignored).

## Tests

- Updated the width suite to stub `offsetWidth` (layout space) separately from `getBoundingClientRect` (screen space, scaled).
- New regression tests:
  - default split computed in **layout** px inside a scaled canvas panel (1020px panel @ zoom 0.5 → 612px transcript / ~40% sidebar, not the 320px floor);
  - drag positions converted to layout px so the sidebar can shrink in scaled panels (screen x=400 @ scale 0.5 → 696px local, persisted to the v3 key).
- Full suite: 2640 passed | 4 skipped; `pnpm typecheck` clean; eslint clean.
