### PR TITLE
feat: add key shortcut to focus composer and just-start-typing

### DIFF
--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -40,7 +40,7 @@ import { KeyboardShortcutsDialog } from './KeyboardShortcutsDialog'
 import { SubtaskPickerDialog } from '@/components/tasks/SubtaskPickerDialog'
 import type { SidebarView } from '@/stores/ui-store'
 import logo20x from '@/assets/logos/20x.svg'
-import { dispatchTaskShortcut, getNextNudgeMessage, isGlobalShortcutBlocked, onShortcutFeedback, TaskShortcutAction } from '@/lib/keyboard-shortcuts'
+import { dispatchTaskShortcut, findComposerElement, focusComposerInput, getNextNudgeMessage, insertIntoComposer, isGlobalShortcutBlocked, onShortcutFeedback, shouldAutoFocusComposer, TaskShortcutAction } from '@/lib/keyboard-shortcuts'
 import { selectVoiceReady, useVoiceStore } from '@/stores/voice-store'
 import { composerCanSubmit, MASTERMIND_COMPOSER_KEY, sendComposerMessage, setActiveComposer } from '@/lib/voice-dictation-target'
 
@@ -368,6 +368,16 @@ export function AppLayout() {
     }, 0)
   }, [sidebarCollapsed, sidebarView])
 
+  const focusComposer = useCallback(() => {
+    // Try to focus the composer for the active task; falls back to any visible composer
+    if (focusComposerInput()) {
+      captureAnalyticsEvent('composer_focused', { source: 'keyboard', trigger: 'shortcut' })
+      return true
+    }
+    showToast('No message composer is available', true)
+    return false
+  }, [showToast])
+
   const completeActiveTask = useCallback(() => {
     if (activeTaskId) dispatchTaskShortcut({ action: TaskShortcutAction.COMPLETE, taskId: activeTaskId })
     else showToast('Select a task first', true)
@@ -434,6 +444,7 @@ export function AppLayout() {
     openTask: openSelectedTask,
     clearSelection: clearTaskSelection,
     focusSearch,
+    focusComposer,
     completeTask: completeActiveTask,
     snoozeTask: () => runTaskShortcut(TaskShortcutAction.SNOOZE),
     runTask: () => runTaskShortcut(TaskShortcutAction.RUN),
@@ -453,7 +464,7 @@ export function AppLayout() {
     copyPullRequestBranch: () => runTaskShortcut(TaskShortcutAction.COPY_PR_BRANCH),
     toggleTaskAudio,
     toggleMastermindAudio
-  }), [clearTaskSelection, completeActiveTask, deleteActiveTask, focusSearch, navigateVisibleTask, nudgeActiveTask, openActiveTaskOnCanvas, openParentTask, openSelectedTask, openSubtasks, runActiveHeartbeat, runTaskShortcut, toggleMastermindAudio, toggleTaskAudio])
+  }), [clearTaskSelection, completeActiveTask, deleteActiveTask, focusComposer, focusSearch, navigateVisibleTask, nudgeActiveTask, openActiveTaskOnCanvas, openParentTask, openSelectedTask, openSubtasks, runActiveHeartbeat, runTaskShortcut, toggleMastermindAudio, toggleTaskAudio])
 
   const overdueCount = useMemo(
     () => tasks.filter(
@@ -594,6 +605,22 @@ export function AppLayout() {
       if (sidebarView === 'canvas') return
       if (e.repeat && key !== 'j' && key !== 'k') return
 
+      // Explicit composer focus (I) — before single-letter task shortcuts
+      if (key === 'i' && !e.shiftKey) { e.preventDefault(); focusComposer(); return }
+
+      // Just start typing: any printable key that is not a defined shortcut focuses the
+      // composer and inserts the character, so the first keystroke is not lost.
+      if (shouldAutoFocusComposer(e)) {
+        const composer = findComposerElement()
+        if (composer) {
+          e.preventDefault()
+          composer.focus()
+          insertIntoComposer(composer, e.key)
+          captureAnalyticsEvent('composer_focused', { source: 'keyboard', trigger: 'auto_type' })
+          return
+        }
+      }
+
       if (key === 'j') { e.preventDefault(); navigateVisibleTask(1) }
       else if (key === 'k') { e.preventDefault(); navigateVisibleTask(-1) }
       else if (e.key === 'Enter' && !(e.target as HTMLElement | null)?.closest('button, a')) { e.preventDefault(); openSelectedTask() }
@@ -613,7 +640,7 @@ export function AppLayout() {
       window.removeEventListener('keydown', onKey)
       if (chordRef.current) window.clearTimeout(chordRef.current.timer)
     }
-  }, [activeModal, activeTaskId, clearTaskSelection, closeModal, completeActiveTask, deleteActiveTask, focusSearch, navigateVisibleTask, nudgeActiveTask, openActiveTaskOnCanvas, openCreateModal, openParentTask, openSelectedTask, openSubtasks, runActiveHeartbeat, runTaskShortcut, setShowOrchestrator, setSidebarView, showOrchestrator, sidebarView, toggleMastermindAudio, toggleTaskAudio])
+  }, [activeModal, activeTaskId, clearTaskSelection, closeModal, completeActiveTask, deleteActiveTask, focusComposer, focusSearch, navigateVisibleTask, nudgeActiveTask, openActiveTaskOnCanvas, openCreateModal, openParentTask, openSelectedTask, openSubtasks, runActiveHeartbeat, runTaskShortcut, setShowOrchestrator, setSidebarView, showOrchestrator, sidebarView, toggleMastermindAudio, toggleTaskAudio])
 
   return (
     <>

--- a/src/renderer/src/components/layout/CommandPalette.tsx
+++ b/src/renderer/src/components/layout/CommandPalette.tsx
@@ -32,6 +32,7 @@ export interface CommandPaletteActions {
   openTask: () => void
   clearSelection: () => void
   focusSearch: () => void
+  focusComposer: () => void
   completeTask: () => void
   nudgeTask: () => void
   snoozeTask: () => void
@@ -97,6 +98,8 @@ export function CommandPalette({ open, onOpenChange, actions }: { open: boolean;
       { id: 'nav-open-task', group: 'Navigation', label: 'Open selected task', icon: ExternalLink, shortcut: 'Enter', run: () => { actions.openTask(); close() } },
       { id: 'nav-clear-task', group: 'Navigation', label: 'Clear task selection', icon: LogOut, shortcut: 'Esc', run: () => { actions.clearSelection(); close() } },
       { id: 'nav-focus-search', group: 'Navigation', label: 'Focus search', icon: Search, shortcut: '/', run: () => { close(); window.setTimeout(actions.focusSearch, 0) } },
+      { id: 'nav-focus-composer', group: 'Navigation', label: 'Focus message composer', icon: Search, shortcut: 'I', run: () => { close(); window.setTimeout(actions.focusComposer, 0) } },
+      { id: 'nav-type-composer', group: 'Navigation', label: 'Just start typing to focus composer', icon: Search, run: () => { close(); window.setTimeout(actions.focusComposer, 0) } },
       { id: 'act-new-task', group: 'Task actions', label: 'New Task', icon: Plus, keywords: 'create add', shortcut: 'C', run: () => { openCreateModal(); close() } },
       { id: 'act-complete-task', group: 'Task actions', label: 'Complete selected task', icon: CircleCheck, shortcut: 'E', run: () => { actions.completeTask(); close() } },
       { id: 'act-snooze-task', group: 'Task actions', label: 'Snooze selected task', icon: Clock3, shortcut: 'H', run: () => { actions.snoozeTask(); close() } },

--- a/src/renderer/src/lib/keyboard-shortcuts.test.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import {
   dispatchTaskShortcut,
+  findComposerElement,
+  focusComposerInput,
   getNextNudgeMessage,
+  insertIntoComposer,
   isGlobalShortcutBlocked,
   isKeyboardInput,
+  isPrintableKey,
   KEYBOARD_SHORTCUT_GROUPS,
   onTaskShortcut,
+  shouldAutoFocusComposer,
   TaskShortcutAction
 } from './keyboard-shortcuts'
 
@@ -53,5 +58,84 @@ describe('keyboard shortcuts', () => {
       expect.objectContaining({ keys: ['G', 'C'], label: 'Open selected task on Canvas or go to Canvas' }),
       expect.objectContaining({ keys: ['Shift', 'H'], label: 'Run heartbeat now' })
     ]))
+  })
+
+  it('lists the focus composer shortcuts', () => {
+    const shortcuts = KEYBOARD_SHORTCUT_GROUPS.reduce<Array<{ keys: readonly string[]; label: string }>>(
+      (all, group) => [...all, ...group.shortcuts],
+      []
+    )
+    expect(shortcuts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ keys: ['I'], label: 'Focus message composer' }),
+      expect.objectContaining({ keys: ['Type'], label: 'Just start typing to focus composer' })
+    ]))
+  })
+
+  it('focuses the composer textarea when present', () => {
+    const textarea = document.createElement('textarea')
+    textarea.setAttribute('placeholder', 'Write a message...')
+    const wrapper = document.createElement('div')
+    wrapper.setAttribute('data-testid', 'transcript-composer')
+    wrapper.appendChild(textarea)
+    document.body.appendChild(wrapper)
+    // jsdom offsetParent is null by default; simulate visible
+    Object.defineProperty(textarea, 'offsetParent', { get: () => wrapper, configurable: true })
+
+    expect(findComposerElement()).toBe(textarea)
+    expect(focusComposerInput()).toBe(true)
+    expect(document.activeElement).toBe(textarea)
+
+    document.body.removeChild(wrapper)
+  })
+
+  it('detects printable keys for auto-focus', () => {
+    expect(isPrintableKey(new KeyboardEvent('keydown', { key: 'a' }))).toBe(true)
+    expect(isPrintableKey(new KeyboardEvent('keydown', { key: 'A' }))).toBe(true)
+    expect(isPrintableKey(new KeyboardEvent('keydown', { key: '1' }))).toBe(true)
+    expect(isPrintableKey(new KeyboardEvent('keydown', { key: 'Enter' }))).toBe(false)
+    expect(isPrintableKey(new KeyboardEvent('keydown', { key: 'Escape' }))).toBe(false)
+    expect(isPrintableKey(new KeyboardEvent('keydown', { key: 'a', metaKey: true }))).toBe(false)
+    expect(isPrintableKey(new KeyboardEvent('keydown', { key: 'a', ctrlKey: true }))).toBe(false)
+  })
+
+  it('does not auto-focus on shortcut keys but does on other printable keys', () => {
+    const textarea = document.createElement('textarea')
+    textarea.setAttribute('placeholder', 'Write a message...')
+    const wrapper = document.createElement('div')
+    wrapper.setAttribute('data-testid', 'transcript-composer')
+    wrapper.appendChild(textarea)
+    document.body.appendChild(wrapper)
+    Object.defineProperty(textarea, 'offsetParent', { get: () => wrapper, configurable: true })
+
+    // Shortcut keys should not auto-focus
+    expect(shouldAutoFocusComposer(new KeyboardEvent('keydown', { key: 'c' }))).toBe(false)
+    expect(shouldAutoFocusComposer(new KeyboardEvent('keydown', { key: 'j' }))).toBe(false)
+    expect(shouldAutoFocusComposer(new KeyboardEvent('keydown', { key: '/' }))).toBe(false)
+    expect(shouldAutoFocusComposer(new KeyboardEvent('keydown', { key: 'g' }))).toBe(false)
+    // Non-shortcut printable keys should auto-focus
+    expect(shouldAutoFocusComposer(new KeyboardEvent('keydown', { key: 'a' }))).toBe(true)
+    expect(shouldAutoFocusComposer(new KeyboardEvent('keydown', { key: 'z' }))).toBe(true)
+    expect(shouldAutoFocusComposer(new KeyboardEvent('keydown', { key: '1' }))).toBe(true)
+    expect(shouldAutoFocusComposer(new KeyboardEvent('keydown', { key: '.' }))).toBe(true)
+
+    document.body.removeChild(wrapper)
+  })
+
+  it('inserts text into the composer at cursor', () => {
+    const textarea = document.createElement('textarea')
+    textarea.value = 'hello'
+    textarea.setSelectionRange(5, 5)
+    insertIntoComposer(textarea, '!')
+    expect(textarea.value).toBe('hello!')
+    expect(textarea.selectionStart).toBe(6)
+  })
+
+  it('blocks auto-focus when typing in an input', () => {
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    const event = new KeyboardEvent('keydown', { key: 'a', bubbles: true })
+    Object.defineProperty(event, 'target', { value: input })
+    expect(shouldAutoFocusComposer(event)).toBe(false)
+    document.body.removeChild(input)
   })
 })

--- a/src/renderer/src/lib/keyboard-shortcuts.ts
+++ b/src/renderer/src/lib/keyboard-shortcuts.ts
@@ -33,6 +33,8 @@ export const KEYBOARD_SHORTCUT_GROUPS = [
       { keys: ['G', 'T'], label: 'Go to Tasks' },
       { keys: ['G', 'S'], label: 'Go to Skills' },
       { keys: ['/'], label: 'Focus search' },
+      { keys: ['I'], label: 'Focus message composer' },
+      { keys: ['Type'], label: 'Just start typing to focus composer' },
       { keys: ['Cmd/Ctrl', 'K'], label: 'Open command palette' },
       { keys: ['Cmd/Ctrl', '1–4'], label: 'Switch main view' }
     ]
@@ -100,6 +102,63 @@ export function isGlobalShortcutBlocked(event: KeyboardEvent): boolean {
     || event.altKey
     || isKeyboardInput(event.target)
     || !!document.querySelector('[role="dialog"], [role="alertdialog"]')
+}
+
+export function findComposerElement(): HTMLTextAreaElement | null {
+  const candidates = [
+    '[data-testid="transcript-composer"] textarea',
+    'textarea[aria-label="Kickoff instructions"]',
+    'textarea[placeholder="Write a message..."]',
+    'textarea[placeholder="Add kickoff instructions…"]'
+  ]
+  for (const selector of candidates) {
+    const el = document.querySelector<HTMLTextAreaElement>(selector)
+    if (el && !el.disabled && el.offsetParent !== null) return el
+  }
+  // Fallback: any visible composer textarea inside the task workspace
+  const fallback = document.querySelector<HTMLTextAreaElement>('[data-voice-composer] textarea')
+  if (fallback && !fallback.disabled && fallback.offsetParent !== null) return fallback
+  return null
+}
+
+export function focusComposerInput(): boolean {
+  const el = findComposerElement()
+  if (!el) return false
+  el.focus()
+  return document.activeElement === el
+}
+
+export function isPrintableKey(event: KeyboardEvent): boolean {
+  return event.key.length === 1 && !event.metaKey && !event.ctrlKey && !event.altKey
+}
+
+const SINGLE_KEY_SHORTCUTS = new Set(['j', 'k', 'c', 'e', 'h', 'r', 'w', '#', '?', '/', 'i'])
+const CHORD_STARTERS = new Set(['g', 'o', 'y', 'v'])
+
+export function shouldAutoFocusComposer(event: KeyboardEvent): boolean {
+  if (isGlobalShortcutBlocked(event)) return false
+  if (!isPrintableKey(event)) return false
+  const lower = event.key.toLowerCase()
+  if (SINGLE_KEY_SHORTCUTS.has(lower) || CHORD_STARTERS.has(lower)) return false
+  const composer = findComposerElement()
+  return !!composer
+}
+
+export function insertIntoComposer(composer: HTMLTextAreaElement, text: string): void {
+  const start = composer.selectionStart ?? composer.value.length
+  const end = composer.selectionEnd ?? composer.value.length
+  const before = composer.value.slice(0, start)
+  const after = composer.value.slice(end)
+  const next = before + text + after
+  const proto = HTMLTextAreaElement.prototype
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set
+  if (setter) setter.call(composer, next)
+  else composer.value = next
+  const cursor = start + text.length
+  composer.setSelectionRange(cursor, cursor)
+  composer.dispatchEvent(new Event('input', { bubbles: true }))
+  // Ensure auto-resize handlers run
+  composer.dispatchEvent(new Event('change', { bubbles: true }))
 }
 
 export function dispatchTaskShortcut(detail: TaskShortcutDetail): void {


### PR DESCRIPTION
## Summary
- Press `I` to focus the visible message composer (transcript or kickoff textarea)
- Just start typing any printable key (excluding existing single-letter shortcuts J/K/C/E/H/R/W and chord starters G/O/Y/V) auto-focuses the composer and inserts the first character so no keystroke is lost
- Shared helpers in `src/renderer/src/lib/keyboard-shortcuts.ts`: `findComposerElement`, `focusComposerInput`, `isPrintableKey`, `shouldAutoFocusComposer`, `insertIntoComposer`
- Exposed via Command Palette (`Focus message composer` / `Just start typing to focus composer`) and Keyboard Shortcuts dialog (Navigation: `I`, `Type`)
- Respects guards: dialogs, inputs, xterm, canvas view, modifier keys

## Testing
- Extended `keyboard-shortcuts.test.ts` (11 tests): focus helper, printable detection, auto-focus allow/block, insertion, dialog/input guards
- Full `pnpm test` passes: 2702 passed, 4 skipped (renderer 941, main + shared)

## Key combos
- `I` — explicit focus composer
- Just type — any printable character (a-z, 0-9, punctuation) not bound to a shortcut focuses composer