### PR TITLE
feat: add GPT-6 Astra (gpt-6-astra) model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Most AI tools make you copy-paste context between tabs. 20x flips it: **your tas
 ### 🤖 Multi-Agent Support
 - **Claude Code** — Anthropic's official agent SDK (Claude Sonnet 4.6)
 - **OpenCode** — Open-source coding agent
-- **Codex** — OpenAI's agent framework (GPT-5.6 Sol)
+- **Codex** — OpenAI's agent framework (GPT-6 Astra)
 - **Pi** — Open-source coding agent with Peakflo AI Gateway models
 - **Live transcripts** — Watch agents think and work in real time with message counts
 - **Human-in-the-loop** — Approve risky actions before execution
@@ -268,7 +268,7 @@ We welcome contributions! Here's how:
 - ✅ Skills 2-way sync with Workflo
 - ✅ Heartbeat monitoring with CI failure detection
 - ✅ Presetup wizard and dashboard templates
-- ✅ Claude Sonnet 4.6 and GPT-5.6 model family support
+- ✅ Claude Sonnet 4.6 and GPT-6 Astra model family support
 - ✅ Multi-agent support (OpenCode, Claude Code, Codex, Pi)
 - ✅ Skills system with auto-learning
 - ✅ Recurring tasks

--- a/src/main/adapters/codex-adapter.test.ts
+++ b/src/main/adapters/codex-adapter.test.ts
@@ -6,8 +6,8 @@ type CodexAdapterWithArgs = {
 }
 
 describe('DEFAULT_CODEX_MODEL', () => {
-  it('defaults Codex sessions to GPT-5.6 Sol', () => {
-    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.6-sol')
+  it('defaults Codex sessions to GPT-6 Astra', () => {
+    expect(DEFAULT_CODEX_MODEL).toBe('gpt-6-astra')
   })
 })
 
@@ -44,9 +44,9 @@ describe('CodexAdapter findCodexExecutable fallback paths', () => {
     const adapter = new CodexAdapter()
     const buildCodexArgs = (adapter as unknown as CodexAdapterWithArgs).buildCodexArgs.bind(adapter)
 
-    expect(buildCodexArgs({ model: 'gpt-5.6-sol', reasoningEffort: 'high' })).toEqual([
+    expect(buildCodexArgs({ model: 'gpt-6-astra', reasoningEffort: 'high' })).toEqual([
       '--model',
-      'gpt-5.6-sol',
+      'gpt-6-astra',
       '-c',
       'model_reasoning_effort="high"',
       '--json-rpc',
@@ -57,9 +57,9 @@ describe('CodexAdapter findCodexExecutable fallback paths', () => {
     const adapter = new CodexAdapter()
     const buildCodexArgs = (adapter as unknown as CodexAdapterWithArgs).buildCodexArgs.bind(adapter)
 
-    expect(buildCodexArgs({ model: 'gpt-5.6-sol', reasoningEffort: 'max' })).toEqual([
+    expect(buildCodexArgs({ model: 'gpt-6-astra', reasoningEffort: 'max' })).toEqual([
       '--model',
-      'gpt-5.6-sol',
+      'gpt-6-astra',
       '--json-rpc',
     ])
   })

--- a/src/main/adapters/codex-adapter.ts
+++ b/src/main/adapters/codex-adapter.ts
@@ -21,7 +21,7 @@ import type {
 } from './coding-agent-adapter'
 import { SessionStatusType, MessagePartType, MessageRole } from './coding-agent-adapter'
 
-export const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol'
+export const DEFAULT_CODEX_MODEL = 'gpt-6-astra'
 
 interface JsonRpcRequest {
   jsonrpc: '2.0'

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -22,7 +22,7 @@ import type {
 } from './coding-agent-adapter'
 import { MessagePartType, MessageRole, SessionStatusType } from './coding-agent-adapter'
 
-const DEFAULT_CODEX_APP_SERVER_MODEL = 'gpt-5.5'
+const DEFAULT_CODEX_APP_SERVER_MODEL = 'gpt-6-astra'
 const MAX_IPC_TOOL_INPUT_CHARS = 20_000
 const MAX_IPC_TOOL_OUTPUT_CHARS = 100_000
 const MIN_THREAD_LEVEL_ASSISTANT_DEDUPE_CHARS = 40

--- a/src/renderer/src/types/index.test.ts
+++ b/src/renderer/src/types/index.test.ts
@@ -18,16 +18,17 @@ describe('CLAUDE_MODELS', () => {
 })
 
 describe('CODEX_MODELS', () => {
-  it('lists GPT-5.6 Sol first as the recommended model', () => {
+  it('lists GPT-6 Astra first as the recommended model', () => {
     expect(CODEX_MODELS[0]).toEqual({
-      id: CodexModel.GPT_5_6_SOL,
-      name: 'GPT-5.6 Sol (Recommended)'
+      id: CodexModel.GPT_6_ASTRA,
+      name: 'GPT-6 Astra (Recommended)'
     })
   })
 
   it('lists the supported Codex models in preferred order', () => {
     expect(CODEX_MODELS).toEqual([
-      { id: CodexModel.GPT_5_6_SOL, name: 'GPT-5.6 Sol (Recommended)' },
+      { id: CodexModel.GPT_6_ASTRA, name: 'GPT-6 Astra (Recommended)' },
+      { id: CodexModel.GPT_5_6_SOL, name: 'GPT-5.6 Sol' },
       { id: CodexModel.GPT_5_6_TERRA, name: 'GPT-5.6 Terra' },
       { id: CodexModel.GPT_5_6_LUNA, name: 'GPT-5.6 Luna' },
       { id: CodexModel.GPT_5_5, name: 'GPT-5.5' },

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -87,6 +87,7 @@ export const CLAUDE_MODELS: { id: ClaudeModel; name: string }[] = [
 ]
 
 export enum CodexModel {
+  GPT_6_ASTRA = 'gpt-6-astra',
   GPT_5_6_SOL = 'gpt-5.6-sol',
   GPT_5_6_TERRA = 'gpt-5.6-terra',
   GPT_5_6_LUNA = 'gpt-5.6-luna',
@@ -97,7 +98,8 @@ export enum CodexModel {
 }
 
 export const CODEX_MODELS: { id: CodexModel; name: string }[] = [
-  { id: CodexModel.GPT_5_6_SOL, name: 'GPT-5.6 Sol (Recommended)' },
+  { id: CodexModel.GPT_6_ASTRA, name: 'GPT-6 Astra (Recommended)' },
+  { id: CodexModel.GPT_5_6_SOL, name: 'GPT-5.6 Sol' },
   { id: CodexModel.GPT_5_6_TERRA, name: 'GPT-5.6 Terra' },
   { id: CodexModel.GPT_5_6_LUNA, name: 'GPT-5.6 Luna' },
   { id: CodexModel.GPT_5_5, name: 'GPT-5.5' },


### PR DESCRIPTION
Add latest GPT model Astra (gpt-6-astra) as recommended Codex model.

- Add CodexModel.GPT_6_ASTRA = 'gpt-6-astra' enum and CODEX_MODELS entry as first element with '(Recommended)'
- Demote previous recommended GPT-5.6 Sol to plain 'GPT-5.6 Sol'
- Update DEFAULT_CODEX_MODEL (codex-adapter) and DEFAULT_CODEX_APP_SERVER_MODEL (codex-app-server-adapter) to gpt-6-astra
- Update unit tests for model ordering and default model expectations
- Update README to reflect GPT-6 Astra

Model ID verified against https://developers.openai.com/api/docs/models/gpt-6-astra (released Sep 3-5 2026, context 1.05M, pricing $10/$50).

Fixes task fshthi1glmyw44u78xjg7fx4