### PR TITLE
Add Organisation Workspace discovery guidance

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -591,6 +591,8 @@ describe('AgentManager skill file paths', () => {
       for (const md of [agentsMd, claudeMd]) {
         expect(md).toContain('Organisation Workspace discovery')
         expect(md).toContain('do a short read-only discovery pass')
+        expect(md).toContain('Permissions, toolset settings, and connected services can hide')
+        expect(md).toContain('not evidence that the data does not exist')
         expect(md).toContain('`integrations_list`')
         expect(md).toContain('`workflow_list`')
         expect(md).toContain('`report_schema`')

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -566,6 +566,46 @@ describe('AgentManager skill file paths', () => {
       expect(md).toContain('task-management (1 tools)')
       expect(md).not.toContain('configured-server')
     })
+
+    it('adds Workflo discovery guidance even when the cached tool list is empty', () => {
+      const workflo = {
+        id: 'srv-workflo',
+        name: '[Workflo] MCP Dev Server',
+        type: 'remote',
+        url: 'https://api.peakflo.ai/api/mcp/dev/mcp',
+        headers: {},
+        tools: [],
+        source: 'enterprise'
+      }
+      const mockDb = createMockDb({ mcp_servers: ['srv-workflo'] }) as any
+      mockDb.getMcpServer = vi.fn(() => workflo)
+      mockDb.getMcpServers = vi.fn(() => [workflo])
+      manager = new AgentManager(mockDb)
+      const injected = {
+        '[Workflo] MCP Dev Server': { type: 'http', url: 'http://127.0.0.1:5555/proxy-id' }
+      }
+
+      const agentsMd: string = (manager as any).generateAgentsMd([], [], '/tmp/ws', 'agent-1', injected)
+      const claudeMd: string = (manager as any).generateClaudeMd([], [], '/tmp/ws', 'agent-1', injected)
+
+      for (const md of [agentsMd, claudeMd]) {
+        expect(md).toContain('Workflo workspace discovery')
+        expect(md).toContain('do a short read-only discovery pass')
+        expect(md).toContain('`integrations_list`')
+        expect(md).toContain('`workflow_list`')
+        expect(md).toContain('`report_schema`')
+      }
+    })
+
+    it('does not add Workflo discovery guidance for unrelated MCP servers', () => {
+      manager = new AgentManager(makeMcpDb())
+
+      const md: string = (manager as any).generateAgentsMd([], [], '/tmp/ws', 'agent-1', {
+        'configured-server': { type: 'stdio', command: '/bin/configured', args: ['a.js'] }
+      })
+
+      expect(md).not.toContain('Workflo workspace discovery')
+    })
   })
 
   describe('getMemoryFileName', () => {

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -570,7 +570,7 @@ describe('AgentManager skill file paths', () => {
     it('adds Workflo discovery guidance even when the cached tool list is empty', () => {
       const workflo = {
         id: 'srv-workflo',
-        name: '[Workflo] MCP Dev Server',
+        name: '[Workflo] Organisation Workspace',
         type: 'remote',
         url: 'https://api.peakflo.ai/api/mcp/dev/mcp',
         headers: {},
@@ -582,14 +582,14 @@ describe('AgentManager skill file paths', () => {
       mockDb.getMcpServers = vi.fn(() => [workflo])
       manager = new AgentManager(mockDb)
       const injected = {
-        '[Workflo] MCP Dev Server': { type: 'http', url: 'http://127.0.0.1:5555/proxy-id' }
+        '[Workflo] Organisation Workspace': { type: 'http', url: 'http://127.0.0.1:5555/proxy-id' }
       }
 
       const agentsMd: string = (manager as any).generateAgentsMd([], [], '/tmp/ws', 'agent-1', injected)
       const claudeMd: string = (manager as any).generateClaudeMd([], [], '/tmp/ws', 'agent-1', injected)
 
       for (const md of [agentsMd, claudeMd]) {
-        expect(md).toContain('Workflo workspace discovery')
+        expect(md).toContain('Organisation Workspace discovery')
         expect(md).toContain('do a short read-only discovery pass')
         expect(md).toContain('`integrations_list`')
         expect(md).toContain('`workflow_list`')
@@ -604,7 +604,7 @@ describe('AgentManager skill file paths', () => {
         'configured-server': { type: 'stdio', command: '/bin/configured', args: ['a.js'] }
       })
 
-      expect(md).not.toContain('Workflo workspace discovery')
+      expect(md).not.toContain('Organisation Workspace discovery')
     })
   })
 
@@ -1165,7 +1165,7 @@ describe('AgentManager MCP server routing', () => {
       })),
       getMcpServer: vi.fn(() => ({
         id: 'workflo-stage-server',
-        name: '[Workflo] MCP Dev Server',
+        name: '[Workflo] Organisation Workspace',
         type: 'remote',
         url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
         headers: {},
@@ -1182,7 +1182,7 @@ describe('AgentManager MCP server routing', () => {
 
     const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
 
-    expect(mcpServers['[Workflo] MCP Dev Server']).toMatchObject({
+    expect(mcpServers['[Workflo] Organisation Workspace']).toMatchObject({
       type: 'http',
       url: 'https://api.peakflo.ai/api/mcp/dev/mcp',
       headers: { Authorization: 'Bearer fresh-prod-jwt' },
@@ -1205,7 +1205,7 @@ describe('AgentManager MCP server routing', () => {
       })),
       getMcpServer: vi.fn(() => ({
         id: 'tan-insurance-workflo',
-        name: '[Workflo] MCP Dev Server',  // user copied the canonical name
+        name: '[Workflo] Organisation Workspace',  // user copied the canonical name
         type: 'remote',
         url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',  // and the canonical URL
         headers: {},
@@ -1222,13 +1222,13 @@ describe('AgentManager MCP server routing', () => {
 
     const mcpServers = await (manager as any).buildMcpServersForAdapter('agent-1')
 
-    expect(mcpServers['[Workflo] MCP Dev Server']).toMatchObject({
+    expect(mcpServers['[Workflo] Organisation Workspace']).toMatchObject({
       type: 'http',
       // URL is NOT rewritten — user pointed at stage, request goes to stage
       url: 'https://stage-api.peakflo.ai/api/mcp/dev/mcp',
     })
     // No Authorization injected — user didn't set one and the proxy is not invoked
-    expect(mcpServers['[Workflo] MCP Dev Server'].headers).not.toHaveProperty('Authorization')
+    expect(mcpServers['[Workflo] Organisation Workspace'].headers).not.toHaveProperty('Authorization')
   })
 
   it('respects a user-supplied Authorization header even when an enterprise-sourced row carries one (defence-in-depth)', async () => {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -57,15 +57,15 @@ const WORKFLO_WORKSPACE_DISCOVERY_GUIDANCE = `### Organisation Workspace discove
 
 The Organisation Workspace is the source of truth for this tenant's live data. When a request can depend on the tenant's workflows, connected apps, tables, reports, or Business Context, do a short read-only discovery pass before you plan or answer. Do not wait for the user to name a tool.
 
-Use the discovery tools that this session exposes:
+First inspect the tools that this session exposes. Permissions, toolset settings, and connected services can hide a category or an individual tool. The names below are possible routes, not a guaranteed tool list. Use a route only when its tools are available:
 
-- Workflows: \`workflow_list\`, then \`workflow_get\` when one is relevant.
-- Connected apps: \`integrations_list\`, then \`integration_mcp_tools_list\` before \`integration_mcp_tool_call\`.
-- Tables: \`table_list\`, then \`table_schema\` and \`table_query\` or \`table_sql\`.
-- Reports and analytics: \`report_schema\`, then \`report_schema_detail\` and \`report_query\`.
-- Business Context: \`datastore_list\` and \`datastore_query\`, or \`datastore_discover\` and \`datastore_get_document\` for provisioned reference documents.
+- Workflows, when available: \`workflow_list\`, then \`workflow_get\` when one is relevant.
+- Connected apps, when available: \`integrations_list\`, then \`integration_mcp_tools_list\` before a permitted \`integration_mcp_tool_call\`.
+- Tables, when available: \`table_list\`, then \`table_schema\` and \`table_query\` or \`table_sql\`.
+- Reports and analytics, when available: \`report_schema\`, then \`report_schema_detail\` and \`report_query\`.
+- Business Context, when available: \`datastore_list\` and \`datastore_query\`, or \`datastore_discover\` and \`datastore_get_document\` for provisioned reference documents.
 
-These first calls inspect available data. Use execute or write tools only when the task requires a change. Treat an empty discovery result as useful evidence and report it clearly.
+These first calls inspect available data. Use execute or write tools only when the task requires a change. Treat an empty successful result as useful evidence. A missing tool or a permission error is not evidence that the data does not exist. Report the access limit clearly.
 
 `
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -53,9 +53,9 @@ const WORKFLO_MCP_DEV_PATH = '/api/mcp/dev/mcp'
  * present for Codex, Claude Code, OpenCode, Pi, and ACP sessions even when the
  * server's cached tool list is empty.
  */
-const WORKFLO_WORKSPACE_DISCOVERY_GUIDANCE = `### Workflo workspace discovery
+const WORKFLO_WORKSPACE_DISCOVERY_GUIDANCE = `### Organisation Workspace discovery
 
-The Workflo MCP Dev Server is the source of truth for this tenant's live data. When a request can depend on the tenant's workflows, connected apps, tables, reports, or Business Context, do a short read-only discovery pass before you plan or answer. Do not wait for the user to name a tool.
+The Organisation Workspace is the source of truth for this tenant's live data. When a request can depend on the tenant's workflows, connected apps, tables, reports, or Business Context, do a short read-only discovery pass before you plan or answer. Do not wait for the user to name a tool.
 
 Use the discovery tools that this session exposes:
 

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -47,6 +47,28 @@ For every standalone user-facing deliverable, first call \`create_artifact\` on 
 const DEFAULT_SERVER_URL = 'http://localhost:4096'
 const WORKFLO_MCP_DEV_PATH = '/api/mcp/dev/mcp'
 
+/**
+ * Agent backends do not all pass the MCP `initialize.instructions` field to
+ * the model. Put the same discovery rule in the workspace context so it is
+ * present for Codex, Claude Code, OpenCode, Pi, and ACP sessions even when the
+ * server's cached tool list is empty.
+ */
+const WORKFLO_WORKSPACE_DISCOVERY_GUIDANCE = `### Workflo workspace discovery
+
+The Workflo MCP Dev Server is the source of truth for this tenant's live data. When a request can depend on the tenant's workflows, connected apps, tables, reports, or Business Context, do a short read-only discovery pass before you plan or answer. Do not wait for the user to name a tool.
+
+Use the discovery tools that this session exposes:
+
+- Workflows: \`workflow_list\`, then \`workflow_get\` when one is relevant.
+- Connected apps: \`integrations_list\`, then \`integration_mcp_tools_list\` before \`integration_mcp_tool_call\`.
+- Tables: \`table_list\`, then \`table_schema\` and \`table_query\` or \`table_sql\`.
+- Reports and analytics: \`report_schema\`, then \`report_schema_detail\` and \`report_query\`.
+- Business Context: \`datastore_list\` and \`datastore_query\`, or \`datastore_discover\` and \`datastore_get_document\` for provisioned reference documents.
+
+These first calls inspect available data. Use execute or write tools only when the task requires a change. Treat an empty discovery result as useful evidence and report it clearly.
+
+`
+
 interface TodoItem {
   content: string
   status: string
@@ -199,6 +221,14 @@ interface DocumentedMcpServer {
   server: McpServerRecord
   enabledTools?: string[]
   injected?: McpServerConfig
+}
+
+function hasWorkfloMcpDevServer(entries: DocumentedMcpServer[]): boolean {
+  return entries.some(({ server, injected }) => {
+    if (isWorkfloMcpDevServerUrl(server.url ?? undefined)) return true
+    if (injected?.type !== 'http' && injected?.type !== 'sse') return false
+    return isWorkfloMcpDevServerUrl(injected.url)
+  })
 }
 
 export class AgentManager extends EventEmitter {
@@ -1280,6 +1310,10 @@ export class AgentManager extends EventEmitter {
         md += `## Available MCP Servers & Tools\n\n`
         md += `This session has access to the following Model Context Protocol (MCP) servers and their tools:\n\n`
 
+        if (hasWorkfloMcpDevServer(documentedServers)) {
+          md += WORKFLO_WORKSPACE_DISCOVERY_GUIDANCE
+        }
+
         for (const entry of documentedServers) {
           const { server: mcpServer, enabledTools } = entry
           const transport = AgentManager.describeMcpTransport(entry)
@@ -1396,6 +1430,10 @@ export class AgentManager extends EventEmitter {
       if (documentedServers.length > 0) {
         md += `## MCP Tools Available\n\n`
         md += `You have access to the following tools through Model Context Protocol (MCP) servers:\n\n`
+
+        if (hasWorkfloMcpDevServer(documentedServers)) {
+          md += WORKFLO_WORKSPACE_DISCOVERY_GUIDANCE
+        }
 
         for (const { server: mcpServer, enabledTools } of documentedServers) {
           if (mcpServer.tools && mcpServer.tools.length > 0) {

--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -252,7 +252,7 @@ describe('MCP Server CRUD', () => {
 
   it("persists `source: 'enterprise'` when set explicitly (used by EnterpriseSyncManager)", () => {
     const server = db.createMcpServer({
-      name: '[Workflo] MCP Dev Server',
+      name: '[Workflo] Organisation Workspace',
       type: 'remote',
       url: 'https://api.peakflo.ai/api/mcp/dev/mcp',
       source: 'enterprise'

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1204,21 +1204,35 @@ export function registerIpcHandlers(
         // workflows-as-tools, integrations, datastores, and data tables).
         // Uses the enterprise JWT for authentication — no separate API key needed.
         try {
-          const mcpDevServerName = '[Workflo] MCP Dev Server'
+          const mcpDevServerName = '[Workflo] Organisation Workspace'
+          const legacyMcpDevServerName = '[Workflo] MCP Dev Server'
           const apiUrl = enterpriseAuth!.getApiUrl()
           const mcpDevUrl = `${apiUrl}/api/mcp/dev/mcp`
 
           const localServers = db.getMcpServers()
-          const existingMcpDev = localServers.find((s) => s.name === mcpDevServerName)
+          const existingMcpDev =
+            localServers.find((s) => s.name === mcpDevServerName) ??
+            localServers.find(
+              (s) =>
+                s.name === legacyMcpDevServerName &&
+                s.source === 'enterprise'
+            )
 
           if (existingMcpDev) {
             // Update URL and ensure source is 'enterprise' (may be missing on
             // servers created before this fix). Also handles env changes
             // (e.g. local → stage → prod).
-            const needsUpdate = existingMcpDev.url !== mcpDevUrl || existingMcpDev.source !== 'enterprise'
+            const needsUpdate =
+              existingMcpDev.name !== mcpDevServerName ||
+              existingMcpDev.url !== mcpDevUrl ||
+              existingMcpDev.source !== 'enterprise'
             if (needsUpdate) {
-              db.updateMcpServer(existingMcpDev.id, { url: mcpDevUrl, source: 'enterprise' })
-              console.log('[enterprise] Updated MCP Dev Server URL:', mcpDevUrl)
+              db.updateMcpServer(existingMcpDev.id, {
+                name: mcpDevServerName,
+                url: mcpDevUrl,
+                source: 'enterprise'
+              })
+              console.log('[enterprise] Updated Organisation Workspace:', mcpDevUrl)
             }
           } else {
             db.createMcpServer({
@@ -1231,7 +1245,7 @@ export function registerIpcHandlers(
               // layer (via EnterpriseAuth.getJwt()), not stored statically here.
               // The MCP client retrieves a fresh JWT before each connection.
             })
-            console.log('[enterprise] Registered MCP Dev Server:', mcpDevUrl)
+            console.log('[enterprise] Registered Organisation Workspace:', mcpDevUrl)
           }
         } catch (mcpErr) {
           console.warn('[enterprise] Failed to register MCP Dev Server (non-fatal):', mcpErr)

--- a/src/main/mcp-auth-proxy.test.ts
+++ b/src/main/mcp-auth-proxy.test.ts
@@ -224,7 +224,7 @@ describe('MCP Auth Proxy', () => {
 
   it('returns 502 when auth fails and includes integration name in error', async () => {
     await startMcpAuthProxy(mockAuth as never)
-    const proxyUrl = registerMcpProxyTarget(`http://127.0.0.1:${upstream.port}`, '[Workflo] MCP Dev Server')!
+    const proxyUrl = registerMcpProxyTarget(`http://127.0.0.1:${upstream.port}`, '[Workflo] Organisation Workspace')!
 
     mockAuth.setFail(true)
 
@@ -232,7 +232,7 @@ describe('MCP Auth Proxy', () => {
     expect(response.status).toBe(502)
     const data = await response.json()
     expect(data.error).toContain('Failed to obtain auth token')
-    expect(data.error).toContain('[Workflo] MCP Dev Server')
+    expect(data.error).toContain('[Workflo] Organisation Workspace')
   })
 
   it('returns 502 with fallback label when no label was set', async () => {

--- a/src/main/mcp-auth-proxy.ts
+++ b/src/main/mcp-auth-proxy.ts
@@ -33,7 +33,7 @@ let authRef: EnterpriseAuth | null = null
 // Registration ID → target URL
 const targets = new Map<string, string>()
 
-// Registration ID → human-readable integration label (e.g. "[Workflo] MCP Dev Server")
+// Registration ID → human-readable integration label (e.g. "[Workflo] Organisation Workspace")
 const targetLabels = new Map<string, string>()
 
 // Reverse lookup: target URL → ID (deduplicates repeated registrations)


### PR DESCRIPTION
## Summary
- rename the user-facing Workflo MCP server to Organisation Workspace
- migrate the existing enterprise-managed server record in place and keep its ID
- add Organisation Workspace discovery guidance to generated AGENTS.md and CLAUDE.md
- show the rule even when the cached MCP tool list is empty
- state that permissions, toolset settings, and connected services control which routes exist
- separate an empty successful result from a missing tool or permission error
- separate read-only discovery from write and execute actions

## Compatibility
- keep the MCP Dev Server route and internal protocol names unchanged
- do not rename user-created servers that use the old label

## Validation
- agent-manager focused tests: 147 passed
- full suite: 2704 passed, 4 skipped
- lint completed with existing warnings only
- typecheck and production build passed