### PR TITLE
fix: theme-aware browser refresh menu + attachment management in task view modal

### DIFF
--- a/src/renderer/src/components/canvas/BrowserPanelContent.tsx
+++ b/src/renderer/src/components/canvas/BrowserPanelContent.tsx
@@ -492,14 +492,14 @@ function BrowserUrlBar({
           <>
             {/* Invisible backdrop to close the menu on outside click */}
             <div className="fixed inset-0 z-40" onClick={() => setRefreshMenuOpen(false)} />
-            <div className="absolute left-0 top-full mt-1 z-50 w-44 rounded-md border border-border/40 bg-[#161b22] shadow-lg py-1">
+            <div className="absolute left-0 top-full mt-1 z-50 w-44 rounded-md border border-border/40 bg-popover shadow-lg py-1">
               <button
                 type="button"
                 onClick={() => {
                   setRefreshMenuOpen(false)
                   onRefresh()
                 }}
-                className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[11px] text-foreground hover:bg-white/5 text-left transition-colors"
+                className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[11px] text-foreground hover:bg-accent text-left transition-colors"
               >
                 <RefreshCw className="h-3 w-3 text-muted-foreground" />
                 Refresh
@@ -511,7 +511,7 @@ function BrowserUrlBar({
                   setRefreshMenuOpen(false)
                   onHardRefresh()
                 }}
-                className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[11px] text-foreground hover:bg-white/5 text-left transition-colors"
+                className="w-full flex items-center gap-2 px-2.5 py-1.5 text-[11px] text-foreground hover:bg-accent text-left transition-colors"
               >
                 <Zap className="h-3 w-3 text-orange-400" />
                 Hard refresh

--- a/src/renderer/src/components/tasks/TaskDetailView.tsx
+++ b/src/renderer/src/components/tasks/TaskDetailView.tsx
@@ -755,15 +755,15 @@ function TaskDetailViewComponent({ task, agents, onEdit, onDelete, onUpdateAttac
             />
           )}
 
-          {task.attachments.length > 0 && (
-            <div className="rounded-md border p-4">
-              <TaskAttachments
-                items={task.attachments}
-                onChange={onUpdateAttachments}
-                taskId={task.id}
-              />
-            </div>
-          )}
+          {/* Always render the attachments section so users can add files directly
+              from the task view modal, even when the task has no attachments yet. */}
+          <div className="rounded-md border p-4">
+            <TaskAttachments
+              items={task.attachments}
+              onChange={onUpdateAttachments}
+              taskId={task.id}
+            />
+          </div>
 
           {/* Heartbeat monitoring — handled inside the properties grid above */}
 


### PR DESCRIPTION
## Summary

Two fixes bundled from parent task "20x: hard refresh sub menu doesn't support light mode":

### 1. Refresh / hard refresh sub menu light mode support
The browser panel's refresh dropdown (`BrowserUrlBar` in `BrowserPanelContent.tsx`) used a hardcoded dark-only background `bg-[#161b22]`, so in light mode it rendered as a dark box with barely-visible text (see task screenshot).

- `bg-[#161b22]` → `bg-popover` (theme token: `#ffffff` light / `#1e1e1e` dark), matching the pattern used by `CanvasContextMenu`, `SearchableSelect` and `Dialog`
- item hover `hover:bg-white/5` → `hover:bg-accent` so hover state is visible in both themes

### 2. Manage task attachments from the task view modal
`TaskDetailView` only rendered the attachments section when `task.attachments.length > 0`, making it impossible to attach files to a task from the task view modal (including the dashboard preview modal, which reuses `TaskWorkspace`).

- The attachments section is now always rendered; `TaskAttachments` already supported pick-files / drag-and-drop add, open/preview, download and remove, and the `onUpdateAttachments` wiring (full view, dashboard preview modal, canvas panels) already existed — so this was the only change needed.

## Verification
- `pnpm run typecheck` — clean
- `pnpm run test:renderer` — 904 tests passed (72 files)
- `pnpm run build` — succeeds
- eslint on changed files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)