### PR TITLE
fix: stop the agent's closing message being stranded in the adapter buffer

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -2496,6 +2496,88 @@ describe('AgentManager startAdapterPolling — IDLE grace period for follow-up m
     expect((mgr as any).pollingEntries.has('session-1')).toBe(true)
   })
 
+  it('pollSingleSession keeps polling when the adapter buffers data after the poll (regression: last message stranded)', async () => {
+    const mgr = buildManager()
+    const adapter = buildAdapter() as any
+
+    const session = {
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      status: 'working',
+      createdAt: new Date(),
+      seenMessageIds: new Set<string>(),
+      seenPartIds: new Set<string>(),
+      partContentLengths: new Map<string, string>(),
+      adapter,
+    }
+    ;(mgr as any).sessions.set('session-1', session)
+    ;(mgr as any).startAdapterPolling(
+      'session-1',
+      adapter,
+      { agentId: 'agent-1', taskId: 'task-1', workspaceDir: '/tmp/ws' },
+      undefined,
+      session
+    )
+
+    const entry = (mgr as any).pollingEntries.get('session-1')
+    // Past both idle grace windows, so only the new guard can hold IDLE off.
+    entry.createdAt = Date.now() - 60_000
+    entry.hasSeenWork = true
+    entry.lastPartReceivedAt = Date.now() - 60_000
+
+    // The real race: the agent's closing message and its `result` land in the
+    // adapter buffer AFTER pollMessages() ran and BEFORE getStatus() is asked.
+    // `result` is what makes the adapter report IDLE.
+    adapter.getStatus = vi.fn(async () => {
+      adapter.onDataAvailable('session-1')
+      return { type: SessionStatusType.IDLE }
+    })
+
+    const transitionSpy = vi.spyOn(mgr as any, 'transitionToIdle').mockResolvedValue(undefined)
+
+    await (mgr as any).pollSingleSession(entry)
+
+    // Unregistering here would strand the buffered message until the next prompt.
+    expect(transitionSpy).not.toHaveBeenCalled()
+    expect((mgr as any).pollingEntries.has('session-1')).toBe(true)
+  })
+
+  it('pollSingleSession still transitions to idle when nothing was buffered after the poll', async () => {
+    const mgr = buildManager()
+    const adapter = buildAdapter() as any
+
+    const session = {
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      status: 'working',
+      createdAt: new Date(),
+      seenMessageIds: new Set<string>(),
+      seenPartIds: new Set<string>(),
+      partContentLengths: new Map<string, string>(),
+      adapter,
+    }
+    ;(mgr as any).sessions.set('session-1', session)
+    ;(mgr as any).startAdapterPolling(
+      'session-1',
+      adapter,
+      { agentId: 'agent-1', taskId: 'task-1', workspaceDir: '/tmp/ws' },
+      undefined,
+      session
+    )
+
+    const entry = (mgr as any).pollingEntries.get('session-1')
+    entry.createdAt = Date.now() - 60_000
+    entry.hasSeenWork = true
+    entry.lastPartReceivedAt = Date.now() - 60_000
+
+    const transitionSpy = vi.spyOn(mgr as any, 'transitionToIdle').mockResolvedValue(undefined)
+
+    await (mgr as any).pollSingleSession(entry)
+
+    expect(transitionSpy).toHaveBeenCalledOnce()
+    expect((mgr as any).pollingEntries.has('session-1')).toBe(false)
+  })
+
   it('pollSingleSession does NOT set hasSeenWork from message content — only from BUSY status (root cause: stale parts)', async () => {
     // ROOT CAUSE regression test: pollMessages can return stale assistant tool
     // parts (fingerprint updates from the previous turn) or user echoes.  The

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -166,6 +166,10 @@ interface PollingEntry {
   createdAt: number  // Timestamp to enforce grace period before IDLE transition
   hasSeenWork?: boolean  // True once we've seen at least one non-IDLE status
   lastPartReceivedAt?: number  // Timestamp of last received data — used for secondary grace period
+  /** True when the adapter buffered new data after this cycle's pollMessages()
+   *  call. The data is still behind the adapter's cursor, so the session must
+   *  NOT be unregistered yet: the next cycle has to drain it first. */
+  dataArrivedSincePoll?: boolean
   /** How many times the tillDone nudge has been sent for this polling cycle.
    *  Capped at MAX_TILLDONE_NUDGES to prevent infinite nudge loops. */
   tillDoneNudgeCount?: number
@@ -303,6 +307,10 @@ export class AgentManager extends EventEmitter {
   // the data to the UI within ~50ms instead of waiting up to 2 seconds.
   private nudgeTimer: ReturnType<typeof setTimeout> | null = null
   private static readonly NUDGE_DELAY_MS = 50
+  /** Set when a nudge arrives while a cycle is already running. The cycle may
+   *  have polled that session already, so the signal cannot simply be dropped;
+   *  tick() re-raises it once the cycle ends. */
+  private nudgeRequestedDuringTick = false
   private transcriptChangedTimer: ReturnType<typeof setTimeout> | null = null
   private pendingTranscriptChanged = new Map<string, { sinceRev: number; maxRev: number }>()
   private static readonly TRANSCRIPT_CHANGED_FLUSH_MS = 125
@@ -1941,6 +1949,11 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         // ends first and the children report back afterwards. Re-register it,
         // otherwise nudgePollingCoordinator() is a no-op and the work is lost.
         this.wakeSessionOnAdapterData(dataSessionId)
+        // Remember that data landed. If it landed after this cycle already
+        // polled the session, the cycle must not unregister it — see the
+        // IDLE branch of pollSingleSession().
+        const dataEntry = this.pollingEntries.get(dataSessionId)
+        if (dataEntry) dataEntry.dataArrivedSincePoll = true
         this.nudgePollingCoordinator()
       }
     }
@@ -2110,6 +2123,14 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       if (this.pollingEntries.size > 0) {
         this.pollingTimer = setTimeout(tick, AgentManager.POLL_INTERVAL_MS)
       }
+
+      // Re-raise any nudge that arrived while this cycle was running, so data
+      // buffered mid-cycle is delivered in ~50ms rather than at the next
+      // heartbeat — or, for a session polled before the data landed, at all.
+      if (this.nudgeRequestedDuringTick) {
+        this.nudgeRequestedDuringTick = false
+        this.nudgePollingCoordinator()
+      }
     }
 
     // Store reference so nudgePollingCoordinator can invoke it
@@ -2132,8 +2153,13 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     // Already have a nudge scheduled, no need to double-schedule
     if (this.nudgeTimer) return
 
-    // If a tick is already running, it will pick up the new data — no nudge needed
-    if (this.pollingInProgress) return
+    // A running tick only picks the data up if it has not polled this session
+    // yet. Once it has, dropping the signal here leaves the data buffered with
+    // nothing scheduled to collect it, so the request is re-raised instead.
+    if (this.pollingInProgress) {
+      this.nudgeRequestedDuringTick = true
+      return
+    }
 
     // No active sessions → nothing to nudge
     if (this.pollingEntries.size === 0) return
@@ -2192,6 +2218,11 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         this.stopAdapterPolling(entry.sessionId)
         return
       }
+
+      // Cleared immediately before the poll, so anything the adapter buffers
+      // from here on is known to be undelivered even if this poll returns it
+      // (at worst that costs one extra cycle; it can never lose a message).
+      entry.dataArrivedSincePoll = false
 
       // Poll for new messages
       const newParts = await adapter.pollMessages(
@@ -2742,6 +2773,19 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
           } else if (incomplete.length > 0) {
             console.log(`[AgentManager] TillDone nudge limit (${AgentManager.MAX_TILLDONE_NUDGES}) reached for ${sessionId}, transitioning to idle`)
           }
+        }
+
+        // The adapter buffered data after this cycle polled it, and the turn's
+        // `result` came with that data — which is why the status now reads
+        // IDLE. Unregistering here strands the buffered part: the nudge that
+        // announced it was swallowed because a cycle was already running, and
+        // stopAdapterPolling() cancels both the nudge and the heartbeat. The
+        // part then sits in the adapter until the NEXT prompt polls it out,
+        // which is how an agent's closing message ended up below the user's
+        // following message. Give the next cycle a chance to drain it.
+        if (pollingEntry?.dataArrivedSincePoll) {
+          console.log(`[AgentManager] IDLE for ${sessionId} deferred: adapter buffered data after this poll`)
+          return
         }
 
         console.log(`[AgentManager] Detected IDLE status for ${sessionId}, calling transitionToIdle`)


### PR DESCRIPTION
## Symptom

The last message of a turn does not appear in the transcript. It shows up only when the user sends the next message — and then it renders **below** that message, because the new user part is written first.

## Evidence

Measured on a real transcript database, this session included:

| seq | role | written at |
|---|---|---|
| 147 | user — "is the issue verified or are you just guessing ?" | 19:37:21 |
| 148-163 | assistant work on that question | 19:37:26 -> 19:39:17 |
| **164** | **user — "latest ?"** | **19:41:56.288** |
| **165** | **assistant — the reply to seq 147** | **19:41:56.364** |

The reply was written 76 ms after the following user message, 2m39s after the agent stopped working.

Across the whole database, 63 assistant messages longer than 200 characters were stored less than 500 ms after a user message — 37 codex, 25 claude-code, 1 opencode. No model writes that text in 500 ms, so every one of those is this defect. It is adapter-independent and goes back weeks.

## Root cause

Adapters do not push parts. They buffer a message and ring a bell:

```ts
session.messageBuffer.push(message)                  // claude-code-adapter.ts:1307
if (this.onDataAvailable) this.onDataAvailable(id)   // :1320
```

The bell was dropped whenever a poll cycle was running:

```ts
// If a tick is already running, it will pick up the new data — no nudge needed
if (this.pollingInProgress) return                   // agent-manager.ts:2136
```

That holds only while the cycle still has the session left to poll. A cycle polls first (`:2197`) and reads the status afterwards (`:2411`). A message buffered between those two steps is missed by the poll, and because the turn's `result` arrives with it, `settleTurnIfComplete` flips the adapter to idle, so the status read now returns IDLE.

The IDLE branch then unregisters the session (`:2761`). `stopAdapterPolling` also cancels the nudge timer (`:2036`), and the heartbeat is not rescheduled once no session is left (`:2109`). Nothing collects the buffered part any more. `wakeSessionOnAdapterData` cannot rescue it either — it only re-registers a session whose adapter reports BUSY again. The part waits until the next prompt restarts polling, and the first poll of that turn flushes it after the new user message.

The 5-second post-data grace window (`:2703`) hides this most of the time. It fails exactly when the cycle that observed IDLE delivered nothing and the previous part is older than 5 seconds — an agent that works, pauses, then writes a long closing summary. That matches the data: long final messages failed, short ones did not.

## Fix

- **Do not go idle while the adapter holds data this cycle did not poll.** `PollingEntry.dataArrivedSincePoll` is cleared immediately before `pollMessages` and set by `onDataAvailable`. When it is set, the IDLE branch returns instead of unregistering, so the next cycle drains the buffer first. At worst this costs one extra cycle; it can never lose a message.
- **Re-raise a nudge that arrived during a cycle** instead of dropping it, so buffered data is delivered in about 50 ms rather than at the next heartbeat.

## Test plan

- [x] New test: the adapter buffers data between `pollMessages` and `getStatus`, and the session must stay registered with no idle transition. It fails against the unfixed code (verified).
- [x] New test: with nothing buffered after the poll, the idle transition still happens and the session is still unregistered — the existing behaviour is unchanged.
- [x] `vitest --project main`: 1686 tests pass.
- [x] `tsc --build --noEmit` clean. `eslint` clean on the changed files.

## Not covered by this PR

`replayMissedTranscriptPartsBeforeIdle` (`:3557`) is a second safety net for the same race, and it did not save the measured message. Its part-id and content filters can drop a genuine message, and it is skipped entirely when the session is already idle (`:3806`). This PR removes the need for it in the common case, but those holes remain.

## Related

Companion to #508, which fixes a different silent message loss (a message sent to a completed task). The two are independent and can ship separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)