### PR TITLE
feat: copy artifact content or the file from the artifacts viewer

### DIFF
--- a/src/main/artifact-clipboard.test.ts
+++ b/src/main/artifact-clipboard.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clipboard as electronClipboard, nativeImage } from 'electron'
+import { ArtifactClipboardMode } from '../shared/artifacts'
+import { writeArtifactFileToClipboard } from './artifact-clipboard'
+
+/** Mirrors the payload shape of the Electron ClipboardItem constructor. */
+const { FakeClipboardItem } = vi.hoisted(() => ({
+  FakeClipboardItem: class {
+    constructor(public readonly items: Record<string, unknown>) {}
+  }
+}))
+
+vi.mock('electron', () => ({
+  clipboard: {
+    write: vi.fn().mockResolvedValue(undefined),
+    writeText: vi.fn().mockResolvedValue(undefined)
+  },
+  ClipboardItem: FakeClipboardItem,
+  nativeImage: {
+    createFromPath: vi.fn(() => ({ isEmpty: () => true }))
+  }
+}))
+
+const clipboard = electronClipboard as unknown as Electron.Clipboard
+const realPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+function writtenItems(): Record<string, unknown> {
+  const [item] = vi.mocked(clipboard.write).mock.calls[0][0]
+  return (item as unknown as InstanceType<typeof FakeClipboardItem>).items
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  setPlatform(realPlatform)
+})
+
+describe('writeArtifactFileToClipboard', () => {
+  it('puts a file URL on the macOS pasteboard so Finder can paste the file', async () => {
+    setPlatform('darwin')
+
+    await expect(writeArtifactFileToClipboard('/tmp/workspace/reports/summary.md')).resolves.toEqual({
+      mode: ArtifactClipboardMode.FILE
+    })
+    expect(writtenItems()).toEqual({
+      'electron application/osclipboard;format="public.file-url"': 'file:///tmp/workspace/reports/summary.md'
+    })
+  })
+
+  it('puts a URI list on the Linux clipboard', async () => {
+    setPlatform('linux')
+
+    await expect(writeArtifactFileToClipboard('/tmp/workspace/reports/summary.md')).resolves.toEqual({
+      mode: ArtifactClipboardMode.FILE
+    })
+    expect(writtenItems()).toEqual({ 'text/uri-list': 'file:///tmp/workspace/reports/summary.md\r\n' })
+  })
+
+  it('copies an image file as an image on Windows', async () => {
+    setPlatform('win32')
+    const image = { isEmpty: () => false, toPNG: () => Buffer.from('png-bytes') }
+    vi.mocked(nativeImage.createFromPath).mockReturnValueOnce(image as unknown as Electron.NativeImage)
+
+    await expect(writeArtifactFileToClipboard('C:\\workspace\\chart.png')).resolves.toEqual({
+      mode: ArtifactClipboardMode.IMAGE
+    })
+    expect(Object.keys(writtenItems())).toEqual(['image/png'])
+    expect(clipboard.writeText).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the file path on Windows for a file that is not an image', async () => {
+    setPlatform('win32')
+
+    await expect(writeArtifactFileToClipboard('C:\\workspace\\summary.md')).resolves.toEqual({
+      mode: ArtifactClipboardMode.PATH
+    })
+    expect(clipboard.writeText).toHaveBeenCalledWith('C:\\workspace\\summary.md')
+    expect(clipboard.write).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/artifact-clipboard.ts
+++ b/src/main/artifact-clipboard.ts
@@ -1,0 +1,46 @@
+import { ClipboardItem, clipboard as electronClipboard, nativeImage } from 'electron'
+import { pathToFileURL } from 'url'
+import { ArtifactClipboardMode, type ArtifactCopyFileResult } from '../shared/artifacts'
+
+/** The DOM `Clipboard` interface shadows Electron's in the main-process type
+ * graph, so the module export is narrowed back to the Electron one. */
+const clipboard = electronClipboard as unknown as Electron.Clipboard
+
+/** Raw pasteboard type Finder reads when one file is copied. Electron exposes
+ * a native clipboard format through this custom MIME wrapper. */
+const MACOS_FILE_URL_FORMAT = 'electron application/osclipboard;format="public.file-url"'
+/** Standard clipboard type a Linux file manager reads for copied files. */
+const URI_LIST_FORMAT = 'text/uri-list'
+const PNG_FORMAT = 'image/png'
+
+/**
+ * Put an artifact file on the OS clipboard so the user can paste the file
+ * itself into a file manager, a chat window, or an email.
+ *
+ * Windows has no supported Electron API for the CF_HDROP file list, so an
+ * image file is copied as an image and every other file falls back to its
+ * path as text. The caller tells the user which of these happened.
+ */
+export async function writeArtifactFileToClipboard(filePath: string): Promise<ArtifactCopyFileResult> {
+  const fileUrl = pathToFileURL(filePath).toString()
+
+  if (process.platform === 'darwin') {
+    await clipboard.write([new ClipboardItem({ [MACOS_FILE_URL_FORMAT]: fileUrl })])
+    return { mode: ArtifactClipboardMode.FILE }
+  }
+
+  if (process.platform === 'linux') {
+    await clipboard.write([new ClipboardItem({ [URI_LIST_FORMAT]: `${fileUrl}\r\n` })])
+    return { mode: ArtifactClipboardMode.FILE }
+  }
+
+  const image = nativeImage.createFromPath(filePath)
+  if (!image.isEmpty()) {
+    const png = new Uint8Array(image.toPNG())
+    await clipboard.write([new ClipboardItem({ [PNG_FORMAT]: new Blob([png], { type: PNG_FORMAT }) })])
+    return { mode: ArtifactClipboardMode.IMAGE }
+  }
+
+  await clipboard.writeText(filePath)
+  return { mode: ArtifactClipboardMode.PATH }
+}

--- a/src/main/artifacts.test.ts
+++ b/src/main/artifacts.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readdir, readFile, rm, symlink, writeFile } from 'fs/promises'
+import { mkdtemp, mkdir, readdir, readFile, realpath, rm, symlink, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -12,6 +12,7 @@ import {
   listTaskArtifactEntries,
   readRegisteredTaskArtifactFile,
   readTaskArtifact,
+  resolveTaskArtifactFilePath,
   scanTaskArtifacts,
   writeRegisteredTaskArtifactFile
 } from './artifacts'
@@ -269,6 +270,25 @@ describe('task artifact files', () => {
     await expect(readTaskArtifact(workspaceDir, 'archive.zip')).resolves.toBeNull()
     await expect(readTaskArtifact(workspaceDir, 'missing.md')).resolves.toBeNull()
     await expect(readTaskArtifact(workspaceDir, 'large.md')).resolves.toBeNull()
+  })
+
+  it('resolves an artifact file path for the clipboard only inside the workspace', async () => {
+    const outsideFile = join(testRoot, 'outside.md')
+    await writeFile(outsideFile, 'secret')
+    await symlink(outsideFile, join(workspaceDir, 'linked.md'))
+    await mkdir(join(workspaceDir, 'reports'))
+    await writeFile(join(workspaceDir, 'reports', 'summary.md'), '# Summary')
+    await writeFile(join(workspaceDir, 'archive.zip'), 'zip')
+
+    await expect(resolveTaskArtifactFilePath(workspaceDir, 'reports/summary.md')).resolves.toBe(
+      join(await realpath(workspaceDir), 'reports', 'summary.md')
+    )
+    await expect(resolveTaskArtifactFilePath(workspaceDir, '../outside.md')).resolves.toBeNull()
+    await expect(resolveTaskArtifactFilePath(workspaceDir, outsideFile)).resolves.toBeNull()
+    await expect(resolveTaskArtifactFilePath(workspaceDir, 'linked.md')).resolves.toBeNull()
+    await expect(resolveTaskArtifactFilePath(workspaceDir, 'archive.zip')).resolves.toBeNull()
+    await expect(resolveTaskArtifactFilePath(workspaceDir, 'reports')).resolves.toBeNull()
+    await expect(resolveTaskArtifactFilePath(workspaceDir, 'missing.md')).resolves.toBeNull()
   })
 
   it('returns an empty scan for a missing workspace', async () => {

--- a/src/main/artifacts.ts
+++ b/src/main/artifacts.ts
@@ -494,6 +494,19 @@ export async function scanTaskArtifacts(workspaceDir: string): Promise<ArtifactF
   return [...artifacts.values()].sort((a, b) => b.updatedAt - a.updatedAt || a.path.localeCompare(b.path))
 }
 
+/** Resolve a previewable artifact to its absolute path while enforcing
+ * task-workspace containment. Used by the "copy the file" clipboard action. */
+export async function resolveTaskArtifactFilePath(workspaceDir: string, artifactPath: string): Promise<string | null> {
+  const filePath = await resolveArtifactPath(workspaceDir, artifactPath)
+  if (!filePath) return null
+  if (!artifactTypeForPath(filePath)) return null
+  try {
+    return (await stat(filePath)).isFile() ? filePath : null
+  } catch {
+    return null
+  }
+}
+
 /** Read a previewable artifact while enforcing task-workspace containment. */
 export async function readTaskArtifact(workspaceDir: string, artifactPath: string): Promise<ArtifactContent | null> {
   const filePath = await resolveArtifactPath(workspaceDir, artifactPath)

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -4,6 +4,11 @@ vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
   dialog: { showOpenDialog: vi.fn() },
   shell: { openPath: vi.fn(), showItemInFolder: vi.fn() },
+  clipboard: { write: vi.fn(async () => undefined), writeText: vi.fn(async () => undefined) },
+  ClipboardItem: class {
+    constructor(public readonly items: Record<string, unknown>) {}
+  },
+  nativeImage: { createFromPath: vi.fn(() => ({ isEmpty: () => true, toPNG: () => Buffer.alloc(0) })) },
   Notification: vi.fn().mockImplementation(() => ({ show: vi.fn() })),
   app: { isPackaged: false }
 }))

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -39,7 +39,9 @@ import type { ClaudePluginManager } from './claude-plugin-manager'
 import type { EnterpriseHeartbeat } from './enterprise-heartbeat'
 import type { EnterpriseStateSync } from './enterprise-state-sync'
 import { analytics } from './analytics-service'
-import { listTaskArtifactEntries, readTaskArtifact } from './artifacts'
+import { listTaskArtifactEntries, readTaskArtifact, resolveTaskArtifactFilePath } from './artifacts'
+import { writeArtifactFileToClipboard } from './artifact-clipboard'
+import { ArtifactClipboardMode, type ArtifactCopyFileResult } from '../shared/artifacts'
 import { guardChildStreams, writeToChildStdin } from './child-stream-guards'
 
 const MIME_MAP: Record<string, string> = {
@@ -293,6 +295,12 @@ export function registerIpcHandlers(
 
   ipcMain.handle('artifacts:read', async (_, taskId: string, relativePath: string) => {
     return readTaskArtifact(db.getWorkspaceDir(taskId), relativePath)
+  })
+
+  ipcMain.handle('artifacts:copyFile', async (_, taskId: string, relativePath: string): Promise<ArtifactCopyFileResult> => {
+    const filePath = await resolveTaskArtifactFilePath(db.getWorkspaceDir(taskId), relativePath)
+    if (!filePath) return { mode: ArtifactClipboardMode.UNAVAILABLE }
+    return writeArtifactFileToClipboard(filePath)
   })
 
   ipcMain.handle('attachments:open', (_, taskId: string, attachmentId: string) => {

--- a/src/mobile/pages/ArtifactViewerPage.test.tsx
+++ b/src/mobile/pages/ArtifactViewerPage.test.tsx
@@ -1,11 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { render } from '@testing-library/react'
-import { ArtifactType } from '@shared/artifacts'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { ArtifactContentKind, ArtifactType } from '@shared/artifacts'
 import { ArtifactViewerPage } from './ArtifactViewerPage'
+import { api } from '../api/client'
 import { useArtifactStore } from '../stores/artifact-store'
+
+const writeText = vi.fn().mockResolvedValue(undefined)
 
 beforeEach(() => {
   useArtifactStore.setState({ artifactsByTask: new Map(), loadingTaskIds: new Set() })
+  writeText.mockClear()
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+    writable: true
+  })
 })
 
 describe('ArtifactViewerPage', () => {
@@ -33,5 +42,55 @@ describe('ArtifactViewerPage', () => {
     expect(getByRole('img', { name: 'Screenshot' }).getAttribute('src')).toBe(
       'https://example.com/screenshot.png'
     )
+  })
+
+  it('copies the content of the artifact on screen', async () => {
+    useArtifactStore.setState({
+      artifactsByTask: new Map([['task-1', [{
+        id: 'task-1:markdown:review',
+        taskId: 'task-1',
+        type: ArtifactType.MARKDOWN,
+        title: 'Review notes',
+        path: 'reports/review.md',
+        updatedAt: 1,
+        reloadTrigger: 0
+      }]]])
+    })
+    vi.mocked(api.artifacts.content).mockResolvedValue({
+      kind: ArtifactContentKind.TEXT,
+      content: '# Review notes'
+    })
+
+    const { getByRole } = render(
+      <ArtifactViewerPage taskId="task-1" artifactId="task-1:markdown:review" onNavigate={vi.fn()} />
+    )
+
+    await waitFor(() => expect(api.artifacts.content).toHaveBeenCalledWith('task-1', 'reports/review.md'))
+    fireEvent.click(getByRole('button', { name: 'Copy content' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('# Review notes'))
+  })
+
+  it('copies the pull request link when the artifact has no file', async () => {
+    useArtifactStore.setState({
+      artifactsByTask: new Map([['task-1', [{
+        id: 'task-1:pr:1',
+        taskId: 'task-1',
+        type: ArtifactType.PR,
+        title: 'Pull request',
+        url: 'https://github.com/peakflo/20x/pull/1',
+        updatedAt: 1,
+        reloadTrigger: 0
+      }]]])
+    })
+
+    const { getByRole, queryByRole } = render(
+      <ArtifactViewerPage taskId="task-1" artifactId="task-1:pr:1" onNavigate={vi.fn()} />
+    )
+
+    expect(queryByRole('button', { name: 'Save file' })).toBeNull()
+    fireEvent.click(getByRole('button', { name: 'Copy link' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('https://github.com/peakflo/20x/pull/1'))
   })
 })

--- a/src/mobile/pages/ArtifactViewerPage.tsx
+++ b/src/mobile/pages/ArtifactViewerPage.tsx
@@ -8,8 +8,16 @@ import {
   type ArtifactContent,
   type PullRequestDetails
 } from '@shared/artifacts'
+import {
+  ARTIFACT_COPY_LABELS,
+  ArtifactCopyOutcome,
+  artifactFileName,
+  copyArtifactContent,
+  copyText,
+  shareOrDownloadArtifactFile
+} from '@/lib/artifact-clipboard'
 import { api } from '../api/client'
-import { ArtifactType, useArtifactStore } from '../stores/artifact-store'
+import { ArtifactType, useArtifactStore, type Artifact } from '../stores/artifact-store'
 import type { Route } from '../App'
 
 const ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS = 30_000
@@ -138,6 +146,7 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
           <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m15 18-6-6 6-6"/></svg>
         </button>
         <span className="min-w-0 flex-1 truncate text-sm font-medium">{artifact?.title || 'Artifact'}</span>
+        {artifact && <ArtifactCopyActions artifact={artifact} content={content} />}
         {artifact?.type === ArtifactType.PR && externalUrl && (
           <a href={externalUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary">Open ↗</a>
         )}
@@ -171,6 +180,77 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
         )}
       </div>
     </div>
+  )
+}
+
+const COPY_FEEDBACK_MS = 2000
+
+enum CopyAction {
+  CONTENT = 'content',
+  FILE = 'file'
+}
+
+/** Copy what the artifact contains, or take the file itself: a phone has no
+ * file clipboard, so the file is shared or downloaded instead. */
+function ArtifactCopyActions({ artifact, content }: { artifact: Artifact; content: ArtifactContent | null }) {
+  const [outcome, setOutcome] = useState<{ action: CopyAction; result: ArtifactCopyOutcome } | null>(null)
+  const timerRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    setOutcome(null)
+  }, [artifact.id])
+
+  useEffect(() => () => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+  }, [])
+
+  const report = (action: CopyAction, result: ArtifactCopyOutcome) => {
+    setOutcome({ action, result })
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+    timerRef.current = window.setTimeout(() => setOutcome(null), COPY_FEEDBACK_MS)
+  }
+
+  const handleCopy = () => {
+    void (async () => {
+      if (!artifact.path) {
+        const done = artifact.url ? await copyText(artifact.url) : false
+        report(CopyAction.CONTENT, done ? ArtifactCopyOutcome.COPIED_CONTENT : ArtifactCopyOutcome.FAILED)
+        return
+      }
+      report(CopyAction.CONTENT, await copyArtifactContent(content))
+    })()
+  }
+
+  const handleFile = () => {
+    void (async () => {
+      report(CopyAction.FILE, await shareOrDownloadArtifactFile(artifactFileName(artifact.path, artifact.title), content))
+    })()
+  }
+
+  const label = (action: CopyAction, fallback: string): string =>
+    outcome?.action === action ? ARTIFACT_COPY_LABELS[outcome.result] : fallback
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={artifact.path ? 'Copy content' : 'Copy link'}
+        className="rounded-md px-2 py-1 text-xs text-muted-foreground active:opacity-60"
+      >
+        {label(CopyAction.CONTENT, 'Copy')}
+      </button>
+      {artifact.path && (
+        <button
+          type="button"
+          onClick={handleFile}
+          aria-label="Save file"
+          className="rounded-md px-2 py-1 text-xs text-muted-foreground active:opacity-60"
+        >
+          {label(CopyAction.FILE, 'File')}
+        </button>
+      )}
+    </>
   )
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
-import type { ArtifactContent, ArtifactFileEntry, PullRequestDetails } from '../shared/artifacts'
+import type { ArtifactContent, ArtifactCopyFileResult, ArtifactFileEntry, PullRequestDetails } from '../shared/artifacts'
 import { UI_COMMAND_CHANNEL, type UiCommand } from '../shared/ui-commands'
 
 contextBridge.exposeInMainWorld('electronAPI', {
@@ -22,7 +22,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     scan: (taskId: string): Promise<ArtifactFileEntry[]> =>
       ipcRenderer.invoke('artifacts:scan', taskId),
     read: (taskId: string, relativePath: string): Promise<ArtifactContent | null> =>
-      ipcRenderer.invoke('artifacts:read', taskId, relativePath)
+      ipcRenderer.invoke('artifacts:read', taskId, relativePath),
+    copyFile: (taskId: string, relativePath: string): Promise<ArtifactCopyFileResult> =>
+      ipcRenderer.invoke('artifacts:copyFile', taskId, relativePath)
   },
   attachments: {
     pick: (): Promise<string[]> => ipcRenderer.invoke('attachments:pick'),

--- a/src/renderer/src/components/artifacts/ArtifactCopyActions.test.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactCopyActions.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {
+  ArtifactClipboardMode,
+  ArtifactContentKind,
+  ArtifactType,
+  type Artifact,
+  type ArtifactApi
+} from '@shared/artifacts'
+import { ArtifactCopyActions } from './ArtifactCopyActions'
+
+const writeText = vi.fn().mockResolvedValue(undefined)
+
+const markdownArtifact: Artifact = {
+  id: 'artifact-1',
+  taskId: 'task-1',
+  type: ArtifactType.MARKDOWN,
+  title: 'Review notes',
+  path: 'reports/review.md',
+  updatedAt: 1,
+  reloadTrigger: 0
+}
+
+function makeApi(overrides: Partial<ArtifactApi> = {}): ArtifactApi {
+  return {
+    scan: vi.fn().mockResolvedValue([]),
+    read: vi.fn().mockResolvedValue({ kind: ArtifactContentKind.TEXT, content: '# Review notes' }),
+    copyFile: vi.fn().mockResolvedValue({ mode: ArtifactClipboardMode.FILE }),
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  writeText.mockClear()
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+    writable: true
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('ArtifactCopyActions', () => {
+  it('copies the text content of the artifact', async () => {
+    const artifactApi = makeApi()
+    render(<ArtifactCopyActions artifact={markdownArtifact} artifactApi={artifactApi} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy content' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('# Review notes'))
+    expect(artifactApi.read).toHaveBeenCalledWith('task-1', 'reports/review.md')
+    await screen.findByText('Copied')
+  })
+
+  it('copies the file itself and reports how the platform copied it', async () => {
+    const artifactApi = makeApi({ copyFile: vi.fn().mockResolvedValue({ mode: ArtifactClipboardMode.PATH }) })
+    render(<ArtifactCopyActions artifact={markdownArtifact} artifactApi={artifactApi} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy file' }))
+
+    await waitFor(() => expect(artifactApi.copyFile).toHaveBeenCalledWith('task-1', 'reports/review.md'))
+    await screen.findByText('Path copied')
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it('reports a failure when the file is no longer inside the workspace', async () => {
+    const artifactApi = makeApi({ copyFile: vi.fn().mockResolvedValue({ mode: ArtifactClipboardMode.UNAVAILABLE }) })
+    render(<ArtifactCopyActions artifact={markdownArtifact} artifactApi={artifactApi} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy file' }))
+
+    await screen.findByText('Copy failed')
+  })
+
+  it('copies the link of a pull request artifact and hides the file option', async () => {
+    const artifactApi = makeApi()
+    const pullRequest: Artifact = {
+      id: 'artifact-pr',
+      taskId: 'task-1',
+      type: ArtifactType.PR,
+      title: 'Pull request',
+      url: 'https://github.com/peakflo/20x/pull/1',
+      updatedAt: 1,
+      reloadTrigger: 0
+    }
+    render(<ArtifactCopyActions artifact={pullRequest} artifactApi={artifactApi} />)
+
+    expect(screen.queryByRole('button', { name: 'Copy file' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Copy link' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('https://github.com/peakflo/20x/pull/1'))
+    expect(artifactApi.read).not.toHaveBeenCalled()
+  })
+
+  it('hides the file option when the viewer has no desktop clipboard bridge', () => {
+    render(<ArtifactCopyActions artifact={markdownArtifact} artifactApi={makeApi({ copyFile: undefined })} />)
+
+    expect(screen.queryByRole('button', { name: 'Copy file' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy content' })).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/artifacts/ArtifactCopyActions.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactCopyActions.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Check, Copy, FileCheck2, Files } from 'lucide-react'
+import { ArtifactType, type Artifact, type ArtifactApi } from '@shared/artifacts'
+import {
+  ARTIFACT_COPY_LABELS,
+  ArtifactCopyOutcome,
+  copyArtifactContent,
+  copyFileOutcomeFor,
+  copyText
+} from '@/lib/artifact-clipboard'
+import { cn } from '@/lib/utils'
+
+export const ARTIFACT_COPY_FEEDBACK_MS = 2000
+
+enum CopyAction {
+  CONTENT = 'content',
+  FILE = 'file'
+}
+
+export interface ArtifactCopyActionsProps {
+  artifact: Artifact
+  artifactApi: ArtifactApi
+  className?: string
+}
+
+/**
+ * Two explicit options for the artifact on screen: copy what it contains, or
+ * copy the file itself so the user can paste it somewhere else.
+ */
+export function ArtifactCopyActions({ artifact, artifactApi, className }: ArtifactCopyActionsProps) {
+  const [result, setResult] = useState<{ action: CopyAction; outcome: ArtifactCopyOutcome } | null>(null)
+  const [busy, setBusy] = useState<CopyAction | null>(null)
+  const timerRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    setResult(null)
+    setBusy(null)
+  }, [artifact.id])
+
+  useEffect(() => () => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+  }, [])
+
+  const report = useCallback((action: CopyAction, outcome: ArtifactCopyOutcome) => {
+    setResult({ action, outcome })
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+    timerRef.current = window.setTimeout(() => setResult(null), ARTIFACT_COPY_FEEDBACK_MS)
+  }, [])
+
+  const run = useCallback(async (action: CopyAction, task: () => Promise<ArtifactCopyOutcome>) => {
+    setBusy(action)
+    try {
+      report(action, await task())
+    } catch {
+      report(action, ArtifactCopyOutcome.FAILED)
+    } finally {
+      setBusy(null)
+    }
+  }, [report])
+
+  const handleCopyContent = useCallback(() => {
+    void run(CopyAction.CONTENT, async () => {
+      // A pull request has no workspace file. Its link is its content.
+      if (!artifact.path) {
+        if (!artifact.url) return ArtifactCopyOutcome.FAILED
+        return (await copyText(artifact.url)) ? ArtifactCopyOutcome.COPIED_CONTENT : ArtifactCopyOutcome.FAILED
+      }
+      return copyArtifactContent(await artifactApi.read(artifact.taskId, artifact.path))
+    })
+  }, [artifact.path, artifact.taskId, artifact.url, artifactApi, run])
+
+  const handleCopyFile = useCallback(() => {
+    void run(CopyAction.FILE, async () => {
+      if (!artifact.path || !artifactApi.copyFile) return ArtifactCopyOutcome.FAILED
+      const outcome = await artifactApi.copyFile(artifact.taskId, artifact.path)
+      return copyFileOutcomeFor(outcome.mode)
+    })
+  }, [artifact.path, artifact.taskId, artifactApi, run])
+
+  const canCopyFile = !!artifact.path && !!artifactApi.copyFile && artifact.type !== ArtifactType.PR
+  const contentLabel = artifact.path ? 'Copy content' : 'Copy link'
+  const contentResult = result?.action === CopyAction.CONTENT ? result.outcome : null
+  const fileResult = result?.action === CopyAction.FILE ? result.outcome : null
+
+  return (
+    <div className={cn('flex items-center gap-1', className)}>
+      <CopyButton
+        label={contentLabel}
+        shortLabel="Copy"
+        icon={Copy}
+        doneIcon={Check}
+        outcome={contentResult}
+        busy={busy === CopyAction.CONTENT}
+        onClick={handleCopyContent}
+      />
+      {canCopyFile && (
+        <CopyButton
+          label="Copy file"
+          shortLabel="File"
+          icon={Files}
+          doneIcon={FileCheck2}
+          outcome={fileResult}
+          busy={busy === CopyAction.FILE}
+          onClick={handleCopyFile}
+        />
+      )}
+    </div>
+  )
+}
+
+function CopyButton({
+  label,
+  shortLabel,
+  icon: Icon,
+  doneIcon: DoneIcon,
+  outcome,
+  busy,
+  onClick
+}: {
+  label: string
+  shortLabel: string
+  icon: typeof Copy
+  doneIcon: typeof Copy
+  outcome: ArtifactCopyOutcome | null
+  busy: boolean
+  onClick: () => void
+}) {
+  const failed = outcome === ArtifactCopyOutcome.FAILED
+  const done = !!outcome && !failed
+  const ActiveIcon = done ? DoneIcon : Icon
+  const text = outcome ? ARTIFACT_COPY_LABELS[outcome] : shortLabel
+
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      disabled={busy}
+      onClick={onClick}
+      className={cn(
+        'flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs transition-colors disabled:opacity-60',
+        done && 'text-emerald-500',
+        failed && 'text-destructive',
+        !outcome && 'text-muted-foreground hover:bg-accent hover:text-foreground'
+      )}
+    >
+      <ActiveIcon className="h-3.5 w-3.5" />
+      <span>{text}</span>
+    </button>
+  )
+}

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
@@ -1,12 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
-import { ArtifactContentKind, ArtifactType, type Artifact, type ArtifactApi, type ArtifactUIState } from '@shared/artifacts'
+import { ArtifactClipboardMode, ArtifactContentKind, ArtifactType, type Artifact, type ArtifactApi, type ArtifactUIState } from '@shared/artifacts'
 import { PinnedArtifactTabId } from '@/stores/artifact-store'
 import { ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS, ArtifactsPanel } from './ArtifactsPanel'
 
 const artifactApi: ArtifactApi = {
   scan: vi.fn().mockResolvedValue([]),
-  read: vi.fn().mockResolvedValue(null)
+  read: vi.fn().mockResolvedValue(null),
+  copyFile: vi.fn().mockResolvedValue({ mode: ArtifactClipboardMode.FILE })
 }
 
 const baseUi: ArtifactUIState = {
@@ -98,5 +99,38 @@ describe('ArtifactsPanel', () => {
 
     rerender(<ArtifactsPanel {...props} artifacts={[{ ...artifact, reloadTrigger: 1 }]} ui={{ ...baseUi, activeTabId: artifact.id }} />)
     await waitFor(() => expect(dynamicArtifactApi.read).toHaveBeenCalledTimes(4))
+  })
+
+  it('offers the copy options only while an artifact tab is selected', () => {
+    const artifact: Artifact = {
+      id: 'artifact-1',
+      taskId: 'task-1',
+      type: ArtifactType.MARKDOWN,
+      title: 'Review notes',
+      path: 'review.md',
+      updatedAt: 1,
+      reloadTrigger: 0
+    }
+    const props = {
+      taskId: 'task-1',
+      artifacts: [artifact],
+      artifactApi,
+      hasChanges: false,
+      hasOutput: false,
+      onSelectTab: vi.fn(),
+      onCloseTab: vi.fn(),
+      onToggleOpen: vi.fn(),
+      onToggleRail: vi.fn(),
+      details: <div>Task details</div>,
+      changes: null,
+      output: null
+    }
+    const { rerender } = render(<ArtifactsPanel {...props} ui={baseUi} />)
+
+    expect(screen.queryByRole('button', { name: 'Copy content' })).not.toBeInTheDocument()
+
+    rerender(<ArtifactsPanel {...props} ui={{ ...baseUi, activeTabId: artifact.id }} />)
+    expect(screen.getByRole('button', { name: 'Copy content' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy file' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
@@ -3,6 +3,7 @@ import { PanelRightClose } from 'lucide-react'
 import { ArtifactType, type Artifact, type ArtifactApi, type ArtifactUIState } from '@shared/artifacts'
 import { PinnedArtifactTabId } from '@/stores/artifact-store'
 import { cn } from '@/lib/utils'
+import { ArtifactCopyActions } from './ArtifactCopyActions'
 import { ArtifactTabStrip } from './ArtifactTabStrip'
 import { MarkdownArtifactView } from './viewers/MarkdownArtifactView'
 import { ImageArtifactView } from './viewers/ImageArtifactView'
@@ -46,8 +47,11 @@ export function ArtifactsPanel({ artifacts, ui, artifactApi, hasChanges, hasOutp
   return (
     <section className={cn('flex h-full min-h-0 min-w-0 flex-col bg-background', className)} data-task-artifacts>
       <div className="relative">
-        <ArtifactTabStrip artifacts={artifacts} activeTabId={active} hasChanges={hasChanges} hasOutput={hasOutput} changesCount={changesCount} onSelectTab={onSelectTab} onCloseTab={onCloseTab} className="pr-11" />
-        <button type="button" aria-label="Close artifacts" onClick={onToggleOpen} className="absolute right-2 top-1.5 grid h-7 w-7 place-items-center rounded-md bg-background text-muted-foreground hover:bg-accent hover:text-foreground"><PanelRightClose className="h-3.5 w-3.5" /></button>
+        <ArtifactTabStrip artifacts={artifacts} activeTabId={active} hasChanges={hasChanges} hasOutput={hasOutput} changesCount={changesCount} onSelectTab={onSelectTab} onCloseTab={onCloseTab} className={activeArtifact ? 'pr-52' : 'pr-11'} />
+        <div className="absolute right-2 top-1.5 flex items-center gap-1 bg-background">
+          {activeArtifact && <ArtifactCopyActions key={activeArtifact.id} artifact={activeArtifact} artifactApi={artifactApi} />}
+          <button type="button" aria-label="Close artifacts" onClick={onToggleOpen} className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"><PanelRightClose className="h-3.5 w-3.5" /></button>
+        </div>
       </div>
       <div className="relative min-h-0 flex-1">
         <div className={active === PinnedArtifactTabId.DETAILS ? 'h-full' : 'hidden'}>{details}</div>

--- a/src/renderer/src/lib/artifact-clipboard.ts
+++ b/src/renderer/src/lib/artifact-clipboard.ts
@@ -1,0 +1,130 @@
+import { ArtifactClipboardMode, ArtifactContentKind, type ArtifactContent } from '@shared/artifacts'
+
+export enum ArtifactCopyOutcome {
+  COPIED_CONTENT = 'copied_content',
+  COPIED_FILE = 'copied_file',
+  COPIED_IMAGE = 'copied_image',
+  COPIED_PATH = 'copied_path',
+  SAVED_FILE = 'saved_file',
+  SHARED_FILE = 'shared_file',
+  FAILED = 'failed'
+}
+
+export const ARTIFACT_COPY_LABELS: Record<ArtifactCopyOutcome, string> = {
+  [ArtifactCopyOutcome.COPIED_CONTENT]: 'Copied',
+  [ArtifactCopyOutcome.COPIED_FILE]: 'File copied',
+  [ArtifactCopyOutcome.COPIED_IMAGE]: 'Image copied',
+  [ArtifactCopyOutcome.COPIED_PATH]: 'Path copied',
+  [ArtifactCopyOutcome.SAVED_FILE]: 'File saved',
+  [ArtifactCopyOutcome.SHARED_FILE]: 'File shared',
+  [ArtifactCopyOutcome.FAILED]: 'Copy failed'
+}
+
+const COPY_FILE_OUTCOMES: Record<ArtifactClipboardMode, ArtifactCopyOutcome> = {
+  [ArtifactClipboardMode.FILE]: ArtifactCopyOutcome.COPIED_FILE,
+  [ArtifactClipboardMode.IMAGE]: ArtifactCopyOutcome.COPIED_IMAGE,
+  [ArtifactClipboardMode.PATH]: ArtifactCopyOutcome.COPIED_PATH,
+  [ArtifactClipboardMode.UNAVAILABLE]: ArtifactCopyOutcome.FAILED
+}
+
+export function copyFileOutcomeFor(mode: ArtifactClipboardMode): ArtifactCopyOutcome {
+  return COPY_FILE_OUTCOMES[mode] || ArtifactCopyOutcome.FAILED
+}
+
+/** Decode a `data:` URL into a Blob without a network request. */
+export function dataUrlToBlob(dataUrl: string): Blob | null {
+  const match = dataUrl.match(/^data:([^;,]+)(;base64)?,(.*)$/s)
+  if (!match) return null
+  const [, mimeType, base64Marker, payload] = match
+  try {
+    if (!base64Marker) return new Blob([decodeURIComponent(payload)], { type: mimeType })
+    const binary = atob(payload)
+    const bytes = new Uint8Array(binary.length)
+    for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index)
+    return new Blob([bytes], { type: mimeType })
+  } catch {
+    return null
+  }
+}
+
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Copy the content the viewer shows: the text of a document, or the pixels of
+ * an image. A browser that refuses the image type gets the data URL as text,
+ * which is still usable.
+ */
+export async function copyArtifactContent(content: ArtifactContent | null): Promise<ArtifactCopyOutcome> {
+  if (!content) return ArtifactCopyOutcome.FAILED
+  if (content.kind === ArtifactContentKind.TEXT) {
+    return (await copyText(content.content)) ? ArtifactCopyOutcome.COPIED_CONTENT : ArtifactCopyOutcome.FAILED
+  }
+
+  const blob = dataUrlToBlob(content.content)
+  const ClipboardItemConstructor = typeof ClipboardItem === 'undefined' ? null : ClipboardItem
+  if (blob && ClipboardItemConstructor && navigator.clipboard?.write) {
+    try {
+      await navigator.clipboard.write([new ClipboardItemConstructor({ [blob.type]: blob })])
+      return ArtifactCopyOutcome.COPIED_IMAGE
+    } catch {
+      // Most browsers accept image/png only. Fall back to the text form.
+    }
+  }
+  return (await copyText(content.content)) ? ArtifactCopyOutcome.COPIED_CONTENT : ArtifactCopyOutcome.FAILED
+}
+
+export function artifactFileName(path: string | undefined, title: string): string {
+  const name = path?.split('/').pop()
+  return name || title || 'artifact'
+}
+
+export function artifactContentToBlob(content: ArtifactContent): Blob | null {
+  return content.kind === ArtifactContentKind.DATA_URL
+    ? dataUrlToBlob(content.content)
+    : new Blob([content.content], { type: content.mimeType || 'text/plain' })
+}
+
+/**
+ * Hand the file to the platform on a device that has no OS clipboard for
+ * files: share it if the browser can, otherwise download it.
+ */
+export async function shareOrDownloadArtifactFile(
+  fileName: string,
+  content: ArtifactContent | null
+): Promise<ArtifactCopyOutcome> {
+  if (!content) return ArtifactCopyOutcome.FAILED
+  const blob = artifactContentToBlob(content)
+  if (!blob) return ArtifactCopyOutcome.FAILED
+
+  const file = new File([blob], fileName, { type: blob.type })
+  if (navigator.canShare?.({ files: [file] }) && navigator.share) {
+    try {
+      await navigator.share({ files: [file], title: fileName })
+      return ArtifactCopyOutcome.SHARED_FILE
+    } catch (reason) {
+      // A user who dismisses the share sheet must not see an error.
+      if (reason instanceof Error && reason.name === 'AbortError') return ArtifactCopyOutcome.SHARED_FILE
+    }
+  }
+
+  try {
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = fileName
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+    return ArtifactCopyOutcome.SAVED_FILE
+  } catch {
+    return ArtifactCopyOutcome.FAILED
+  }
+}

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -54,7 +54,8 @@ export const taskApi = {
 
 export const artifactApi: ArtifactApi = {
   scan: (taskId) => window.electronAPI.artifacts.scan(taskId),
-  read: (taskId, relativePath) => window.electronAPI.artifacts.read(taskId, relativePath)
+  read: (taskId, relativePath) => window.electronAPI.artifacts.read(taskId, relativePath),
+  copyFile: (taskId, relativePath) => window.electronAPI.artifacts.copyFile(taskId, relativePath)
 }
 
 export const mcpServerApi = {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -226,7 +226,9 @@ interface ElectronAPI {
   tasks: {
     getWorkspaceDir: (taskId: string) => Promise<string>
   }
-  artifacts: ArtifactApi
+  /** The preload bridge always exposes every artifact capability, including
+   * the desktop-only file clipboard action. */
+  artifacts: Required<ArtifactApi>
   mcpServers: {
     getAll: () => Promise<McpServer[]>
     get: (id: string) => Promise<McpServer | undefined>

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -93,9 +93,28 @@ export interface ArtifactContent {
   mimeType?: string
 }
 
+/** How a "copy the file" request landed on the OS clipboard. Platforms differ
+ * in what they accept, so the caller reports the outcome to the user. */
+export enum ArtifactClipboardMode {
+  /** The file itself is on the clipboard and pastes into a file manager. */
+  FILE = 'file',
+  /** The file was copied as an image (Windows has no file-list clipboard API). */
+  IMAGE = 'image',
+  /** Only the file path was copied. */
+  PATH = 'path',
+  /** The file could not be resolved inside the task workspace. */
+  UNAVAILABLE = 'unavailable'
+}
+
+export interface ArtifactCopyFileResult {
+  mode: ArtifactClipboardMode
+}
+
 export interface ArtifactApi {
   scan: (taskId: string) => Promise<ArtifactFileEntry[]>
   read: (taskId: string, relativePath: string) => Promise<ArtifactContent | null>
+  /** Desktop only. Absent when the viewer runs outside Electron. */
+  copyFile?: (taskId: string, relativePath: string) => Promise<ArtifactCopyFileResult>
 }
 
 export interface Artifact {

--- a/test/setup-main.ts
+++ b/test/setup-main.ts
@@ -27,6 +27,18 @@ vi.mock('electron', () => ({
     showItemInFolder: vi.fn(),
     openExternal: vi.fn()
   },
+  clipboard: {
+    write: vi.fn(async () => undefined),
+    writeText: vi.fn(async () => undefined),
+    readText: vi.fn(async () => ''),
+    clear: vi.fn()
+  },
+  ClipboardItem: class {
+    constructor(public readonly items: Record<string, unknown>) {}
+  },
+  nativeImage: {
+    createFromPath: vi.fn(() => ({ isEmpty: () => true, toPNG: () => Buffer.alloc(0) }))
+  },
   BrowserWindow: vi.fn(),
   globalShortcut: {
     register: vi.fn(() => true),

--- a/test/setup-mobile.ts
+++ b/test/setup-mobile.ts
@@ -44,7 +44,8 @@ vi.mock('../src/mobile/api/client', () => ({
       getOrg: vi.fn().mockResolvedValue({ org: '' }),
       getOrgs: vi.fn().mockResolvedValue([]),
       setOrg: vi.fn().mockResolvedValue({ org: '' }),
-      fetchRepos: vi.fn().mockResolvedValue([])
+      fetchRepos: vi.fn().mockResolvedValue([]),
+      pullRequest: vi.fn().mockResolvedValue(null)
     }
   }
 }))


### PR DESCRIPTION
## What

The artifacts viewer showed a deliverable but gave no way to take it out of the app. Each artifact tab now has two copy options:

- **Copy** — the content on screen: the text of a document, the pixels of an image, or the link of a pull request.
- **File** — the file itself on the OS clipboard, so the user can paste it into a file manager, a chat window, or an email.

Both options give feedback in the button for two seconds (`Copied`, `File copied`, `Path copied`, `Copy failed`).

## How

**Desktop (Electron)**
- `src/main/artifact-clipboard.ts` — new helper. Electron 44 replaced the synchronous clipboard module with an async, MIME-based API, so the helper uses `clipboard.write([new ClipboardItem(...)])`:
  - macOS: the `public.file-url` pasteboard type through the `electron application/osclipboard` raw-format wrapper. macOS derives `NSFilenamesPboardType` from it, so Finder pastes the file. (Verified against a real Electron 44 process.)
  - Linux: the standard `text/uri-list` type.
  - Windows: no supported Electron API for the CF_HDROP file list. An image file copies as an image; every other file falls back to its path as text. The button tells the user which of these happened.
- `resolveTaskArtifactFilePath()` in `src/main/artifacts.ts` reuses the containment rules of the artifact read handler, so traversal, absolute paths, non-previewable files, and escaping symlinks stay rejected.
- New `artifacts:copyFile` IPC handler, preload bridge, and `artifactApi.copyFile`.
- New `ArtifactCopyActions` component in the artifacts panel header. It appears only while an artifact tab is selected.

**Mobile (PWA)**
- The viewer header has the same two options. A phone has no OS clipboard for files, so the file button shares the file when the browser supports it and downloads it if it does not.

**Shared**
- `ArtifactClipboardMode` enum and `ArtifactCopyFileResult` in `src/shared/artifacts.ts`.
- `src/renderer/src/lib/artifact-clipboard.ts` holds the browser-side copy logic that desktop and mobile share.

## Tests

- `src/main/artifact-clipboard.test.ts` — per-platform clipboard payloads.
- `src/main/artifacts.test.ts` — path resolution stays inside the task workspace.
- `src/renderer/src/components/artifacts/ArtifactCopyActions.test.tsx` and `ArtifactsPanel.test.tsx`.
- `src/mobile/pages/ArtifactViewerPage.test.tsx`.

`pnpm typecheck`, `pnpm lint` (0 errors), and the full suite (168 files, 2653 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)