### PR TITLE
fix(mcp-auth-proxy): unguessable per-session link ids (+ terminal JSON 404)

### DIFF
--- a/src/main/mcp-auth-proxy.test.ts
+++ b/src/main/mcp-auth-proxy.test.ts
@@ -244,7 +244,9 @@ describe('MCP Auth Proxy', () => {
     const response = await fetch(proxyUrl, { method: 'POST', body: '{}' })
     expect(response.status).toBe(502)
     const data = await response.json()
-    expect(data.error).toContain('target 1')
+    // The fallback label is `target <id>`, and the id is the unguessable
+    // hex from the link itself — not a monotonic counter.
+    expect(data.error).toContain(`target ${idOf(proxyUrl)}`)
   })
 
   it('shows a notification on first JWT failure per integration', async () => {

--- a/src/main/mcp-auth-proxy.test.ts
+++ b/src/main/mcp-auth-proxy.test.ts
@@ -117,20 +117,25 @@ describe('MCP Auth Proxy', () => {
     expect(port1).toBe(port2)
   })
 
-  it('registers a target and returns a proxy URL', async () => {
+  // The link id is an UNGUESSABLE 32-hex string, not a monotonic counter.
+  // Each agent/session gets its own link to the one proxy; a guessable /1, /2
+  // would let one session reach another's target (and its credential).
+  const idOf = (proxyUrl: string): string => new URL(proxyUrl).pathname.split('/')[1]
+
+  it('registers a target and returns a proxy URL with an unguessable id', async () => {
     const port = await startMcpAuthProxy(mockAuth as never)
     const proxyUrl = registerMcpProxyTarget(`http://127.0.0.1:${upstream.port}`)
-    expect(proxyUrl).toBe(`http://127.0.0.1:${port}/1`)
+    expect(proxyUrl).toMatch(new RegExp(`^http://127\\.0\\.0\\.1:${port}/[0-9a-f]{32}$`))
   })
 
   it('registers a target with a label', async () => {
     const port = await startMcpAuthProxy(mockAuth as never)
     const proxyUrl = registerMcpProxyTarget(`http://127.0.0.1:${upstream.port}`, 'My Integration')
-    expect(proxyUrl).toBe(`http://127.0.0.1:${port}/1`)
+    expect(proxyUrl).toMatch(new RegExp(`^http://127\\.0\\.0\\.1:${port}/[0-9a-f]{32}$`))
   })
 
   it('deduplicates repeated registrations for the same target URL', async () => {
-    const port = await startMcpAuthProxy(mockAuth as never)
+    await startMcpAuthProxy(mockAuth as never)
     const targetUrl = `http://127.0.0.1:${upstream.port}`
 
     const url1 = registerMcpProxyTarget(targetUrl)
@@ -138,13 +143,13 @@ describe('MCP Auth Proxy', () => {
     const url3 = registerMcpProxyTarget(targetUrl)
 
     // All calls should return the same proxy URL (same ID)
-    expect(url1).toBe(`http://127.0.0.1:${port}/1`)
     expect(url2).toBe(url1)
     expect(url3).toBe(url1)
 
-    // A different target URL should get a new ID
+    // A different target URL gets a DIFFERENT, independent id.
     const url4 = registerMcpProxyTarget('http://example.com:9999')
-    expect(url4).toBe(`http://127.0.0.1:${port}/2`)
+    expect(idOf(url4!)).not.toBe(idOf(url1!))
+    expect(idOf(url4!)).toMatch(/^[0-9a-f]{32}$/)
   })
 
   it('returns null from registerMcpProxyTarget when proxy is not running', () => {
@@ -201,12 +206,20 @@ describe('MCP Auth Proxy', () => {
     expect(upstream.lastMethod()).toBe('GET')
   })
 
-  it('returns 404 for unknown target IDs', async () => {
+  it('returns a TERMINAL, VALID-JSON 404 for unknown target IDs (never the bare text that broke OAuth parsing)', async () => {
     await startMcpAuthProxy(mockAuth as never)
 
     const port = getMcpAuthProxyPort()!
-    const response = await fetch(`http://127.0.0.1:${port}/999`, { method: 'POST', body: '{}' })
+    const response = await fetch(`http://127.0.0.1:${port}/deadbeef`, { method: 'POST', body: '{}' })
+    const raw = await response.text()
+
     expect(response.status).toBe(404)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(raw).not.toBe('Unknown proxy target')
+    const parsed = JSON.parse(raw) as { reason?: string; terminal?: boolean; retryable?: boolean }
+    expect(parsed.reason).toBe('unknown_proxy_target')
+    expect(parsed.terminal).toBe(true)
+    expect(parsed.retryable).toBe(false)
   })
 
   it('returns 502 when auth fails and includes integration name in error', async () => {

--- a/src/main/mcp-auth-proxy.ts
+++ b/src/main/mcp-auth-proxy.ts
@@ -22,6 +22,7 @@
 
 import { createServer, request as httpRequest, type Server as HttpServer, type IncomingMessage, type ServerResponse } from 'http'
 import { request as httpsRequest } from 'https'
+import { randomBytes } from 'crypto'
 import { Notification } from 'electron'
 import type { EnterpriseAuth } from './enterprise-auth'
 
@@ -41,9 +42,6 @@ const targetsByUrl = new Map<string, string>()
 // Track integrations that have already shown a JWT-failure notification this app run.
 // Prevents spamming the user with repeated notifications for the same integration.
 const notifiedJwtFailures = new Set<string>()
-
-// Monotonic counter for short, collision-free IDs
-let nextId = 1
 
 export function getMcpAuthProxyPort(): number | null {
   return port
@@ -70,7 +68,12 @@ export function registerMcpProxyTarget(targetUrl: string, label?: string): strin
     return `http://127.0.0.1:${port}/${existingId}`
   }
 
-  const id = String(nextId++)
+  // UNGUESSABLE, not a monotonic counter. Each agent/session gets its OWN link
+  // to this one proxy, and that link is how the proxy tells sessions apart and
+  // attaches the right credential. `String(nextId++)` made the link guessable —
+  // one agent could reach another session's target (and its token) by requesting
+  // /1, /2, /3. 16 random bytes makes a link a genuine per-session capability.
+  const id = randomBytes(16).toString('hex')
   targets.set(id, targetUrl)
   targetsByUrl.set(targetUrl, id)
   if (label) targetLabels.set(id, label)
@@ -132,7 +135,6 @@ export function stopMcpAuthProxy(): void {
   targetLabels.clear()
   notifiedJwtFailures.clear()
   authRef = null
-  nextId = 1
 }
 
 // ── Request handler ───────────────────────────────────────────────
@@ -147,8 +149,26 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise
     if (!id || !targets.has(id)) {
       console.warn(`[McpAuthProxy] 404 — unknown target ID "${id}"`)
 
-      res.writeHead(404, { 'Content-Type': 'text/plain' })
-      res.end('Unknown proxy target')
+      // A TERMINAL routing failure, as VALID JSON. The bare text `Unknown proxy
+      // target` made the MCP client (which treats a non-2xx during connect as a
+      // possible OAuth challenge and JSON.parses the body) throw
+      // `SyntaxError: Unexpected identifier "Unknown"`, reported as an
+      // "Invalid OAuth error response". Valid JSON removes that misdirection and
+      // marks the failure non-retryable — this link is not registered with this
+      // proxy, which no amount of retrying resolves.
+      res.writeHead(404, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' })
+      res.end(
+        JSON.stringify({
+          error: 'unknown_proxy_target',
+          reason: 'unknown_proxy_target',
+          terminal: true,
+          retryable: false,
+          message:
+            'MCP loopback proxy: no target is registered for this id, so this ' +
+            'server is not routable for this session. Terminal routing failure ' +
+            '(not authentication) — do not retry.'
+        })
+      )
       return
     }
 


### PR DESCRIPTION
## What
Aligns the desktop loopback MCP auth proxy with the design used in the cloud harness: **one proxy per machine, each agent gets its own link, the proxy routes by that link.**

- **Unguessable link ids.** `registerMcpProxyTarget` used `String(nextId++)`, so a link was guessable — one agent could reach another session's target (and the credential the proxy injects for it) by requesting `/1`, `/2`, `/3`. Now `randomBytes(16).toString('hex')`, so a link is a genuine per-session capability. Removed the `nextId` counter.
- **Terminal JSON 404.** The unknown-target branch returned the bare text `Unknown proxy target`; an MCP client treats a non-2xx during connect as a possible OAuth challenge and `JSON.parse`s the body, which threw `SyntaxError: Unexpected identifier "Unknown"` and was reported as an "Invalid OAuth error response". Now returns terminal, valid JSON (`{reason:'unknown_proxy_target', terminal:true, retryable:false, ...}`).

## Why
Companion to `workflow-builder#1671`, which fixes the same class of loopback-proxy issue on the agent-harness (cloud) side. Desktop and cloud now share the pattern: one proxy per machine, a distinct per-session link, routed and credentialed by that link.

## Tests
`src/main/mcp-auth-proxy.test.ts` updated: asserts the id is a 32-hex string (not `/1`,`/2`), that a second target gets an independent id, and that the 404 body is terminal valid JSON.

Note: 20x deps weren't installed in the authoring environment, so its jest wasn't run here — please let CI validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)