### PR TITLE
fix(skills): report usage as a delta so two machines sum instead of clobber

### DIFF
--- a/src/main/enterprise-sync.test.ts
+++ b/src/main/enterprise-sync.test.ts
@@ -130,6 +130,8 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
         content: '# Test',
         confidence: 0.8,
         uses: 5,
+        // uses(5) - uses_at_last_sync(0): what this machine has not reported yet
+        usesDelta: 5,
         lastUsed: '2026-03-10T00:00:00Z',
         updatedAt: '2026-03-10T00:00:00Z',
         tags: ['test']
@@ -979,6 +981,99 @@ describe('EnterpriseSyncManager — Skills 2-Way Sync (Batch)', () => {
           enterprise_skill_id: 'cloud-1'
         })
       )
+    })
+  })
+
+  // ── Usage delta ──────────────────────────────────────────────────────
+
+  describe('usage reporting', () => {
+    it('reports only the usage accrued since the last sync', async () => {
+      mockDb.getSkills.mockReturnValue([
+        makeLocalSkill({ uses: 12, uses_at_last_sync: 8, enterprise_skill_id: 'server-1' })
+      ])
+      mockApiClient.batchSyncSkills.mockResolvedValue({
+        created: 0,
+        updated: 1,
+        skills: [makeServerSkill({ id: 'server-1' })]
+      })
+
+      await syncManager.syncAll('user-1')
+
+      const payload = mockApiClient.batchSyncSkills.mock.calls[0][0]
+      // 12 - 8. Sending the absolute 12 would let the server's max() discard
+      // whatever another machine contributed.
+      expect(payload[0].usesDelta).toBe(4)
+    })
+
+    it('sends no delta when nothing was used since the last sync', async () => {
+      mockDb.getSkills.mockReturnValue([
+        makeLocalSkill({ uses: 8, uses_at_last_sync: 8, enterprise_skill_id: 'server-1' })
+      ])
+      mockApiClient.batchSyncSkills.mockResolvedValue({
+        created: 0,
+        updated: 1,
+        skills: [makeServerSkill({ id: 'server-1' })]
+      })
+
+      await syncManager.syncAll('user-1')
+
+      const payload = mockApiClient.batchSyncSkills.mock.calls[0][0]
+      expect(payload[0].usesDelta).toBeUndefined()
+    })
+
+    it('never reports a negative delta if the local counter went backwards', async () => {
+      mockDb.getSkills.mockReturnValue([
+        makeLocalSkill({ uses: 2, uses_at_last_sync: 9, enterprise_skill_id: 'server-1' })
+      ])
+      mockApiClient.batchSyncSkills.mockResolvedValue({
+        created: 0,
+        updated: 1,
+        skills: [makeServerSkill({ id: 'server-1' })]
+      })
+
+      await syncManager.syncAll('user-1')
+
+      const payload = mockApiClient.batchSyncSkills.mock.calls[0][0]
+      expect(payload[0].usesDelta).toBeUndefined()
+    })
+
+    it('advances the usage baseline once the server accepts the push', async () => {
+      mockDb.getSkills.mockReturnValue([
+        makeLocalSkill({ uses: 12, uses_at_last_sync: 8, enterprise_skill_id: 'server-1' })
+      ])
+      mockApiClient.batchSyncSkills.mockResolvedValue({
+        created: 0,
+        updated: 1,
+        conflicts: [],
+        skills: [makeServerSkill({ id: 'server-1' })]
+      })
+
+      await syncManager.syncAll('user-1')
+
+      expect(mockDb.updateSkill).toHaveBeenCalledWith('local-1', {
+        enterprise_skill_id: 'server-1',
+        uses_at_last_sync: 12
+      })
+    })
+
+    it('holds the baseline when the server refused the item', async () => {
+      mockDb.getSkills.mockReturnValue([
+        makeLocalSkill({ uses: 12, uses_at_last_sync: 8, enterprise_skill_id: 'server-1' })
+      ])
+      mockApiClient.batchSyncSkills.mockResolvedValue({
+        created: 0,
+        updated: 0,
+        skipped: 1,
+        conflicts: [{ id: 'server-1', name: 'Test Skill', reason: 'stale' }],
+        skills: [makeServerSkill({ id: 'server-1' })]
+      })
+
+      await syncManager.syncAll('user-1')
+
+      // Advancing here would discard the 4 uses the server never added.
+      expect(mockDb.updateSkill).toHaveBeenCalledWith('local-1', {
+        enterprise_skill_id: 'server-1'
+      })
     })
   })
 })

--- a/src/main/enterprise-sync.ts
+++ b/src/main/enterprise-sync.ts
@@ -19,7 +19,7 @@
  *     node.taskSources[]        → auto-create matching local task_sources entries
  */
 import type { DatabaseManager, SkillRecord } from './database'
-import type { WorkfloApiClient, WorkfloOrgNode, WorkfloMcpServer, WorkfloSkill, WorkfloAgent } from './workflo-api-client'
+import type { WorkfloApiClient, WorkfloOrgNode, WorkfloMcpServer, WorkfloSkill, WorkfloAgent, BatchSyncSkillsResult } from './workflo-api-client'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -382,6 +382,7 @@ export class EnterpriseSyncManager {
         lastUsed?: string | null
         updatedAt?: string
         tags?: string[]
+        usesDelta?: number
       }
     }> = []
 
@@ -432,6 +433,11 @@ export class EnterpriseSyncManager {
           uses: typeof skill.uses === 'number' && skill.uses >= 0
             ? Math.floor(skill.uses)
             : undefined,
+          // What this machine accrued since its own last sync. The server ADDS
+          // this, so two machines each using a skill sum correctly. Sending the
+          // absolute count instead loses the smaller side, because the server
+          // can only take the max of two absolute numbers.
+          usesDelta: this.usesSinceLastSync(skill),
           lastUsed: this.normalizeDateTime(skill.last_used),
           tags: Array.isArray(skill.tags) ? skill.tags : undefined
         }
@@ -447,6 +453,21 @@ export class EnterpriseSyncManager {
     let totalCreated = 0
     let totalUpdated = 0
     let batchFailed = false
+
+    // Server ids and names the server refused. Their usage delta was NOT
+    // applied, so the local usage baseline must not advance for them, or the
+    // usage they represent is lost for good.
+    const conflictedIds = new Set<string>()
+    const conflictedNames = new Set<string>()
+    const noteConflicts = (r: { conflicts?: Array<{ id?: string; name: string; reason: string }> }): void => {
+      for (const c of r.conflicts ?? []) {
+        if (c.id) conflictedIds.add(c.id)
+        conflictedNames.add(c.name)
+        console.log(
+          `[EnterpriseSyncManager] Server refused "${c.name}": ${c.reason}`
+        )
+      }
+    }
 
     if (skillsToSync.length > 0) {
       const chunks = this.chunkArray(
@@ -464,6 +485,7 @@ export class EnterpriseSyncManager {
           totalUpdated += batchResult.updated
           // Last chunk's response has the full tenant skill set
           allServerSkills = batchResult.skills
+          noteConflicts(batchResult)
           console.log(
             `[EnterpriseSyncManager] Batch chunk ${i + 1}/${chunks.length}: created=${batchResult.created}, updated=${batchResult.updated}, total_skills=${batchResult.skills.length}`
           )
@@ -479,6 +501,7 @@ export class EnterpriseSyncManager {
               totalCreated += singleResult.created
               totalUpdated += singleResult.updated
               allServerSkills = singleResult.skills
+              noteConflicts(singleResult)
             } catch (singleErr) {
               batchFailed = true
               const singleMsg = singleErr instanceof Error ? singleErr.message : String(singleErr)
@@ -533,9 +556,16 @@ export class EnterpriseSyncManager {
         // timestamp is the conflict token for the next sync.
         const localSkill = localSkills.find((s) => s.id === localId)
         if (localSkill) {
+          const refused =
+            conflictedIds.has(serverSkill.id) ||
+            conflictedNames.has(payload.name)
+
           this.db.updateSkill(localId, {
             enterprise_skill_id: serverSkill.id,
-            uses_at_last_sync: localSkill.uses
+            // Only move the usage baseline when the server actually accepted
+            // the item. Advancing it after a refusal would discard the usage
+            // this machine reported but the server never added.
+            ...(refused ? {} : { uses_at_last_sync: localSkill.uses })
           })
         }
         pushedSkillIds.push(serverSkill.id)
@@ -554,15 +584,18 @@ export class EnterpriseSyncManager {
    */
   private async batchSyncWithRetry(
     skills: Array<{
+      id?: string
       name: string
       description: string
       content: string
       confidence?: number
       uses?: number
+      usesDelta?: number
       lastUsed?: string | null
+      updatedAt?: string
       tags?: string[]
     }>
-  ): Promise<{ created: number; updated: number; skills: WorkfloSkill[] }> {
+  ): Promise<BatchSyncSkillsResult> {
     let lastError: Error | null = null
 
     for (let attempt = 0; attempt < EnterpriseSyncManager.BATCH_SYNC_MAX_RETRIES; attempt++) {
@@ -773,6 +806,22 @@ export class EnterpriseSyncManager {
   private isBuiltInSkill(skill: SkillRecord): boolean {
     const builtInNames = ['Mastermind', 'mastermind']
     return builtInNames.includes(skill.name)
+  }
+
+  /**
+   * Usage this machine has accrued since its last successful sync.
+   *
+   * `uses_at_last_sync` is the count at the moment the server last confirmed a
+   * push. Anything above that has not been reported yet. Clamped at zero — a
+   * negative would mean the local counter went backwards (a restore from an
+   * older copy), and re-reporting nothing is safer than subtracting.
+   */
+  private usesSinceLastSync(skill: SkillRecord): number | undefined {
+    const current = typeof skill.uses === 'number' ? skill.uses : 0
+    const baseline =
+      typeof skill.uses_at_last_sync === 'number' ? skill.uses_at_last_sync : 0
+    const delta = Math.floor(current - baseline)
+    return delta > 0 ? delta : undefined
   }
 
   /**

--- a/src/main/workflo-api-client.ts
+++ b/src/main/workflo-api-client.ts
@@ -129,6 +129,26 @@ export interface WorkfloSkill {
   updatedAt: string
 }
 
+/**
+ * Response from POST /api/skills/batch-sync.
+ *
+ * `conflicts` reports per-item outcomes the counts cannot express — most
+ * importantly a rename the server refused, which is otherwise invisible
+ * because the item is still written, just under its old name.
+ */
+export interface BatchSyncSkillsResult {
+  created: number
+  updated: number
+  skipped?: number
+  conflicts?: Array<{
+    id?: string
+    name: string
+    reason: 'under_review' | 'stale' | 'duplicate_in_batch' | 'rename_refused'
+  }>
+  createdIds?: string[]
+  skills: WorkfloSkill[]
+}
+
 export interface WorkfloOrgNodeDetail {
   node: WorkfloOrgNode
   mcpServers: WorkfloMcpServer[]
@@ -339,15 +359,16 @@ export class WorkfloApiClient {
     content: string
     confidence?: number
     uses?: number
+    usesDelta?: number
     lastUsed?: string | null
     updatedAt?: string
     tags?: string[]
-  }>): Promise<{ created: number; updated: number; skipped?: number; skills: WorkfloSkill[] }> {
+  }>): Promise<BatchSyncSkillsResult> {
     const result = (await this.auth.apiRequest(
       'POST',
       '/api/skills/batch-sync',
       { skills }
-    )) as { created: number; updated: number; skipped?: number; skills: WorkfloSkill[] }
+    )) as BatchSyncSkillsResult
     return result
   }
 


### PR DESCRIPTION
Client half of peakflo/workflow-builder#1654.

## Why

The client sent an **absolute** `uses` count and the server took `max(stored, incoming)`. With two machines that is simply wrong:

| | Machine A | Machine B | Server after both sync |
|---|---|---|---|
| Uses | 5 | 3 | **5** (should be 8) |

The smaller side's usage is discarded every time. `uses_at_last_sync` had existed for exactly this purpose since the column was added — nothing ever read it.

## What changed

The client now sends `usesDelta`: what **this machine** accrued since its own last confirmed sync. The server adds it rather than taking a maximum.

```ts
const delta = Math.floor(current - baseline)
return delta > 0 ? delta : undefined
```

Clamped at zero on purpose — a local counter that went backwards (a restore from an older copy) reports nothing rather than subtracting.

## The baseline only moves on acceptance

The server's new `conflicts` array says which items it refused (`stale`, `under_review`, `rename_refused`, `duplicate_in_batch`). Advancing `uses_at_last_sync` after a refusal would discard the usage the client reported but the server never added, so the baseline is held for those items:

```ts
...(refused ? {} : { uses_at_last_sync: localSkill.uses })
```

Refusals are also logged. A refused rename is otherwise **invisible** to the client — the item is still written, just under its old name.

## Compatibility

`usesDelta` is optional and the absolute `uses` is still sent, so an older server ignores the new field and behaves exactly as before. Deploy order does not matter.

## Known limit, accepted

Delivery is at-least-once. If the server commits but the response is lost, the client retries and the delta applies twice. Usage is a soft metric and over-counting on a lost response is strictly better than the current guaranteed under-count, but it is a real property and worth knowing.

## Testing

5 tests added; the ones asserting the fix were verified to **fail without it** by reverting the source file.

- `pnpm test run` — **169 files passed**
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)