### PR TITLE
fix: open feedback dialog from completion shortcut

### DIFF
--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -369,10 +369,9 @@ export function AppLayout() {
   }, [sidebarCollapsed, sidebarView])
 
   const completeActiveTask = useCallback(() => {
-    if (dashboardPreviewTaskId) void handleCompleteDashboardPreviewTask()
-    else if (selectedTaskId) void handleCompleteSelectedTask()
+    if (activeTaskId) dispatchTaskShortcut({ action: TaskShortcutAction.COMPLETE, taskId: activeTaskId })
     else showToast('Select a task first', true)
-  }, [dashboardPreviewTaskId, handleCompleteDashboardPreviewTask, handleCompleteSelectedTask, selectedTaskId, showToast])
+  }, [activeTaskId, showToast])
 
   const deleteActiveTask = useCallback(() => {
     if (dashboardPreviewTaskId) handleDeleteDashboardPreviewTask()

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -40,7 +40,7 @@ import { KeyboardShortcutsDialog } from './KeyboardShortcutsDialog'
 import { SubtaskPickerDialog } from '@/components/tasks/SubtaskPickerDialog'
 import type { SidebarView } from '@/stores/ui-store'
 import logo20x from '@/assets/logos/20x.svg'
-import { dispatchTaskShortcut, getNextNudgeMessage, isKeyboardInput, onShortcutFeedback, TaskShortcutAction } from '@/lib/keyboard-shortcuts'
+import { dispatchTaskShortcut, getNextNudgeMessage, isGlobalShortcutBlocked, onShortcutFeedback, TaskShortcutAction } from '@/lib/keyboard-shortcuts'
 import { selectVoiceReady, useVoiceStore } from '@/stores/voice-store'
 import { composerCanSubmit, MASTERMIND_COMPOSER_KEY, sendComposerMessage, setActiveComposer } from '@/lib/voice-dictation-target'
 
@@ -537,8 +537,9 @@ export function AppLayout() {
         }
         return
       }
-      if (e.metaKey || e.ctrlKey || e.altKey || isKeyboardInput(e.target)) return
-      if (document.querySelector('[role="dialog"]')) return
+      // Radix dialogs prevent the Escape event after they close. Respect that
+      // marker so this listener does not also close the task behind the popup.
+      if (isGlobalShortcutBlocked(e)) return
 
       const pending = chordRef.current
       if (pending) {

--- a/src/renderer/src/components/tasks/SubtaskPickerDialog.test.tsx
+++ b/src/renderer/src/components/tasks/SubtaskPickerDialog.test.tsx
@@ -3,14 +3,14 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { SubtaskPickerDialog } from './SubtaskPickerDialog'
 import { TaskStatus, type WorkfloTask } from '@/types'
 
-function makeTask(id: string, title: string): WorkfloTask {
+function makeTask(id: string, title: string, status = TaskStatus.NotStarted): WorkfloTask {
   return {
     id,
     title,
     description: '',
     type: 'general',
     priority: 'medium',
-    status: TaskStatus.NotStarted,
+    status,
     assignee: '',
     due_date: null,
     labels: [],
@@ -45,6 +45,23 @@ function makeTask(id: string, title: string): WorkfloTask {
 afterEach(cleanup)
 
 describe('SubtaskPickerDialog', () => {
+  it('shows each subtask status', () => {
+    render(
+      <SubtaskPickerDialog
+        open
+        onOpenChange={vi.fn()}
+        subtasks={[
+          makeTask('sub-1', 'First subtask', TaskStatus.AgentWorking),
+          makeTask('sub-2', 'Second subtask', TaskStatus.ReadyForReview)
+        ]}
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Agent Working')).toBeInTheDocument()
+    expect(screen.getByText('Ready for Review')).toBeInTheDocument()
+  })
+
   it('opens the highlighted subtask with arrow keys and Enter', () => {
     const onSelect = vi.fn()
     const onOpenChange = vi.fn()
@@ -82,5 +99,32 @@ describe('SubtaskPickerDialog', () => {
     fireEvent.keyDown(dialog, { key: 'Enter' })
 
     expect(onSelect).toHaveBeenCalledWith('sub-1')
+  })
+
+  it('closes only the popup when Escape is pressed', () => {
+    const onOpenChange = vi.fn()
+    let parentClosed = false
+    const closeParentUnlessHandled = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !event.defaultPrevented) parentClosed = true
+    }
+    window.addEventListener('keydown', closeParentUnlessHandled)
+
+    try {
+      render(
+        <SubtaskPickerDialog
+          open
+          onOpenChange={onOpenChange}
+          subtasks={[makeTask('sub-1', 'First subtask')]}
+          onSelect={vi.fn()}
+        />
+      )
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+      expect(parentClosed).toBe(false)
+    } finally {
+      window.removeEventListener('keydown', closeParentUnlessHandled)
+    }
   })
 })

--- a/src/renderer/src/components/tasks/SubtaskPickerDialog.tsx
+++ b/src/renderer/src/components/tasks/SubtaskPickerDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { CheckSquare, CornerDownLeft } from 'lucide-react'
 import type { WorkfloTask } from '@/types'
+import { TaskStatusBadge } from './TaskStatusBadge'
 
 interface SubtaskPickerDialogProps {
   open: boolean
@@ -70,6 +71,7 @@ export function SubtaskPickerDialog({ open, onOpenChange, subtasks, onSelect }: 
               >
                 <CheckSquare className="h-4 w-4 shrink-0 text-muted-foreground" />
                 <span className="min-w-0 flex-1 truncate">{subtask.title}</span>
+                <TaskStatusBadge status={subtask.status} />
                 {index === activeIndex && <CornerDownLeft className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
               </button>
             ))}

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -138,6 +138,19 @@ describe('clampTranscriptWidth', () => {
 })
 
 describe('TaskWorkspace keyboard actions', () => {
+  it('opens session feedback instead of completing immediately', () => {
+    const task = makeRendererTask({
+      status: TaskStatus.ReadyForReview,
+      session_id: 'persisted-session-1'
+    })
+
+    renderWorkspace(task)
+    act(() => dispatchTaskShortcut({ action: TaskShortcutAction.COMPLETE, taskId: task.id }))
+
+    expect(screen.getByText('Session Feedback')).toBeInTheDocument()
+    expect(noopFn).not.toHaveBeenCalled()
+  })
+
   it('opens the snooze dialog for the selected task', () => {
     renderWorkspace(makeRendererTask())
     act(() => dispatchTaskShortcut({ action: TaskShortcutAction.SNOOZE, taskId: 'task-1' }))

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -938,6 +938,10 @@ Update existing skills that were helpful or create new ones for patterns worth r
     if (!task || task.id !== taskId) return
     const workspace = workspaceBodyRef.current
     if (workspace && window.getComputedStyle(workspace).visibility === 'hidden') return
+    if (action === TaskShortcutAction.COMPLETE) {
+      void handleCompleteTask()
+      return
+    }
     if (action === TaskShortcutAction.RUN) {
       handleRunShortcut()
       return
@@ -984,7 +988,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
         .then(() => dispatchShortcutFeedback('Pull-request branch copied'))
         .catch(() => dispatchShortcutFeedback('Could not copy the pull-request branch', true))
     }
-  }), [artifacts, handleRunShortcut, newestPullRequest, selectArtifactTab, setRailExpanded, task])
+  }), [artifacts, handleCompleteTask, handleRunShortcut, newestPullRequest, selectArtifactTab, setRailExpanded, task])
 
   if (!task) {
     return (

--- a/src/renderer/src/lib/keyboard-shortcuts.test.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   dispatchTaskShortcut,
   getNextNudgeMessage,
+  isGlobalShortcutBlocked,
   isKeyboardInput,
   KEYBOARD_SHORTCUT_GROUPS,
   onTaskShortcut,
@@ -16,6 +17,13 @@ describe('keyboard shortcuts', () => {
     editable.contentEditable = 'true'
     expect(isKeyboardInput(editable)).toBe(true)
     expect(isKeyboardInput(document.createElement('div'))).toBe(false)
+  })
+
+  it('blocks a key event that a popup already handled', () => {
+    const event = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true })
+    event.preventDefault()
+
+    expect(isGlobalShortcutBlocked(event)).toBe(true)
   })
 
   it('cycles through different Nudge messages', () => {

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -1,4 +1,5 @@
 export enum TaskShortcutAction {
+  COMPLETE = 'complete',
   RUN = 'run',
   SNOOZE = 'snooze',
   OPEN_DETAILS = 'open_details',

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -93,6 +93,15 @@ export function isKeyboardInput(target: EventTarget | null): boolean {
     || !!target.closest('[contenteditable="true"], .xterm')
 }
 
+export function isGlobalShortcutBlocked(event: KeyboardEvent): boolean {
+  return event.defaultPrevented
+    || event.metaKey
+    || event.ctrlKey
+    || event.altKey
+    || isKeyboardInput(event.target)
+    || !!document.querySelector('[role="dialog"], [role="alertdialog"]')
+}
+
 export function dispatchTaskShortcut(detail: TaskShortcutDetail): void {
   window.dispatchEvent(new CustomEvent<TaskShortcutDetail>(TASK_SHORTCUT_EVENT, { detail }))
 }


### PR DESCRIPTION
## Summary
- Route the E shortcut and command-palette completion action through the active TaskWorkspace.
- Reuse the existing session feedback flow, so tasks with a session show the five-star rating and optional feedback dialog before completion.
- Show each subtask status in the keyboard subtask picker.
- Keep the current task selected when Escape closes a popup by respecting handled keyboard events in the app-level shortcut listener.
- Desktop only: the mobile app has no global keyboard shortcut system.

## Test plan
- [x] Focused keyboard and subtask picker tests pass (9 tests).
- [x] Full renderer suite passes (934 tests).
- [x] Full commit hook passes lint, typecheck, build, and all tests (2695 passed, 4 skipped).
- [x] Regression tests fail against the unfixed status and Escape behavior and pass with these changes.

Generated with Codex