### PR TITLE
feat(mcp): add title to update_task tool

### DIFF
--- a/src/main/mcp-servers/task-management-core.ts
+++ b/src/main/mcp-servers/task-management-core.ts
@@ -235,6 +235,7 @@ const mastermindTools: Tool[] = [
       type: 'object',
       properties: {
         task_id: { type: 'string' },
+        title: { type: 'string', description: 'Update task title' },
         description: { type: 'string', description: 'Update task description' },
         resolution: { type: 'string', description: 'Set task resolution/output summary' },
         attachments: { type: 'array', items: { type: 'object', properties: { name: { type: 'string' }, path: { type: 'string' }, type: { type: 'string' } } }, description: 'Set task attachments (e.g. files, screenshots). Each item needs name and path.' },
@@ -713,6 +714,7 @@ const subtaskTools: Tool[] = [
     inputSchema: {
       type: 'object',
       properties: {
+        title: { type: 'string', description: 'Update title' },
         description: { type: 'string', description: 'Update description' },
         resolution: { type: 'string', description: 'Set resolution/output summary (read by sibling subtasks for coordination)' },
         attachments: { type: 'array', items: { type: 'object', properties: { name: { type: 'string' }, path: { type: 'string' }, type: { type: 'string' } } }, description: 'Set attachments (e.g. files, screenshots)' },

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -444,6 +444,11 @@ export async function handleRoute(db: DatabaseManager, route: string, params: Re
         }
       }
 
+      if (params.title !== undefined) {
+        const title = typeof params.title === 'string' ? params.title.trim() : ''
+        if (!title) return { error: 'Title cannot be empty' }
+        updates.push('title = ?'); qParams.push(title)
+      }
       if (params.description !== undefined) { updates.push('description = ?'); qParams.push(params.description) }
       if (params.resolution !== undefined) { updates.push('resolution = ?'); qParams.push(params.resolution) }
       if (params.attachments !== undefined) { updates.push('attachments = ?'); qParams.push(JSON.stringify(params.attachments)) }


### PR DESCRIPTION
Add `title` param to `update_task` (and `update_own_task` for consistency) MCP tools in `task-management-core.ts:232,711` and handle it in `task-api-server.ts:430` `/update_task` route with trimmed non-empty validation. Enables agents to rename tasks via MCP.

- `task-management-core.ts:238` – add `title` to `update_task` inputSchema
- `task-management-core.ts:717` – add `title` to `update_own_task` inputSchema
- `task-api-server.ts:447` – handle `params.title`, trim, error if empty, push `title = ?` update
