### PR TITLE
Add task navigation and heartbeat shortcuts

### DIFF
--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -37,6 +37,7 @@ import { ThemeToggle } from './ThemeToggle'
 import { StatusBar } from './StatusBar'
 import { CommandPalette } from './CommandPalette'
 import { KeyboardShortcutsDialog } from './KeyboardShortcutsDialog'
+import { SubtaskPickerDialog } from '@/components/tasks/SubtaskPickerDialog'
 import type { SidebarView } from '@/stores/ui-store'
 import logo20x from '@/assets/logos/20x.svg'
 import { dispatchTaskShortcut, getNextNudgeMessage, isKeyboardInput, onShortcutFeedback, TaskShortcutAction } from '@/lib/keyboard-shortcuts'
@@ -84,10 +85,12 @@ export function AppLayout() {
   const clearCreateTaskPrefill = useUIStore((s) => s.clearCreateTaskPrefill)
   const sidebarCollapsed = useUIStore((s) => s.sidebarCollapsed)
   const toggleSidebarCollapsed = useUIStore((s) => s.toggleSidebarCollapsed)
+  const openTaskOnCanvas = useUIStore((s) => s.openTaskOnCanvas)
 
   // ── Command palette ──
   const [cmdOpen, setCmdOpen] = useState(false)
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
+  const [subtaskPickerOpen, setSubtaskPickerOpen] = useState(false)
   const chordRef = useRef<{ key: 'g' | 'o' | 'y' | 'v'; timer: number } | null>(null)
 
   // ── Update indicator state ──
@@ -242,12 +245,88 @@ export function AppLayout() {
   }, [completeTask, dashboardPreviewTaskId])
 
   const activeTaskId = dashboardPreviewTaskId || selectedTaskId || null
+  const handleNavigateFromDashboardPreview = useCallback(
+    (taskId: string) => {
+      closeDashboardPreview()
+      handleGoToFullView(taskId)
+    },
+    [closeDashboardPreview, handleGoToFullView]
+  )
+  const activeTask = useMemo(
+    () => activeTaskId ? allTasks.find((task) => task.id === activeTaskId) : undefined,
+    [activeTaskId, allTasks]
+  )
+  const activeSubtasks = useMemo(
+    () => activeTask
+      ? allTasks
+          .filter((task) => task.parent_task_id === activeTask.id)
+          .sort((a, b) => (a.sort_order ?? 0) - (b.sort_order ?? 0) || a.created_at.localeCompare(b.created_at))
+      : [],
+    [activeTask, allTasks]
+  )
   const runTaskShortcut = useCallback((action: TaskShortcutAction) => {
     if (!activeTaskId) {
       showToast('Select a task first', true)
       return
     }
     dispatchTaskShortcut({ action, taskId: activeTaskId })
+  }, [activeTaskId, showToast])
+
+  const openSubtasks = useCallback(() => {
+    if (!activeTask) {
+      showToast('Select a task first', true)
+    } else if (activeSubtasks.length === 0) {
+      showToast('This task has no subtasks', true)
+    } else {
+      setSubtaskPickerOpen(true)
+    }
+  }, [activeSubtasks.length, activeTask, showToast])
+
+  const openParentTask = useCallback(() => {
+    if (!activeTask) {
+      showToast('Select a task first', true)
+      return
+    }
+    if (!activeTask.parent_task_id) {
+      showToast('This task has no parent', true)
+      return
+    }
+    if (dashboardPreviewTaskId) handleNavigateFromDashboardPreview(activeTask.parent_task_id)
+    else selectTask(activeTask.parent_task_id)
+  }, [activeTask, dashboardPreviewTaskId, handleNavigateFromDashboardPreview, selectTask, showToast])
+
+  const openActiveTaskOnCanvas = useCallback(() => {
+    if (!activeTaskId) {
+      setSidebarView('canvas')
+      return
+    }
+    openTaskOnCanvas(activeTaskId)
+  }, [activeTaskId, openTaskOnCanvas, setSidebarView])
+
+  const selectSubtask = useCallback((taskId: string) => {
+    if (dashboardPreviewTaskId) handleNavigateFromDashboardPreview(taskId)
+    else selectTask(taskId)
+  }, [dashboardPreviewTaskId, handleNavigateFromDashboardPreview, selectTask])
+
+  const runActiveHeartbeat = useCallback(async () => {
+    if (!activeTaskId) {
+      showToast('Select a task first', true)
+      return
+    }
+    try {
+      const result = await window.electronAPI.heartbeat.runNow(activeTaskId)
+      const feedback = {
+        sent: ['Heartbeat check started', false],
+        no_file: ['This task has no heartbeat.md file', true],
+        no_agent: ['This task has no heartbeat agent', true],
+        in_progress: ['A heartbeat check is already running', true],
+        error: ['Could not run the heartbeat check', true]
+      } as const
+      const [message, isError] = feedback[result]
+      showToast(message, isError)
+    } catch {
+      showToast('Could not run the heartbeat check', true)
+    }
   }, [activeTaskId, showToast])
 
   const navigateVisibleTask = useCallback((direction: 1 | -1) => {
@@ -367,18 +446,15 @@ export function AppLayout() {
     openOutput: () => runTaskShortcut(TaskShortcutAction.OPEN_OUTPUT),
     openArtifact: () => runTaskShortcut(TaskShortcutAction.OPEN_ARTIFACT),
     openPullRequest: () => runTaskShortcut(TaskShortcutAction.OPEN_PR),
+    openSubtasks,
+    openParentTask,
+    openTaskOnCanvas: openActiveTaskOnCanvas,
+    runHeartbeat: () => { void runActiveHeartbeat() },
     copyPullRequestUrl: () => runTaskShortcut(TaskShortcutAction.COPY_PR_URL),
     copyPullRequestBranch: () => runTaskShortcut(TaskShortcutAction.COPY_PR_BRANCH),
     toggleTaskAudio,
     toggleMastermindAudio
-  }), [clearTaskSelection, completeActiveTask, deleteActiveTask, focusSearch, navigateVisibleTask, nudgeActiveTask, openSelectedTask, runTaskShortcut, toggleMastermindAudio, toggleTaskAudio])
-  const handleNavigateFromDashboardPreview = useCallback(
-    (taskId: string) => {
-      closeDashboardPreview()
-      handleGoToFullView(taskId)
-    },
-    [closeDashboardPreview, handleGoToFullView]
-  )
+  }), [clearTaskSelection, completeActiveTask, deleteActiveTask, focusSearch, navigateVisibleTask, nudgeActiveTask, openActiveTaskOnCanvas, openParentTask, openSelectedTask, openSubtasks, runActiveHeartbeat, runTaskShortcut, toggleMastermindAudio, toggleTaskAudio])
 
   const overdueCount = useMemo(
     () => tasks.filter(
@@ -470,7 +546,7 @@ export function AppLayout() {
         window.clearTimeout(pending.timer)
         chordRef.current = null
         const chord = `${pending.key}${key}`
-        const views: Record<string, SidebarView> = { gd: 'dashboard', gc: 'canvas', gt: 'tasks', gs: 'skills' }
+        const views: Record<string, SidebarView> = { gd: 'dashboard', gt: 'tasks', gs: 'skills' }
         const taskActions: Record<string, TaskShortcutAction> = {
           od: TaskShortcutAction.OPEN_DETAILS,
           oc: TaskShortcutAction.OPEN_CHANGES,
@@ -487,6 +563,16 @@ export function AppLayout() {
         } else if (taskActions[chord]) {
           e.preventDefault()
           runTaskShortcut(taskActions[chord])
+        } else if (chord === 'gc') {
+          e.preventDefault()
+          if (activeTaskId) openActiveTaskOnCanvas()
+          else setSidebarView('canvas')
+        } else if (chord === 'gp') {
+          e.preventDefault()
+          openParentTask()
+        } else if (chord === 'os') {
+          e.preventDefault()
+          openSubtasks()
         } else if (chord === 'vt') {
           e.preventDefault()
           toggleTaskAudio()
@@ -514,6 +600,7 @@ export function AppLayout() {
       else if (e.key === 'Escape') { e.preventDefault(); if (showOrchestrator) setShowOrchestrator(false); else clearTaskSelection() }
       else if (key === 'c') { e.preventDefault(); openCreateModal() }
       else if (key === 'e') { e.preventDefault(); completeActiveTask() }
+      else if (key === 'h' && e.shiftKey) { e.preventDefault(); void runActiveHeartbeat() }
       else if (key === 'h') { e.preventDefault(); runTaskShortcut(TaskShortcutAction.SNOOZE) }
       else if (key === 'r') { e.preventDefault(); runTaskShortcut(TaskShortcutAction.RUN) }
       else if (key === 'w') { e.preventDefault(); nudgeActiveTask() }
@@ -526,7 +613,7 @@ export function AppLayout() {
       window.removeEventListener('keydown', onKey)
       if (chordRef.current) window.clearTimeout(chordRef.current.timer)
     }
-  }, [activeModal, clearTaskSelection, closeModal, completeActiveTask, deleteActiveTask, focusSearch, navigateVisibleTask, nudgeActiveTask, openCreateModal, openSelectedTask, runTaskShortcut, setShowOrchestrator, setSidebarView, showOrchestrator, sidebarView, toggleMastermindAudio, toggleTaskAudio])
+  }, [activeModal, activeTaskId, clearTaskSelection, closeModal, completeActiveTask, deleteActiveTask, focusSearch, navigateVisibleTask, nudgeActiveTask, openActiveTaskOnCanvas, openCreateModal, openParentTask, openSelectedTask, openSubtasks, runActiveHeartbeat, runTaskShortcut, setShowOrchestrator, setSidebarView, showOrchestrator, sidebarView, toggleMastermindAudio, toggleTaskAudio])
 
   return (
     <>
@@ -882,6 +969,12 @@ export function AppLayout() {
 
       {/* Command palette (⌘K / Ctrl+K) */}
       <CommandPalette open={cmdOpen} onOpenChange={setCmdOpen} actions={commandActions} />
+      <SubtaskPickerDialog
+        open={subtaskPickerOpen}
+        onOpenChange={setSubtaskPickerOpen}
+        subtasks={activeSubtasks}
+        onSelect={selectSubtask}
+      />
       <KeyboardShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
 
       {/* Background progress toasts (setup, task progress, etc.) */}

--- a/src/renderer/src/components/layout/CommandPalette.tsx
+++ b/src/renderer/src/components/layout/CommandPalette.tsx
@@ -4,7 +4,7 @@ import {
   Search, LayoutDashboard, Layers, CheckSquare, Zap, Settings, MessageSquare,
   Plus, Sun, Moon, CornerDownLeft, LayoutGrid, ArrowDown, ArrowUp, ExternalLink,
   PanelRightOpen, FileDiff, PackageOpen, Copy, GitBranch, Mic, CircleHelp,
-  CircleCheck, Clock3, Play, Trash2, LogOut, type LucideIcon
+  CircleCheck, Clock3, Play, Trash2, LogOut, ListTree, CornerUpLeft, type LucideIcon
 } from 'lucide-react'
 import { useUIStore } from '@/stores/ui-store'
 import { useThemeStore } from '@/stores/theme-store'
@@ -43,6 +43,10 @@ export interface CommandPaletteActions {
   openOutput: () => void
   openArtifact: () => void
   openPullRequest: () => void
+  openSubtasks: () => void
+  openParentTask: () => void
+  openTaskOnCanvas: () => void
+  runHeartbeat: () => void
   copyPullRequestUrl: () => void
   copyPullRequestBranch: () => void
   toggleTaskAudio: () => void
@@ -85,7 +89,7 @@ export function CommandPalette({ open, onOpenChange, actions }: { open: boolean;
     const goto = (view: 'dashboard' | 'canvas' | 'tasks' | 'skills') => () => { closeModal(); setSidebarView(view); close() }
     const base: CommandItem[] = [
       { id: 'nav-dashboard', group: 'Navigation', label: 'Go to Dashboard', icon: LayoutDashboard, keywords: 'home overview', shortcut: `G D · ${mod}1`, run: goto('dashboard') },
-      { id: 'nav-canvas', group: 'Navigation', label: 'Go to Canvas', icon: Layers, keywords: 'board panels', shortcut: `G C · ${mod}2`, run: goto('canvas') },
+      { id: 'nav-canvas', group: 'Navigation', label: 'Go to Canvas', icon: Layers, keywords: 'board panels', shortcut: `${mod}2`, run: goto('canvas') },
       { id: 'nav-tasks', group: 'Navigation', label: 'Go to Tasks', icon: CheckSquare, keywords: 'todo list', shortcut: `G T · ${mod}3`, run: goto('tasks') },
       { id: 'nav-skills', group: 'Navigation', label: 'Go to Skills', icon: Zap, keywords: 'abilities', shortcut: `G S · ${mod}4`, run: goto('skills') },
       { id: 'nav-next-task', group: 'Navigation', label: 'Next visible task', icon: ArrowDown, shortcut: 'J', run: () => { actions.nextTask(); close() } },
@@ -105,6 +109,10 @@ export function CommandPalette({ open, onOpenChange, actions }: { open: boolean;
       { id: 'panel-output', group: 'Task panels', label: 'Open Output', icon: PackageOpen, shortcut: 'O O', run: () => { actions.openOutput(); close() } },
       { id: 'panel-artifact', group: 'Task panels', label: 'Open newest artifact', icon: LayoutGrid, shortcut: 'O A', run: () => { actions.openArtifact(); close() } },
       { id: 'panel-pr', group: 'Task panels', label: 'Open newest pull request', icon: ExternalLink, shortcut: 'O P', run: () => { actions.openPullRequest(); close() } },
+      { id: 'nav-subtasks', group: 'Task navigation', label: 'Choose a subtask to open', icon: ListTree, shortcut: 'O S', run: () => { actions.openSubtasks(); close() } },
+      { id: 'nav-parent-task', group: 'Task navigation', label: 'Go to parent task', icon: CornerUpLeft, shortcut: 'G P', run: () => { actions.openParentTask(); close() } },
+      { id: 'nav-task-canvas', group: 'Task navigation', label: 'Open task on Canvas', icon: Layers, shortcut: 'G C', run: () => { actions.openTaskOnCanvas(); close() } },
+      { id: 'act-run-heartbeat', group: 'Task actions', label: 'Run heartbeat now', icon: Zap, shortcut: 'Shift H', run: () => { actions.runHeartbeat(); close() } },
       { id: 'copy-pr-url', group: 'Pull request', label: 'Copy pull-request URL', icon: Copy, shortcut: 'Y P', run: () => { actions.copyPullRequestUrl(); close() } },
       { id: 'copy-pr-branch', group: 'Pull request', label: 'Copy pull-request branch', icon: GitBranch, shortcut: 'Y B', run: () => { actions.copyPullRequestBranch(); close() } },
       { id: 'audio-task', group: 'Audio', label: 'Toggle task audio', icon: Mic, shortcut: 'V T', run: () => { actions.toggleTaskAudio(); close() } },

--- a/src/renderer/src/components/tasks/SubtaskPickerDialog.test.tsx
+++ b/src/renderer/src/components/tasks/SubtaskPickerDialog.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { SubtaskPickerDialog } from './SubtaskPickerDialog'
+import { TaskStatus, type WorkfloTask } from '@/types'
+
+function makeTask(id: string, title: string): WorkfloTask {
+  return {
+    id,
+    title,
+    description: '',
+    type: 'general',
+    priority: 'medium',
+    status: TaskStatus.NotStarted,
+    assignee: '',
+    due_date: null,
+    labels: [],
+    attachments: [],
+    repos: [],
+    output_fields: [],
+    agent_id: null,
+    session_id: null,
+    external_id: null,
+    source_id: null,
+    source: 'manual',
+    skill_ids: null,
+    snoozed_until: null,
+    resolution: null,
+    feedback_rating: null,
+    feedback_comment: null,
+    is_recurring: false,
+    recurrence_pattern: null,
+    recurrence_parent_id: null,
+    last_occurrence_at: null,
+    next_occurrence_at: null,
+    auto_start_agent: false,
+    auto_complete_without_review: false,
+    complete_at_source: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    parent_task_id: 'parent-1',
+    sort_order: 0
+  }
+}
+
+afterEach(cleanup)
+
+describe('SubtaskPickerDialog', () => {
+  it('opens the highlighted subtask with arrow keys and Enter', () => {
+    const onSelect = vi.fn()
+    const onOpenChange = vi.fn()
+    render(
+      <SubtaskPickerDialog
+        open
+        onOpenChange={onOpenChange}
+        subtasks={[makeTask('sub-1', 'First subtask'), makeTask('sub-2', 'Second subtask')]}
+        onSelect={onSelect}
+      />
+    )
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.keyDown(dialog, { key: 'ArrowDown' })
+    fireEvent.keyDown(dialog, { key: 'Enter' })
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(onSelect).toHaveBeenCalledWith('sub-2')
+  })
+
+  it('supports J and K navigation', () => {
+    const onSelect = vi.fn()
+    render(
+      <SubtaskPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        subtasks={[makeTask('sub-1', 'First subtask'), makeTask('sub-2', 'Second subtask')]}
+        onSelect={onSelect}
+      />
+    )
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.keyDown(dialog, { key: 'j' })
+    fireEvent.keyDown(dialog, { key: 'k' })
+    fireEvent.keyDown(dialog, { key: 'Enter' })
+
+    expect(onSelect).toHaveBeenCalledWith('sub-1')
+  })
+})

--- a/src/renderer/src/components/tasks/SubtaskPickerDialog.tsx
+++ b/src/renderer/src/components/tasks/SubtaskPickerDialog.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { CheckSquare, CornerDownLeft } from 'lucide-react'
+import type { WorkfloTask } from '@/types'
+
+interface SubtaskPickerDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  subtasks: WorkfloTask[]
+  onSelect: (taskId: string) => void
+}
+
+export function SubtaskPickerDialog({ open, onOpenChange, subtasks, onSelect }: SubtaskPickerDialogProps) {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (open) setActiveIndex(0)
+  }, [open])
+
+  useEffect(() => {
+    listRef.current?.querySelector<HTMLElement>('[data-active="true"]')?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
+  const select = (taskId: string) => {
+    onOpenChange(false)
+    onSelect(taskId)
+  }
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    const key = event.key.toLowerCase()
+    if (event.key === 'ArrowDown' || key === 'j') {
+      event.preventDefault()
+      setActiveIndex((index) => Math.min(index + 1, subtasks.length - 1))
+    } else if (event.key === 'ArrowUp' || key === 'k') {
+      event.preventDefault()
+      setActiveIndex((index) => Math.max(index - 1, 0))
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      const subtask = subtasks[activeIndex]
+      if (subtask) select(subtask.id)
+    }
+  }
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          onKeyDown={onKeyDown}
+          className="fixed left-1/2 top-[24%] z-50 w-[min(520px,calc(100vw-2rem))] -translate-x-1/2 overflow-hidden rounded-2xl border border-border bg-popover shadow-2xl outline-none"
+        >
+          <DialogPrimitive.Title className="border-b border-border/60 px-4 py-3 text-sm font-semibold">
+            Open subtask
+          </DialogPrimitive.Title>
+          <div ref={listRef} role="listbox" aria-label="Subtasks" className="max-h-[360px] overflow-y-auto p-2">
+            {subtasks.map((subtask, index) => (
+              <button
+                key={subtask.id}
+                type="button"
+                role="option"
+                aria-selected={index === activeIndex}
+                data-active={index === activeIndex}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => select(subtask.id)}
+                className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors ${
+                  index === activeIndex ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50'
+                }`}
+              >
+                <CheckSquare className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate">{subtask.title}</span>
+                {index === activeIndex && <CornerDownLeft className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center justify-between border-t border-border/60 px-4 py-2 text-[11px] text-muted-foreground">
+            <span>Use ↑/↓ or J/K to select</span>
+            <span>Enter to open · Esc to close</span>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}

--- a/src/renderer/src/lib/keyboard-shortcuts.test.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.test.ts
@@ -3,6 +3,7 @@ import {
   dispatchTaskShortcut,
   getNextNudgeMessage,
   isKeyboardInput,
+  KEYBOARD_SHORTCUT_GROUPS,
   onTaskShortcut,
   TaskShortcutAction
 } from './keyboard-shortcuts'
@@ -31,5 +32,18 @@ describe('keyboard shortcuts', () => {
     dispatchTaskShortcut({ action: TaskShortcutAction.OPEN_DETAILS, taskId: 'task-1' })
     unsubscribe()
     expect(received).toEqual({ action: TaskShortcutAction.OPEN_DETAILS, taskId: 'task-1' })
+  })
+
+  it('lists the task navigation and heartbeat shortcuts', () => {
+    const shortcuts = KEYBOARD_SHORTCUT_GROUPS.reduce<Array<{ keys: readonly string[]; label: string }>>(
+      (all, group) => [...all, ...group.shortcuts],
+      []
+    )
+    expect(shortcuts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ keys: ['O', 'S'], label: 'Choose a subtask to open' }),
+      expect.objectContaining({ keys: ['G', 'P'], label: 'Go to parent task' }),
+      expect.objectContaining({ keys: ['G', 'C'], label: 'Open selected task on Canvas or go to Canvas' }),
+      expect.objectContaining({ keys: ['Shift', 'H'], label: 'Run heartbeat now' })
+    ]))
   })
 })

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -27,7 +27,8 @@ export const KEYBOARD_SHORTCUT_GROUPS = [
       { keys: ['Enter'], label: 'Open selected task' },
       { keys: ['Esc'], label: 'Close or clear selection' },
       { keys: ['G', 'D'], label: 'Go to Dashboard' },
-      { keys: ['G', 'C'], label: 'Go to Canvas' },
+      { keys: ['G', 'C'], label: 'Open selected task on Canvas or go to Canvas' },
+      { keys: ['G', 'P'], label: 'Go to parent task' },
       { keys: ['G', 'T'], label: 'Go to Tasks' },
       { keys: ['G', 'S'], label: 'Go to Skills' },
       { keys: ['/'], label: 'Focus search' },
@@ -43,6 +44,7 @@ export const KEYBOARD_SHORTCUT_GROUPS = [
       { keys: ['H'], label: 'Snooze selected task' },
       { keys: ['R'], label: 'Run or resume selected task' },
       { keys: ['W'], label: 'Nudge agent to continue' },
+      { keys: ['Shift', 'H'], label: 'Run heartbeat now' },
       { keys: ['#'], label: 'Delete selected task' },
       { keys: ['?'], label: 'Show keyboard shortcuts' }
     ]
@@ -55,6 +57,7 @@ export const KEYBOARD_SHORTCUT_GROUPS = [
       { keys: ['O', 'O'], label: 'Open Output' },
       { keys: ['O', 'A'], label: 'Open newest artifact' },
       { keys: ['O', 'P'], label: 'Open newest pull request' },
+      { keys: ['O', 'S'], label: 'Choose a subtask to open' },
       { keys: ['Y', 'P'], label: 'Copy pull-request URL' },
       { keys: ['Y', 'B'], label: 'Copy pull-request branch' }
     ]


### PR DESCRIPTION
## Summary

- add an O S subtask picker with arrow-key and J/K selection
- use G P to return to the active task parent
- make G C open the active task on Canvas, with the old view-only fallback when no task is active
- add Shift+H to run the active task heartbeat now
- show all new actions in the shortcut dialog and command palette

## Validation

- 171 test files passed: 2690 tests passed, 4 skipped
- pnpm typecheck
- pnpm build
- pnpm lint (0 errors; 129 existing warnings)