### PR TITLE
feat: allow changing agent from task top bar

### DIFF
--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -89,12 +89,23 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
   // 5-star rating/comment only when withFeedback is true.
   const [completeModal, setCompleteModal] = useState<{ withFeedback: boolean } | null>(null)
   const [activeSection, setActiveSection] = useState<'details' | 'artifacts'>('details')
+  const [agentMenuOpen, setAgentMenuOpen] = useState(false)
+  const agentMenuRef = useRef<HTMLDivElement>(null)
   const artifactsByTask = useArtifactStore((s) => s.artifactsByTask)
   const hydrateArtifacts = useArtifactStore((s) => s.hydrate)
   const artifactLoadingTaskIds = useArtifactStore((s) => s.loadingTaskIds)
   const artifacts = artifactsByTask.get(taskId) || []
   const artifactsLoading = artifactLoadingTaskIds.has(taskId)
   const { handleStart: _startSession, handleResume: _resumeSession, handleStop: _stopSession, busyRef } = useSessionControls(taskId)
+
+  useEffect(() => {
+    if (!agentMenuOpen) return
+    const close = (event: PointerEvent) => {
+      if (!agentMenuRef.current?.contains(event.target as Node)) setAgentMenuOpen(false)
+    }
+    window.addEventListener('pointerdown', close)
+    return () => window.removeEventListener('pointerdown', close)
+  }, [agentMenuOpen])
 
   useEffect(() => {
     if (task) void hydrateArtifacts(taskId)
@@ -335,6 +346,59 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
           </button>
         }
       />
+
+      {/* Top-bar agent switcher — mirrors desktop TaskHeaderBar, always visible without opening Details */}
+      <div className="shrink-0 flex items-center gap-2 px-4 py-2 border-b border-border/50">
+        <span className="text-xs text-muted-foreground shrink-0">Agent</span>
+        <div ref={agentMenuRef} className="relative">
+          <button
+            type="button"
+            onClick={() => setAgentMenuOpen((o) => !o)}
+            className="inline-flex max-w-40 items-center gap-1.5 rounded-full border border-border/50 bg-card px-2.5 py-1 text-xs text-muted-foreground"
+            aria-label="Change agent"
+            aria-haspopup="menu"
+            aria-expanded={agentMenuOpen}
+            data-testid="mobile-header-agent-trigger"
+          >
+            <svg className="h-3 w-3 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>
+            <span className="truncate">{assignedAgent?.name || 'Unassigned'}</span>
+            <svg className="h-3 w-3 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          </button>
+          {agentMenuOpen && (
+            <div role="menu" aria-label="Agent" className="absolute left-0 top-7 z-50 w-48 overflow-hidden rounded-lg border border-border/50 bg-popover p-1 shadow-xl">
+              <button
+                type="button"
+                role="menuitemradio"
+                aria-checked={!task.agent_id}
+                onClick={() => { setAgentMenuOpen(false); if (task.agent_id) void handleAssignAgent(null) }}
+                className="flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-xs text-foreground active:bg-accent"
+                data-testid="mobile-header-agent-option-unassigned"
+              >
+                <span>Unassigned</span>
+                {!task.agent_id && <svg className="h-3.5 w-3.5 text-primary shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5"/></svg>}
+              </button>
+              {agents.map((a) => (
+                <button
+                  key={a.id}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={task.agent_id === a.id}
+                  onClick={() => { setAgentMenuOpen(false); if (task.agent_id !== a.id) void handleAssignAgent(a.id) }}
+                  className="flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-xs text-foreground active:bg-accent"
+                  data-testid={`mobile-header-agent-option-${a.id}`}
+                >
+                  <span className="truncate">{a.name}</span>
+                  {task.agent_id === a.id && <svg className="h-3.5 w-3.5 text-primary shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 6 9 17l-5-5"/></svg>}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <span className="ml-auto text-[11px] text-muted-foreground flex items-center gap-1">
+          <span className={`h-1.5 w-1.5 rounded-full ${task.status === 'completed' ? 'bg-emerald-400' : task.status === 'agent_working' ? 'bg-amber-400' : 'bg-muted-foreground'}`} />
+          {task.status}
+        </span>
+      </div>
 
       <div className="shrink-0 border-b border-border/50 px-4 py-2">
         <div className="grid grid-cols-2 rounded-md bg-muted/40 p-0.5 text-xs">

--- a/src/renderer/src/components/tasks/TaskHeaderBar.tsx
+++ b/src/renderer/src/components/tasks/TaskHeaderBar.tsx
@@ -25,6 +25,8 @@ const ACTION_META = {
 interface TaskHeaderBarProps {
   task: WorkfloTask
   agent?: Agent | null
+  agents?: Agent[]
+  onAssignAgent?: (agentId: string | null) => void | Promise<void>
   action?: TaskPrimaryAction | null
   onAction?: () => void
   onComplete?: () => void
@@ -45,6 +47,8 @@ interface TaskHeaderBarProps {
 export function TaskHeaderBar({
   task,
   agent,
+  agents,
+  onAssignAgent,
   action,
   onAction,
   onComplete,
@@ -65,8 +69,10 @@ export function TaskHeaderBar({
   const [title, setTitle] = useState(task.title)
   const [menuOpen, setMenuOpen] = useState(false)
   const [statusMenuOpen, setStatusMenuOpen] = useState(false)
+  const [agentMenuOpen, setAgentMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const statusMenuRef = useRef<HTMLDivElement>(null)
+  const agentMenuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => setTitle(task.title), [task.title])
   useEffect(() => {
@@ -85,6 +91,14 @@ export function TaskHeaderBar({
     window.addEventListener('pointerdown', close)
     return () => window.removeEventListener('pointerdown', close)
   }, [statusMenuOpen])
+  useEffect(() => {
+    if (!agentMenuOpen) return
+    const close = (event: PointerEvent) => {
+      if (!agentMenuRef.current?.contains(event.target as Node)) setAgentMenuOpen(false)
+    }
+    window.addEventListener('pointerdown', close)
+    return () => window.removeEventListener('pointerdown', close)
+  }, [agentMenuOpen])
 
   const commitTitle = async () => {
     const next = title.trim()
@@ -163,12 +177,65 @@ export function TaskHeaderBar({
           </div>
         )}
       </div>
-      <div className="hidden items-center gap-1.5 lg:flex">
+      <div className="flex items-center gap-1.5">
         <TaskPriorityBadge priority={task.priority} />
-        <span className="inline-flex max-w-36 items-center gap-1.5 rounded-full border border-border/50 bg-card px-2 py-1 text-[11px] text-muted-foreground">
-          <Bot className="h-3 w-3" />
-          <span className="truncate">{agent?.name || 'Unassigned'}</span>
-        </span>
+        {onAssignAgent && agents ? (
+          <div ref={agentMenuRef} className="relative">
+            <button
+              type="button"
+              onClick={() => setAgentMenuOpen((open) => !open)}
+              className="group inline-flex max-w-36 items-center gap-1.5 rounded-full border border-border/50 bg-card px-2 py-1 text-[11px] text-muted-foreground outline-none hover:border-border hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+              aria-label="Change agent"
+              aria-haspopup="menu"
+              aria-expanded={agentMenuOpen}
+              data-testid="header-agent-trigger"
+            >
+              <Bot className="h-3 w-3 shrink-0" />
+              <span className="truncate">{agent?.name || 'Unassigned'}</span>
+              <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
+            </button>
+            {agentMenuOpen && (
+              <div role="menu" aria-label="Agent" className="absolute right-0 top-7 z-50 w-48 overflow-hidden rounded-lg border border-border/50 bg-popover p-1 shadow-xl">
+                <button
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={!task.agent_id}
+                  onClick={() => {
+                    setAgentMenuOpen(false)
+                    if (task.agent_id) void onAssignAgent(null)
+                  }}
+                  className="flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-xs text-foreground hover:bg-accent"
+                  data-testid="header-agent-option-unassigned"
+                >
+                  <span>Unassigned</span>
+                  {!task.agent_id && <Check className="h-3.5 w-3.5 text-primary" />}
+                </button>
+                {agents.map((a) => (
+                  <button
+                    key={a.id}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={task.agent_id === a.id}
+                    onClick={() => {
+                      setAgentMenuOpen(false)
+                      if (task.agent_id !== a.id) void onAssignAgent(a.id)
+                    }}
+                    className="flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-2 text-left text-xs text-foreground hover:bg-accent"
+                    data-testid={`header-agent-option-${a.id}`}
+                  >
+                    <span className="truncate">{a.name}</span>
+                    {task.agent_id === a.id && <Check className="h-3.5 w-3.5 shrink-0 text-primary" />}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          <span className="hidden items-center gap-1.5 rounded-full border border-border/50 bg-card px-2 py-1 text-[11px] text-muted-foreground lg:inline-flex">
+            <Bot className="h-3 w-3" />
+            <span className="truncate">{agent?.name || 'Unassigned'}</span>
+          </span>
+        )}
       </div>
       {actionMeta && onAction && (
         <Button size="sm" onClick={onAction} className="h-8 gap-1.5 px-3" data-testid={`header-cta-${action}`}>

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -1090,6 +1090,8 @@ Update existing skills that were helpful or create new ones for patterns worth r
         <TaskHeaderBar
           task={task}
           agent={assignedAgent}
+          agents={agents}
+          onAssignAgent={handleAssignAgent}
           action={primaryAction}
           onAction={handlePrimaryAction}
           onComplete={() => void handleCompleteTask()}


### PR DESCRIPTION
Allow changing agent from the top bar without opening Details.

- **Desktop**: TaskHeaderBar agent badge becomes an interactive dropdown (Unassigned + agent list with checkmark). Wired via TaskWorkspace (passes agents + onAssignAgent). Reuses existing handleAssignAgent logic (stops session when unassigning).
- **Mobile**: Added matching top-bar agent switcher in TaskDetailPage, always visible above Details/Artifacts tabs, with same menu and handleAssignAgent.

Closes 20x: allow changing agent from top bar of the task without going into details

Test: pnpm test TaskHeaderBar.test.tsx and TaskWorkspace.test.tsx pass; tsc --noEmit clean.