### PR TITLE
feat: add Superhuman-style keyboard controls

### DIFF
--- a/src/renderer/src/components/artifacts/viewers/PrArtifactView.test.tsx
+++ b/src/renderer/src/components/artifacts/viewers/PrArtifactView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, cleanup, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import {
   ArtifactType,
   PullRequestCheckState,
@@ -46,6 +46,10 @@ const details: PullRequestDetails = {
 }
 
 beforeEach(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) }
+  })
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
     value: {
@@ -89,5 +93,16 @@ describe('PrArtifactView', () => {
 
     act(() => resolveRefresh({ ...details, title: 'Updated task artifacts', commentsCount: 4 }))
     expect(await screen.findByText('Updated task artifacts')).toBeInTheDocument()
+  })
+
+  it('copies the PR URL and source branch from the PR view', async () => {
+    render(<PrArtifactView artifact={artifact} />)
+    await screen.findByText('Task artifacts')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy URL' }))
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith(details.url))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy branch' }))
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith(details.headRefName))
   })
 })

--- a/src/renderer/src/components/artifacts/viewers/PrArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/PrArtifactView.tsx
@@ -6,6 +6,7 @@ import {
   CircleCheck,
   CircleDot,
   CircleX,
+  Copy,
   ExternalLink,
   Files,
   GitCommitHorizontal,
@@ -53,7 +54,23 @@ export function PrArtifactView({ artifact, refreshTrigger = 0 }: { artifact: Art
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
+  const [copied, setCopied] = useState<'url' | 'branch' | null>(null)
   const settledUrlRef = useRef<string | null>(null)
+  const copyTimerRef = useRef<number | null>(null)
+
+  useEffect(() => () => {
+    if (copyTimerRef.current !== null) window.clearTimeout(copyTimerRef.current)
+  }, [])
+
+  const copy = (kind: 'url' | 'branch', value: string) => {
+    void navigator.clipboard.writeText(value)
+      .then(() => {
+        setCopied(kind)
+        if (copyTimerRef.current !== null) window.clearTimeout(copyTimerRef.current)
+        copyTimerRef.current = window.setTimeout(() => setCopied(null), 2000)
+      })
+      .catch(() => setCopied(null))
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -146,7 +163,17 @@ export function PrArtifactView({ artifact, refreshTrigger = 0 }: { artifact: Art
                 </span>
               </div>
             </div>
-            <Button type="button" size="sm" variant="outline" className="shrink-0" onClick={() => window.electronAPI.shell.openExternal(details.url)}><ExternalLink className="h-3.5 w-3.5" />Open</Button>
+            <div className="flex shrink-0 flex-wrap justify-end gap-1.5">
+              <Button type="button" size="sm" variant="outline" onClick={() => copy('url', details.url)}>
+                {copied === 'url' ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                {copied === 'url' ? 'Copied URL' : 'Copy URL'}
+              </Button>
+              <Button type="button" size="sm" variant="outline" onClick={() => copy('branch', details.headRefName)}>
+                {copied === 'branch' ? <Check className="h-3.5 w-3.5" /> : <GitCommitHorizontal className="h-3.5 w-3.5" />}
+                {copied === 'branch' ? 'Copied branch' : 'Copy branch'}
+              </Button>
+              <Button type="button" size="sm" variant="outline" onClick={() => window.electronAPI.shell.openExternal(details.url)}><ExternalLink className="h-3.5 w-3.5" />Open</Button>
+            </div>
           </div>
           {details.body && <p className="mt-4 line-clamp-4 whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">{details.body}</p>}
         </div>

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -36,8 +36,12 @@ import { Button } from '@/components/ui/Button'
 import { ThemeToggle } from './ThemeToggle'
 import { StatusBar } from './StatusBar'
 import { CommandPalette } from './CommandPalette'
+import { KeyboardShortcutsDialog } from './KeyboardShortcutsDialog'
 import type { SidebarView } from '@/stores/ui-store'
 import logo20x from '@/assets/logos/20x.svg'
+import { dispatchTaskShortcut, isKeyboardInput, onShortcutFeedback, TaskShortcutAction } from '@/lib/keyboard-shortcuts'
+import { selectVoiceReady, useVoiceStore } from '@/stores/voice-store'
+import { composerCanSubmit, MASTERMIND_COMPOSER_KEY, setActiveComposer } from '@/lib/voice-dictation-target'
 
 const isWindows = navigator.platform.toLowerCase().startsWith('win') || navigator.userAgent.includes('Windows')
 const isMac = navigator.platform.toLowerCase().includes('mac')
@@ -83,6 +87,8 @@ export function AppLayout() {
 
   // ── Command palette ──
   const [cmdOpen, setCmdOpen] = useState(false)
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
+  const chordRef = useRef<{ key: 'g' | 'o' | 'y' | 'v'; timer: number } | null>(null)
 
   // ── Update indicator state ──
   const [updateAvailableVersion, setUpdateAvailableVersion] = useState<string | null>(null)
@@ -145,6 +151,8 @@ export function AppLayout() {
     setToast({ message, isError })
     setTimeout(() => setToast(null), isError ? 5000 : 3000)
   }, [])
+
+  useEffect(() => onShortcutFeedback(({ message, isError }) => showToast(message, isError)), [showToast])
 
   // Source-backed tasks ask the user whether to close the task in the source
   // system or only in 20x. `completionDialog` renders that question.
@@ -232,6 +240,126 @@ export function AppLayout() {
   const handleCompleteDashboardPreviewTask = useCallback(async () => {
     if (dashboardPreviewTaskId) await completeTask(dashboardPreviewTaskId)
   }, [completeTask, dashboardPreviewTaskId])
+
+  const activeTaskId = dashboardPreviewTaskId || selectedTaskId || null
+  const runTaskShortcut = useCallback((action: TaskShortcutAction) => {
+    if (!activeTaskId) {
+      showToast('Select a task first', true)
+      return
+    }
+    dispatchTaskShortcut({ action, taskId: activeTaskId })
+  }, [activeTaskId, showToast])
+
+  const navigateVisibleTask = useCallback((direction: 1 | -1) => {
+    const renderedIds = Array.from(document.querySelectorAll<HTMLElement>('[data-keyboard-task-id]'))
+      .filter((element) => element.offsetParent !== null)
+      .map((element) => element.dataset.keyboardTaskId)
+      .filter((id): id is string => !!id)
+    const fallbackIds = tasks
+      .filter((task) => !task.parent_task_id && task.status !== TaskStatus.Completed && !isSnoozed(task.snoozed_until))
+      .map((task) => task.id)
+    const ids = renderedIds.length > 0 ? renderedIds : fallbackIds
+    if (ids.length === 0) return
+    const currentIndex = selectedTaskId ? ids.indexOf(selectedTaskId) : -1
+    const nextIndex = currentIndex < 0
+      ? direction > 0 ? 0 : ids.length - 1
+      : Math.max(0, Math.min(ids.length - 1, currentIndex + direction))
+    if (activeModal === 'settings') closeModal()
+    setSidebarView('tasks')
+    selectTask(ids[nextIndex])
+  }, [activeModal, closeModal, selectTask, selectedTaskId, setSidebarView, tasks])
+
+  const openSelectedTask = useCallback(() => {
+    if (activeTaskId) handleGoToFullView(activeTaskId)
+  }, [activeTaskId, handleGoToFullView])
+
+  const clearTaskSelection = useCallback(() => {
+    if (dashboardPreviewTaskId) closeDashboardPreview()
+    else selectTask(null)
+  }, [closeDashboardPreview, dashboardPreviewTaskId, selectTask])
+
+  const focusSearch = useCallback(() => {
+    if (sidebarView !== 'tasks' && sidebarView !== 'skills') {
+      setCmdOpen(true)
+      return
+    }
+    if (sidebarCollapsed) useUIStore.getState().setSidebarCollapsed(false)
+    window.setTimeout(() => {
+      document.querySelector<HTMLInputElement>(`[data-keyboard-shortcut-search="${sidebarView}"]`)?.focus()
+    }, 0)
+  }, [sidebarCollapsed, sidebarView])
+
+  const completeActiveTask = useCallback(() => {
+    if (dashboardPreviewTaskId) void handleCompleteDashboardPreviewTask()
+    else if (selectedTaskId) void handleCompleteSelectedTask()
+    else showToast('Select a task first', true)
+  }, [dashboardPreviewTaskId, handleCompleteDashboardPreviewTask, handleCompleteSelectedTask, selectedTaskId, showToast])
+
+  const deleteActiveTask = useCallback(() => {
+    if (dashboardPreviewTaskId) handleDeleteDashboardPreviewTask()
+    else if (selectedTaskId) handleDeleteSelectedTask()
+    else showToast('Select a task first', true)
+  }, [dashboardPreviewTaskId, handleDeleteDashboardPreviewTask, handleDeleteSelectedTask, selectedTaskId, showToast])
+
+  const toggleTaskAudio = useCallback(() => {
+    const voice = useVoiceStore.getState()
+    if (!selectVoiceReady(voice)) {
+      showToast('Voice input is not ready', true)
+      return
+    }
+    if (voice.turnId) {
+      void voice.endTurn()
+      return
+    }
+    if (!activeTaskId || !composerCanSubmit(activeTaskId)) {
+      showToast('Open a task with an active message composer first', true)
+      return
+    }
+    setActiveComposer(activeTaskId)
+    const loop = voice.conversation && composerCanSubmit(activeTaskId)
+    void voice.toggleTurn(loop ? 'conversation' : 'dictation')
+  }, [activeTaskId, showToast])
+
+  const toggleMastermindAudio = useCallback(() => {
+    const voice = useVoiceStore.getState()
+    if (!selectVoiceReady(voice)) {
+      showToast('Voice input is not ready', true)
+      return
+    }
+    if (voice.turnId) {
+      void voice.endTurn()
+      return
+    }
+    setShowOrchestrator(true)
+    setActiveComposer(MASTERMIND_COMPOSER_KEY)
+    window.setTimeout(() => {
+      const loop = useVoiceStore.getState().conversation && composerCanSubmit(MASTERMIND_COMPOSER_KEY)
+      void useVoiceStore.getState().toggleTurn(loop ? 'conversation' : 'dictation')
+    }, 0)
+  }, [setShowOrchestrator, showToast])
+
+  const commandActions = useMemo(() => ({
+    nextTask: () => navigateVisibleTask(1),
+    previousTask: () => navigateVisibleTask(-1),
+    openTask: openSelectedTask,
+    clearSelection: clearTaskSelection,
+    focusSearch,
+    completeTask: completeActiveTask,
+    snoozeTask: () => runTaskShortcut(TaskShortcutAction.SNOOZE),
+    runTask: () => runTaskShortcut(TaskShortcutAction.RUN),
+    whipTask: () => runTaskShortcut(TaskShortcutAction.WHIP),
+    deleteTask: deleteActiveTask,
+    showShortcuts: () => setShortcutsOpen(true),
+    openDetails: () => runTaskShortcut(TaskShortcutAction.OPEN_DETAILS),
+    openChanges: () => runTaskShortcut(TaskShortcutAction.OPEN_CHANGES),
+    openOutput: () => runTaskShortcut(TaskShortcutAction.OPEN_OUTPUT),
+    openArtifact: () => runTaskShortcut(TaskShortcutAction.OPEN_ARTIFACT),
+    openPullRequest: () => runTaskShortcut(TaskShortcutAction.OPEN_PR),
+    copyPullRequestUrl: () => runTaskShortcut(TaskShortcutAction.COPY_PR_URL),
+    copyPullRequestBranch: () => runTaskShortcut(TaskShortcutAction.COPY_PR_BRANCH),
+    toggleTaskAudio,
+    toggleMastermindAudio
+  }), [clearTaskSelection, completeActiveTask, deleteActiveTask, focusSearch, navigateVisibleTask, openSelectedTask, runTaskShortcut, toggleMastermindAudio, toggleTaskAudio])
   const handleNavigateFromDashboardPreview = useCallback(
     (taskId: string) => {
       closeDashboardPreview()
@@ -302,30 +430,91 @@ export function AppLayout() {
     return () => window.removeEventListener('resize', update)
   }, [])
 
-  // ── Global keyboard shortcuts: ⌘/Ctrl+K command palette, ⌘/Ctrl+1–4 view switch ──
+  // ── Global keyboard shortcuts: command palette, navigation chords, and task actions ──
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.altKey) return
-      if (e.key.toLowerCase() === 'k') {
-        e.preventDefault()
-        setCmdOpen((v) => !v)
-        captureAnalyticsEvent('command_palette_toggled', { source: 'keyboard' })
+      const key = e.key.toLowerCase()
+      if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+        if (key === 'k') {
+          e.preventDefault()
+          setCmdOpen((value) => !value)
+          captureAnalyticsEvent('command_palette_toggled', { source: 'keyboard' })
+          return
+        }
+        const number = Number(e.key)
+        if (Number.isInteger(number) && number >= 1 && number <= NAV_ITEMS.length) {
+          e.preventDefault()
+          if (activeModal === 'settings') closeModal()
+          setSidebarView(NAV_ITEMS[number - 1].key)
+          captureAnalyticsEvent('workspace_view_selected', { view: NAV_ITEMS[number - 1].key, source: 'keyboard' })
+        }
         return
       }
-      const n = Number(e.key)
-      if (Number.isInteger(n) && n >= 1 && n <= NAV_ITEMS.length) {
-        e.preventDefault()
-        if (activeModal === 'settings') closeModal()
-        setSidebarView(NAV_ITEMS[n - 1].key)
-        captureAnalyticsEvent('workspace_view_selected', {
-          view: NAV_ITEMS[n - 1].key,
-          source: 'keyboard'
-        })
+      if (e.metaKey || e.ctrlKey || e.altKey || isKeyboardInput(e.target)) return
+      if (document.querySelector('[role="dialog"]')) return
+
+      const pending = chordRef.current
+      if (pending) {
+        window.clearTimeout(pending.timer)
+        chordRef.current = null
+        const chord = `${pending.key}${key}`
+        const views: Record<string, SidebarView> = { gd: 'dashboard', gc: 'canvas', gt: 'tasks', gs: 'skills' }
+        const taskActions: Record<string, TaskShortcutAction> = {
+          od: TaskShortcutAction.OPEN_DETAILS,
+          oc: TaskShortcutAction.OPEN_CHANGES,
+          oo: TaskShortcutAction.OPEN_OUTPUT,
+          oa: TaskShortcutAction.OPEN_ARTIFACT,
+          op: TaskShortcutAction.OPEN_PR,
+          yp: TaskShortcutAction.COPY_PR_URL,
+          yb: TaskShortcutAction.COPY_PR_BRANCH
+        }
+        if (views[chord]) {
+          e.preventDefault()
+          if (activeModal === 'settings') closeModal()
+          setSidebarView(views[chord])
+        } else if (taskActions[chord]) {
+          e.preventDefault()
+          runTaskShortcut(taskActions[chord])
+        } else if (chord === 'vt') {
+          e.preventDefault()
+          toggleTaskAudio()
+        } else if (chord === 'vm') {
+          e.preventDefault()
+          toggleMastermindAudio()
+        }
+        return
       }
+
+      if (key === 'g' || (sidebarView !== 'canvas' && (key === 'o' || key === 'y' || key === 'v'))) {
+        e.preventDefault()
+        chordRef.current = {
+          key: key as 'g' | 'o' | 'y' | 'v',
+          timer: window.setTimeout(() => { chordRef.current = null }, 1200)
+        }
+        return
+      }
+      if (sidebarView === 'canvas') return
+      if (e.repeat && key !== 'j' && key !== 'k') return
+
+      if (key === 'j') { e.preventDefault(); navigateVisibleTask(1) }
+      else if (key === 'k') { e.preventDefault(); navigateVisibleTask(-1) }
+      else if (e.key === 'Enter' && !(e.target as HTMLElement | null)?.closest('button, a')) { e.preventDefault(); openSelectedTask() }
+      else if (e.key === 'Escape') { e.preventDefault(); if (showOrchestrator) setShowOrchestrator(false); else clearTaskSelection() }
+      else if (key === 'c') { e.preventDefault(); openCreateModal() }
+      else if (key === 'e') { e.preventDefault(); completeActiveTask() }
+      else if (key === 'h') { e.preventDefault(); runTaskShortcut(TaskShortcutAction.SNOOZE) }
+      else if (key === 'r') { e.preventDefault(); runTaskShortcut(TaskShortcutAction.RUN) }
+      else if (key === 'w') { e.preventDefault(); runTaskShortcut(TaskShortcutAction.WHIP) }
+      else if (e.key === '#') { e.preventDefault(); deleteActiveTask() }
+      else if (e.key === '?') { e.preventDefault(); setShortcutsOpen(true) }
+      else if (e.key === '/') { e.preventDefault(); focusSearch() }
     }
     window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [activeModal, closeModal, setSidebarView])
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      if (chordRef.current) window.clearTimeout(chordRef.current.timer)
+    }
+  }, [activeModal, clearTaskSelection, closeModal, completeActiveTask, deleteActiveTask, focusSearch, navigateVisibleTask, openCreateModal, openSelectedTask, runTaskShortcut, setShowOrchestrator, setSidebarView, showOrchestrator, sidebarView, toggleMastermindAudio, toggleTaskAudio])
 
   return (
     <>
@@ -680,7 +869,8 @@ export function AppLayout() {
       )}
 
       {/* Command palette (⌘K / Ctrl+K) */}
-      <CommandPalette open={cmdOpen} onOpenChange={setCmdOpen} />
+      <CommandPalette open={cmdOpen} onOpenChange={setCmdOpen} actions={commandActions} />
+      <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
 
       {/* Background progress toasts (setup, task progress, etc.) */}
       <ProgressToastStack />

--- a/src/renderer/src/components/layout/CommandPalette.tsx
+++ b/src/renderer/src/components/layout/CommandPalette.tsx
@@ -2,7 +2,9 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import {
   Search, LayoutDashboard, Layers, CheckSquare, Zap, Settings, MessageSquare,
-  Plus, Sun, Moon, CornerDownLeft, LayoutGrid, type LucideIcon
+  Plus, Sun, Moon, CornerDownLeft, LayoutGrid, ArrowDown, ArrowUp, ExternalLink,
+  PanelRightOpen, FileDiff, PackageOpen, Copy, GitBranch, Mic, CircleHelp,
+  CircleCheck, Clock3, Play, Trash2, LogOut, type LucideIcon
 } from 'lucide-react'
 import { useUIStore } from '@/stores/ui-store'
 import { useThemeStore } from '@/stores/theme-store'
@@ -24,7 +26,30 @@ interface CommandItem {
 const isMac = navigator.platform.toLowerCase().includes('mac')
 const mod = isMac ? '⌘' : 'Ctrl'
 
-export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenChange: (v: boolean) => void }) {
+export interface CommandPaletteActions {
+  nextTask: () => void
+  previousTask: () => void
+  openTask: () => void
+  clearSelection: () => void
+  focusSearch: () => void
+  completeTask: () => void
+  whipTask: () => void
+  snoozeTask: () => void
+  runTask: () => void
+  deleteTask: () => void
+  showShortcuts: () => void
+  openDetails: () => void
+  openChanges: () => void
+  openOutput: () => void
+  openArtifact: () => void
+  openPullRequest: () => void
+  copyPullRequestUrl: () => void
+  copyPullRequestBranch: () => void
+  toggleTaskAudio: () => void
+  toggleMastermindAudio: () => void
+}
+
+export function CommandPalette({ open, onOpenChange, actions }: { open: boolean; onOpenChange: (v: boolean) => void; actions: CommandPaletteActions }) {
   const [query, setQuery] = useState('')
   const [active, setActive] = useState(0)
   const listRef = useRef<HTMLDivElement>(null)
@@ -59,11 +84,31 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
   const items = useMemo<CommandItem[]>(() => {
     const goto = (view: 'dashboard' | 'canvas' | 'tasks' | 'skills') => () => { closeModal(); setSidebarView(view); close() }
     const base: CommandItem[] = [
-      { id: 'nav-dashboard', group: 'Navigation', label: 'Go to Dashboard', icon: LayoutDashboard, keywords: 'home overview', shortcut: `${mod}1`, run: goto('dashboard') },
-      { id: 'nav-canvas', group: 'Navigation', label: 'Go to Canvas', icon: Layers, keywords: 'board panels', shortcut: `${mod}2`, run: goto('canvas') },
-      { id: 'nav-tasks', group: 'Navigation', label: 'Go to Tasks', icon: CheckSquare, keywords: 'todo list', shortcut: `${mod}3`, run: goto('tasks') },
-      { id: 'nav-skills', group: 'Navigation', label: 'Go to Skills', icon: Zap, keywords: 'abilities', shortcut: `${mod}4`, run: goto('skills') },
-      { id: 'act-new-task', group: 'Actions', label: 'New Task', icon: Plus, keywords: 'create add', run: () => { openCreateModal(); close() } },
+      { id: 'nav-dashboard', group: 'Navigation', label: 'Go to Dashboard', icon: LayoutDashboard, keywords: 'home overview', shortcut: `G D · ${mod}1`, run: goto('dashboard') },
+      { id: 'nav-canvas', group: 'Navigation', label: 'Go to Canvas', icon: Layers, keywords: 'board panels', shortcut: `G C · ${mod}2`, run: goto('canvas') },
+      { id: 'nav-tasks', group: 'Navigation', label: 'Go to Tasks', icon: CheckSquare, keywords: 'todo list', shortcut: `G T · ${mod}3`, run: goto('tasks') },
+      { id: 'nav-skills', group: 'Navigation', label: 'Go to Skills', icon: Zap, keywords: 'abilities', shortcut: `G S · ${mod}4`, run: goto('skills') },
+      { id: 'nav-next-task', group: 'Navigation', label: 'Next visible task', icon: ArrowDown, shortcut: 'J', run: () => { actions.nextTask(); close() } },
+      { id: 'nav-previous-task', group: 'Navigation', label: 'Previous visible task', icon: ArrowUp, shortcut: 'K', run: () => { actions.previousTask(); close() } },
+      { id: 'nav-open-task', group: 'Navigation', label: 'Open selected task', icon: ExternalLink, shortcut: 'Enter', run: () => { actions.openTask(); close() } },
+      { id: 'nav-clear-task', group: 'Navigation', label: 'Clear task selection', icon: LogOut, shortcut: 'Esc', run: () => { actions.clearSelection(); close() } },
+      { id: 'nav-focus-search', group: 'Navigation', label: 'Focus search', icon: Search, shortcut: '/', run: () => { close(); window.setTimeout(actions.focusSearch, 0) } },
+      { id: 'act-new-task', group: 'Task actions', label: 'New Task', icon: Plus, keywords: 'create add', shortcut: 'C', run: () => { openCreateModal(); close() } },
+      { id: 'act-complete-task', group: 'Task actions', label: 'Complete selected task', icon: CircleCheck, shortcut: 'E', run: () => { actions.completeTask(); close() } },
+      { id: 'act-snooze-task', group: 'Task actions', label: 'Snooze selected task', icon: Clock3, shortcut: 'H', run: () => { actions.snoozeTask(); close() } },
+      { id: 'act-run-task', group: 'Task actions', label: 'Run or resume selected task', icon: Play, shortcut: 'R', run: () => { actions.runTask(); close() } },
+      { id: 'act-whip-task', group: 'Task actions', label: 'Whip agent to continue', icon: Zap, shortcut: 'W', run: () => { actions.whipTask(); close() } },
+      { id: 'act-delete-task', group: 'Task actions', label: 'Delete selected task', icon: Trash2, shortcut: '#', run: () => { actions.deleteTask(); close() } },
+      { id: 'act-shortcuts', group: 'Actions', label: 'Keyboard shortcuts', icon: CircleHelp, shortcut: '?', run: () => { close(); actions.showShortcuts() } },
+      { id: 'panel-details', group: 'Task panels', label: 'Open Details', icon: PanelRightOpen, shortcut: 'O D', run: () => { actions.openDetails(); close() } },
+      { id: 'panel-changes', group: 'Task panels', label: 'Open Changes', icon: FileDiff, shortcut: 'O C', run: () => { actions.openChanges(); close() } },
+      { id: 'panel-output', group: 'Task panels', label: 'Open Output', icon: PackageOpen, shortcut: 'O O', run: () => { actions.openOutput(); close() } },
+      { id: 'panel-artifact', group: 'Task panels', label: 'Open newest artifact', icon: LayoutGrid, shortcut: 'O A', run: () => { actions.openArtifact(); close() } },
+      { id: 'panel-pr', group: 'Task panels', label: 'Open newest pull request', icon: ExternalLink, shortcut: 'O P', run: () => { actions.openPullRequest(); close() } },
+      { id: 'copy-pr-url', group: 'Pull request', label: 'Copy pull-request URL', icon: Copy, shortcut: 'Y P', run: () => { actions.copyPullRequestUrl(); close() } },
+      { id: 'copy-pr-branch', group: 'Pull request', label: 'Copy pull-request branch', icon: GitBranch, shortcut: 'Y B', run: () => { actions.copyPullRequestBranch(); close() } },
+      { id: 'audio-task', group: 'Audio', label: 'Toggle task audio', icon: Mic, shortcut: 'V T', run: () => { actions.toggleTaskAudio(); close() } },
+      { id: 'audio-mastermind', group: 'Audio', label: 'Toggle Mastermind audio', icon: Mic, shortcut: 'V M', run: () => { actions.toggleMastermindAudio(); close() } },
       { id: 'act-mastermind', group: 'Actions', label: 'Toggle Mastermind', icon: MessageSquare, keywords: 'orchestrator chat', run: () => { toggleOrchestrator(); close() } },
       { id: 'act-settings', group: 'Actions', label: 'Open Settings', icon: Settings, keywords: 'preferences config', run: () => { openSettings(); close() } },
       { id: 'act-theme', group: 'Actions', label: themeResolved === 'dark' ? 'Switch to Light mode' : 'Switch to Dark mode', icon: themeResolved === 'dark' ? Sun : Moon, keywords: 'theme dark light appearance', run: () => { toggleTheme(); close() } },
@@ -115,7 +160,7 @@ export function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenCh
       : []
 
     return [...filteredBase, ...appItems, ...taskItems, ...skillItems]
-  }, [query, tasks, skills, applications, themeResolved, closeModal, setSidebarView, openCreateModal, toggleOrchestrator, openSettings, toggleTheme, selectTask, selectSkill, openApplication])
+  }, [query, tasks, skills, applications, themeResolved, closeModal, setSidebarView, openCreateModal, toggleOrchestrator, openSettings, toggleTheme, selectTask, selectSkill, openApplication, actions])
 
   // Keep highlight within bounds when the list shrinks.
   useEffect(() => { setActive((a) => Math.min(a, Math.max(0, items.length - 1))) }, [items.length])

--- a/src/renderer/src/components/layout/KeyboardShortcutsDialog.tsx
+++ b/src/renderer/src/components/layout/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,45 @@
+import { Dialog, DialogBody, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/Dialog'
+import { KEYBOARD_SHORTCUT_GROUPS } from '@/lib/keyboard-shortcuts'
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcutsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+        </DialogHeader>
+        <DialogBody className="space-y-6">
+          {KEYBOARD_SHORTCUT_GROUPS.map((group) => (
+            <section key={group.label}>
+              <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                {group.label}
+              </h3>
+              <div className="divide-y divide-border/50 rounded-xl border border-border/60">
+                {group.shortcuts.map((shortcut) => (
+                  <div key={shortcut.label} className="flex items-center justify-between gap-4 px-3 py-2.5 text-sm">
+                    <span>{shortcut.label}</span>
+                    <span className="flex items-center gap-1">
+                      {shortcut.keys.map((key) => (
+                        <kbd key={key} className="min-w-6 rounded-md border border-border bg-muted px-1.5 py-0.5 text-center text-[11px] text-muted-foreground shadow-xs">
+                          {key}
+                        </kbd>
+                      ))}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+          <p className="text-xs text-muted-foreground">
+            Shortcuts pause while you type. Canvas drawing controls keep priority in Canvas.
+          </p>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -197,6 +197,7 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
             <div className="relative">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
               <input
+                data-keyboard-shortcut-search="tasks"
                 type="search"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
@@ -322,6 +323,7 @@ export function Sidebar({ tasks, selectedTaskId, overdueCount, onSelectTask, onC
             <div className="relative">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
               <input
+                data-keyboard-shortcut-search="skills"
                 type="search"
                 value={skillSearchQuery}
                 onChange={(e) => setSkillSearchQuery(e.target.value)}

--- a/src/renderer/src/components/tasks/TaskListItem.tsx
+++ b/src/renderer/src/components/tasks/TaskListItem.tsx
@@ -113,6 +113,7 @@ export const TaskListItem = memo(function TaskListItem({ task, isSelected, onSel
 
   return (
     <button
+      data-keyboard-task-id={task.id}
       onClick={onSelect}
       aria-current={isSelected ? 'true' : undefined}
       className={cn(

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -6,6 +6,8 @@ import { useSettingsStore } from '@/stores/settings-store'
 import { useArtifactStore } from '@/stores/artifact-store'
 import { TaskStatus } from '@/types'
 import type { WorkfloTask, Agent } from '@/types'
+import { dispatchTaskShortcut, TaskShortcutAction } from '@/lib/keyboard-shortcuts'
+import { PinnedArtifactTabId } from '@/stores/artifact-store'
 
 vi.mock('@/components/agents/AgentTranscriptPanel', () => ({
   AgentTranscriptPanel: ({ onSend }: { onSend?: (message: string) => void }) => (
@@ -132,6 +134,20 @@ describe('clampTranscriptWidth', () => {
   it('keeps both split panes visible when a persisted width exceeds the container', () => {
     expect(clampTranscriptWidth(1_200, 900)).toBe(576)
     expect(clampTranscriptWidth(100, 900)).toBe(320)
+  })
+})
+
+describe('TaskWorkspace keyboard actions', () => {
+  it('opens the snooze dialog for the selected task', () => {
+    renderWorkspace(makeRendererTask())
+    act(() => dispatchTaskShortcut({ action: TaskShortcutAction.SNOOZE, taskId: 'task-1' }))
+    expect(screen.getByText('Snooze Task')).toBeInTheDocument()
+  })
+
+  it('opens the requested task panel', () => {
+    renderWorkspace(makeRendererTask())
+    act(() => dispatchTaskShortcut({ action: TaskShortcutAction.OPEN_DETAILS, taskId: 'task-1' }))
+    expect(useArtifactStore.getState().getUI('task-1').activeTabId).toBe(PinnedArtifactTabId.DETAILS)
   })
 })
 

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -36,6 +36,7 @@ import { ArtifactType } from '@shared/artifacts'
 import { ArtifactsPanel } from '@/components/artifacts/ArtifactsPanel'
 import { ArtifactRail } from '@/components/artifacts/ArtifactRail'
 import type { Artifact, ArtifactUIState } from '@shared/artifacts'
+import { dispatchShortcutFeedback, getNextWhipMessage, onTaskShortcut, TaskShortcutAction } from '@/lib/keyboard-shortcuts'
 
 const EMPTY_ARTIFACTS: Artifact[] = []
 const DEFAULT_ARTIFACT_UI: ArtifactUIState = { open: false, activeTabId: null, railExpanded: false }
@@ -889,6 +890,87 @@ Update existing skills that were helpful or create new ones for patterns worth r
       }, false)
     }
   }, [task?.id, upsertArtifact])
+
+  const newestPullRequest = useCallback(() => {
+    if (!task) return undefined
+    const active = artifacts.find((artifact) => artifact.id === artifactUI.activeTabId && artifact.type === ArtifactType.PR)
+    if (active) return active
+    return artifacts
+      .filter((artifact) => artifact.type === ArtifactType.PR)
+      .sort((a, b) => b.updatedAt - a.updatedAt)[0]
+  }, [artifactUI.activeTabId, artifacts, task])
+
+  const handleRunShortcut = useCallback(() => {
+    if (!task) return
+    const assignedAgent = task.agent_id ? agents.find((agent) => agent.id === task.agent_id) : null
+    const triageAgent = !task.agent_id ? (agents.find((agent) => agent.is_default) || agents[0] || null) : null
+    const idle = session.status === SessionStatus.IDLE
+    if (task.agent_id && isAgentConfigured(assignedAgent) && !task.session_id && !session.sessionId && idle && task.status !== TaskStatus.Completed) {
+      void handleStartSession()
+    } else if (task.agent_id && task.session_id && !session.sessionId && idle && session.messages.length === 0) {
+      void handleResumeSession()
+    } else if (task.agent_id && task.session_id && !session.sessionId && idle && session.messages.length > 0) {
+      void handleStartFreshSession()
+    } else if (!task.agent_id && triageAgent && isAgentConfigured(triageAgent) && idle && task.status !== TaskStatus.Completed && task.status !== TaskStatus.Triaging) {
+      void handleTriage()
+    }
+  }, [agents, handleResumeSession, handleStartFreshSession, handleStartSession, handleTriage, session.messages.length, session.sessionId, session.status, task])
+
+  useEffect(() => onTaskShortcut(({ action, taskId }) => {
+    if (!task || task.id !== taskId) return
+    const workspace = workspaceBodyRef.current
+    if (workspace && window.getComputedStyle(workspace).visibility === 'hidden') return
+    if (action === TaskShortcutAction.RUN) {
+      handleRunShortcut()
+      return
+    }
+    if (action === TaskShortcutAction.SNOOZE) {
+      setShowSnooze(true)
+      return
+    }
+    if (action === TaskShortcutAction.WHIP) {
+      void handleSend(getNextWhipMessage())
+      return
+    }
+    if (action === TaskShortcutAction.OPEN_DETAILS) {
+      selectArtifactTab(task.id, PinnedArtifactTabId.DETAILS, true)
+      return
+    }
+    if (action === TaskShortcutAction.OPEN_CHANGES) {
+      selectArtifactTab(task.id, PinnedArtifactTabId.CHANGES, true)
+      return
+    }
+    if (action === TaskShortcutAction.OPEN_OUTPUT) {
+      if (task.output_fields.length > 0) selectArtifactTab(task.id, PinnedArtifactTabId.OUTPUT, true)
+      else dispatchShortcutFeedback('This task has no output fields', true)
+      return
+    }
+    if (action === TaskShortcutAction.OPEN_ARTIFACT) {
+      const artifact = artifacts
+        .filter((candidate) => candidate.type !== ArtifactType.PR)
+        .sort((a, b) => b.updatedAt - a.updatedAt)[0]
+      if (artifact) selectArtifactTab(task.id, artifact.id, true)
+      else setRailExpanded(task.id, true)
+      return
+    }
+    const pullRequest = newestPullRequest()
+    if (!pullRequest) {
+      dispatchShortcutFeedback('This task has no pull request', true)
+      return
+    }
+    if (action === TaskShortcutAction.OPEN_PR) {
+      selectArtifactTab(task.id, pullRequest.id, true)
+    } else if (action === TaskShortcutAction.COPY_PR_URL && pullRequest.url) {
+      void navigator.clipboard.writeText(pullRequest.url)
+        .then(() => dispatchShortcutFeedback('Pull-request URL copied'))
+        .catch(() => dispatchShortcutFeedback('Could not copy the pull-request URL', true))
+    } else if (action === TaskShortcutAction.COPY_PR_BRANCH && pullRequest.url) {
+      void window.electronAPI.github.fetchPullRequestDetails(pullRequest.url)
+        .then((details) => navigator.clipboard.writeText(details.headRefName))
+        .then(() => dispatchShortcutFeedback('Pull-request branch copied'))
+        .catch(() => dispatchShortcutFeedback('Could not copy the pull-request branch', true))
+    }
+  }), [artifacts, handleRunShortcut, handleSend, newestPullRequest, selectArtifactTab, setRailExpanded, task])
 
   if (!task) {
     return (

--- a/src/renderer/src/lib/keyboard-shortcuts.test.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  dispatchTaskShortcut,
+  getNextWhipMessage,
+  isKeyboardInput,
+  onTaskShortcut,
+  TaskShortcutAction
+} from './keyboard-shortcuts'
+
+describe('keyboard shortcuts', () => {
+  it('blocks shortcuts in fields and editable content', () => {
+    expect(isKeyboardInput(document.createElement('input'))).toBe(true)
+    expect(isKeyboardInput(document.createElement('textarea'))).toBe(true)
+    const editable = document.createElement('div')
+    editable.contentEditable = 'true'
+    expect(isKeyboardInput(editable)).toBe(true)
+    expect(isKeyboardInput(document.createElement('div'))).toBe(false)
+  })
+
+  it('cycles through different Whip messages', () => {
+    const first = getNextWhipMessage()
+    const second = getNextWhipMessage()
+    expect(first).not.toBe(second)
+    expect(first.length).toBeGreaterThan(10)
+    expect(second.length).toBeGreaterThan(10)
+  })
+
+  it('sends task shortcut events to subscribers', () => {
+    let received: { action: TaskShortcutAction; taskId: string } | undefined
+    const unsubscribe = onTaskShortcut((detail) => { received = detail })
+    dispatchTaskShortcut({ action: TaskShortcutAction.OPEN_DETAILS, taskId: 'task-1' })
+    unsubscribe()
+    expect(received).toEqual({ action: TaskShortcutAction.OPEN_DETAILS, taskId: 'task-1' })
+  })
+})

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -1,0 +1,111 @@
+export enum TaskShortcutAction {
+  RUN = 'run',
+  SNOOZE = 'snooze',
+  OPEN_DETAILS = 'open_details',
+  OPEN_CHANGES = 'open_changes',
+  OPEN_OUTPUT = 'open_output',
+  OPEN_ARTIFACT = 'open_artifact',
+  OPEN_PR = 'open_pr',
+  COPY_PR_URL = 'copy_pr_url',
+  COPY_PR_BRANCH = 'copy_pr_branch',
+  WHIP = 'whip'
+}
+
+const TASK_SHORTCUT_EVENT = '20x:task-shortcut'
+const SHORTCUT_FEEDBACK_EVENT = '20x:shortcut-feedback'
+
+export interface TaskShortcutDetail {
+  action: TaskShortcutAction
+  taskId: string
+}
+
+export const KEYBOARD_SHORTCUT_GROUPS = [
+  {
+    label: 'Navigation',
+    shortcuts: [
+      { keys: ['J'], label: 'Next visible task' },
+      { keys: ['K'], label: 'Previous visible task' },
+      { keys: ['Enter'], label: 'Open selected task' },
+      { keys: ['Esc'], label: 'Close or clear selection' },
+      { keys: ['G', 'D'], label: 'Go to Dashboard' },
+      { keys: ['G', 'C'], label: 'Go to Canvas' },
+      { keys: ['G', 'T'], label: 'Go to Tasks' },
+      { keys: ['G', 'S'], label: 'Go to Skills' },
+      { keys: ['/'], label: 'Focus search' },
+      { keys: ['Cmd/Ctrl', 'K'], label: 'Open command palette' },
+      { keys: ['Cmd/Ctrl', '1–4'], label: 'Switch main view' }
+    ]
+  },
+  {
+    label: 'Task actions',
+    shortcuts: [
+      { keys: ['C'], label: 'Create task' },
+      { keys: ['E'], label: 'Complete selected task' },
+      { keys: ['H'], label: 'Snooze selected task' },
+      { keys: ['R'], label: 'Run or resume selected task' },
+      { keys: ['W'], label: 'Whip agent to continue' },
+      { keys: ['#'], label: 'Delete selected task' },
+      { keys: ['?'], label: 'Show keyboard shortcuts' }
+    ]
+  },
+  {
+    label: 'Task panels',
+    shortcuts: [
+      { keys: ['O', 'D'], label: 'Open Details' },
+      { keys: ['O', 'C'], label: 'Open Changes' },
+      { keys: ['O', 'O'], label: 'Open Output' },
+      { keys: ['O', 'A'], label: 'Open newest artifact' },
+      { keys: ['O', 'P'], label: 'Open newest pull request' },
+      { keys: ['Y', 'P'], label: 'Copy pull-request URL' },
+      { keys: ['Y', 'B'], label: 'Copy pull-request branch' }
+    ]
+  },
+  {
+    label: 'Audio',
+    shortcuts: [
+      { keys: ['V', 'T'], label: 'Toggle task audio' },
+      { keys: ['V', 'M'], label: 'Toggle Mastermind audio' }
+    ]
+  }
+] as const
+
+const WHIP_MESSAGES = [
+  'Keep going and take the next useful step.',
+  'Continue from where you stopped.',
+  'Carry on until the task is ready.',
+  'Please keep working toward completion.'
+] as const
+let whipMessageIndex = 0
+
+export function getNextWhipMessage(): string {
+  const message = WHIP_MESSAGES[whipMessageIndex % WHIP_MESSAGES.length]
+  whipMessageIndex += 1
+  return message
+}
+
+export function isKeyboardInput(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  return target.isContentEditable
+    || ['INPUT', 'TEXTAREA', 'SELECT', 'WEBVIEW'].includes(target.tagName)
+    || !!target.closest('[contenteditable="true"], .xterm')
+}
+
+export function dispatchTaskShortcut(detail: TaskShortcutDetail): void {
+  window.dispatchEvent(new CustomEvent<TaskShortcutDetail>(TASK_SHORTCUT_EVENT, { detail }))
+}
+
+export function onTaskShortcut(listener: (detail: TaskShortcutDetail) => void): () => void {
+  const handleEvent = (event: Event) => listener((event as CustomEvent<TaskShortcutDetail>).detail)
+  window.addEventListener(TASK_SHORTCUT_EVENT, handleEvent)
+  return () => window.removeEventListener(TASK_SHORTCUT_EVENT, handleEvent)
+}
+
+export function dispatchShortcutFeedback(message: string, isError = false): void {
+  window.dispatchEvent(new CustomEvent(SHORTCUT_FEEDBACK_EVENT, { detail: { message, isError } }))
+}
+
+export function onShortcutFeedback(listener: (detail: { message: string; isError: boolean }) => void): () => void {
+  const handleEvent = (event: Event) => listener((event as CustomEvent<{ message: string; isError: boolean }>).detail)
+  window.addEventListener(SHORTCUT_FEEDBACK_EVENT, handleEvent)
+  return () => window.removeEventListener(SHORTCUT_FEEDBACK_EVENT, handleEvent)
+}


### PR DESCRIPTION
## Summary

- add Superhuman-style task navigation, quick actions, view chords, panel controls, PR copy controls, and voice toggles
- list every keyboard action in the command palette and add a `?` shortcut reference dialog
- add a cycling `W` Whip command that tells the selected agent to continue
- add Copy URL and Copy branch controls to the pull-request artifact view
- ignore plain-key shortcuts while typing and keep Canvas drawing controls in priority

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm build`
- `pnpm test:run` (2,660 passed, 4 skipped)