### PR TITLE
fix(skills): stop enterprise sync wiping org-node skills and undoing deletes

### DIFF
--- a/docs/enterprise-sync-implementation.md
+++ b/docs/enterprise-sync-implementation.md
@@ -95,12 +95,48 @@ Runs on enterprise connect and before every task sync. Fetches org nodes from wo
 ### Sync Flow
 
 ```
+Phase 1 — node resources
 GET /api/org-nodes → filter by user assignment → for each node:
   ├─ node.agents[]     → upsert local agents
-  ├─ node.skillIds[]   → GET /api/skills → upsert local skills
   ├─ node.mcpServers[] → upsert local mcp_servers (remote type)
   └─ node.taskSources[]→ auto-create local task_sources
+
+Phase 2 — skills, two-way (runs even if phase 1 fails)
+  ├─ collect local tombstones (soft-deleted skills that hold a server id)
+  ├─ POST /api/skills/batch-sync   → push local skills, receive all active
+  │                                   tenant skills back
+  ├─ PUT /api/org-nodes/:id        → MERGE pushed ids into node.skillIds,
+  │                                   minus tombstones; skipped when unchanged
+  └─ pull the returned skills into SQLite, skipping tombstoned ids
 ```
+
+### Skills — identity and conflict rules
+
+These rules are what make the skill sync converge. Read them before changing
+anything in `batchSyncSkills` or `pullServerSkills`.
+
+- **Identity is the server id**, carried locally in `skills.enterprise_skill_id`
+  and sent as `id` in the batch-sync payload. Name is only a fallback for a
+  skill that has never synced. Matching on name alone turns a rename into a
+  second skill, which is what the `cleanup-duplicates` endpoint used to mop up.
+- **`updated_at` is the conflict token.** It is sent as `updatedAt` and the
+  server refuses to overwrite a stored skill that is newer, reporting those in
+  `skipped`. For this to work, `updateSkill` only touches `updated_at` on a real
+  content change — never on a metadata-only write such as linking the server id.
+- **A local delete is a tombstone, not a server delete.** One user removing a
+  skill from their machine must not destroy it for the whole tenant. The
+  soft-deleted row is kept, its id is dropped from the node assignment, and the
+  pull phase skips it. Hard-deleting the row instead makes the next pull
+  re-create the skill, silently undoing the delete.
+- **The org node assignment is a merge, never a replace.** `PUT /api/org-nodes/:id`
+  replaces `skillIds` wholesale, and this client only knows its own skills.
+  Sending just what it pushed would delete every skill an admin or another
+  member assigned to the shared node.
+- **A `[Workflo] `-prefixed skill is pushed back once it is linked**, so a local
+  edit to an enterprise skill reaches the server instead of diverging forever.
+  An unlinked prefixed skill is skipped — it has no identity and would duplicate.
+- **Skills under review are never overwritten.** The server skips any skill whose
+  status is not `active`, so a sync push cannot bypass the approval pipeline.
 
 ### Resource Naming
 
@@ -116,7 +152,8 @@ Enterprise-synced resources use the `wf_` prefix to avoid conflicts with user-cr
 ```typescript
 interface EnterpriseSyncResult {
   agents: { created: number; updated: number }
-  skills: { created: number; updated: number }
+  // `pushed` counts skills the server created or updated from this client.
+  skills: { created: number; updated: number; pushed: number }
   mcpServers: { created: number; updated: number }
   taskSources: { created: number; updated: number }
   errors: string[]
@@ -324,8 +361,9 @@ Unique index on `(source_id, external_id)` prevents duplicates.
 
 2. User clicks "Sync" (or auto-sync fires)
    ├─ EnterpriseSyncManager.syncAll()
-   │   ├─ GET /api/org-nodes → upsert agents, skills, MCP servers, task sources
-   │   └─ GET /api/skills → upsert skills
+   │   ├─ GET /api/org-nodes → upsert agents, MCP servers, task sources
+   │   └─ POST /api/skills/batch-sync → push local skills, pull tenant skills
+   │       (falls back to GET /api/skills when there is nothing to push)
    └─ SyncManager.importTasks(sourceId)
        └─ PeakfloPlugin.importTasksEnterprise()
            ├─ GET /api/tasks?myTasks=true (paginated)

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -1590,6 +1590,13 @@ export class DatabaseManager {
       this.db.exec(`ALTER TABLE skills ADD COLUMN uses_at_last_sync INTEGER NOT NULL DEFAULT 0`)
     }
 
+    // Enterprise sync looks skills up by name and by server id on every run.
+    // Created after the ALTER TABLE above so the column is guaranteed to exist.
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name);
+      CREATE INDEX IF NOT EXISTS idx_skills_enterprise_id ON skills(enterprise_skill_id);
+    `)
+
     // Seed default agent if none exist
     const agentCount = this.db.prepare('SELECT COUNT(*) as count FROM agents').get() as { count: number }
     if (agentCount.count === 0) {
@@ -2468,8 +2475,14 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
     if (isContentChange) {
       setClauses.push('version = version + 1')
     }
-    setClauses.push('updated_at = ?')
-    values.push(new Date().toISOString())
+    // `updated_at` is the conflict token used by enterprise sync: it must mean
+    // "when the content last changed". Bumping it for a metadata-only write
+    // (enterprise_skill_id / uses_at_last_sync linking) would make every local
+    // copy look newer than the server and defeat conflict resolution.
+    if (isContentChange) {
+      setClauses.push('updated_at = ?')
+      values.push(new Date().toISOString())
+    }
     values.push(id)
 
     this.db.prepare(

--- a/src/main/enterprise-sync.test.ts
+++ b/src/main/enterprise-sync.test.ts
@@ -124,12 +124,14 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
       // Should use batchSyncSkills instead of createSkill/updateSkill
       expect(mockApiClient.batchSyncSkills).toHaveBeenCalledTimes(1)
       expect(mockApiClient.batchSyncSkills).toHaveBeenCalledWith([{
+        id: undefined,
         name: 'Test Skill',
         description: 'A test skill',
         content: '# Test',
         confidence: 0.8,
         uses: 5,
         lastUsed: '2026-03-10T00:00:00Z',
+        updatedAt: '2026-03-10T00:00:00Z',
         tags: ['test']
       }])
 
@@ -334,6 +336,85 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
   })
 
   // ── Pull server skills ────────────────────────────────────────────────
+
+  describe('local deletes', () => {
+    it('does not re-create a skill the user deleted locally', async () => {
+      // The skill is gone locally (soft-deleted) but the server still lists it.
+      mockDb.getSkills.mockReturnValue([])
+      mockDb.getDeletedEnterpriseSkills.mockReturnValue([
+        makeLocalSkill({ id: 'local-del', enterprise_skill_id: 'server-del' })
+      ])
+      mockApiClient.listSkills.mockResolvedValue([
+        makeServerSkill({ id: 'server-del', name: 'Deleted Skill' })
+      ])
+
+      const result = await syncManager.syncAll('user-1')
+
+      expect(mockDb.createSkill).not.toHaveBeenCalled()
+      expect(result.skills.created).toBe(0)
+    })
+
+    it('keeps the tombstone so the delete survives later syncs', async () => {
+      mockDb.getSkills.mockReturnValue([])
+      mockDb.getDeletedEnterpriseSkills.mockReturnValue([
+        makeLocalSkill({ id: 'local-del', enterprise_skill_id: 'server-del' })
+      ])
+      mockApiClient.listSkills.mockResolvedValue([
+        makeServerSkill({ id: 'server-del', name: 'Deleted Skill' })
+      ])
+
+      await syncManager.syncAll('user-1')
+
+      // Hard-deleting the tombstone is what previously let the skill come back.
+      expect(mockDb.hardDeleteSkill).not.toHaveBeenCalled()
+    })
+
+    it('never deletes the skill from the server on a local delete', async () => {
+      mockDb.getSkills.mockReturnValue([])
+      mockDb.getDeletedEnterpriseSkills.mockReturnValue([
+        makeLocalSkill({ id: 'local-del', enterprise_skill_id: 'server-del' })
+      ])
+      mockApiClient.listSkills.mockResolvedValue([])
+
+      await syncManager.syncAll('user-1')
+
+      expect(mockApiClient.deleteSkill).not.toHaveBeenCalled()
+    })
+
+    it('removes a locally-deleted skill from the node assignment', async () => {
+      mockDb.getSkills.mockReturnValue([])
+      mockDb.getDeletedEnterpriseSkills.mockReturnValue([
+        makeLocalSkill({ id: 'local-del', enterprise_skill_id: 'server-del' })
+      ])
+      mockApiClient.listOrgNodes.mockResolvedValue([
+        makeOrgNode({ skillIds: ['server-del', 'admin-skill-1'] })
+      ])
+      mockApiClient.listSkills.mockResolvedValue([])
+
+      await syncManager.syncAll('user-1')
+
+      expect(mockApiClient.updateOrgNode).toHaveBeenCalledWith('node-1', {
+        skillIds: ['admin-skill-1']
+      })
+    })
+  })
+
+  describe('cleanup-duplicates', () => {
+    it('is not called on a normal sync', async () => {
+      mockDb.getSkills.mockReturnValue([makeLocalSkill()])
+      mockApiClient.batchSyncSkills.mockResolvedValue({
+        created: 0,
+        updated: 1,
+        skills: [makeServerSkill()]
+      })
+
+      await syncManager.syncAll('user-1')
+
+      // Destructive, admin-only, and no longer needed now that identity is
+      // resolved by id rather than by name.
+      expect(mockApiClient.cleanupDuplicateSkills).not.toHaveBeenCalled()
+    })
+  })
 
   describe('pullServerSkills', () => {
     it('creates new local skill from server skill not seen before', async () => {
@@ -550,29 +631,77 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
 
       // Batch sync should NOT be called (Mastermind filtered out, 0 skills to push)
       expect(mockApiClient.batchSyncSkills).not.toHaveBeenCalled()
-      // Should assign empty skillIds
-      expect(mockApiClient.updateOrgNode).toHaveBeenCalledWith(
-        'node-1',
-        { skillIds: [] }
-      )
+      // The node must be left alone. Writing `skillIds: []` here would delete
+      // every skill other members and admins assigned to the shared node.
+      expect(mockApiClient.updateOrgNode).not.toHaveBeenCalled()
     })
 
-    it('skips [Workflo]-prefixed skills from batch sync and node assignment', async () => {
+    it('never clears a node whose skills this client does not know about', async () => {
+      // Fresh install: the user has no pushable skills of their own, but the
+      // shared org node already holds skills assigned by an admin.
+      mockDb.getSkills.mockReturnValue([])
+      mockApiClient.listOrgNodes.mockResolvedValue([
+        makeOrgNode({ skillIds: ['admin-skill-1', 'admin-skill-2'] })
+      ])
+      mockApiClient.listSkills.mockResolvedValue([])
+
+      await syncManager.syncAll('user-1')
+
+      expect(mockApiClient.updateOrgNode).not.toHaveBeenCalled()
+    })
+
+    it('merges pushed skills into the node instead of replacing them', async () => {
+      const localSkill = makeLocalSkill({ enterprise_skill_id: null })
+      mockDb.getSkills.mockReturnValue([localSkill])
+      mockApiClient.listOrgNodes.mockResolvedValue([
+        makeOrgNode({ skillIds: ['admin-skill-1'] })
+      ])
+      mockApiClient.batchSyncSkills.mockResolvedValue({
+        created: 1,
+        updated: 0,
+        skills: [makeServerSkill({ id: 'server-new', name: 'Test Skill' })]
+      })
+
+      await syncManager.syncAll('user-1')
+
+      expect(mockApiClient.updateOrgNode).toHaveBeenCalledWith('node-1', {
+        skillIds: ['admin-skill-1', 'server-new']
+      })
+    })
+
+    it('pushes a linked [Workflo] skill so local edits reach the server', async () => {
+      const pulledSkill = makeLocalSkill({
+        name: '[Workflo] other-team-skill',
+        enterprise_skill_id: 'other-team-id'
+      })
+      mockDb.getSkills.mockReturnValue([pulledSkill])
+      mockApiClient.batchSyncSkills.mockResolvedValue({
+        created: 0,
+        updated: 1,
+        skills: [makeServerSkill({ id: 'other-team-id', name: 'other-team-skill' })]
+      })
+
+      await syncManager.syncAll('user-1')
+
+      const payload = mockApiClient.batchSyncSkills.mock.calls[0][0]
+      expect(payload).toHaveLength(1)
+      // Pushed under its server id, with the display prefix stripped.
+      expect(payload[0].id).toBe('other-team-id')
+      expect(payload[0].name).toBe('other-team-skill')
+    })
+
+    it('skips an UNLINKED [Workflo] skill so it cannot become a duplicate', async () => {
       const pulledSkill = makeLocalSkill({
         name: '[Workflo] Other Team Skill',
-        enterprise_skill_id: 'other-team-id'
+        enterprise_skill_id: null
       })
       mockDb.getSkills.mockReturnValue([pulledSkill])
       mockApiClient.listSkills.mockResolvedValue([])
 
       await syncManager.syncAll('user-1')
 
-      // Batch sync should NOT be called (all skills filtered out)
       expect(mockApiClient.batchSyncSkills).not.toHaveBeenCalled()
-      expect(mockApiClient.updateOrgNode).toHaveBeenCalledWith(
-        'node-1',
-        { skillIds: [] }
-      )
+      expect(mockApiClient.updateOrgNode).not.toHaveBeenCalled()
     })
 
     it('handles assign skills failure gracefully with domain in error', async () => {
@@ -693,23 +822,22 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
 
       const result = await syncManager.syncAll('user-1')
 
-      // Batch sync should only include non-skipped skills
+      // Batch sync includes the user's own skills plus the linked [Workflo]
+      // one (so its local edits propagate). Mastermind stays excluded.
       const batchPayload = mockApiClient.batchSyncSkills.mock.calls[0][0]
-      expect(batchPayload).toHaveLength(2) // New Skill + Existing Skill
-      expect(batchPayload.map((p: { name: string }) => p.name)).toEqual(['New Skill', 'Existing Skill'])
+      const pushedNames = batchPayload.map((p: { name: string }) => p.name)
+      expect(pushedNames).toEqual(['New Skill', 'Pulled Skill', 'Existing Skill'])
+      expect(pushedNames).not.toContain('Mastermind')
 
-      // Should NOT include [Workflo] or Mastermind
-      expect(batchPayload.map((p: { name: string }) => p.name)).not.toContain('[Workflo] Pulled Skill')
-      expect(batchPayload.map((p: { name: string }) => p.name)).not.toContain('Mastermind')
+      // The prefixed skill is pushed under its server id, not its display name.
+      const pulled = batchPayload.find((p: { name: string }) => p.name === 'Pulled Skill')
+      expect(pulled.id).toBe('server-pulled')
 
       expect(result.skills.pushed).toBe(2)
 
-      // Node should only have local skills, not pulled [Workflo] ones
       expect(mockApiClient.updateOrgNode).toHaveBeenCalledWith('node-1', {
         skillIds: expect.arrayContaining(['server-new', 'server-existing'])
       })
-      const assignedIds = mockApiClient.updateOrgNode.mock.calls[0][1].skillIds
-      expect(assignedIds).not.toContain('server-pulled')
     })
 
     it('makes only 1 API call for skills instead of N per-skill calls', async () => {

--- a/src/main/enterprise-sync.ts
+++ b/src/main/enterprise-sync.ts
@@ -173,18 +173,12 @@ export class EnterpriseSyncManager {
     try {
       const skillSyncStart = Date.now()
 
-      // Step 0: Clean up server-side duplicates (one-time fix for prior sync bugs)
-      try {
-        const cleanup = await this.apiClient.cleanupDuplicateSkills()
-        if (cleanup.deleted > 0) {
-          console.log(
-            `[EnterpriseSyncManager] Cleaned up ${cleanup.deleted} duplicate server skills, kept ${cleanup.kept}`
-          )
-        }
-      } catch (cleanupErr) {
-        // Non-fatal — endpoint may not exist yet on older servers
-        console.log('[EnterpriseSyncManager] Cleanup endpoint not available, skipping')
-      }
+      // NOTE: this used to call POST /api/skills/cleanup-duplicates on every
+      // single sync. That endpoint deletes tenant rows, needs an admin
+      // permission (so it 403s for ordinary users on every run), and was only
+      // ever a mop-up for duplicates created by name-based identity. Skills are
+      // now pushed with their server id, so duplicates are not created in the
+      // first place. Cleanup stays available as an explicit admin action.
 
       // Step A0: Collect locally-deleted skill IDs (to exclude from node assignment)
       const removedSkillIds = this.getLocallyRemovedSkillIds()
@@ -200,7 +194,7 @@ export class EnterpriseSyncManager {
         )
       } else {
         for (const node of targetNodes) {
-          await this.assignSkillsToNode(node.id, pushedSkillIds, removedSkillIds, result)
+          await this.assignSkillsToNode(node, pushedSkillIds, removedSkillIds, result)
         }
       }
 
@@ -210,7 +204,7 @@ export class EnterpriseSyncManager {
         allServerSkills.map((s) => ({ id: s.id, name: s.name }))
       )
       if (allServerSkills.length > 0) {
-        await this.pullServerSkills(allServerSkills, result)
+        await this.pullServerSkills(allServerSkills, result, removedSkillIds)
       } else {
         console.log('[EnterpriseSyncManager] No server skills to pull (batch-sync returned empty)')
       }
@@ -314,8 +308,14 @@ export class EnterpriseSyncManager {
 
   /**
    * Collect enterprise skill IDs that were soft-deleted locally.
-   * These should be unassigned from the node (but NOT deleted from server).
-   * Hard-deletes the local rows after collecting.
+   * These are unassigned from the node, but NOT deleted from the server —
+   * one user removing a skill from their machine must not destroy it for the
+   * whole tenant.
+   *
+   * The soft-deleted rows are kept as TOMBSTONES. They are what tells the pull
+   * phase "I deleted this on purpose, do not re-create it". Hard-deleting them
+   * here would make the very next pull re-create the skill, because the server
+   * still returns it in the tenant skill set.
    */
   private getLocallyRemovedSkillIds(): Set<string> {
     const deletedSkills = this.db.getDeletedEnterpriseSkills()
@@ -325,13 +325,11 @@ export class EnterpriseSyncManager {
       if (skill.enterprise_skill_id) {
         removedIds.add(skill.enterprise_skill_id)
       }
-      // Hard-delete locally — the skill stays on server but won't be assigned to this node
-      this.db.hardDeleteSkill(skill.id)
     }
 
     if (removedIds.size > 0) {
       console.log(
-        `[EnterpriseSyncManager] ${removedIds.size} locally-deleted skills will be unassigned from node`
+        `[EnterpriseSyncManager] ${removedIds.size} locally-deleted skills will be unassigned from the node and skipped on pull`
       )
     }
 
@@ -375,12 +373,14 @@ export class EnterpriseSyncManager {
     const skillsToSync: Array<{
       localId: string
       payload: {
+        id?: string
         name: string
         description: string
         content: string
         confidence?: number
         uses?: number
         lastUsed?: string | null
+        updatedAt?: string
         tags?: string[]
       }
     }> = []
@@ -389,8 +389,13 @@ export class EnterpriseSyncManager {
       // Skip built-in system skills
       if (this.isBuiltInSkill(skill)) continue
 
-      // Skip [Workflo]-prefixed skills — these were pulled from the server
-      if (skill.name.startsWith(WORKFLO_SKILL_PREFIX)) continue
+      // A [Workflo]-prefixed skill came from the server. It is still pushed
+      // back when it is linked, so that a local edit to an enterprise skill
+      // reaches the server instead of silently diverging. The server decides
+      // who wins from the timestamps below. An UNLINKED prefixed skill is
+      // skipped — it has no identity yet and would create a duplicate.
+      const isPrefixed = skill.name.startsWith(WORKFLO_SKILL_PREFIX)
+      if (isPrefixed && !skill.enterprise_skill_id) continue
 
       const localName = this.stripWorkfloPrefix(skill.name)
 
@@ -408,11 +413,15 @@ export class EnterpriseSyncManager {
         continue
       }
 
-      // Include the skill in the batch — server does upsert by name
+      // Include the skill in the batch. The server resolves identity from `id`
+      // when we have one (so a local rename stays a rename), and uses
+      // `updatedAt` to refuse a stale overwrite.
       skillsToSync.push({
         localId: skill.id,
         payload: {
+          id: skill.enterprise_skill_id ?? undefined,
           name: localName,
+          updatedAt: this.normalizeDateTime(skill.updated_at) ?? undefined,
           // Truncate description to server max (1024 chars)
           description: skill.description.slice(0, 1024),
           // Truncate content to server max (500KB)
@@ -500,20 +509,28 @@ export class EnterpriseSyncManager {
 
     result.skills.pushed = totalCreated + totalUpdated
 
-    // Build a name→server skill map for linking local skills
+    // Build id→ and name→server skill maps for linking local skills
+    const serverSkillById = new Map<string, WorkfloSkill>()
     const serverSkillByName = new Map<string, WorkfloSkill>()
     for (const s of allServerSkills) {
+      serverSkillById.set(s.id, s)
       if (!serverSkillByName.has(s.name)) {
         serverSkillByName.set(s.name, s)
       }
     }
 
-    // Link local skills to their server counterparts and collect IDs for node assignment
+    // Link local skills to their server counterparts and collect IDs for node
+    // assignment. Resolve by id first so that a renamed skill stays linked to
+    // the same server row instead of adopting a same-named stranger.
     const pushedSkillIds: string[] = []
     for (const { localId, payload } of skillsToSync) {
-      const serverSkill = serverSkillByName.get(payload.name)
+      const serverSkill =
+        (payload.id ? serverSkillById.get(payload.id) : undefined) ??
+        serverSkillByName.get(payload.name)
       if (serverSkill) {
-        // Update local record with server ID and sync baseline
+        // Update local record with server ID and sync baseline. This is a
+        // metadata-only write, so it must not disturb `updated_at` — that
+        // timestamp is the conflict token for the next sync.
         const localSkill = localSkills.find((s) => s.id === localId)
         if (localSkill) {
           this.db.updateSkill(localId, {
@@ -590,26 +607,47 @@ export class EnterpriseSyncManager {
    * Merges the pushed skill IDs with any existing node skill IDs.
    */
   private async assignSkillsToNode(
-    nodeId: string,
+    node: WorkfloOrgNode,
     pushedSkillIds: string[],
     removedSkillIds: Set<string>,
     result: EnterpriseSyncResult
   ): Promise<void> {
+    const nodeId = node.id
     try {
-      // pushedSkillIds already represents ALL skills this node should have
-      // (every local skill that was pushed or already linked).
-      // Just exclude locally-deleted ones and deduplicate.
-      const finalIds = [...new Set(
-        pushedSkillIds.filter((id) => !removedSkillIds.has(id))
-      )]
+      // The org node is shared by every member of the node, and the API replaces
+      // `skillIds` wholesale. This client only knows about its OWN skills, so it
+      // must MERGE into the node's current set — sending only what this client
+      // pushed would delete every skill that another member or an admin added.
+      const currentIds = Array.isArray(node.skillIds) ? node.skillIds : []
+
+      const finalIds = [...new Set([...currentIds, ...pushedSkillIds])].filter(
+        (id) => !removedSkillIds.has(id)
+      )
+
+      // Nothing to add and nothing to remove — don't write at all. This keeps
+      // the sync idempotent and avoids pointless writes on every run.
+      const unchanged =
+        finalIds.length === currentIds.length &&
+        finalIds.every((id) => currentIds.includes(id))
+
+      if (unchanged) {
+        console.log(
+          `[EnterpriseSyncManager] assignSkillsToNode: node=${nodeId} already up to date (${currentIds.length} skills)`
+        )
+        return
+      }
 
       console.log(
-        `[EnterpriseSyncManager] assignSkillsToNode: node=${nodeId}, skills=${finalIds.length}, removed=${removedSkillIds.size}`
+        `[EnterpriseSyncManager] assignSkillsToNode: node=${nodeId}, current=${currentIds.length}, final=${finalIds.length}, removed=${removedSkillIds.size}`
       )
 
       await this.apiClient.updateOrgNode(nodeId, {
         skillIds: finalIds
       })
+
+      // Keep the in-memory node consistent with what the server now holds so a
+      // second pass in the same run does not re-send the same write.
+      node.skillIds = finalIds
 
       console.log(
         `[EnterpriseSyncManager] Assigned ${finalIds.length} skills to node ${nodeId}`
@@ -627,10 +665,15 @@ export class EnterpriseSyncManager {
    */
   private async pullServerSkills(
     serverSkills: WorkfloSkill[],
-    result: EnterpriseSyncResult
+    result: EnterpriseSyncResult,
+    tombstonedSkillIds: Set<string> = new Set()
   ): Promise<void> {
     for (const skill of serverSkills) {
       try {
+        // Respect a local delete. Without this the skill is re-created on the
+        // very next pull and the user's delete silently undoes itself.
+        if (tombstonedSkillIds.has(skill.id)) continue
+
         // First, check if we already have this skill linked by enterprise_skill_id
         const linkedSkill = this.db.getSkillByEnterpriseId(skill.id)
 

--- a/src/main/workflo-api-client.ts
+++ b/src/main/workflo-api-client.ts
@@ -321,23 +321,33 @@ export class WorkfloApiClient {
 
   /**
    * Batch sync skills — push multiple skills in a single API call.
-   * The server upserts by name and returns ALL tenant skills after sync.
+   * The server returns ALL active tenant skills after the sync.
    * Max 200 skills per request; caller must chunk if more.
+   *
+   * `id` is the server skill id we already hold. Sending it makes the server
+   * resolve the skill by identity rather than by name, so a rename stays a
+   * rename instead of creating a second skill.
+   *
+   * `updatedAt` is our last local content-change time. The server refuses to
+   * overwrite a stored skill that is newer than this, and reports those in
+   * `skipped`. Older servers ignore both fields, so this stays compatible.
    */
   async batchSyncSkills(skills: Array<{
+    id?: string
     name: string
     description: string
     content: string
     confidence?: number
     uses?: number
     lastUsed?: string | null
+    updatedAt?: string
     tags?: string[]
-  }>): Promise<{ created: number; updated: number; skills: WorkfloSkill[] }> {
+  }>): Promise<{ created: number; updated: number; skipped?: number; skills: WorkfloSkill[] }> {
     const result = (await this.auth.apiRequest(
       'POST',
       '/api/skills/batch-sync',
       { skills }
-    )) as { created: number; updated: number; skills: WorkfloSkill[] }
+    )) as { created: number; updated: number; skipped?: number; skills: WorkfloSkill[] }
     return result
   }
 


### PR DESCRIPTION
## Why

An audit of the 20x ↔ workflow-builder skill sync found two defects that make it **destructive rather than convergent**, plus several smaller correctness gaps.

### 1. Every sync could wipe the shared org node's skills (data loss)

`assignSkillsToNode` replaced the node's `skillIds` with **only the ids this client had just pushed**. `PUT /api/org-nodes/:id` replaces the array wholesale.

A user with no locally-created, non-`[Workflo]`-prefixed skills — **a fresh install**, or anyone who only consumes admin-published skills — therefore sent `skillIds: []` on **every sync** and deleted the node's entire skill assignment for every member.

It then compounds into a permanent lockout: with the node emptied, `resolveOrgNodeSkillRestrictions` reports the user as restricted with an empty allowed set, so `batch-sync` returns `{created: 0, updated: 0, skills: []}` forever and the user can never push a skill again.

**Fix:** the assignment is now a **merge** into the node's current `skillIds`, and is skipped entirely when the resulting set is unchanged.

### 2. Deleting a skill locally did not stick

`getLocallyRemovedSkillIds` hard-deleted the soft-deleted row while the server kept the skill. Because `batch-sync` returns **all** active tenant skills, `pullServerSkills` re-created it in the **same run** as `[Workflo] <name>`.

**Fix:** soft-deleted rows are kept as **tombstones** and the pull phase skips them. The skill is still never deleted from the server — one user clearing their machine must not destroy it for the whole tenant.

## Also fixed

- **Identity.** Skills are pushed with their server `id` and their `updated_at`, so a rename stays a rename and the server can refuse a stale overwrite. Linking now resolves by id first.
- **`updated_at` was meaningless.** `updateSkill` bumped it for metadata-only writes, so linking the server id made every local copy look newer than the server — defeating conflict resolution entirely. It now moves only on a real content change.
- **Enterprise skills could diverge forever.** A `[Workflo] `-prefixed skill was never pushed back, so a local edit to it was silently lost. Linked prefixed skills are now pushed under their server id; unlinked ones are still skipped so they cannot duplicate.
- **`cleanup-duplicates` was called on every sync.** It deletes tenant rows, needs an admin permission it 403s without for ordinary users, and was only ever a mop-up for the name-based identity now fixed. Removed from the sync path; it remains available as an explicit admin action.
- **Missing indexes.** `skills(name)` and `skills(enterprise_skill_id)` are looked up on every sync and were full table scans. Created after the column migration so old databases upgrade cleanly.

## Requires

Server-side companion: peakflo/workflow-builder#1638. The two are **independently deployable** — the new fields are optional and ignored by an older server, and an older client keeps its previous behaviour against the new server.

## Testing

- `src/main/enterprise-sync.test.ts` — 40 passing, 8 new cases covering the node-wipe guard, merge behaviour, delete tombstones, no server-side delete, node unassignment, linked-vs-unlinked prefixed skills, and the removed cleanup call. Four tests that asserted the buggy behaviour (`Should assign empty skillIds`) were rewritten.
- `pnpm test run` — **1535 passed / 1535**.
- `pnpm typecheck` and `pnpm lint` — clean (0 errors).

## Note

Docs updated in `docs/enterprise-sync-implementation.md` with the identity and conflict rules, so the next change to this code has the invariants written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)