### PR TITLE
fix: prevent OpenCode plugin bootstrap hangs

### DIFF
--- a/src/main/adapters/opencode-adapter.test.ts
+++ b/src/main/adapters/opencode-adapter.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, it, expect, vi } from 'vitest'
 import { OpencodeAdapter } from './opencode-adapter'
 import { SessionStatusType } from './coding-agent-adapter'
 import { ENTERPRISE_AI_GATEWAY_PROVIDER_ID } from '../enterprise-ai-gateway'
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -34,6 +34,8 @@ describe('OpencodeAdapter', () => {
         expect(pluginPaths).toHaveLength(2)
         expect(pluginPaths.some(path => path.endsWith('20x-tilldone.js'))).toBe(true)
         expect(pluginPaths.some(path => path.endsWith('20x-secret-injector.js'))).toBe(true)
+        expect(pluginPaths.every(path => path.includes(`${join('.opencode', '.20x-plugins')}`))).toBe(true)
+        expect(pluginPaths.every(path => !path.includes(`${join('.opencode', 'plugins')}`))).toBe(true)
         expect(supportPaths.some(path => path.endsWith('.20x-secrets'))).toBe(true)
         expect(supportPaths.some(path => path.endsWith('.20x-tilldone-state.json'))).toBe(true)
         expect(supportPaths.some(path => path.endsWith('.20x-tilldone-config.json'))).toBe(true)
@@ -82,7 +84,7 @@ describe('OpencodeAdapter', () => {
       }
     })
 
-    it('passes disabled tilldone config through to the generated extension', () => {
+    it('does not generate a local tilldone plugin when tilldone is disabled', () => {
       const adapter = new OpencodeAdapter()
       const workspaceDir = mkdtempSync(join(tmpdir(), 'opencode-adapter-test-'))
 
@@ -96,10 +98,42 @@ describe('OpencodeAdapter', () => {
 
         const pluginPaths = (adapter as any).pluginFilePaths as string[]
         const supportPaths = (adapter as any).runtimeSupportFilePaths as string[]
-        const tillDoneConfigPath = supportPaths.find(path => path.endsWith('.20x-tilldone-config.json'))!
 
-        expect(pluginPaths.some(path => path.endsWith('20x-tilldone.js'))).toBe(true)
-        expect(JSON.parse(readFileSync(tillDoneConfigPath, 'utf-8'))).toEqual({ defaultEnabled: false, sessions: {} })
+        expect(pluginPaths).toEqual([])
+        expect(supportPaths).toEqual([])
+        expect(existsSync(join(workspaceDir, '.opencode', 'plugins', '20x-tilldone.js'))).toBe(false)
+        expect(existsSync(join(workspaceDir, '.opencode', '.20x-plugins', '20x-tilldone.js'))).toBe(false)
+      } finally {
+        rmSync(workspaceDir, { recursive: true, force: true })
+      }
+    })
+
+    it('removes a stale local tilldone plugin when tilldone is disabled', () => {
+      const adapter = new OpencodeAdapter()
+      const workspaceDir = mkdtempSync(join(tmpdir(), 'opencode-adapter-test-'))
+
+      try {
+        ;(adapter as any).writeRuntimePluginFiles({
+          agentId: 'agent-1',
+          taskId: 'task-1',
+          workspaceDir,
+          tillDone: true
+        })
+        const stalePluginPath = join(workspaceDir, '.opencode', 'plugins', '20x-tilldone.js')
+        mkdirSync(join(workspaceDir, '.opencode', 'plugins'), { recursive: true })
+        writeFileSync(stalePluginPath, 'legacy plugin', 'utf-8')
+        expect(existsSync(stalePluginPath)).toBe(true)
+
+        ;(adapter as any).writeRuntimePluginFiles({
+          agentId: 'agent-1',
+          taskId: 'triage-task',
+          workspaceDir,
+          tillDone: false
+        })
+
+        expect(existsSync(stalePluginPath)).toBe(false)
+        expect(existsSync(join(workspaceDir, '.opencode', '.20x-plugins', '20x-tilldone.js'))).toBe(false)
+        expect((adapter as any).pluginFilePaths).toEqual([])
       } finally {
         rmSync(workspaceDir, { recursive: true, force: true })
       }
@@ -135,7 +169,7 @@ describe('OpencodeAdapter', () => {
       }
     })
 
-    it('preserves per-session tilldone config when another session starts in the same workspace', () => {
+    it('creates fresh tilldone config when an enabled session follows a disabled session', () => {
       const adapter = new OpencodeAdapter()
       const workspaceDir = mkdtempSync(join(tmpdir(), 'opencode-adapter-test-'))
 
@@ -146,8 +180,6 @@ describe('OpencodeAdapter', () => {
           workspaceDir,
           tillDone: false
         })
-        ;(adapter as any).writeTillDoneSessionConfig('triage-session', false)
-
         ;(adapter as any).writeRuntimePluginFiles({
           agentId: 'agent-1',
           taskId: 'regular-task',
@@ -162,7 +194,6 @@ describe('OpencodeAdapter', () => {
         expect(JSON.parse(readFileSync(tillDoneConfigPath, 'utf-8'))).toEqual({
           defaultEnabled: true,
           sessions: {
-            'triage-session': false,
             'regular-session': true
           }
         })

--- a/src/main/adapters/opencode-adapter.ts
+++ b/src/main/adapters/opencode-adapter.ts
@@ -1737,10 +1737,35 @@ export class OpencodeAdapter implements CodingAgentAdapter {
     }
 
     const openCodeDir = join(config.workspaceDir, '.opencode')
-    const pluginsDir = join(openCodeDir, 'plugins')
-    mkdirSync(pluginsDir, { recursive: true })
+    // Do not put generated plugins in `.opencode/plugins`. OpenCode 1.16+
+    // can hang while it auto-discovers project-local plugins (upstream issue
+    // #30904), and it can install another copy of plugin dependencies in each
+    // workspace. We register these files explicitly through config.update().
+    const pluginsDir = join(openCodeDir, '.20x-plugins')
+    mkdirSync(openCodeDir, { recursive: true })
 
-    this.writeTillDonePlugin(openCodeDir, pluginsDir, config.tillDone !== false)
+    // Remove files created by older 20x versions so a retry can recover an
+    // already-stuck workspace. Leave user-owned plugins in the directory.
+    const legacyPluginsDir = join(openCodeDir, 'plugins')
+    for (const fileName of ['20x-tilldone.js', '20x-secret-injector.js']) {
+      const legacyPluginPath = join(legacyPluginsDir, fileName)
+      if (existsSync(legacyPluginPath)) {
+        unlinkSync(legacyPluginPath)
+      }
+      const generatedPluginPath = join(pluginsDir, fileName)
+      if (existsSync(generatedPluginPath)) {
+        unlinkSync(generatedPluginPath)
+      }
+    }
+
+    if (config.tillDone !== false) {
+      mkdirSync(pluginsDir, { recursive: true })
+      this.writeTillDonePlugin(openCodeDir, pluginsDir, true)
+    }
+
+    if (config.secretEnvVars && Object.keys(config.secretEnvVars).length > 0) {
+      mkdirSync(pluginsDir, { recursive: true })
+    }
     this.writeSecretPlugin(config, openCodeDir, pluginsDir)
   }
 


### PR DESCRIPTION
## Summary
- move generated 20x OpenCode plugins out of the auto-discovered `.opencode/plugins` directory
- register generated plugins explicitly from `.opencode/.20x-plugins`
- skip the TillDone plugin for triage and other sessions where TillDone is disabled
- remove stale generated plugin files so existing stuck workspaces recover on retry

## Cause
OpenCode 1.16+ can hang during project-local plugin discovery. Local reproduction on OpenCode 1.18.x stopped before session creation, and the OpenCode log also showed per-workspace plugin dependency installation failing with `ENOSPC`.

Upstream: https://github.com/anomalyco/opencode/issues/30904

## Validation
- focused OpenCode adapter tests: 38 passed
- TypeScript type check passed
- full pre-commit checks passed