### PR TITLE
feat(notion): let the user select the next task statuses

### DIFF
--- a/src/main/plugins/notion-plugin.test.ts
+++ b/src/main/plugins/notion-plugin.test.ts
@@ -110,12 +110,15 @@ describe('NotionPlugin', () => {
     expect(plugin.requiresMcpServer).toBe(false)
   })
 
-  it('returns config schema with api_token, data_source_id, and filters', () => {
+  it('returns config schema with token, data source, filters, and statuses', () => {
     const schema = plugin.getConfigSchema()
-    expect(schema).toHaveLength(3)
-    expect(schema[0].key).toBe('api_token')
-    expect(schema[1].key).toBe('data_source_id')
-    expect(schema[2].key).toBe('filters')
+    expect(schema.map((f) => f.key)).toEqual([
+      'api_token',
+      'data_source_id',
+      'filters',
+      'next_statuses',
+      'completion_status'
+    ])
   })
 
   it('returns field mapping', () => {
@@ -545,6 +548,159 @@ describe('NotionPlugin', () => {
       if (result.error) {
         expect(result.error).not.toMatch(/Unknown action/)
       }
+    })
+  })
+
+  // ── Next statuses ───────────────────────────────────────
+
+  describe('next statuses', () => {
+    const CUSTOM_SCHEMA = {
+      ...DB_SCHEMA,
+      properties: {
+        Name: { id: 'title', name: 'Name', type: 'title' },
+        Status: {
+          id: 'status',
+          name: 'Status',
+          type: 'status',
+          status: {
+            options: [
+              { id: 's1', name: 'Icebox', color: 'default' },
+              { id: 's2', name: 'Ready for QA', color: 'blue' },
+              { id: 's3', name: 'Shipped', color: 'green' }
+            ],
+            groups: []
+          }
+        }
+      }
+    }
+
+    const configuredConfig = {
+      ...defaultConfig,
+      next_statuses: ['Ready for QA', 'Shipped'],
+      completion_status: 'Shipped'
+    }
+
+    beforeEach(() => {
+      mockClientInstance.getDataSource.mockResolvedValue(CUSTOM_SCHEMA)
+    })
+
+    it('resolves the status options of the data source', async () => {
+      const options = await plugin.resolveOptions('status_options', defaultConfig, makeContext())
+      expect(options).toEqual([
+        { value: 'Icebox', label: 'Icebox' },
+        { value: 'Ready for QA', label: 'Ready for QA' },
+        { value: 'Shipped', label: 'Shipped' }
+      ])
+    })
+
+    it('offers the configured statuses as action input options', () => {
+      const [changeStatus] = plugin.getActions(configuredConfig)
+      expect(changeStatus.inputOptions).toEqual([
+        { value: 'Ready for QA', label: 'Ready for QA' },
+        { value: 'Shipped', label: 'Shipped' }
+      ])
+    })
+
+    it('leaves the action free-text when no status is configured', () => {
+      const [changeStatus] = plugin.getActions(defaultConfig)
+      expect(changeStatus.inputOptions).toBeUndefined()
+      expect(changeStatus.inputPlaceholder).toBe('e.g. Done, In Progress')
+    })
+
+    it('completes at source with the status the user selected', async () => {
+      const ctx = makeContext()
+      const task = { id: 'local-1', external_id: 'ext-1' } as TaskRecord
+
+      const result = await plugin.executeAction('complete', task, undefined, configuredConfig, ctx)
+
+      expect(result.success).toBe(true)
+      expect(mockClientInstance.updatePage).toHaveBeenCalledWith('ext-1', {
+        Status: { status: { name: 'Shipped' } }
+      })
+      expect(result.taskUpdate).toEqual({ status: TaskStatus.Completed })
+    })
+
+    it('writes a selected status that the name heuristics do not know', async () => {
+      const ctx = makeContext()
+      const task = { id: 'local-1', external_id: 'ext-1' } as TaskRecord
+
+      const result = await plugin.executeAction(
+        'change_status',
+        task,
+        'ready for qa',
+        configuredConfig,
+        ctx
+      )
+
+      expect(result.success).toBe(true)
+      // The spelling from the config is used, not the spelling the user typed.
+      expect(mockClientInstance.updatePage).toHaveBeenCalledWith('ext-1', {
+        Status: { status: { name: 'Ready for QA' } }
+      })
+    })
+
+    it('ignores a completion status that is no longer in the list', async () => {
+      const ctx = makeContext()
+      const task = { id: 'local-1', external_id: 'ext-1' } as TaskRecord
+      const staleConfig = {
+        ...defaultConfig,
+        next_statuses: ['Ready for QA'],
+        completion_status: 'Shipped'
+      }
+
+      await plugin.executeAction('complete', task, undefined, staleConfig, ctx)
+
+      // Falls back to the heuristics, which find no Done option in this schema.
+      expect(mockClientInstance.updatePage).toHaveBeenCalledWith('ext-1', {
+        Status: { status: { name: 'completed' } }
+      })
+    })
+
+    it('exports a completed task to the selected status', async () => {
+      const ctx = makeContext()
+      const task = { id: 'local-1', external_id: 'ext-1' } as TaskRecord
+
+      await plugin.exportUpdate(task, { status: TaskStatus.Completed }, configuredConfig, ctx)
+
+      expect(mockClientInstance.updatePage).toHaveBeenCalledWith('ext-1', {
+        Status: { status: { name: 'Shipped' } }
+      })
+    })
+
+    it('imports the completion status as a completed task', async () => {
+      const ctx = makeContext()
+      mockClientInstance.queryAllPages.mockResolvedValue([
+        makePage({
+          properties: {
+            Name: { id: 'title', type: 'title', title: [{ plain_text: 'Shipped Task' }] },
+            Status: { id: 'status', type: 'status', status: { id: 's3', name: 'Shipped' } }
+          }
+        })
+      ])
+
+      await plugin.importTasks('source-1', configuredConfig, ctx)
+
+      expect(ctx.db.createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ status: TaskStatus.Completed })
+      )
+    })
+
+    it('imports an unconfigured custom status as not started', async () => {
+      const ctx = makeContext()
+      mockClientInstance.queryAllPages.mockResolvedValue([
+        makePage({
+          properties: {
+            Name: { id: 'title', type: 'title', title: [{ plain_text: 'Iced Task' }] },
+            Status: { id: 'status', type: 'status', status: { id: 's1', name: 'Icebox' } }
+          }
+        })
+      ])
+
+      await plugin.importTasks('source-1', configuredConfig, ctx)
+
+      expect(ctx.db.createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ status: TaskStatus.NotStarted })
+      )
     })
   })
 })

--- a/src/main/plugins/notion-plugin.ts
+++ b/src/main/plugins/notion-plugin.ts
@@ -126,6 +126,54 @@ function buildPropertyFilter(
   }
 }
 
+// ── Next statuses (stored in source config) ──────────────────
+
+/**
+ * The statuses a user can move a task to from 20x. The user selects these in
+ * the source form from the real options of the Notion status property, because
+ * the name heuristics below only know the default Notion board names.
+ */
+export function readNextStatuses(config: Record<string, unknown>): string[] {
+  const raw = config.next_statuses
+  if (!Array.isArray(raw)) return []
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of raw) {
+    if (typeof value !== 'string') continue
+    const name = value.trim()
+    if (!name || seen.has(name.toLowerCase())) continue
+    seen.add(name.toLowerCase())
+    result.push(name)
+  }
+  return result
+}
+
+/**
+ * The status a completed task moves to. Returns null when the user selected
+ * none, or when the selection is stale — the status list can change in Notion
+ * after the source was configured.
+ */
+export function readCompletionStatus(config: Record<string, unknown>): string | null {
+  const raw = config.completion_status
+  if (typeof raw !== 'string') return null
+  const name = raw.trim()
+  if (!name) return null
+  const nextStatuses = readNextStatuses(config)
+  if (nextStatuses.length === 0) return name
+  const match = nextStatuses.find((s) => s.toLowerCase() === name.toLowerCase())
+  return match ?? null
+}
+
+/** All status names the user configured, in the spelling Notion expects. */
+function configuredStatuses(config: Record<string, unknown>): string[] {
+  const nextStatuses = readNextStatuses(config)
+  const completion = readCompletionStatus(config)
+  if (completion && !nextStatuses.some((s) => s.toLowerCase() === completion.toLowerCase())) {
+    return [...nextStatuses, completion]
+  }
+  return nextStatuses
+}
+
 // ── Status mapping ───────────────────────────────────────────
 
 const STATUS_TO_LOCAL: Record<string, TaskStatus> = {
@@ -219,6 +267,23 @@ export class NotionPlugin implements TaskSourcePlugin {
         dependsOn: { field: 'data_source_id', value: '__any__' },
         description: 'Structured filter configuration (managed by custom form)'
       },
+      {
+        key: 'next_statuses',
+        label: 'Next statuses',
+        type: 'dynamic-select',
+        optionsResolver: 'status_options',
+        multiSelect: true,
+        dependsOn: { field: 'data_source_id', value: '__any__' },
+        description: 'Statuses a task can be moved to from 20x'
+      },
+      {
+        key: 'completion_status',
+        label: 'Status on completion',
+        type: 'dynamic-select',
+        optionsResolver: 'status_options',
+        dependsOn: { field: 'data_source_id', value: '__any__' },
+        description: 'Status written to Notion when a task is completed at source'
+      }
     ]
   }
 
@@ -242,6 +307,24 @@ export class NotionPlugin implements TaskSourcePlugin {
       } catch (err) {
         console.error('[notion] Failed to fetch data sources:', err)
         throw err
+      }
+    }
+
+    if (resolverKey === 'status_options') {
+      const dataSourceId = config.data_source_id as string
+      if (!dataSourceId) return []
+
+      try {
+        const db = await client.getDataSource(dataSourceId)
+        const propMap = this.buildPropertyMap(db)
+        if (!propMap.status) return []
+        return this.statusOptionNames(db.properties[propMap.status.name]).map((name) => ({
+          value: name,
+          label: name
+        }))
+      } catch (err) {
+        console.error('[notion] Failed to fetch status options:', err)
+        return []
       }
     }
 
@@ -326,16 +409,25 @@ export class NotionPlugin implements TaskSourcePlugin {
     }
   }
 
-  getActions(_config: Record<string, unknown>): PluginAction[] {
+  getActions(config: Record<string, unknown>): PluginAction[] {
+    const nextStatuses = readNextStatuses(config)
+    const changeStatus: PluginAction = {
+      id: PluginActionId.ChangeStatus,
+      label: 'Change Status',
+      icon: 'ArrowRightCircle',
+      requiresInput: true,
+      inputLabel: 'New Status',
+      inputPlaceholder:
+        nextStatuses.length > 0 ? `e.g. ${nextStatuses[0]}` : 'e.g. Done, In Progress'
+    }
+    // With next statuses configured the user picks one instead of typing a
+    // name that Notion may not have.
+    if (nextStatuses.length > 0) {
+      changeStatus.inputOptions = nextStatuses.map((name) => ({ value: name, label: name }))
+    }
+
     return [
-      {
-        id: PluginActionId.ChangeStatus,
-        label: 'Change Status',
-        icon: 'ArrowRightCircle',
-        requiresInput: true,
-        inputLabel: 'New Status',
-        inputPlaceholder: 'e.g. Done, In Progress'
-      },
+      changeStatus,
       {
         id: PluginActionId.UpdatePriority,
         label: 'Update Priority',
@@ -380,7 +472,7 @@ export class NotionPlugin implements TaskSourcePlugin {
         if (page.archived) continue
 
         try {
-          const mapped = this.mapPage(page, propMap)
+          const mapped = this.mapPage(page, propMap, config)
           if (!mapped.title) continue
 
           // Fetch page blocks for both content rendering and file extraction
@@ -505,10 +597,10 @@ export class NotionPlugin implements TaskSourcePlugin {
       }
 
       if (changedFields.status && propMap.status) {
-        const notionStatus = this.localStatusToNotion(
-          changedFields.status as string,
-          db.properties[propMap.status.name]
-        )
+        const localStatus = changedFields.status as string
+        const notionStatus =
+          (localStatus === TaskStatus.Completed ? readCompletionStatus(config) : null) ??
+          this.localStatusToNotion(localStatus, db.properties[propMap.status.name])
         if (notionStatus) {
           if (propMap.status.type === NotionPropertyType.Status) {
             properties[propMap.status.name] = { status: { name: notionStatus } }
@@ -554,10 +646,11 @@ export class NotionPlugin implements TaskSourcePlugin {
     }
 
     // "complete" is a generic completion action — treat it as a status change
-    // to "completed" so Notion moves the page to its Done/Complete status.
+    // so Notion moves the page on. The status the user selected wins; without
+    // one, fall back to the Done/Complete name heuristics.
     if (actionId === PluginActionId.Complete) {
       actionId = PluginActionId.ChangeStatus
-      input = 'completed'
+      input = readCompletionStatus(config) ?? 'completed'
     }
 
     if (!input) {
@@ -574,8 +667,12 @@ export class NotionPlugin implements TaskSourcePlugin {
       const properties: Record<string, unknown> = {}
 
       if (actionId === PluginActionId.ChangeStatus && propMap.status) {
-        // Try to find a matching status in the DB schema, or use input as-is
-        const notionStatus = this.localStatusToNotion(input, db.properties[propMap.status.name]) || input
+        // Prefer a status the user selected, then the name heuristics against
+        // the DB schema, and finally the input as typed.
+        const notionStatus =
+          this.matchConfiguredStatus(input, config) ??
+          this.localStatusToNotion(input, db.properties[propMap.status.name]) ??
+          input
         if (propMap.status.type === NotionPropertyType.Status) {
           properties[propMap.status.name] = { status: { name: notionStatus } }
         } else {
@@ -592,7 +689,11 @@ export class NotionPlugin implements TaskSourcePlugin {
 
       const taskUpdate: Record<string, unknown> = {}
       if (actionId === PluginActionId.ChangeStatus) {
-        const localStatus = STATUS_TO_LOCAL[input.toLowerCase()]
+        const completionStatus = readCompletionStatus(config)
+        const localStatus =
+          completionStatus && completionStatus.toLowerCase() === input.toLowerCase()
+            ? TaskStatus.Completed
+            : STATUS_TO_LOCAL[input.toLowerCase()]
         if (localStatus) taskUpdate.status = localStatus
       } else if (actionId === PluginActionId.UpdatePriority) {
         const localPriority = PRIORITY_TO_LOCAL[input.toLowerCase()]
@@ -708,7 +809,8 @@ Alternatively, open the database in Notion → click **...** → **Connections**
 1. Paste your **Integration Token**
 2. Select the **Database** from the dropdown
 3. Optionally select **Filters** to only import specific items (e.g. Status = In Progress)
-4. Click **Save** and **Sync**
+4. Optionally select the **Next statuses** a task can move to from 20x
+5. Click **Save** and **Sync**
 
 ## Features
 
@@ -716,6 +818,12 @@ Alternatively, open the database in Notion → click **...** → **Connections**
 Select property values to filter by. Values from the same property are combined with OR; different properties with AND.
 
 Example: Status = "In Progress" OR "To Do" AND Priority = "High"
+
+### Next Statuses
+Select the statuses of your data source that a task can move to from 20x, and
+which one a completed task moves to. Use this when your board has custom status
+names such as "Ready for QA" or "Shipped" — without it, 20x can only recognise
+the default Notion names (To Do, In progress, In review, Done).
 
 ### Incremental Sync
 After the first full sync, subsequent syncs only fetch pages modified since the last sync.
@@ -821,7 +929,8 @@ The integration automatically maps Notion properties to task fields:
    */
   private mapPage(
     page: NotionPage,
-    propMap: PropertyMap
+    propMap: PropertyMap,
+    config: Record<string, unknown> = {}
   ): {
     title: string
     status?: string
@@ -845,7 +954,14 @@ The integration automatically maps Notion properties to task fields:
           ? statusProp.status?.name
           : statusProp.select?.name
         if (rawStatus) {
-          status = STATUS_TO_LOCAL[rawStatus.toLowerCase()] || TaskStatus.NotStarted
+          // A configured completion status wins over the name heuristics, so a
+          // custom name such as "Shipped" does not import back as not started
+          // and re-open a task 20x just completed.
+          const completionStatus = readCompletionStatus(config)
+          status =
+            completionStatus && completionStatus.toLowerCase() === rawStatus.toLowerCase()
+              ? TaskStatus.Completed
+              : STATUS_TO_LOCAL[rawStatus.toLowerCase()] || TaskStatus.NotStarted
         }
       }
     }
@@ -1090,6 +1206,31 @@ The integration automatically maps Notion properties to task fields:
   }
 
   /**
+   * Option names of a Notion status or select property, in board order.
+   */
+  private statusOptionNames(propSchema: NotionPropertySchema | undefined): string[] {
+    if (!propSchema) return []
+    const options =
+      propSchema.type === NotionPropertyType.Status
+        ? propSchema.status?.options
+        : propSchema.select?.options
+    return options?.map((o) => o.name) ?? []
+  }
+
+  /**
+   * Match user input against the statuses the user configured, so the value
+   * written to Notion always uses the spelling Notion knows.
+   */
+  private matchConfiguredStatus(
+    input: string,
+    config: Record<string, unknown>
+  ): string | null {
+    const wanted = input.trim().toLowerCase()
+    if (!wanted) return null
+    return configuredStatuses(config).find((s) => s.toLowerCase() === wanted) ?? null
+  }
+
+  /**
    * Map local status to a Notion status option name
    */
   private localStatusToNotion(
@@ -1101,13 +1242,8 @@ The integration automatically maps Notion properties to task fields:
     const candidates = LOCAL_TO_NOTION_STATUS[localStatus]
     if (!candidates) return null
 
-    // Get available options from schema
-    const options = propSchema.type === NotionPropertyType.Status
-      ? propSchema.status?.options
-      : propSchema.select?.options
-    if (!options) return null
-
-    const optionNames = options.map((o) => o.name)
+    const optionNames = this.statusOptionNames(propSchema)
+    if (optionNames.length === 0) return null
 
     // Find first matching candidate
     for (const candidate of candidates) {

--- a/src/main/plugins/types.ts
+++ b/src/main/plugins/types.ts
@@ -67,6 +67,11 @@ export interface PluginAction {
   requiresInput?: boolean
   inputLabel?: string
   inputPlaceholder?: string
+  /**
+   * For 'requiresInput' actions: the values the user can choose from. When the
+   * plugin supplies these, the UI shows a picker instead of a free-text box.
+   */
+  inputOptions?: ConfigFieldOption[]
 }
 
 export interface ActionResult {

--- a/src/renderer/src/components/plugins/NotionConfigForm.test.tsx
+++ b/src/renderer/src/components/plugins/NotionConfigForm.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { NotionConfigForm } from './NotionConfigForm'
+
+afterEach(cleanup)
+
+const mockResolveOptions = vi.fn()
+vi.mock('@/lib/ipc-client', () => ({
+  pluginApi: {
+    resolveOptions: (...args: unknown[]) => mockResolveOptions(...args)
+  },
+  onTaskDeleted: vi.fn(() => vi.fn())
+}))
+
+const STATUS_PROPERTY = {
+  name: 'Status',
+  type: 'status',
+  options: [
+    { value: 'Icebox', label: 'Icebox' },
+    { value: 'Ready for QA', label: 'Ready for QA' },
+    { value: 'Shipped', label: 'Shipped' }
+  ]
+}
+
+const CONNECTED = { api_token: 'ntn_test', data_source_id: 'db-1' }
+
+beforeEach(() => {
+  mockResolveOptions.mockReset()
+  // data_sources resolves first, then data_source_properties.
+  mockResolveOptions.mockImplementation((_plugin: string, resolverKey: string) => {
+    if (resolverKey === 'data_sources') {
+      return Promise.resolve([{ value: 'db-1', label: 'Tasks DB' }])
+    }
+    return Promise.resolve([{ value: JSON.stringify(STATUS_PROPERTY), label: 'Status' }])
+  })
+})
+
+describe('NotionConfigForm — next statuses', () => {
+  it('lists the status options of the selected data source', async () => {
+    render(<NotionConfigForm value={CONNECTED} onChange={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('notion-next-statuses')).toBeDefined()
+    })
+    expect(screen.getByLabelText('Ready for QA')).toBeDefined()
+    expect(screen.getByLabelText('Shipped')).toBeDefined()
+  })
+
+  it('stores the statuses the user selects', async () => {
+    const onChange = vi.fn()
+    render(<NotionConfigForm value={CONNECTED} onChange={onChange} />)
+
+    await waitFor(() => expect(screen.getByLabelText('Shipped')).toBeDefined())
+    fireEvent.click(screen.getByLabelText('Shipped'))
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ next_statuses: ['Shipped'] })
+    )
+  })
+
+  it('offers a completion status once statuses are selected', async () => {
+    render(
+      <NotionConfigForm
+        value={{ ...CONNECTED, next_statuses: ['Ready for QA', 'Shipped'] }}
+        onChange={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(screen.getByTestId('notion-completion-status')).toBeDefined())
+    const select = screen.getByTestId('notion-completion-status') as HTMLSelectElement
+    // "Detect automatically" plus the two selected statuses.
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      '',
+      'Ready for QA',
+      'Shipped'
+    ])
+  })
+
+  it('hides the completion status until a next status is selected', async () => {
+    render(<NotionConfigForm value={CONNECTED} onChange={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getByTestId('notion-next-statuses')).toBeDefined())
+    expect(screen.queryByTestId('notion-completion-status')).toBeNull()
+  })
+
+  it('clears a completion status the user removes from the list', async () => {
+    const onChange = vi.fn()
+    render(
+      <NotionConfigForm
+        value={{ ...CONNECTED, next_statuses: ['Shipped'], completion_status: 'Shipped' }}
+        onChange={onChange}
+      />
+    )
+
+    await waitFor(() => expect(screen.getByLabelText('Shipped')).toBeDefined())
+    fireEvent.click(screen.getByLabelText('Shipped'))
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ next_statuses: [], completion_status: '' })
+    )
+  })
+})

--- a/src/renderer/src/components/plugins/NotionConfigForm.tsx
+++ b/src/renderer/src/components/plugins/NotionConfigForm.tsx
@@ -42,6 +42,20 @@ interface NotionFilterRow {
   values: string[]
 }
 
+/**
+ * Finds the property the plugin treats as the task status: the first Status
+ * property, else a Select property named "status". Mirrors buildPropertyMap()
+ * in src/main/plugins/notion-plugin.ts.
+ */
+function findStatusProperty(
+  properties: NotionPropertyInfo[]
+): NotionPropertyInfo | undefined {
+  return (
+    properties.find((p) => p.type === 'status') ??
+    properties.find((p) => p.type === 'select' && p.name.toLowerCase() === 'status')
+  )
+}
+
 // ── Main Form ────────────────────────────────────────────────
 
 export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps) {
@@ -119,6 +133,20 @@ export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps)
   const hasToken = !!(value.api_token as string)
   const hasDataSource = !!(value.data_source_id as string)
 
+  const statusProperty = findStatusProperty(dbProperties)
+  const nextStatuses = (value.next_statuses as string[]) ?? []
+  const completionStatus = (value.completion_status as string) ?? ''
+
+  const updateNextStatuses = (statuses: string[]) => {
+    // Drop a completion status the user just removed from the list.
+    const keepCompletion = statuses.some((s) => s === completionStatus)
+    onChange({
+      ...value,
+      next_statuses: statuses,
+      completion_status: keepCompletion ? completionStatus : ''
+    })
+  }
+
   return (
     <div className="space-y-3">
       {/* Integration Token */}
@@ -166,7 +194,15 @@ export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps)
             <SearchableSelect
               options={dataSources}
               value={(value.data_source_id as string) ?? ''}
-              onChange={(v) => onChange({ ...value, data_source_id: v, filters: [] })}
+              onChange={(v) =>
+                onChange({
+                  ...value,
+                  data_source_id: v,
+                  filters: [],
+                  next_statuses: [],
+                  completion_status: ''
+                })
+              }
               placeholder="Select data source..."
             />
           )}
@@ -225,6 +261,49 @@ export function NotionConfigForm({ value, onChange, sourceId }: PluginFormProps)
         </div>
       )}
 
+      {/* Next statuses */}
+      {hasDataSource && !loadingProps && statusProperty && (
+        <div className="space-y-1.5" data-testid="notion-next-statuses">
+          <Label>Next statuses</Label>
+          <p className="text-xs text-muted-foreground">
+            Statuses a task can move to from 20x, from the "{statusProperty.name}"
+            property.
+          </p>
+          {statusProperty.options?.length ? (
+            <MultiSelectValues
+              options={statusProperty.options}
+              selected={nextStatuses}
+              onChange={updateNextStatuses}
+            />
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              This property has no status options.
+            </p>
+          )}
+
+          {nextStatuses.length > 0 && (
+            <div className="space-y-1.5 pt-1">
+              <Label>Status on completion</Label>
+              <p className="text-xs text-muted-foreground">
+                Written to Notion when a task is completed at source.
+              </p>
+              <select
+                value={completionStatus}
+                onChange={(e) => updateField('completion_status', e.target.value)}
+                className="w-full rounded-md border border-input bg-transparent px-3 py-1.5 text-sm cursor-pointer"
+                data-testid="notion-completion-status"
+              >
+                <option value="">Detect automatically</option>
+                {nextStatuses.map((status) => (
+                  <option key={status} value={status}>
+                    {status}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -570,6 +570,7 @@ export interface PluginAction {
   requiresInput?: boolean
   inputLabel?: string
   inputPlaceholder?: string
+  inputOptions?: ConfigFieldOption[]
 }
 
 export interface ActionResult {


### PR DESCRIPTION
## Problem

A Notion board with custom status names — "Ready for QA", "Shipped" — could not be driven from 20x.

The plugin only knew the default Notion names (`To Do`, `In progress`, `In review`, `Done`) through two hardcoded tables. On a custom board:

- completing a task at source wrote nothing back to Notion (`localStatusToNotion` returned `null`), or wrote the literal string `completed`;
- a page that did move imported back as **not started**, which re-opened a task 20x had just completed.

## Change

The Notion source form now lets the user select, from the real options of the data source status property:

- **Next statuses** — the statuses a task can move to from 20x;
- **Status on completion** — the status written to Notion when a task is completed at source (defaults to "Detect automatically", the previous behaviour).

The plugin consults these before the name heuristics:

| Path | Behaviour |
|---|---|
| `executeAction('complete')` | Writes the selected completion status |
| `executeAction('change_status')` | Matches the input against the configured statuses first, so the spelling Notion knows is written |
| `exportUpdate` | A completed task exports to the selected status |
| `importTasks` | A page in the completion status imports as completed, not as not started |
| `getActions` | The Change Status action carries the configured values as `inputOptions`, so a consumer can show a picker instead of a free-text box |

A stale completion status — one the user later removed from the list — is ignored, and the plugin falls back to the heuristics.

## Scope

Configuration is desktop only, as for every other task source; mobile has no plugin config form.

## Tests

- 10 new plugin tests (`notion-plugin.test.ts`) covering the resolver, the actions, both action paths, export, import, and the stale-status fallback.
- 5 new form tests (`NotionConfigForm.test.tsx`).
- Full suite: 170 files, 2684 tests pass. `typecheck` clean, `lint` reports 0 errors.
- Mutation-checked: removing the configured-status lookups makes the new tests fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)