### PR TITLE
feat: add Claude Fable 5.1 model

### DIFF
--- a/src/renderer/src/types/index.test.ts
+++ b/src/renderer/src/types/index.test.ts
@@ -3,12 +3,17 @@ import { CLAUDE_MODELS, ClaudeModel, CODEX_MODELS, CodexModel } from './index'
 
 describe('CLAUDE_MODELS', () => {
   it('lists the latest Claude models first in preferred order', () => {
-    expect(CLAUDE_MODELS.slice(0, 4)).toEqual([
+    expect(CLAUDE_MODELS.slice(0, 5)).toEqual([
+      { id: ClaudeModel.FABLE_5_1, name: 'Claude Fable 5.1' },
       { id: ClaudeModel.FABLE_5, name: 'Claude Fable 5' },
       { id: ClaudeModel.OPUS_5, name: 'Claude Opus 5' },
       { id: ClaudeModel.SONNET_5, name: 'Claude Sonnet 5' },
       { id: ClaudeModel.OPUS_4_8, name: 'Claude Opus 4.8' }
     ])
+  })
+
+  it('defaults new agents to Claude Fable 5.1', () => {
+    expect(CLAUDE_MODELS[0].id).toBe('claude-fable-5-1')
   })
 })
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -55,6 +55,7 @@ export const CURSOR_MODELS: { id: string; name: string }[] = [
 ]
 
 export enum ClaudeModel {
+  FABLE_5_1 = 'claude-fable-5-1',
   FABLE_5 = 'claude-fable-5',
   OPUS_5 = 'claude-opus-5',
   SONNET_5 = 'claude-sonnet-5',
@@ -70,6 +71,7 @@ export enum ClaudeModel {
 }
 
 export const CLAUDE_MODELS: { id: ClaudeModel; name: string }[] = [
+  { id: ClaudeModel.FABLE_5_1, name: 'Claude Fable 5.1' },
   { id: ClaudeModel.FABLE_5, name: 'Claude Fable 5' },
   { id: ClaudeModel.OPUS_5, name: 'Claude Opus 5' },
   { id: ClaudeModel.SONNET_5, name: 'Claude Sonnet 5' },


### PR DESCRIPTION
## Summary
- Adds the latest Anthropic model **Claude Fable 5.1** (`claude-fable-5-1`) to the Claude model catalog, first in preferred order per the [models overview](https://platform.claude.com/docs/en/models/overview)
- Since `CLAUDE_MODELS[0]` is the fallback default (e.g. in the onboarding wizard), new Claude Code agents now default to Claude Fable 5.1
- Kept Claude Fable 5 and all older models as fallbacks, matching the existing catalog convention
- Updated the catalog test to assert the new preferred order and the new default

## Test plan
- [x] `npx vitest run src/renderer/src/types/index.test.ts` — 5 passed
- [x] OnboardingWizard + agents component suites — 32 passed
- [x] `eslint` on touched files — clean
- [x] `tsc -b tsconfig.web.json` — clean

Generated with [opencode](https://opencode.ai)