### PR TITLE
feat: include enterprise login email in PostHog payloads

### DIFF
--- a/src/main/analytics-service.ts
+++ b/src/main/analytics-service.ts
@@ -93,6 +93,15 @@ export class AnalyticsService {
   private readonly buffer: BufferedAnalyticsEvent[] = []
   private flushTimer: ReturnType<typeof setInterval> | null = null
   private isFlushing = false
+  private enterpriseEmail: string | null = null
+
+  setEnterpriseEmail(email: string | null): void {
+    this.enterpriseEmail = email && email.trim() ? email.trim() : null
+  }
+
+  getEnterpriseEmail(): string | null {
+    return this.enterpriseEmail
+  }
 
   constructor(options: AnalyticsServiceOptions = {}) {
     this.posthogKey = options.posthogKey ?? nonEmpty(process.env['POSTHOG_KEY']) ?? nonEmpty(buildPosthogKey()) ?? ''
@@ -153,6 +162,7 @@ export class AnalyticsService {
             timestamp: item.capturedAt,
             properties: {
               ...item.properties,
+              ...(this.enterpriseEmail ? { email: this.enterpriseEmail, enterprise_email: this.enterpriseEmail } : {}),
               $process_person_profile: false,
               platform: process.platform,
               arch: process.arch,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -947,6 +947,17 @@ app.whenReady().then(async () => {
   db = new DatabaseManager()
   db.initialize()
 
+  // Sync enterprise email into PostHog payloads before any analytics event
+  try {
+    const storedEmail = db.getSetting('enterprise_user_email')
+    if (storedEmail) {
+      const { analytics: getAnalytics } = await import('./analytics-service')
+      getAnalytics()?.setEnterpriseEmail(storedEmail)
+    }
+  } catch {
+    // ignore
+  }
+
   // The BOOT sweep for workspace processes. It runs here rather than beside the
   // MCP sweep above because it needs the task table to tell a leaked workspace
   // from one an agent is working in. This is the call that catches a machine
@@ -1024,6 +1035,17 @@ app.whenReady().then(async () => {
   void voiceSessionManager.initialize()
   watchAgentAnswersForSpeech(agentManager, db)
 
+  // Sync enterprise email into PostHog payloads if user is logged in
+  try {
+    const storedEmail = db.getSetting('enterprise_user_email')
+    if (storedEmail) {
+      const { analytics: getAnalytics } = await import('./analytics-service')
+      getAnalytics()?.setEnterpriseEmail(storedEmail)
+    }
+  } catch {
+    // ignore
+  }
+
   // Eagerly restore enterprise connection on startup so sync works immediately
   if (enterpriseAuth) {
     try {
@@ -1034,6 +1056,10 @@ app.whenReady().then(async () => {
         userId: session.userId,
         hasTenant: !!session.currentTenant
       })
+      if (session.userEmail) {
+        const { analytics: getAnalytics } = await import('./analytics-service')
+        getAnalytics()?.setEnterpriseEmail(session.userEmail)
+      }
       if (session.isAuthenticated && session.currentTenant && session.userId) {
         const { WorkfloApiClient } = await import('./workflo-api-client')
         const { EnterpriseSyncManager } = await import('./enterprise-sync')

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1095,6 +1095,9 @@ export function registerIpcHandlers(
 
       // Use the received tokens to log in
       const result = await enterpriseAuth.loginWithTokens(tokens.access_token, tokens.refresh_token)
+      if (result?.email) {
+        analytics()?.setEnterpriseEmail(result.email)
+      }
 
       return result
     } catch (err) {
@@ -1105,7 +1108,11 @@ export function registerIpcHandlers(
 
   ipcMain.handle('enterprise:login', async (_, email: string, password: string) => {
     if (!enterpriseAuth) throw new Error('Enterprise auth not available')
-    return await enterpriseAuth.login(email, password)
+    const result = await enterpriseAuth.login(email, password)
+    if (result?.email) {
+      analytics()?.setEnterpriseEmail(result.email)
+    }
+    return result
   })
 
   ipcMain.handle('enterprise:listCompanies', async () => {
@@ -1116,6 +1123,12 @@ export function registerIpcHandlers(
   ipcMain.handle('enterprise:selectTenant', async (event, tenantId: string) => {
     if (!enterpriseAuth) throw new Error('Enterprise auth not available')
     const result = await enterpriseAuth.selectTenant(tenantId)
+    try {
+      const session = await enterpriseAuth.getSession()
+      if (session.userEmail) analytics()?.setEnterpriseEmail(session.userEmail)
+    } catch {
+      // non-fatal
+    }
 
     // Return auth result immediately — run post-connect setup (sync, MCP, etc.) in background
     // so the UI shows "Connected" right away with a "Syncing..." indicator.
@@ -1321,6 +1334,7 @@ export function registerIpcHandlers(
     agentManager.setEnterpriseStateSync(null)
 
     await enterpriseAuth.logout()
+    analytics()?.setEnterpriseEmail(null)
 
     try {
       new Notification({
@@ -1337,6 +1351,11 @@ export function registerIpcHandlers(
       return { isAuthenticated: false, userEmail: null, userId: null, currentTenant: null }
     }
     const session = await enterpriseAuth.getSession()
+    if (session.userEmail) {
+      analytics()?.setEnterpriseEmail(session.userEmail)
+    } else if (!session.isAuthenticated) {
+      analytics()?.setEnterpriseEmail(null)
+    }
 
     // Restore enterprise connection if authenticated but sync manager not wired
     if (session.isAuthenticated && session.currentTenant && session.userId) {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 import { AppLayout } from '@/components/layout/AppLayout'
 import { useEffect } from 'react'
-import { identifyAnalyticsUser, resetAnalyticsUser } from '@/lib/analytics'
+import { identifyAnalyticsUser, resetAnalyticsUser, setAnalyticsEnterpriseEmail } from '@/lib/analytics'
 import { useEnterpriseStore } from '@/stores/enterprise-store'
 import { useUserStore } from '@/stores/user-store'
 
@@ -12,6 +12,7 @@ export default function App() {
   const currentUserEmail = useUserStore((s) => s.currentUserEmail)
 
   useEffect(() => {
+    setAnalyticsEnterpriseEmail(userEmail || null)
     const distinctId = userId || userEmail || currentUserEmail
     if (distinctId) {
       identifyAnalyticsUser(distinctId, {

--- a/src/renderer/src/lib/analytics.ts
+++ b/src/renderer/src/lib/analytics.ts
@@ -11,9 +11,34 @@ const POSTHOG_RECORD_SESSIONS = import.meta.env.VITE_POSTHOG_RECORD_SESSIONS !==
 let initialized = false
 let identifiedId: string | null = null
 let appPlatform: AnalyticsPlatform = 'desktop'
+let enterpriseEmail: string | null = null
 
 function isEnabled(): boolean {
   return typeof window !== 'undefined' && Boolean(POSTHOG_KEY)
+}
+
+export function setAnalyticsEnterpriseEmail(email: string | null): void {
+  enterpriseEmail = email && email.trim() ? email.trim() : null
+  if (initialized && isEnabled()) {
+    try {
+      if (enterpriseEmail) {
+        posthog.register({ email: enterpriseEmail, enterprise_email: enterpriseEmail })
+      } else {
+        posthog.unregister('email')
+        posthog.unregister('enterprise_email')
+      }
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export function getAnalyticsEnterpriseEmail(): string | null {
+  return enterpriseEmail
+}
+
+function getEnterpriseEmailProperties(): AnalyticsProperties {
+  return enterpriseEmail ? { email: enterpriseEmail, enterprise_email: enterpriseEmail } : {}
 }
 
 export function initAnalytics(platform: AnalyticsPlatform = 'desktop'): void {
@@ -33,6 +58,13 @@ export function initAnalytics(platform: AnalyticsPlatform = 'desktop'): void {
   })
 
   initialized = true
+  if (enterpriseEmail) {
+    try {
+      posthog.register({ email: enterpriseEmail, enterprise_email: enterpriseEmail })
+    } catch {
+      // ignore
+    }
+  }
 }
 
 export function identifyAnalyticsUser(
@@ -43,6 +75,7 @@ export function identifyAnalyticsUser(
   if (!isEnabled() || !distinctId || identifiedId === distinctId) return
 
   posthog.identify(distinctId, cleanProperties({
+    ...getEnterpriseEmailProperties(),
     ...properties,
     app_platform: appPlatform
   }))
@@ -61,6 +94,7 @@ export function captureAnalyticsEvent(event: string, properties: AnalyticsProper
 
   posthog.capture(event, cleanProperties({
     ...properties,
+    ...getEnterpriseEmailProperties(),
     app_platform: appPlatform
   }))
 }


### PR DESCRIPTION
## Summary
- When user is logged into Workflo enterprise, include his login email (`email` and `enterprise_email`) in all PostHog payloads.
- **Main process** (`src/main/analytics-service.ts`): `AnalyticsService` now stores `enterpriseEmail` via `setEnterpriseEmail()` and merges it into every batched event in `flush()` (`...enterpriseEmail ? { email, enterprise_email }`).
- **Main wiring** (`src/main/index.ts`, `src/main/ipc-handlers.ts`): sync email from DB/setting on startup, on `enterprise:login`, `enterprise:signupInBrowser`, `enterprise:selectTenant`, `enterprise:getSession` restore, and clear on `enterprise:logout`.
- **Renderer** (`src/renderer/src/lib/analytics.ts`): adds `enterpriseEmail` state, `setAnalyticsEnterpriseEmail`/`getAnalyticsEnterpriseEmail`, `getEnterpriseEmailProperties()` and merges into `captureAnalyticsEvent` (and `identify`) + registers as PostHog super props. Handles pre-init and unregister on logout.
- **App** (`src/renderer/src/App.tsx`): calls `setAnalyticsEnterpriseEmail(userEmail)` on enterprise store changes, so all subsequent captures carry the email; `resetAnalyticsUser` still called when unauthenticated.

## Test plan
- [ ] `pnpm exec tsc --noEmit --skipLibCheck` passes for changed files
- [ ] Manual: login to Workflo enterprise, verify PostHog capture payloads contain `email` / `enterprise_email`; logout clears them; anonymous users send no email.