### PR TITLE
fix: a message sent to a completed task starts the agent again

### DIFF
--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -13,6 +13,7 @@ import { ArtifactContentKind, ArtifactType, type Artifact } from '@shared/artifa
 import { VoiceMicButton } from '@/components/voice/VoiceMicButton'
 import { SpeakMessageButton } from '@/components/voice/SpeakMessageButton'
 import { MASTERMIND_COMPOSER_KEY, registerComposer } from '@/lib/voice-dictation-target'
+import { dispatchShortcutFeedback } from '@/lib/keyboard-shortcuts'
 
 const EMPTY_ARTIFACTS: Artifact[] = []
 
@@ -247,7 +248,8 @@ interface AgentTranscriptPanelProps {
   status: SessionStatus
   onStop: () => void
   onRestart?: () => void
-  onSend?: (message: string, options?: { attachments?: ComposerAttachment[] }) => void
+  /** May be async: a rejected send is reported to the user instead of vanishing. */
+  onSend?: (message: string, options?: { attachments?: ComposerAttachment[] }) => void | Promise<void>
   onPickAttachments?: () => Promise<ComposerAttachment[]>
   onAddAttachmentPaths?: (filePaths: string[]) => Promise<ComposerAttachment[]>
   className?: string
@@ -1134,11 +1136,21 @@ export function AgentTranscriptPanel({
       // sentence goes through here too and arms a fresh expectation of its own
       // straight afterwards, so the conversation loop is unaffected.
       void voiceApi.answerNotExpected(taskId)
-      onSend(value, pendingAttachments.length > 0 ? { attachments: pendingAttachments } : undefined)
+      const attachmentsAtSend = pendingAttachments
+      const sent = onSend(value, attachmentsAtSend.length > 0 ? { attachments: attachmentsAtSend } : undefined)
       inputRef.current!.value = ''
       // Reset textarea height back to single row
       inputRef.current!.style.height = 'auto'
       setPendingAttachments([])
+      // The composer clears the text before the send resolves, so a rejected
+      // send used to leave no trace at all — no message, no session, no error.
+      // The text goes back into the box and the failure is announced.
+      void Promise.resolve(sent).catch((error: unknown) => {
+        console.error('[AgentTranscriptPanel] Message send failed:', error)
+        if (inputRef.current && !inputRef.current.value) inputRef.current.value = value
+        setPendingAttachments(attachmentsAtSend)
+        dispatchShortcutFeedback('Could not send the message — the agent session did not start', true)
+      })
     }
   }
   // The registration calls through this ref, so a conversation always uses the

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -283,6 +283,45 @@ describe('TaskWorkspace – artifacts/details sidebar default width', () => {
   })
 })
 
+describe('TaskWorkspace – messaging a task whose session has ended', () => {
+  const sessionApi = () => window.electronAPI.agentSession as unknown as Record<string, ReturnType<typeof vi.fn>>
+
+  const renderCompletedTask = () =>
+    renderWorkspace(
+      makeRendererTask({ status: TaskStatus.Completed, session_id: 'persisted-session-1' })
+    )
+
+  it('starts a fresh session and delivers the message when the persisted session has ended', async () => {
+    // What the main process reports for a completed task whose adapter session
+    // is gone: it clears session_id and answers "ended" instead of a session.
+    sessionApi().resume.mockResolvedValue({ sessionId: '', ended: true })
+    sessionApi().start.mockResolvedValue({ sessionId: 'fresh-session-1' })
+
+    renderCompletedTask()
+    fireEvent.click(screen.getByTestId('mock-send'))
+
+    await waitFor(() => expect(sessionApi().start).toHaveBeenCalled())
+    // The task description must not be replayed — the typed message is the
+    // instruction, so the initial prompt is skipped.
+    expect(sessionApi().start).toHaveBeenCalledWith('agent-1', 'task-1', undefined, true)
+    await waitFor(() =>
+      expect(sessionApi().send).toHaveBeenCalledWith('fresh-session-1', 'approved', 'task-1', 'agent-1', undefined)
+    )
+  })
+
+  it('resumes without starting a second session when the persisted session is still alive', async () => {
+    sessionApi().resume.mockResolvedValue({ sessionId: 'persisted-session-1' })
+
+    renderCompletedTask()
+    fireEvent.click(screen.getByTestId('mock-send'))
+
+    await waitFor(() =>
+      expect(sessionApi().send).toHaveBeenCalledWith('persisted-session-1', 'approved', 'task-1', 'agent-1', undefined)
+    )
+    expect(sessionApi().start).not.toHaveBeenCalled()
+  })
+})
+
 describe('TaskWorkspace – stale triage session cleanup', () => {
   it('sets up worktrees when adding repos to a task with only a persisted session_id', async () => {
     ;(window.electronAPI.github.checkCli as ReturnType<typeof vi.fn>).mockResolvedValue({ installed: true, authenticated: true })

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -537,7 +537,18 @@ function TaskWorkspaceComponent({
     [approve]
   )
 
-  const ensureChatSession = useCallback(async (): Promise<string | null> => {
+  /**
+   * Gives the composer a session to talk to, starting or resuming one if the
+   * task has none live.
+   *
+   * `allowFreshStart` covers the case where the persisted `session_id` can no
+   * longer be resumed. The main process reports that as "ended" — it does so
+   * for every completed or reviewed task whose adapter session is gone, and
+   * for a session left behind by a previously assigned agent. Answering a
+   * question in a dead session is meaningless, so that caller keeps the old
+   * behaviour, but a plain message must still wake the agent.
+   */
+  const ensureChatSession = useCallback(async (allowFreshStart = false): Promise<string | null> => {
     if (!task?.agent_id) return null
 
     const latestSession = useAgentStore.getState().sessions.get(task.id)
@@ -546,8 +557,12 @@ function TaskWorkspaceComponent({
     if (task.session_id) {
       const resumedSessionId = await resume(task.agent_id, task.id, task.session_id)
       if (!resumedSessionId) {
+        // `resume` has already cleared the dead `session_id` in the database.
         fetchTasks()
-        return null
+        if (!allowFreshStart) return null
+        // The initial prompt is skipped: the transcript already carries the
+        // task, and the message the user just typed is the new instruction.
+        return start(task.agent_id, task.id, undefined, true)
       }
       return resumedSessionId
     }
@@ -592,8 +607,11 @@ function TaskWorkspaceComponent({
         return
       }
 
-      const readySessionId = await ensureChatSession()
-      if (!readySessionId) return
+      const readySessionId = await ensureChatSession(true)
+      // Thrown, not swallowed: the composer has already cleared the text, so a
+      // silent return leaves the user staring at an idle transcript with no
+      // idea that the message went nowhere.
+      if (!readySessionId) throw new Error('Could not start an agent session for this task')
       await sendMessage(message, options)
     },
     [approve, ensureChatSession, sendMessage, task?.id]


### PR DESCRIPTION
## Symptom

Sending a message to a completed task does nothing. No session starts, no error appears, and the typed text is gone from the composer.

## Root cause

`TaskWorkspace.handleSend` routes every message through `ensureChatSession()`:

1. The task still carries a persisted `session_id`, so the renderer calls `resume()`.
2. For a task in `completed` or `ready_for_review`, `AgentManager.resumeAdapterSession` treats an unresumable adapter session as a normal ending: it clears `session_id` and returns an empty string. The IPC layer turns that into `{ sessionId: '', ended: true }`.
3. `use-agent-session.resume()` drops the pre-registered session and returns `''`.
4. `ensureChatSession()` mapped that falsy value to `null`, and `handleSend` did `if (!readySessionId) return`.

The message was discarded between the composer and the agent. Nothing was queued, nothing was retried, and nothing was shown — the composer had already cleared the textarea, and it called `onSend(...)` without awaiting or catching, so an exception on the same path was equally invisible.

The main process already implements the correct recovery for this exact case (`AgentManager.sendMessage` resumes and, failing that, starts a session with `skipInitialPrompt`), and the canvas transcript panel reaches it through the `sendByTaskId` fallback. Only the task-workspace composer stopped short of it.

An agent switch makes this easy to hit: reassigning a task never clears `session_id`, so the new agent cannot resume the old agent's session and takes the same `ended` branch.

## Fix

- `ensureChatSession(allowFreshStart)` — after an ended resume, a plain message now opens a fresh session with `skipInitialPrompt: true`, so the agent resumes work on the task instead of replaying the task description. The question/approval caller keeps the previous behaviour, because answering a question in a session that no longer exists is meaningless.
- `handleSend` throws instead of returning silently when no session can be obtained.
- `AgentTranscriptPanel` now observes the send promise: on failure it puts the text and its attachments back in the composer and reports the error, so a lost message can never be silent again.

## Test plan

- [x] New tests in `TaskWorkspace.test.tsx`: an ended resume starts a fresh session with `skipInitialPrompt` and delivers the message; a live persisted session still resumes and never starts a second one.
- [x] Both are non-vacuous — the first fails against the unfixed code.
- [x] `vitest --project renderer`: 926 tests pass.
- [x] `tsc --build --noEmit` clean, `eslint` clean on the changed files.

## Follow-up (not in this PR)

- Mobile `ConversationPage.handleSend` returns early when there is no live `sessionId`, so the same message is dropped there. The mobile API has no by-task send endpoint yet, so this needs a small server change.
- Reassigning an agent leaves a stale `session_id` on the task. This PR makes the consequence harmless; clearing it at the point of reassignment would be cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)