### PR TITLE
feat(mcp): add create_skill tool to task-management MCP

### DIFF
--- a/src/main/mcp-servers/task-management-core.ts
+++ b/src/main/mcp-servers/task-management-core.ts
@@ -136,6 +136,21 @@ const sharedTools: Tool[] = [
     }
   },
   {
+    name: 'create_skill',
+    description: 'Create a new skill with name, description, and content (markdown body). Returns the created skill with its ID.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Skill name (lowercase hyphenated, 1-64 chars, e.g. "my-skill")' },
+        description: { type: 'string', description: 'Skill description (1-1024 chars)' },
+        content: { type: 'string', description: 'Skill content (the full skill file body, markdown)' },
+        confidence: { type: 'number', description: 'Confidence score (0.0 to 1.0, defaults to 0.5)' },
+        tags: { type: 'array', items: { type: 'string' }, description: 'Tags for categorization' }
+      },
+      required: ['name', 'description', 'content']
+    }
+  },
+  {
     name: 'update_skill',
     description: 'Update an existing skill. Only provided fields will be updated.',
     inputSchema: {

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -536,14 +536,47 @@ export async function handleRoute(db: DatabaseManager, route: string, params: Re
       return skill
     }
 
+    case '/create_skill': {
+      const name = typeof params.name === 'string' ? params.name.trim() : ''
+      const description = typeof params.description === 'string' ? params.description.trim() : ''
+      const content = typeof params.content === 'string' ? params.content : ''
+      if (!name) return { error: 'Skill name is required' }
+      if (!description) return { error: 'Skill description is required' }
+      if (!content) return { error: 'Skill content is required' }
+      if (params.confidence !== undefined) {
+        const c = Number(params.confidence)
+        if (!Number.isFinite(c) || c < 0 || c > 1) return { error: 'confidence must be a number between 0.0 and 1.0' }
+      }
+      if (params.tags !== undefined && !Array.isArray(params.tags)) return { error: 'tags must be an array of strings' }
+      // Prevent duplicate names — an update should be used instead
+      const existingByName = rawDb.prepare('SELECT id FROM skills WHERE name = ? AND is_deleted = 0').get(name) as { id: string } | undefined
+      if (existingByName) return { error: `Skill with name "${name}" already exists (id: ${existingByName.id}). Use update_skill to modify it.` }
+
+      const skill = db.createSkill({
+        name,
+        description,
+        content,
+        confidence: params.confidence !== undefined ? Number(params.confidence) : undefined,
+        tags: Array.isArray(params.tags) ? (params.tags as string[]) : undefined
+      })
+      if (!skill) return { error: 'Failed to create skill' }
+      return { success: true, skill }
+    }
+
     case '/update_skill': {
+      if (params.confidence !== undefined) {
+        const c = Number(params.confidence)
+        if (!Number.isFinite(c) || c < 0 || c > 1) return { error: 'confidence must be a number between 0.0 and 1.0' }
+      }
+      if (params.tags !== undefined && !Array.isArray(params.tags)) return { error: 'tags must be an array of strings' }
+
       const skillUpdates: string[] = []
       const skillParams: unknown[] = []
 
       if (params.name !== undefined) { skillUpdates.push('name = ?'); skillParams.push(params.name) }
       if (params.description !== undefined) { skillUpdates.push('description = ?'); skillParams.push(params.description) }
       if (params.content !== undefined) { skillUpdates.push('content = ?'); skillParams.push(params.content) }
-      if (params.confidence !== undefined) { skillUpdates.push('confidence = ?'); skillParams.push(params.confidence) }
+      if (params.confidence !== undefined) { skillUpdates.push('confidence = ?'); skillParams.push(Number(params.confidence)) }
       if (params.tags !== undefined) { skillUpdates.push('tags = ?'); skillParams.push(JSON.stringify(params.tags)) }
 
       if (skillUpdates.length === 0) return { error: 'No updates provided' }


### PR DESCRIPTION
Add create_skill to the task-management MCP server and harden update_skill.

### MCP tool (task-management-core.ts)
- New shared tool create_skill (available to both scoped and unscoped sessions) with required name, description, content and optional confidence (0.0–1.0) and tags.
- Existing update_skill remains; both route through the same validation now.

### API (task-api-server.ts)
- New POST /create_skill route: validates required fields, checks confidence range, validates tags is an array, guards against duplicate name (suggests update_skill instead), then delegates to db.createSkill and returns { success, skill }.
- POST /update_skill now validates confidence range and tags array upfront and coerces confidence to number before the SQL update; preserves version bump and updated_at.

Verified via HTTP + MCP integration tests (direct fetch and StreamableHTTPClientTransport client) covering create, duplicate guard, missing-field guard, confidence validation, tags round-trip, and scoped-session availability. Existing task-api-server.test.ts (45 tests) and task-mcp-endpoint.test.ts (13 tests) continue to pass; tsc --noEmit clean.