### PR TITLE
Use server task commands and remove local-only completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "20x",
-  "version": "0.0.145",
+  "version": "0.0.146",
   "packageManager": "pnpm@9.15.2",
   "description": "20x — AI-powered desktop task manager",
   "main": "./out/main/index.js",

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1329,102 +1329,19 @@ describe('AgentManager transitionToIdle — completing without review', () => {
     return { mgr, session }
   }
 
-  it('completes the task in main, with no renderer involved', async () => {
-    const mockDb = makeDb()
-    const { mgr, session } = setup(mockDb)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-    expect(mockDb.updateTask).not.toHaveBeenCalledWith('task-1', { status: TaskStatus.ReadyForReview })
+  it.each([true,false])('desktop work requires server review with auto-complete=%s', async auto => {
+    const mockDb=makeDb({auto_complete_without_review:auto});const {mgr,session}=setup(mockDb)
+    const executeAction=vi.fn();mgr.setSyncManager({executeAction} as never)
+    await (mgr as any).transitionToIdle('session-1',session)
+    expect(mockDb.updateTask).not.toHaveBeenCalledWith('task-1',{status:TaskStatus.Completed})
+    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1',{status:TaskStatus.ReadyForReview})
+    expect(executeAction).not.toHaveBeenCalled()
   })
-
-  it('leaves an unflagged task for review, as before', async () => {
-    const mockDb = makeDb({ auto_complete_without_review: false })
-    const { mgr, session } = setup(mockDb)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.ReadyForReview })
-    expect(mockDb.updateTask).not.toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-  })
-
-  it('tells the source system before completing an enterprise task', async () => {
-    const mockDb = makeDb({ source_id: 'source-1' })
-    const { mgr, session } = setup(mockDb)
-    const syncManager = { executeAction: vi.fn().mockResolvedValue({ success: true }) }
-    mgr.setSyncManager(syncManager as any)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    expect(syncManager.executeAction).toHaveBeenCalledWith(
-      'complete',
-      expect.objectContaining({ id: 'task-1' }),
-      undefined,
-      'source-1'
-    )
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-  })
-
-  it('never marks it done locally when the source system refuses', async () => {
-    const mockDb = makeDb({ source_id: 'source-1' })
-    const { mgr, session } = setup(mockDb)
-    const syncManager = {
-      executeAction: vi.fn().mockResolvedValue({ success: false, error: 'upstream rejected' }),
-    }
-    mgr.setSyncManager(syncManager as any)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    // Completed there but not here would leave the two systems disagreeing.
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.ReadyForReview })
-    expect(mockDb.updateTask).not.toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-  })
-
-  /**
-   * The same completion has to be reachable without a session.
-   *
-   * A task can land in ready_for_review by routes that never run
-   * transitionToIdle — a coordinator marking its parent once every subtask is
-   * done, an MCP client setting the status, the mobile API. Those routes used
-   * to ignore auto_complete_without_review entirely, which is why a recurring
-   * task could reach review and then sit there for ever.
-   */
-  describe('completeTaskWithoutReview — no session required', () => {
-    it('completes a task that no session is attached to', async () => {
-      const mockDb = makeDb({ status: TaskStatus.ReadyForReview })
-      const mgr = new AgentManager(mockDb)
-      vi.spyOn(mgr as any, 'sendToRenderer').mockImplementation(() => undefined)
-
-      await expect(mgr.completeTaskWithoutReview('task-1')).resolves.toBe(true)
-
-      expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-    })
-
-    it('reports failure and leaves the task in review when the source refuses', async () => {
-      const mockDb = makeDb({ status: TaskStatus.ReadyForReview, source_id: 'source-1' })
-      const mgr = new AgentManager(mockDb)
-      vi.spyOn(mgr as any, 'sendToRenderer').mockImplementation(() => undefined)
-      mgr.setSyncManager({
-        executeAction: vi.fn().mockResolvedValue({ success: false, error: 'upstream rejected' }),
-      } as any)
-
-      await expect(mgr.completeTaskWithoutReview('task-1')).resolves.toBe(false)
-
-      expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.ReadyForReview })
-      expect(mockDb.updateTask).not.toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-    })
-
-    it('does nothing for a task that no longer exists', async () => {
-      const mockDb = makeDb()
-      ;(mockDb.getTask as any).mockReturnValue(undefined)
-      const mgr = new AgentManager(mockDb)
-      vi.spyOn(mgr as any, 'sendToRenderer').mockImplementation(() => undefined)
-
-      await expect(mgr.completeTaskWithoutReview('task-gone')).resolves.toBe(false)
-
-      expect(mockDb.updateTask).not.toHaveBeenCalled()
-    })
+  it('cannot complete from a desktop agent without a server credential', async()=>{
+    const mockDb=makeDb();const {mgr}=setup(mockDb)
+    const executeAction=vi.fn();mgr.setSyncManager({executeAction} as never)
+    expect(await mgr.completeTaskWithoutReview('task-1')).toBe(false)
+    expect(mockDb.updateTask).not.toHaveBeenCalled();expect(executeAction).not.toHaveBeenCalled()
   })
 })
 
@@ -1479,189 +1396,12 @@ describe('AgentManager transitionToIdle — enterprise task completion after fee
     return { mgr, session }
   }
 
-  it('calls executeAction for enterprise tasks (source_id) before completing', async () => {
-    const mockDb = createEnterpriseTaskDb()
-    const { mgr, session } = setupManager(mockDb)
-
-    const mockSyncManager = {
-      executeAction: vi.fn().mockResolvedValue({ success: true, taskUpdate: { status: TaskStatus.Completed } }),
-    }
-    mgr.setSyncManager(mockSyncManager as any)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    // executeAction should be called with default 'complete' action
-    expect(mockSyncManager.executeAction).toHaveBeenCalledWith(
-      'complete',
-      expect.objectContaining({ id: 'task-1', source_id: 'source-1' }),
-      undefined,
-      'source-1'
-    )
-
-    // Task should be marked as Completed
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-  })
-
-  it('uses explicit action value from output_fields if present', async () => {
-    const mockDb = createEnterpriseTaskDb({
-      output_fields: [{ id: 'action', name: 'Action', type: 'text', value: 'approve' }],
-    })
-    const { mgr, session } = setupManager(mockDb)
-
-    const mockSyncManager = {
-      executeAction: vi.fn().mockResolvedValue({ success: true }),
-    }
-    mgr.setSyncManager(mockSyncManager as any)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    expect(mockSyncManager.executeAction).toHaveBeenCalledWith(
-      'approve',
-      expect.anything(),
-      undefined,
-      'source-1'
-    )
-  })
-
-  it('reverts to ReadyForReview when executeAction fails', async () => {
-    const mockDb = createEnterpriseTaskDb()
-    const { mgr, session } = setupManager(mockDb)
-
-    const mockSyncManager = {
-      executeAction: vi.fn().mockResolvedValue({ success: false, error: 'API unavailable' }),
-    }
-    mgr.setSyncManager(mockSyncManager as any)
-
-    const sendSpy = vi.spyOn(mgr as any, 'sendToRenderer')
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    // Task should be reverted to ReadyForReview
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.ReadyForReview })
-
-    // Renderer should be notified with ReadyForReview
-    const taskUpdatedCall = sendSpy.mock.calls.find(
-      (call) => call[0] === 'task:updated' && (call[1] as any)?.updates?.status === TaskStatus.ReadyForReview
-    )
-    expect(taskUpdatedCall).toBeDefined()
-
-    // Task should NOT be marked as Completed
-    const completedCall = (mockDb.updateTask as any).mock.calls.find(
-      (call: any[]) => call[1]?.status === TaskStatus.Completed
-    )
-    expect(completedCall).toBeUndefined()
-  })
-
-  it('reverts to ReadyForReview when executeAction throws', async () => {
-    const mockDb = createEnterpriseTaskDb()
-    const { mgr, session } = setupManager(mockDb)
-
-    const mockSyncManager = {
-      executeAction: vi.fn().mockRejectedValue(new Error('Network error')),
-    }
-    mgr.setSyncManager(mockSyncManager as any)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    // Task should be reverted to ReadyForReview
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.ReadyForReview })
-  })
-
-  it('skips executeAction for non-enterprise tasks (no source_id)', async () => {
-    const mockDb = createEnterpriseTaskDb({ source_id: null })
-    const { mgr, session } = setupManager(mockDb)
-
-    const mockSyncManager = {
-      executeAction: vi.fn().mockResolvedValue({ success: true }),
-    }
-    mgr.setSyncManager(mockSyncManager as any)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    // executeAction should NOT be called
-    expect(mockSyncManager.executeAction).not.toHaveBeenCalled()
-
-    // Task should still be marked as Completed
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-  })
-
-  // ── complete_at_source: the user's answer from the feedback dialog ──
-
-  it('skips executeAction when the user chose to update the source themselves', async () => {
-    const mockDb = createEnterpriseTaskDb({ complete_at_source: false })
-    const { mgr, session } = setupManager(mockDb)
-
-    const mockSyncManager = {
-      executeAction: vi.fn().mockResolvedValue({ success: true }),
-    }
-    mgr.setSyncManager(mockSyncManager as any)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    // The user closes it in the source system, so 20x must not.
-    expect(mockSyncManager.executeAction).not.toHaveBeenCalled()
-    // The task still completes locally.
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-  })
-
-  it('calls executeAction when the user chose to close it at the source', async () => {
-    const mockDb = createEnterpriseTaskDb({ complete_at_source: true })
-    const { mgr, session } = setupManager(mockDb)
-
-    const mockSyncManager = {
-      executeAction: vi.fn().mockResolvedValue({ success: true }),
-    }
-    mgr.setSyncManager(mockSyncManager as any)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    expect(mockSyncManager.executeAction).toHaveBeenCalled()
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-  })
-
-  it('still pushes to the source when nobody was asked (unattended run)', async () => {
-    const mockDb = createEnterpriseTaskDb({ complete_at_source: null })
-    const { mgr, session } = setupManager(mockDb)
-
-    const mockSyncManager = {
-      executeAction: vi.fn().mockResolvedValue({ success: true }),
-    }
-    mgr.setSyncManager(mockSyncManager as any)
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    expect(mockSyncManager.executeAction).toHaveBeenCalled()
-  })
-
-  it('tells the renderer when the source refuses the completion', async () => {
-    const mockDb = createEnterpriseTaskDb()
-    const { mgr, session } = setupManager(mockDb)
-
-    const mockSyncManager = {
-      executeAction: vi.fn().mockResolvedValue({ success: false, error: 'API unavailable' }),
-    }
-    mgr.setSyncManager(mockSyncManager as any)
-
-    const sendSpy = vi.spyOn(mgr as any, 'sendToRenderer')
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    // Without this event the task silently returns to review.
-    const failureCall = sendSpy.mock.calls.find((call) => call[0] === 'task:source-action-failed')
-    expect(failureCall).toBeDefined()
-    expect(failureCall?.[1]).toMatchObject({ taskId: 'task-1', error: 'API unavailable' })
-  })
-
-  it('skips executeAction when syncManager is not set', async () => {
-    const mockDb = createEnterpriseTaskDb()
-    const { mgr, session } = setupManager(mockDb)
-
-    // Do NOT set syncManager
-
-    await (mgr as any).transitionToIdle('session-1', session)
-
-    // Task should still be marked as Completed (graceful degradation)
-    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+  it('learning never completes with the human credential',async()=>{
+    const mockDb=createEnterpriseTaskDb();const {mgr,session}=setupManager(mockDb)
+    const executeAction=vi.fn();mgr.setSyncManager({executeAction} as never)
+    await (mgr as any).transitionToIdle('session-1',session)
+    expect(executeAction).not.toHaveBeenCalled()
+    expect(mockDb.updateTask).not.toHaveBeenCalledWith('task-1',{status:TaskStatus.Completed})
   })
 
   it('replays missed transcript parts before transitioning idle', async () => {
@@ -4044,5 +3784,19 @@ describe('AgentManager background subagent protection', () => {
 
       expect(resumeSpy).toHaveBeenCalledWith('real-id', expect.anything())
     })
+  })
+})
+
+describe('Workflo task execution owner', () => {
+  it('refuses a desktop session for autonomous server work', async () => {
+    const db = createMockDb()
+    vi.mocked(db.getSetting).mockImplementation(key => key === 'workflo-task:task-1' ? JSON.stringify({ executionMode: 'autonomous' }) : undefined)
+    await expect(new AgentManager(db).startSession('agent-1', 'task-1', '/tmp/workflo-guard')).rejects.toThrow('Task help runs in Workflo')
+  })
+
+  it('refuses a desktop session while task upload is pending', async () => {
+    const db = createMockDb()
+    vi.mocked(db.getSetting).mockImplementation(key => key === 'workflo-upload:task-1' ? '{}' : undefined)
+    await expect(new AgentManager(db).startSession('agent-1', 'task-1', '/tmp/workflo-guard')).rejects.toThrow('Wait for the Workflo task upload')
   })
 })

--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -3788,10 +3788,45 @@ describe('AgentManager background subagent protection', () => {
 })
 
 describe('Workflo task execution owner', () => {
+  it('starts and resumes local help for a human-owned server task without claiming task status', async () => {
+    const db = createMockDb()
+    vi.mocked(db.getSetting).mockImplementation(key => key === 'workflo-task:task-1' ? JSON.stringify({ executionMode: 'human', status: 'not_started' }) : undefined)
+    vi.mocked(db.getAgent).mockReturnValue({ id: 'agent-1', config: {} } as any)
+    const manager = new AgentManager(db)
+    vi.spyOn(manager as any, 'getAdapter').mockReturnValue({})
+    const start = vi.spyOn(manager as any, 'startAdapterSession').mockResolvedValue('help-session')
+    const resume = vi.spyOn(manager as any, 'resumeAdapterSession').mockResolvedValue('help-session')
+    await expect(manager.startSession('agent-1', 'task-1', '/tmp/help')).resolves.toBe('help-session')
+    await expect(manager.resumeSession('agent-1', 'task-1', 'help-session')).resolves.toBe('help-session')
+    expect(start).toHaveBeenCalledTimes(1)
+    expect(resume).toHaveBeenCalledTimes(1)
+    ;(manager as any).updateTaskFromLocalAgent('task-1', { status: TaskStatus.AgentWorking, session_id: 'help-session' })
+    ;(manager as any).updateTaskFromLocalAgent('task-1', { status: TaskStatus.ReadyForReview })
+    expect(db.updateTask).toHaveBeenCalledExactlyOnceWith('task-1', { session_id: 'help-session' })
+  })
+
+  it('does not publish local helper status as canonical task status', () => {
+    const db = createMockDb()
+    vi.mocked(db.getSetting).mockImplementation(key => key === 'workflo-task:task-1' ? JSON.stringify({ executionMode: 'human' }) : undefined)
+    const manager = new AgentManager(db)
+    const send = vi.fn()
+    ;(manager as any).mainWindow = { isDestroyed: () => false, webContents: { send } }
+    ;(manager as any).sendToRenderer('task:updated', { taskId: 'task-1', updates: { status: TaskStatus.AgentWorking } })
+    expect(send).not.toHaveBeenCalled()
+    ;(manager as any).sendToRenderer('task:updated', { taskId: 'task-1', updates: { status: TaskStatus.ReadyForReview, session_id: 'help-session' } })
+    expect(send).toHaveBeenCalledExactlyOnceWith('task:updated', { taskId: 'task-1', updates: { session_id: 'help-session' } })
+  })
+
+  it('refuses resuming local help after assignment changes to an agent', async () => {
+    const db = createMockDb()
+    vi.mocked(db.getSetting).mockImplementation(key => key === 'workflo-task:task-1' ? JSON.stringify({ executionMode: 'autonomous' }) : undefined)
+    await expect(new AgentManager(db).resumeSession('agent-1', 'task-1', 'help-session')).rejects.toThrow('Agent-assigned tasks')
+  })
+
   it('refuses a desktop session for autonomous server work', async () => {
     const db = createMockDb()
     vi.mocked(db.getSetting).mockImplementation(key => key === 'workflo-task:task-1' ? JSON.stringify({ executionMode: 'autonomous' }) : undefined)
-    await expect(new AgentManager(db).startSession('agent-1', 'task-1', '/tmp/workflo-guard')).rejects.toThrow('Task help runs in Workflo')
+    await expect(new AgentManager(db).startSession('agent-1', 'task-1', '/tmp/workflo-guard')).rejects.toThrow('Agent-assigned tasks run through Workflo')
   })
 
   it('refuses a desktop session while task upload is pending', async () => {

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -1560,6 +1560,7 @@ export class AgentManager extends EventEmitter {
     workspaceDir?: string,
     skipInitialPrompt?: boolean
   ): Promise<string> {
+    this.assertLocalHelpAllowed(taskId)
     // Helper: yield event loop between bursts of synchronous DB / FS calls
     // so the renderer can process IPC and paint frames during session setup.
     const yieldEL = (): Promise<void> => new Promise((r) => setImmediate(r))
@@ -1709,12 +1710,12 @@ export class AgentManager extends EventEmitter {
     })
 
     // Store session ID in database
-    this.db.updateTask(taskId, { session_id: adapterSessionId })
+    this.updateTaskFromLocalAgent(taskId, { session_id: adapterSessionId })
     console.log(`[SessionTracker] CREATED session=${adapterSessionId} task=${taskId} agent=${agentId} reason=new_session`)
 
     // Update task status (preserve Triaging status for triage sessions)
     if (!isTriageSession) {
-      this.db.updateTask(taskId, { status: TaskStatus.AgentWorking })
+      this.updateTaskFromLocalAgent(taskId, { status: TaskStatus.AgentWorking })
 
       // Notify renderer about task status change
       this.sendToRenderer('task:updated', {
@@ -2045,7 +2046,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         // put it back to working so the UI reflects the still-running children.
         const task = this.db.getTask(session!.taskId)
         if (task && task.status === TaskStatus.ReadyForReview) {
-          this.db.updateTask(session!.taskId, { status: TaskStatus.AgentWorking })
+          this.updateTaskFromLocalAgent(session!.taskId, { status: TaskStatus.AgentWorking })
           this.sendToRenderer('task:updated', {
             taskId: session!.taskId,
             updates: { status: TaskStatus.AgentWorking }
@@ -2250,7 +2251,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         console.log(`[SessionTracker] REKEYED old=${sessionId} new=${realSessionId} task=${config.taskId} reason=adapter_provided_real_id`)
 
         // Update database with real session ID
-        this.db.updateTask(config.taskId, { session_id: realSessionId })
+        this.updateTaskFromLocalAgent(config.taskId, { session_id: realSessionId })
 
         // Re-key the sessions map
         const session = this.sessions.get(sessionId)
@@ -2453,7 +2454,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       if (status.type === SessionStatusType.ERROR) {
         if (status.message?.includes('INCOMPATIBLE_SESSION_ID')) {
           console.warn('[AgentManager] Incompatible session detected during polling:', sessionId)
-          this.db.updateTask(config.taskId, { session_id: null })
+          this.updateTaskFromLocalAgent(config.taskId, { session_id: null })
           this.sendToRenderer('agent:incompatible-session', {
             taskId: config.taskId,
             agentId: config.agentId,
@@ -2818,6 +2819,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     taskId: string,
     adapterSessionId: string
   ): Promise<string> {
+    this.assertLocalHelpAllowed(taskId)
     // Helper: yield event loop between bursts of sync DB/FS calls
     const yieldEL = (): Promise<void> => new Promise((r) => setImmediate(r))
 
@@ -2926,7 +2928,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         const currentTask = this.db.getTask(taskId)
         if (currentTask && (currentTask.status === TaskStatus.ReadyForReview || currentTask.status === TaskStatus.Completed)) {
           console.log(`[AgentManager] Session ended normally for ${currentTask.status} task ${taskId} — clearing session_id`)
-          this.db.updateTask(taskId, { session_id: null })
+          this.updateTaskFromLocalAgent(taskId, { session_id: null })
           this.sendToRenderer('task:updated', { taskId, updates: { session_id: null } })
           // Return a sentinel value instead of throwing, so the IPC handler doesn't
           // log a noisy error. The public resumeSession() method returns empty string
@@ -2935,7 +2937,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         }
 
         // Clear the old session_id in the database
-        this.db.updateTask(taskId, { session_id: null })
+        this.updateTaskFromLocalAgent(taskId, { session_id: null })
 
         // Determine user-friendly error message
         let userMessage = 'Session not found. Would you like to start a new session?'
@@ -3018,7 +3020,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     // (e.g. an event-driven wake-up after the runtime was released) leaves the
     // renderer bound to a stale session id and the wake turn's output renders
     // late or not at all.
-    this.db.updateTask(taskId, { session_id: adapterSessionId })
+    this.updateTaskFromLocalAgent(taskId, { session_id: adapterSessionId })
     this.sendToRenderer('task:updated', { taskId, updates: { session_id: adapterSessionId } })
 
     // Notify renderer — session is resumed but idle (no work in progress)
@@ -3041,12 +3043,26 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
    * Creates an OpenCode session and returns the sessionId immediately.
    * Uses promptAsync to send the initial prompt without blocking.
    */
-  async startSession(agentId: string, taskId: string, workspaceDir?: string, skipInitialPrompt?: boolean): Promise<string> {
+  private assertLocalHelpAllowed(taskId: string): void {
     if (this.db.getSetting(`workflo-upload:${taskId}`)) throw new Error('Wait for the Workflo task upload to finish.')
-    const serverTask = serverTaskSnapshot(this.db, taskId)
-    if (serverTask) {
-      throw new Error('Task help runs in Workflo. Open its server session.')
+    const task = serverTaskSnapshot(this.db, taskId)
+    if (!task) return
+    if (task.executionMode !== 'human') throw new Error('Agent-assigned tasks run through Workflo, not a local help session.')
+    if (task.isRecurring || ['completed', 'cancelled', 'expired'].includes(task.status)) {
+      throw new Error('This Workflo task cannot start a help session.')
     }
+  }
+
+  /** Local help can save its session and results, but cannot set canonical status. */
+  private updateTaskFromLocalAgent(taskId: string, updates: Parameters<DatabaseManager['updateTask']>[1]): TaskRecord | undefined {
+    const fields = { ...updates }
+    if (serverTaskSnapshot(this.db, taskId)) delete fields.status
+    if (Object.keys(fields).length === 0) return this.db.getTask(taskId)
+    return this.db.updateTask(taskId, fields)
+  }
+
+  async startSession(agentId: string, taskId: string, workspaceDir?: string, skipInitialPrompt?: boolean): Promise<string> {
+    this.assertLocalHelpAllowed(taskId)
     const agent = this.db.getAgent(agentId)
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`)
@@ -3070,6 +3086,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     startedTaskId?: string
     agentId?: string
   }> {
+    this.assertLocalHelpAllowed(taskId)
     const task = this.db.getTask(taskId)
     if (!task) {
       throw new Error(`Task not found: ${taskId}`)
@@ -3128,7 +3145,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         return { action: 'no_action', startedTaskId: taskId }
       }
 
-      this.db.updateTask(taskId, { status: TaskStatus.Triaging })
+      this.updateTaskFromLocalAgent(taskId, { status: TaskStatus.Triaging })
       this.sendToRenderer('task:updated', {
         taskId,
         updates: { status: TaskStatus.Triaging }
@@ -3578,6 +3595,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
    * Replays all messages to the renderer and resumes polling.
    */
   async resumeSession(agentId: string, taskId: string, sessionId: string): Promise<string> {
+    this.assertLocalHelpAllowed(taskId)
     console.log('[AgentManager] resumeSession called:', { agentId, taskId, sessionId })
     const agent = this.db.getAgent(agentId)
     if (!agent) {
@@ -3721,37 +3739,13 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     })
   }
 
-  /**
-   * Marks a task complete once its agent is done, telling the source system
-   * first when there is one.
-   *
-   * Two callers need exactly this: a learning session finishing, and a task
-   * flagged to complete without review. An enterprise task that cannot be
-   * closed upstream falls back to ready_for_review, so it is never marked done
-   * locally while the system of record still shows it open.
-   *
-   * Returns false when the task was left for review instead.
-   */
-
-  /**
-   * Completes a task that must not wait for a human review, telling the source
-   * system first when there is one.
-   *
-   * This is deliberately session-independent: a task can reach this point
-   * without a live agent session — a coordinator marked its parent
-   * ready_for_review, an MCP client set the status, or the periodic
-   * reconciliation sweep found a task that was left in review while its
-   * auto_complete_without_review flag was set. Every one of those routes must
-   * honour the flag, not just the one that runs inside transitionToIdle.
-   *
-   * Returns false when the task was left for review instead.
-   */
+  /** Local agents help a human owner; only that human can accept completion. */
   async completeTaskWithoutReview(taskId: string, knownTask?: TaskRecord): Promise<boolean> {
     const task = knownTask ?? this.db.getTask(taskId)
     if (!task) return false
 
-    // Desktop sessions have no server session credential. Never use the
-    // signed-in user's token to complete an agent action.
+    // Agent-owned work completes through agent-harness. Local help must not
+    // use the human owner's token to accept its own result.
     return false
   }
 
@@ -3778,7 +3772,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     if (session.isTriageSession) {
       session.status = 'idle'
       console.log(`[AgentManager] Triage session completed for task ${session.taskId}, reverting to NotStarted`)
-      this.db.updateTask(session.taskId, { status: TaskStatus.NotStarted, session_id: null })
+      this.updateTaskFromLocalAgent(session.taskId, { status: TaskStatus.NotStarted, session_id: null })
       await yieldEventLoop()
 
       this.sendToRenderer('task:updated', {
@@ -3857,7 +3851,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       }
       await yieldEventLoop()
 
-      if (this.db.getTask(session.taskId)?.status !== TaskStatus.Completed) this.db.updateTask(session.taskId, { status: TaskStatus.ReadyForReview })
+      if (this.db.getTask(session.taskId)?.status !== TaskStatus.Completed) this.updateTaskFromLocalAgent(session.taskId, { status: TaskStatus.ReadyForReview })
       this.sendToRenderer('agent:status', {
         sessionId, agentId: session.agentId, taskId: session.taskId, status: 'idle'
       })
@@ -3890,7 +3884,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     // Update task status to ready_for_review (only if task exists)
     if (task) {
       console.log(`[AgentManager] Updating task ${session.taskId} status to ReadyForReview`)
-      this.db.updateTask(session.taskId, { status: TaskStatus.ReadyForReview })
+      this.updateTaskFromLocalAgent(session.taskId, { status: TaskStatus.ReadyForReview })
       await yieldEventLoop()
 
       // Auto-enable heartbeat if agent wrote a heartbeat.md file
@@ -4068,7 +4062,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     if (resetTaskStatus) {
       const task = this.db.getTask(session.taskId)
       if (task?.status !== TaskStatus.Completed) {
-        this.db.updateTask(session.taskId, { status: TaskStatus.NotStarted })
+        this.updateTaskFromLocalAgent(session.taskId, { status: TaskStatus.NotStarted })
       }
     }
 
@@ -4248,7 +4242,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     session.lastActivityAt = Date.now()
     const currentTask = this.db.getTask(session.taskId)
     if (currentTask?.status !== TaskStatus.AgentLearning) {
-      this.db.updateTask(session.taskId, { status: TaskStatus.AgentWorking })
+      this.updateTaskFromLocalAgent(session.taskId, { status: TaskStatus.AgentWorking })
     }
     this.sendToRenderer('agent:status', {
       sessionId,
@@ -4402,7 +4396,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       session.status = 'working'
       const currentTask = this.db.getTask(session.taskId)
       if (currentTask?.status !== TaskStatus.AgentLearning) {
-        this.db.updateTask(session.taskId, { status: TaskStatus.AgentWorking })
+        this.updateTaskFromLocalAgent(session.taskId, { status: TaskStatus.AgentWorking })
       }
       this.sendToRenderer('agent:status', {
         sessionId, agentId: session.agentId, taskId: session.taskId, status: 'working'
@@ -5043,7 +5037,7 @@ Important:
       })
 
       // Save updated output fields
-      this.db.updateTask(session.taskId, { output_fields: updatedFields })
+      this.updateTaskFromLocalAgent(session.taskId, { output_fields: updatedFields })
       console.log(`[AgentManager] Extracted output values for task ${session.taskId}`)
     } catch (error) {
       console.error(`[AgentManager] Error extracting output values:`, error)
@@ -5294,7 +5288,7 @@ Important:
           const now = new Date()
           const nextCheck = new Date(now.getTime() + defaultInterval * 60_000)
 
-          this.db.updateTask(taskId, {
+          this.updateTaskFromLocalAgent(taskId, {
             heartbeat_enabled: true,
             heartbeat_interval_minutes: defaultInterval,
             heartbeat_next_check_at: nextCheck.toISOString()
@@ -5498,6 +5492,15 @@ Important:
   }
 
   private sendToRenderer(channel: string, data: unknown): void {
+    if (channel === 'task:updated' && data && typeof data === 'object') {
+      const event = data as { taskId?: string; updates?: Record<string, unknown> }
+      if (event.taskId && event.updates && serverTaskSnapshot(this.db, event.taskId)) {
+        const updates = { ...event.updates }
+        delete updates.status
+        if (Object.keys(updates).length === 0) return
+        data = { ...event, updates }
+      }
+    }
     // Durable transcript projection: persist every transcript part BEFORE any
     // client sees it. The main process owns the source of truth; renderer and
     // mobile hydrate from snapshots (transcript:get) instead of depending on

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -1,3 +1,4 @@
+import { serverTaskSnapshot } from './workflo-task-sync'
 import { EventEmitter } from 'events'
 import { spawn } from 'child_process'
 import { join } from 'path'
@@ -6,7 +7,7 @@ import { mkdir, writeFile } from 'fs/promises'
 import { Notification, powerSaveBlocker } from 'electron'
 import type { BrowserWindow } from 'electron'
 import type { DatabaseManager, AgentMcpServerEntry, McpServerRecord, McpServerSource, OutputFieldRecord, SecretRecord, SkillRecord, TaskRecord } from './database'
-import { TaskStatus, SessionStatus, PluginActionId } from '../shared/constants'
+import { TaskStatus, SessionStatus } from '../shared/constants'
 import type { WorktreeManager } from './worktree-manager'
 import type { GitHubManager } from './github-manager'
 import type { GitLabManager } from './gitlab-manager'
@@ -246,7 +247,6 @@ export class AgentManager extends EventEmitter {
   private enterpriseAuth: import('./enterprise-auth').EnterpriseAuth | null = null
   private externalListeners: Array<(channel: string, data: unknown) => void> = []
   private enterpriseStateSync: import('./enterprise-state-sync').EnterpriseStateSync | null = null
-  private syncManager: import('./sync-manager').SyncManager | null = null
 
   // ── Centralized Polling Coordinator ──
   // Instead of N independent setTimeout loops (one per session),
@@ -560,7 +560,7 @@ export class AgentManager extends EventEmitter {
    * Called after both AgentManager and SyncManager are created.
    */
   setSyncManager(syncManager: import('./sync-manager').SyncManager): void {
-    this.syncManager = syncManager
+    void syncManager
   }
 
   setMainWindow(window: BrowserWindow): void {
@@ -3042,6 +3042,11 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
    * Uses promptAsync to send the initial prompt without blocking.
    */
   async startSession(agentId: string, taskId: string, workspaceDir?: string, skipInitialPrompt?: boolean): Promise<string> {
+    if (this.db.getSetting(`workflo-upload:${taskId}`)) throw new Error('Wait for the Workflo task upload to finish.')
+    const serverTask = serverTaskSnapshot(this.db, taskId)
+    if (serverTask) {
+      throw new Error('Task help runs in Workflo. Open its server session.')
+    }
     const agent = this.db.getAgent(agentId)
     if (!agent) {
       throw new Error(`Agent not found: ${agentId}`)
@@ -3727,14 +3732,6 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
    *
    * Returns false when the task was left for review instead.
    */
-  private async completeTaskAfterAgent(
-    session: AgentSession,
-    sessionId: string,
-    task: TaskRecord
-  ): Promise<boolean> {
-    void sessionId
-    return this.completeTaskWithoutReview(session.taskId, task)
-  }
 
   /**
    * Completes a task that must not wait for a human review, telling the source
@@ -3753,91 +3750,9 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
     const task = knownTask ?? this.db.getTask(taskId)
     if (!task) return false
 
-    const yieldEventLoop = (): Promise<void> => new Promise((r) => setImmediate(r))
-
-    // A coordinator is not finished while its children are still to run.
-    //
-    // An agent that creates subtasks and then stops leaves them in
-    // not_started. Completing the parent there would mark the whole recurring
-    // occurrence done while none of the actual work had run. Park it in review
-    // instead; the parent is woken again by notifyParentOfSubtaskCompletion
-    // once every child reaches a terminal state, and completes then.
-    const pendingSubtasks = this.db.getSubtasks(taskId).filter(
-      (subtask) =>
-        subtask.status !== TaskStatus.Completed && subtask.status !== TaskStatus.ReadyForReview
-    )
-    if (pendingSubtasks.length > 0) {
-      console.log(
-        `[AgentManager] Task ${taskId} completes without review, but ${pendingSubtasks.length} ` +
-        `subtask(s) have not finished — leaving it for review`
-      )
-      if (task.status !== TaskStatus.ReadyForReview) {
-        this.db.updateTask(taskId, { status: TaskStatus.ReadyForReview })
-        await yieldEventLoop()
-        this.sendToRenderer('task:updated', {
-          taskId,
-          updates: { status: TaskStatus.ReadyForReview }
-        })
-      }
-      return false
-    }
-
-    /**
-     * The user answers this in the feedback dialog before the learning session
-     * starts, and the answer is stored on the task. `false` means the user
-     * closes the task in the source system themselves, so 20x must not do it.
-     * `null` means nobody was asked — an unattended run (auto-complete without
-     * review, a scheduled run, an MCP caller) — which keeps pushing, as before.
-     */
-    const pushToSource = task.complete_at_source !== false
-
-    if (task.source_id && this.syncManager && pushToSource) {
-      const actionField = task.output_fields?.find((f: OutputFieldRecord) => f.id === 'action')
-      const actionValue = actionField?.value ? String(actionField.value) : PluginActionId.Complete
-      console.log(`[AgentManager] Enterprise task — calling executeAction("${actionValue}") for source ${task.source_id}`)
-      let failure: string | null = null
-      try {
-        const result = await this.syncManager.executeAction(actionValue, task, undefined, task.source_id)
-        if (!result.success) failure = result.error ?? 'unknown error'
-      } catch (err) {
-        failure = err instanceof Error ? err.message : String(err)
-      }
-      if (failure) {
-        console.error(`[AgentManager] executeAction failed, leaving task for review:`, failure)
-        this.db.updateTask(taskId, { status: TaskStatus.ReadyForReview })
-        await yieldEventLoop()
-        this.sendToRenderer('task:updated', {
-          taskId,
-          updates: { status: TaskStatus.ReadyForReview }
-        })
-        // Without this the task silently returns to review and the user is
-        // never told that the source system refused the completion.
-        this.sendToRenderer('task:source-action-failed', {
-          taskId,
-          taskTitle: task.title,
-          error: failure
-        })
-        return false
-      }
-      await yieldEventLoop()
-    } else if (task.source_id && !pushToSource) {
-      console.log(`[AgentManager] Task ${taskId} completes locally — the user updates the source`)
-    }
-
-    this.db.updateTask(taskId, { status: TaskStatus.Completed })
-    await yieldEventLoop()
-    this.sendToRenderer('task:updated', {
-      taskId,
-      updates: { status: TaskStatus.Completed }
-    })
-
-    // A subtask that finishes must still wake its parent.
-    if (task.parent_task_id) {
-      this.notifyParentOfSubtaskCompletion(task.parent_task_id, taskId).catch((err) => {
-        console.error(`[AgentManager] Failed to wake parent ${task.parent_task_id} after subtask ${taskId} completed:`, err)
-      })
-    }
-    return true
+    // Desktop sessions have no server session credential. Never use the
+    // signed-in user's token to complete an agent action.
+    return false
   }
 
   private async transitionToIdle(sessionId: string, session: AgentSession): Promise<void> {
@@ -3942,7 +3857,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       }
       await yieldEventLoop()
 
-      await this.completeTaskAfterAgent(session, sessionId, task)
+      if (this.db.getTask(session.taskId)?.status !== TaskStatus.Completed) this.db.updateTask(session.taskId, { status: TaskStatus.ReadyForReview })
       this.sendToRenderer('agent:status', {
         sessionId, agentId: session.agentId, taskId: session.taskId, status: 'idle'
       })
@@ -3970,30 +3885,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
       return
     }
 
-    /**
-     * A task told to finish without review finishes here, in main.
-     *
-     * This used to be done by the renderer, watching for ready_for_review — so
-     * a task could only self-resolve while a window happened to be open. An
-     * agent driving 20x through MCP, or a scheduled run on a machine with the
-     * window closed, would leave the task sitting in review for ever.
-     */
-    if (task.auto_complete_without_review) {
-      console.log(`[AgentManager] Task ${session.taskId} completes without review`)
-      const completed = await this.completeTaskAfterAgent(session, sessionId, task)
-      if (completed) {
-        this.autoEnableHeartbeat(session.taskId)
-        this.sendToRenderer('agent:status', {
-          sessionId, agentId: session.agentId, taskId: session.taskId, status: 'idle'
-        })
-        return
-      }
-      // Completion was refused upstream; it is already back in review.
-      this.sendToRenderer('agent:status', {
-        sessionId, agentId: session.agentId, taskId: session.taskId, status: 'idle'
-      })
-      return
-    }
+    // Desktop agent work is help. Only the server can accept completion.
 
     // Update task status to ready_for_review (only if task exists)
     if (task) {

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -1,3 +1,4 @@
+import { isWorkfloLinkedTask } from './workflo-task-sync'
 import Database from 'better-sqlite3'
 import { app, safeStorage } from 'electron'
 import { join } from 'path'
@@ -330,6 +331,12 @@ export interface TranscriptPartRecord {
 }
 
 export interface TaskRecord {
+  server_pending_edits?: Record<string, unknown>
+  server_managed?: boolean
+  server_execution_mode?: 'human' | 'autonomous'
+  server_cron?: string | null
+  server_sync_pending?: boolean
+  server_sync_error?: string
   id: string
   title: string
   description: string
@@ -415,6 +422,9 @@ export interface CreateTaskData {
 }
 
 export interface UpdateTaskData {
+  external_id?: string | null
+  source_id?: string | null
+  source?: string
   title?: string
   description?: string
   type?: string
@@ -450,6 +460,7 @@ export interface UpdateTaskData {
 
 /** Columns that can be dynamically updated via updateTask. */
 const UPDATABLE_COLUMNS = new Set([
+  'external_id', 'source_id', 'source',
   'title',
   'description',
   'type',
@@ -2089,7 +2100,14 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
       'SELECT * FROM tasks ORDER BY created_at DESC'
     ).all() as TaskRow[]
 
-    return rows.map(deserializeTask)
+    return rows.map(row => this.withServerOwnership(deserializeTask(row)))
+  }
+
+  private withServerOwnership(task: TaskRecord): TaskRecord {
+    if (this.getSetting(`workflo-upload:${task.id}`)) return { ...task, server_pending_edits: JSON.parse(this.getSetting(`workflo-update:${task.id}`) || '{}').fields, server_managed: true, server_sync_pending: true, server_sync_error: this.getSetting(`workflo-upload:${task.id}:error`) }
+    if (!isWorkfloLinkedTask(this, task)) return task
+    const snapshot = this.getSetting(`workflo-task:${task.id}`)
+    return { ...task, server_pending_edits: JSON.parse(this.getSetting(`workflo-update:${task.id}`) || '{}').fields, server_managed: true, server_cron: snapshot ? JSON.parse(snapshot).cron : null, server_execution_mode: snapshot ? JSON.parse(snapshot).executionMode : 'human', server_sync_pending: !!this.getSetting(`workflo-update:${task.id}`) || !!this.getSetting(`workflo-completion:${task.id}`), server_sync_error: this.getSetting(`workflo-update:${task.id}:error`) ?? this.getSetting(`workflo-completion:${task.id}:error`) }
   }
 
   getTask(id: string): TaskRecord | undefined {
@@ -2099,7 +2117,7 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
       'SELECT * FROM tasks WHERE id = ?'
     ).get(id) as TaskRow | undefined
 
-    return row ? deserializeTask(row) : undefined
+    return row ? this.withServerOwnership(deserializeTask(row)) : undefined
   }
 
   getSubtasks(parentId: string): TaskRecord[] {
@@ -2344,7 +2362,27 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
     return this.getTask(id)
   }
 
-  updateTask(id: string, data: UpdateTaskData): TaskRecord | undefined {
+  updateTask(id: string, data: UpdateTaskData, origin?: 'workflo-server'): TaskRecord | undefined {
+    if (origin !== 'workflo-server' && ('external_id' in data || 'source_id' in data || 'source' in data)) {
+      throw new Error('Only the sync service can change a task source link.')
+    }
+    if (data.status && origin !== 'workflo-server') {
+      const task = this.getTask(id)
+      const snapshot = this.getSetting(`workflo-task:${id}`)
+      const remote = snapshot ? JSON.parse(snapshot) : undefined
+      if (task && data.status !== task.status && isWorkfloLinkedTask(this, task)) {
+        throw new Error('Workflo controls task status. Use a server task action.')
+      }
+      if (task && data.status !== task.status && remote?.status === 'completed') {
+        throw new Error('This task is completed in Workflo.')
+      }
+    }
+    if (data.status === TaskStatus.Completed && origin !== 'workflo-server') {
+      const task = this.getTask(id)
+      if (task && task.status !== TaskStatus.Completed) {
+        throw new Error('Workflo must confirm completion before this task can close in 20x.')
+      }
+    }
     const setClauses: string[] = []
     const values: (string | number | null)[] = []
 

--- a/src/main/enterprise-auth.ts
+++ b/src/main/enterprise-auth.ts
@@ -588,13 +588,14 @@ export class EnterpriseAuth {
 
   // ── API Request Proxy ────────────────────────────────────────────
 
-  async apiRequest(method: string, path: string, body?: unknown): Promise<unknown> {
+  async apiRequest(method: string, path: string, body?: unknown, requestHeaders?: Record<string, string>): Promise<unknown> {
     const jwt = await this.getValidJwt()
 
     const url = `${this.apiUrl}${path.startsWith('/') ? path : `/${path}`}`
     const normalizedMethod = method.toUpperCase()
 
     const headers: Record<string, string> = {
+      ...requestHeaders,
       'Authorization': `Bearer ${jwt}`
     }
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -104,15 +104,21 @@ export function registerIpcHandlers(
     return db.getTask(id)
   })
 
-  ipcMain.handle('db:createTask', (event, data: CreateTaskData) => {
-    const task = db.createTask(data)
+  ipcMain.handle('db:createTask', async (event, data: CreateTaskData) => {
+    if (data.status === TaskStatus.Completed) throw new Error('Workflo must confirm completion.')
+    let task = db.createTask(data)
+    if (task && !task.source_id && syncManager.canUploadTasks()) {
+      try { await syncManager.uploadTask(task.id) }
+      catch (error) { db.setSetting(`workflo-upload:${task.id}:error`, error instanceof Error ? error.message : String(error)) }
+      task = db.getTask(task.id)
+    }
     // Initialize recurring task if it has a recurrence pattern
-    if (task && task.is_recurring && recurrenceScheduler) {
+    if (task && !task.server_managed && task.is_recurring && recurrenceScheduler) {
       recurrenceScheduler.initializeRecurringTask(task.id)
     }
     // Hand a self-starting task straight to the main-process automation loop
     // instead of relying on a renderer listener seeing this one event.
-    if (task?.auto_start_agent) {
+    if (task?.auto_start_agent && !task.server_managed) {
       void taskAutomationScheduler?.runNow()
     }
     // Notify renderer so auto-start hook can trigger triage for UI-created tasks
@@ -687,8 +693,12 @@ export function registerIpcHandlers(
     return result
   })
 
-  ipcMain.handle('taskSource:exportUpdate', async (_, taskId: string, fields: Record<string, unknown>) => {
+  ipcMain.handle('taskSource:upload', async (_, taskId: string, autonomous?: boolean) => syncManager.uploadTask(taskId, autonomous === true))
+
+  ipcMain.handle('taskSource:exportUpdate', async (event, taskId: string, fields: Record<string, unknown>) => {
     await syncManager.exportTaskUpdate(taskId, fields)
+    const updated = db.getTask(taskId)
+    if (updated) event.sender.send('task:updated', { taskId, updates: updated })
   })
 
   ipcMain.handle('taskSource:getUsers', (_, sourceId: string) => {

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -716,30 +716,34 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
 
   // POST /api/tasks — create task (must be checked before the :id update route)
   if (pathname === '/api/tasks') {
+    if (params.status === TaskStatus.Completed) throw Object.assign(new Error('Workflo must confirm completion.'), { status: 409 })
     const { title } = params as { title?: string }
     if (!title) throw Object.assign(new Error('title is required'), { status: 400 })
-    const task = db.createTask(params as unknown as Parameters<DatabaseManager['createTask']>[0])
+    let task = db.createTask(params as unknown as Parameters<DatabaseManager['createTask']>[0])
     if (!task) throw Object.assign(new Error('Failed to create task'), { status: 500 })
+    if (!task.source_id && syncManagerRef?.canUploadTasks()) {
+      try { await syncManagerRef.uploadTask(task.id) }
+      catch (error) { db.setSetting(`workflo-upload:${task.id}:error`, error instanceof Error ? error.message : String(error)) }
+      task = db.getTask(task.id)!
+    }
     broadcastToMobileClients('task:created', { task })
     if (notifyDesktop) notifyDesktop('task:created', { task })
     if (task.auto_start_agent) triggerTaskAutomation()
     return task
   }
 
-  // POST /api/tasks/:id/complete — complete a task, closing it at its source
-  // when the user chooses to (matches the desktop completion flow). Reuses
-  // completeTaskWithoutReview, which honours the recorded complete_at_source
-  // answer and leaves a task the source refuses in review.
+  // Human mobile completion uses the same durable server command as desktop.
   const taskCompleteMatch = pathname.match(/^\/api\/tasks\/([^/]+)\/complete$/)
   if (taskCompleteMatch) {
     const taskId = taskCompleteMatch[1]
     const task = db.getTask(taskId)
     if (!task) throw Object.assign(new Error('Task not found'), { status: 404 })
-    const { completeAtSource } = params as { completeAtSource?: boolean }
-    if (task.source_id && completeAtSource !== undefined) {
-      db.updateTask(taskId, { complete_at_source: completeAtSource })
+    if (!syncManagerRef || !task.source_id || db.getTaskSource(task.source_id)?.plugin_id !== 'peakflo') {
+      throw Object.assign(new Error('Sync this task with Workflo before completing it.'), { status: 409 })
     }
-    const completed = await agent.completeTaskWithoutReview(taskId)
+    const result = await syncManagerRef.executeAction('complete', task, undefined, task.source_id)
+    if (!result.success) throw Object.assign(new Error(result.error || 'Completion is pending.'), { status: 409 })
+    const completed = true
     const fresh = db.getTask(taskId)
     if (fresh) {
       broadcastToMobileClients('task:updated', { taskId, updates: fresh })

--- a/src/main/plugins/peakflo-plugin.test.ts
+++ b/src/main/plugins/peakflo-plugin.test.ts
@@ -7,6 +7,8 @@ import type { DatabaseManager, McpServerRecord, TaskRecord } from '../database'
 function makeContext(overrides: Partial<PluginContext> = {}): PluginContext {
   return {
     db: {
+      setSetting: vi.fn(),
+      getSetting: vi.fn(),
       getTaskSource: vi.fn().mockReturnValue({ name: 'Peakflo' }),
       getTaskByExternalId: vi.fn().mockReturnValue(undefined),
       createTask: vi.fn(),
@@ -147,34 +149,14 @@ describe('PeakfloPlugin', () => {
   })
 
   describe('executeAction', () => {
-    it('calls task_complete for approve', async () => {
+    it.each(['approve', 'reject'])('refuses legacy MCP %s writes', async (action) => {
       const ctx = makeContext()
-      ;(ctx.toolCaller.callTool as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true })
-
       const task = { id: 'local-1', external_id: 'ext-1', output_fields: [] } as unknown as TaskRecord
-      const result = await plugin.executeAction('approve', task, undefined, {}, ctx)
-
-      expect(result.success).toBe(true)
-      expect(result.taskUpdate).toEqual({ status: TaskStatus.Completed })
-      expect(ctx.toolCaller.callTool).toHaveBeenCalledWith(
-        ctx.mcpServer,
-        'task_complete',
-        expect.objectContaining({
-          taskId: 'ext-1',
-          outputs: expect.objectContaining({ action: 'approve' })
-        })
-      )
-    })
-
-    it('calls task_complete for reject with reason', async () => {
-      const ctx = makeContext()
-      ;(ctx.toolCaller.callTool as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true })
-
-      const task = { id: 'local-1', external_id: 'ext-1', output_fields: [] } as unknown as TaskRecord
-      const result = await plugin.executeAction('reject', task, 'Bad quality', {}, ctx)
-
-      expect(result.success).toBe(true)
-      expect(result.taskUpdate).toEqual({ status: TaskStatus.Completed })
+      const result = await plugin.executeAction(action, task, undefined, {}, ctx)
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('0.0.146')
+      expect(ctx.toolCaller.callTool).not.toHaveBeenCalled()
+      expect(ctx.db.updateTask).not.toHaveBeenCalled()
     })
 
     it('returns error when no external_id', async () => {
@@ -188,6 +170,7 @@ describe('PeakfloPlugin', () => {
       const mockExecuteAction = vi.fn().mockResolvedValue(undefined)
       const ctx = makeContext({
         workfloApiClient: {
+          getTask: vi.fn().mockResolvedValue({ status: 'completed' }),
           executeAction: mockExecuteAction
         } as unknown as PluginContext['workfloApiClient']
       })
@@ -208,13 +191,14 @@ describe('PeakfloPlugin', () => {
       expect(mockExecuteAction).toHaveBeenCalledWith('wf-task-123', {
         action: 'approve',
         reason: 'Looks good'
-      })
+      }, undefined)
     })
 
     it('enterprise mode: sends default "complete" action for tasks without action field', async () => {
       const mockExecuteAction = vi.fn().mockResolvedValue(undefined)
       const ctx = makeContext({
         workfloApiClient: {
+          getTask: vi.fn().mockResolvedValue({ status: 'completed' }),
           executeAction: mockExecuteAction
         } as unknown as PluginContext['workfloApiClient']
       })
@@ -231,7 +215,7 @@ describe('PeakfloPlugin', () => {
       expect(result.taskUpdate).toEqual({ status: TaskStatus.Completed })
       expect(mockExecuteAction).toHaveBeenCalledWith('wf-task-456', {
         action: 'complete'
-      })
+      }, undefined)
     })
 
     it('enterprise mode: returns error when workfloApiClient is missing', async () => {
@@ -267,7 +251,9 @@ describe('PeakfloPlugin', () => {
       })
 
       const db = {
-        getTaskSource: vi.fn().mockReturnValue({ name: 'Workflo Test' }),
+        setSetting: vi.fn(),
+      getSetting: vi.fn(),
+      getTaskSource: vi.fn().mockReturnValue({ name: 'Workflo Test' }),
         getTaskByExternalId: vi.fn().mockReturnValue(existingTask || undefined),
         createTask: vi.fn(),
         updateTask: vi.fn(),
@@ -277,7 +263,7 @@ describe('PeakfloPlugin', () => {
       const ctx = makeContext({
         db,
         workfloApiClient: {
-          listTasks: mockListTasks,
+          listTaskCache: mockListTasks,
           downloadFile: vi.fn()
         } as unknown as PluginContext['workfloApiClient']
       })
@@ -285,7 +271,7 @@ describe('PeakfloPlugin', () => {
       return { ctx, db }
     }
 
-    it('preserves local Completed status within the 2-minute race window', async () => {
+    it('uses server status even when local completion is recent', async () => {
       // Task was completed very recently (30 seconds ago)
       const recentUpdate = new Date(Date.now() - 30_000).toISOString()
       const { ctx, db } = makeEnterpriseCtx({
@@ -299,7 +285,8 @@ describe('PeakfloPlugin', () => {
       // Should keep Completed (within race window)
       expect(db.updateTask).toHaveBeenCalledWith(
         'local-1',
-        expect.objectContaining({ status: TaskStatus.Completed })
+        expect.objectContaining({ status: TaskStatus.NotStarted }),
+        'workflo-server'
       )
     })
 
@@ -317,7 +304,8 @@ describe('PeakfloPlugin', () => {
       // Should update to server status (NotStarted, mapped from "pending")
       expect(db.updateTask).toHaveBeenCalledWith(
         'local-1',
-        expect.objectContaining({ status: TaskStatus.NotStarted })
+        expect.objectContaining({ status: TaskStatus.NotStarted }),
+        'workflo-server'
       )
     })
   })

--- a/src/main/plugins/peakflo-plugin.ts
+++ b/src/main/plugins/peakflo-plugin.ts
@@ -1,3 +1,4 @@
+import { saveServerTaskSnapshot, serverTaskFields, serverTaskSnapshot, serverTaskStatus } from '../workflo-task-sync'
 import {
   PluginActionId,
   type TaskSourcePlugin,
@@ -369,7 +370,7 @@ export class PeakfloPlugin implements TaskSourcePlugin {
 
   private async importTasksEnterprise(
     sourceId: string,
-    config: Record<string, unknown>,
+    _config: Record<string, unknown>,
     ctx: PluginContext,
     result: PluginSyncResult
   ): Promise<PluginSyncResult> {
@@ -381,37 +382,28 @@ export class PeakfloPlugin implements TaskSourcePlugin {
 
     const source = ctx.db.getTaskSource(sourceId)
     const sourceName = source?.name ?? 'Peakflo'
-    const statusFilter = (config.status_filter as string) || 'all'
+    // Read every status, including completed tasks, so a cache cannot stay open.
 
     // Collect file download jobs to run after the sync loop
     const fileDownloadJobs: Array<{ taskId: string; fields: PeakfloField[] }> = []
 
     try {
-      // Paginated fetch from Workflo API
-      let page = 1
-      const pageSize = 100
+      let cursor: string | undefined
       let hasMore = true
-
       while (hasMore) {
-        const response = await apiClient.listTasks({
-          status: statusFilter !== 'all' ? statusFilter : undefined,
-          page,
-          pageSize,
-          myTasks: true
-        })
-
-        console.log(
-          `[peakflo] Enterprise sync page ${page}: ${response.tasks.length} tasks, ` +
-          `total=${response.pagination.total}, totalPages=${response.pagination.totalPages}`
-        )
-
+        const response = await apiClient.listTaskCache(cursor)
         for (const task of response.tasks) {
           try {
             const externalId = task.id // Workflo task ID is the external ID
-            const existing = ctx.db.getTaskByExternalId(sourceId, externalId)
+            const existing = ctx.db.getTaskByExternalId(sourceId, externalId) ??
+              ctx.db.getTasks().find(local => local.external_id === externalId &&
+                serverTaskSnapshot(ctx.db, local.id)?.tenantId === task.tenantId)
 
+            if (task.deletedAt) {
+              if (existing) ctx.db.deleteTask(existing.id)
+              continue
+            }
             // Map Workflo task status to local status
-            const status = this.mapWorkfloStatus(task.status)
             const priority = task.priority || 'medium'
             const assignee = task.assignees?.[0]?.assigneeValue
 
@@ -438,32 +430,16 @@ export class PeakfloPlugin implements TaskSourcePlugin {
             })
 
             if (existing) {
-              // Guard against a narrow race condition: the user completes a task
-              // in 20x (executeAction succeeds on the server) but the next sync
-              // fetch returns stale data before the server has processed it.
-              //
-              // We only preserve the local Completed status for a brief window
-              // (2 minutes).  After that we trust the server — if the action was
-              // processed, the server will already report "completed".  If it
-              // didn't, we should let the server status flow through so the user
-              // can see the task is still open and retry.
-              const RACE_WINDOW_MS = 2 * 60 * 1000
-              const completedRecently =
-                existing.status === TaskStatus.Completed &&
-                status !== TaskStatus.Completed &&
-                (Date.now() - new Date(existing.updated_at).getTime()) < RACE_WINDOW_MS
-
-              const effectiveStatus = completedRecently ? TaskStatus.Completed : status
-
+              saveServerTaskSnapshot(ctx.db, existing.id, task)
               ctx.db.updateTask(existing.id, {
                 title: task.title,
                 description,
-                status: effectiveStatus,
+                ...serverTaskFields(ctx.db, task),
                 priority,
                 assignee,
                 due_date: task.dueDate,
-                output_fields: outputFields.length > 0 ? outputFields : undefined
-              })
+                output_fields: outputFields.length > 0 ? outputFields : undefined,
+              }, 'workflo-server')
               result.updated++
 
               // Queue file download for after sync completes
@@ -476,7 +452,7 @@ export class PeakfloPlugin implements TaskSourcePlugin {
                 description,
                 type: 'general',
                 priority,
-                status,
+                ...serverTaskFields(ctx.db, task),
                 assignee,
                 due_date: task.dueDate,
                 external_id: externalId,
@@ -484,6 +460,7 @@ export class PeakfloPlugin implements TaskSourcePlugin {
                 source: sourceName,
                 output_fields: outputFields.length > 0 ? outputFields : undefined
               })
+              if (created) saveServerTaskSnapshot(ctx.db, created.id, task)
               result.imported++
 
               // Queue file download for after sync completes
@@ -497,14 +474,8 @@ export class PeakfloPlugin implements TaskSourcePlugin {
           }
         }
 
-        if (
-          response.tasks.length < pageSize ||
-          page >= response.pagination.totalPages
-        ) {
-          hasMore = false
-        } else {
-          page++
-        }
+        cursor = response.nextCursor ?? undefined
+        hasMore = !!cursor
       }
 
       ctx.db.updateTaskSourceLastSynced(sourceId)
@@ -665,19 +636,6 @@ export class PeakfloPlugin implements TaskSourcePlugin {
     }
   }
 
-  private mapWorkfloStatus(status: string): TaskStatus {
-    switch (status?.toLowerCase()) {
-      case 'completed':
-        return TaskStatus.Completed
-      case 'in_progress':
-        return TaskStatus.Triaging
-      case 'pending':
-        return TaskStatus.NotStarted
-      default:
-        return TaskStatus.NotStarted
-    }
-  }
-
   async exportUpdate(
     task: TaskRecord,
     changedFields: Record<string, unknown>,
@@ -691,17 +649,32 @@ export class PeakfloPlugin implements TaskSourcePlugin {
       if (changedFields.description !== undefined) updateData.description = changedFields.description
       if (changedFields.priority !== undefined) updateData.priority = changedFields.priority
       if (changedFields.due_date !== undefined) updateData.dueDate = changedFields.due_date
-      // Note: status is NOT exported — 20x statuses (not_started, triaging, etc.)
-      // don't map to workflo statuses (pending, in_progress). Completion goes
-      // through executeAction instead.
-
+      // Human ownership is independent of the selected helper agent.
+      if (changedFields.agent_id !== undefined) {
+        const agent = changedFields.agent_id ? ctx.db.getAgent(String(changedFields.agent_id)) : undefined
+        const agentId = (agent?.config as Record<string, unknown> | undefined)?.enterprise_agent_id
+        if (changedFields.agent_id && !agentId) throw new Error('Select an agent from Workflo.')
+        updateData.agentId = agentId ?? null
+      }
+      if (changedFields.skill_ids !== undefined) {
+        const ids = (changedFields.skill_ids as string[] | null) ?? []
+        const skills = ids.map(id => ctx.db.getSkill(id)?.enterprise_skill_id)
+        if (skills.some(id => !id)) throw new Error('Sync the selected skills to Workflo first.')
+        updateData.skillIds = skills
+      }
+      const snapshot = serverTaskSnapshot(ctx.db, task.id)
+      const expectedVersion = changedFields.__expectedVersion ?? snapshot?.version
+      if (expectedVersion !== undefined) updateData.expectedVersion = expectedVersion
       if (Object.keys(updateData).length > 0) {
         await ctx.workfloApiClient.updateTask(task.external_id, updateData)
+        const current = await ctx.workfloApiClient.getTask(task.external_id)
+        saveServerTaskSnapshot(ctx.db, task.id, current)
+        ctx.db.updateTask(task.id, serverTaskFields(ctx.db, current), 'workflo-server')
       }
       return
     }
 
-    // Legacy MCP mode: no-op (uses action-based completion)
+    throw new Error('Task writes require a Workflo connection with task contract v2. Use 20x 0.0.146 or later.')
   }
 
   async executeAction(
@@ -734,59 +707,19 @@ export class PeakfloPlugin implements TaskSourcePlugin {
       if (!ctx.workfloApiClient) {
         return { success: false, error: 'Enterprise API client not available — please reconnect to enterprise' }
       }
-      await ctx.workfloApiClient.executeAction(task.external_id, outputs)
-
+      await ctx.workfloApiClient.executeAction(task.external_id, outputs, serverTaskSnapshot(ctx.db, task.id)?.version)
+      const confirmed = await ctx.workfloApiClient.getTask(task.external_id)
+      saveServerTaskSnapshot(ctx.db, task.id, confirmed)
+      if (serverTaskStatus(confirmed.status) !== TaskStatus.Completed) {
+        ctx.db.updateTask(task.id, serverTaskFields(ctx.db, confirmed), 'workflo-server')
+        return { success: false, error: 'Workflo has not completed this task. Review its current status.' }
+      }
+      ctx.db.updateTask(task.id, serverTaskFields(ctx.db, confirmed), 'workflo-server')
       return { success: true, taskUpdate: { status: TaskStatus.Completed } }
     }
 
-    // ── Legacy MCP mode ─────────────────────────────────────────
-    if (!ctx.mcpServer) {
-      return { success: false, error: 'Missing MCP server and enterprise not connected' }
-    }
+    return { success: false, error: 'Task writes require a Workflo connection with task contract v2. Reconnect using 20x 0.0.146 or later.' }
 
-    // Build outputs from all output_fields with values
-    const outputs: Record<string, unknown> = {}
-    for (const field of task.output_fields) {
-      if (field.value !== undefined && field.value !== null && field.value !== '') {
-        outputs[field.id] = field.value
-      }
-    }
-    // Override action with the explicitly passed actionId
-    outputs.action = actionId
-    if (input) outputs.reason = input
-
-    const args = {
-      taskId: task.external_id,
-      outputs
-    }
-    console.log('[peakflo] task_complete request:', JSON.stringify(args))
-
-    const callResult = await ctx.toolCaller.callTool(ctx.mcpServer, 'task_complete', args)
-    console.log('[peakflo] task_complete response:', JSON.stringify(callResult))
-
-    if (!callResult.success) {
-      return { success: false, error: callResult.error || 'Action failed' }
-    }
-
-    // Check for application-level errors in the MCP response content
-    const res = callResult.result as McpResult | undefined
-    if (res?.isError) {
-      const errText = this.extractContentText(res)
-      return { success: false, error: errText || 'Action failed' }
-    }
-    const contentText = this.extractContentText(res)
-    if (contentText) {
-      try {
-        const parsed = JSON.parse(contentText)
-        if (parsed.error) {
-          return { success: false, error: String(parsed.error) }
-        }
-      } catch {
-        // Not JSON, that's fine
-      }
-    }
-
-    return { success: true, taskUpdate: { status: TaskStatus.Completed } }
   }
 
   async getUsers(

--- a/src/main/recurrence-scheduler.ts
+++ b/src/main/recurrence-scheduler.ts
@@ -1,3 +1,4 @@
+import { isWorkfloLinkedTask } from './workflo-task-sync'
 import { BrowserWindow } from 'electron'
 import { CronExpressionParser } from 'cron-parser'
 import type { DatabaseManager, RecurrencePatternRecord, RecurrencePatternObject, TaskRecord } from './database'
@@ -215,6 +216,7 @@ export class RecurrenceScheduler {
    * then fast-forward next_occurrence_at to the next future time.
    */
   private async catchUpMissedOccurrences(template: TaskRecord): Promise<void> {
+    if (isWorkfloLinkedTask(this.dbManager, template)) return
     if (!template.recurrence_pattern || !template.next_occurrence_at) {
       return
     }

--- a/src/main/sync-manager.test.ts
+++ b/src/main/sync-manager.test.ts
@@ -144,7 +144,7 @@ describe('SyncManager', () => {
       ;(db.getMcpServer as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'srv-1' })
 
       await syncManager.exportTaskUpdate('t1', { status: 'completed', complete_at_source: false })
-      expect(plugin.exportUpdate).not.toHaveBeenCalled()
+      expect(plugin.exportUpdate).toHaveBeenCalledWith(expect.anything(), {status:'completed'}, {}, expect.anything())
     })
 
     it('still syncs non-status edits when the user chose "I\'ll do it manually"', async () => {
@@ -161,7 +161,7 @@ describe('SyncManager', () => {
       await syncManager.exportTaskUpdate('t1', { title: 'New', status: 'in_progress' })
       expect(plugin.exportUpdate).toHaveBeenCalledWith(
         expect.objectContaining({ id: 't1' }),
-        { title: 'New' },
+        { title: 'New', status: 'in_progress' },
         {},
         expect.anything()
       )

--- a/src/main/sync-manager.test.ts
+++ b/src/main/sync-manager.test.ts
@@ -52,6 +52,23 @@ describe('SyncManager', () => {
   })
 
   describe('importTasks', () => {
+    it('imports canonical tasks without waiting for unrelated resource uploads', async () => {
+      const plugin = makeMockPlugin({ id: 'peakflo' })
+      const resourceSync = vi.fn().mockRejectedValue(new Error('Duplicate skill ids'))
+      Object.assign(syncManager, {
+        enterpriseSyncManager: { syncAll: resourceSync },
+        enterpriseUserId: 'human-1'
+      })
+      vi.mocked(db.getTaskSource).mockReturnValue({
+        id: 'src-1', plugin_id: 'peakflo', config: {}
+      } as ReturnType<DatabaseManager['getTaskSource']>)
+      vi.mocked(registry.get).mockReturnValue(plugin)
+      const result = await syncManager.importTasks('src-1')
+      expect(plugin.importTasks).toHaveBeenCalledOnce()
+      expect(result.imported).toBe(5)
+      expect(resourceSync).not.toHaveBeenCalled()
+    })
+
     it('returns error when source not found', async () => {
       ;(db.getTaskSource as unknown as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
       const result = await syncManager.importTasks('src-1')

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto'
+import { serverTaskFields, saveServerTaskSnapshot, serverTaskSnapshot } from './workflo-task-sync'
 import type { DatabaseManager, TaskRecord } from './database'
 import type { EnterpriseStateSync } from './enterprise-state-sync'
 import type { McpToolCaller } from './mcp-tool-caller'
@@ -20,13 +22,17 @@ export class SyncManager {
   private enterpriseSyncManager?: EnterpriseSyncManager
   private enterpriseStateSync?: EnterpriseStateSync
   private enterpriseUserId?: string
+  private uploadInFlight = false
+  private updateInFlight = false
+  private completionInFlight = false
 
   constructor(
     private db: DatabaseManager,
     private toolCaller: McpToolCaller,
     private pluginRegistry: PluginRegistry,
     private oauthManager?: OAuthManager
-  ) {}
+  ) {
+  }
 
   /**
    * Set the enterprise connection for REST API-based task import.
@@ -42,6 +48,16 @@ export class SyncManager {
     this.enterpriseSyncManager = syncManager
     this.enterpriseUserId = userId
     this.enterpriseStateSync = stateSync
+    const scope = this.taskUploadScope()
+    if (scope) this.db.setSetting('workflo-sync-scope', scope)
+    let source = this.db.getTaskSources().find(s => s.plugin_id === 'peakflo' && s.config?.unified_scope === scope)
+    if (!source && scope) source = this.db.createTaskSource({
+      name: '[Workflo] My tasks', plugin_id: 'peakflo', mcp_server_id: null,
+      config: { enterprise_mode: true, unified_scope: scope },
+      list_tool: '', list_tool_args: {}, update_tool: '', update_tool_args: {}
+    })
+    if (source) void this.importTasks(source.id)
+    else void this.flushTaskUploads()
   }
 
   clearEnterpriseConnection(): void {
@@ -83,6 +99,10 @@ export class SyncManager {
       return result
     }
 
+    if (source.config?.unified_scope && source.config.unified_scope !== this.taskUploadScope()) {
+      result.errors.push('This task source belongs to a different Workflo account or organization.')
+      return result
+    }
     const plugin = this.pluginRegistry.get(source.plugin_id)
     if (!plugin) {
       result.errors.push(`Plugin "${source.plugin_id}" not found`)
@@ -90,6 +110,9 @@ export class SyncManager {
       return result
     }
 
+    await this.flushTaskUploads()
+    await this.flushTaskUpdates()
+    await this.flushTaskCompletions()
     const ctx = this.buildContext(source.mcp_server_id || undefined, sourceId)
     console.log('[sync] Importing from:', source.name)
 
@@ -125,6 +148,86 @@ export class SyncManager {
     return result
   }
 
+  /** A durable command, retried on reconnect and on each task sync. */
+  async uploadTask(taskId: string, autonomous = false): Promise<{ queued: boolean }> {
+    const task = this.db.getTask(taskId)
+    if (!task || task.source_id || task.external_id) throw new Error('Only a local task can be sent to Workflo.')
+    if (task.session_id || !['not_started', 'ready_for_review'].includes(task.status)) {
+      throw new Error('Stop the local session before sending this task to Workflo.')
+    }
+    const scope = this.taskUploadScope()
+    if (!scope) throw new Error('Connect to Workflo and select an organization first.')
+    const key = `workflo-upload:${taskId}`
+    if (!this.db.getSetting(key)) {
+      const agent = task.agent_id ? this.db.getAgent(task.agent_id) : undefined
+      const agentId = (agent?.config as Record<string, unknown> | undefined)?.enterprise_agent_id as string | undefined
+      if (autonomous && !agentId) throw new Error('Select an agent from Workflo for autonomous work.')
+      if (task.agent_id && !agentId) throw new Error('Select an agent from Workflo before sending this task.')
+      const skills = (task.skill_ids ?? []).map(id => this.db.getSkill(id)?.enterprise_skill_id)
+      if (skills.some(id => !id)) throw new Error('Sync the selected skills to Workflo first.')
+      if (task.recurrence_pattern && typeof task.recurrence_pattern !== 'string') {
+        throw new Error('Use a cron expression before sending this recurring task to Workflo.')
+      }
+      this.db.setSetting(key, JSON.stringify({ scope, taskId, data: {
+        clientRequestId: `20x:${randomUUID()}`,
+        title: task.title, description: task.description,
+        agentId, skillIds: skills,
+        // Selecting an agent for help does not transfer human ownership.
+        assignees: autonomous ? [{ assigneeType: 'agent', assigneeValue: agentId }] : [{ assigneeType: 'user', assigneeValue: this.enterpriseUserId }],
+        cron: task.is_recurring ? task.recurrence_pattern ?? undefined : undefined,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        autoCompleteWithoutReview: autonomous && task.auto_complete_without_review
+      } }))
+    }
+    this.db.updateTask(taskId, { auto_start_agent: false, is_recurring: false, recurrence_pattern: null, next_occurrence_at: null })
+    await this.flushTaskUploads()
+    return { queued: !!this.db.getSetting(key) }
+  }
+
+  canUploadTasks(): boolean { return !!this.taskUploadScope() }
+
+  private taskUploadScope(): string | undefined {
+    const tenant = this.db.getSetting('enterprise_tenant_id')
+    if (!this.workfloApiClient || !this.enterpriseUserId || !tenant) return undefined
+    return JSON.stringify([this.workfloApiClient.getDomain(), tenant, this.enterpriseUserId])
+  }
+
+  async flushTaskUploads(): Promise<void> {
+    if (this.uploadInFlight || !this.workfloApiClient) return
+    const scope = this.taskUploadScope()
+    if (!scope) return
+    this.uploadInFlight = true
+    try {
+      const settings = this.db.getAllSettings()
+      for (const [key, value] of Object.entries(settings)) {
+        if (!key.startsWith('workflo-upload:') || key.endsWith(':error')) continue
+        const command = JSON.parse(value)
+        if (command.scope !== scope) continue
+        try {
+          const local = this.db.getTask(command.taskId)
+          if (!local) { this.db.deleteSetting(key); continue }
+          const remote = await this.workfloApiClient.createTask(command.data)
+          let source = this.db.getTaskSources().find(s => s.plugin_id === 'peakflo' && s.config?.unified_scope === scope)
+          if (!source) source = this.db.createTaskSource({
+            name: '[Workflo] My tasks', plugin_id: 'peakflo', mcp_server_id: null,
+            config: { enterprise_mode: true, unified_scope: scope },
+            list_tool: '', list_tool_args: {}, update_tool: '', update_tool_args: {}
+          })
+          if (!source) throw new Error('Could not create the Workflo task source.')
+          saveServerTaskSnapshot(this.db, local.id, remote)
+          this.db.updateTask(local.id, { ...serverTaskFields(this.db, remote),
+            title: remote.title, description: remote.description ?? '', external_id: remote.id, source_id: source.id, source: source.name
+          }, 'workflo-server')
+          this.db.deleteSetting(key)
+          this.db.deleteSetting(`${key}:error`)
+        } catch (error) {
+          // Retain the exact command and request ID after network failures.
+          this.db.setSetting(`${key}:error`, error instanceof Error ? error.message : String(error))
+        }
+      }
+    } finally { this.uploadInFlight = false }
+  }
+
   async exportTaskUpdate(taskId: string, changedFields: Record<string, unknown>): Promise<void> {
     const task = this.db.getTask(taskId)
     if (!task?.source_id || !task.external_id) return
@@ -135,14 +238,7 @@ export class SyncManager {
     const plugin = this.pluginRegistry.get(source.plugin_id)
     if (!plugin) return
 
-    // The user picked "I'll do it manually", meaning they close the task in the
-    // source system themselves. A status change in 20x must then stay local —
-    // pushing it (e.g. marking the Notion page done) would complete the ticket
-    // at the source against their explicit choice. Other edits still sync.
     const fields = { ...changedFields }
-    if (task.complete_at_source === false && 'status' in fields) {
-      delete fields.status
-    }
     // Internal completion control — never a source field.
     delete fields.complete_at_source
     if (Object.keys(fields).length === 0) return
@@ -150,7 +246,78 @@ export class SyncManager {
     const ctx = this.buildContext(source.mcp_server_id || undefined, task.source_id || undefined)
     const config = this.getConfig(source)
 
+    if (source.plugin_id === 'peakflo' && this.workfloApiClient) {
+      // Status is confirmed through task actions and server reads.
+      delete fields.status
+      const allowed = ['title', 'description', 'priority', 'due_date', 'agent_id', 'skill_ids']
+      const edits = Object.fromEntries(Object.entries(fields).filter(([key]) => allowed.includes(key)))
+      if (Object.keys(edits).length === 0) return
+      const scope = this.taskUploadScope()
+      if (!scope) throw new Error('Select a Workflo organization before editing this task.')
+      const key = `workflo-update:${taskId}`
+      const pending = this.db.getSetting(key)
+      const previous = pending ? JSON.parse(pending) : undefined
+      this.db.setSetting(key, JSON.stringify({ scope, taskId,
+        expectedVersion: previous?.expectedVersion ?? serverTaskSnapshot(this.db, taskId)?.version,
+        fields: { ...previous?.fields, ...edits }
+      }))
+      await this.flushTaskUpdates()
+      return
+    }
     await plugin.exportUpdate(task, fields, config, ctx)
+  }
+
+  async flushTaskUpdates(): Promise<void> {
+    if (this.updateInFlight || !this.workfloApiClient) return
+    const scope = this.taskUploadScope()
+    if (!scope) return
+    this.updateInFlight = true
+    try {
+      for (const [key, value] of Object.entries(this.db.getAllSettings())) {
+        if (!key.startsWith('workflo-update:') || key.endsWith(':error')) continue
+        const command = JSON.parse(value)
+        if (command.scope !== scope) continue
+        const task = this.db.getTask(command.taskId)
+        const source = task?.source_id ? this.db.getTaskSource(task.source_id) : undefined
+        if (!task || !source) continue
+        const plugin = this.pluginRegistry.get(source.plugin_id)
+        if (!plugin) continue
+        try {
+          await plugin.exportUpdate(task, { ...command.fields, __expectedVersion: command.expectedVersion },
+            this.getConfig(source), this.buildContext(source.mcp_server_id || undefined, source.id))
+          // Keep any edit that arrived while this request was in flight.
+          if (this.db.getSetting(key) === value) this.db.deleteSetting(key)
+          this.db.deleteSetting(`${key}:error`)
+        } catch (error) {
+          this.db.setSetting(`${key}:error`, error instanceof Error ? error.message : String(error))
+        }
+      }
+    } finally { this.updateInFlight = false }
+  }
+
+  async flushTaskCompletions(): Promise<void> {
+    if (this.completionInFlight || !this.workfloApiClient) return
+    const scope = this.taskUploadScope()
+    if (!scope) return
+    this.completionInFlight = true
+    try {
+      for (const [key, value] of Object.entries(this.db.getAllSettings())) {
+        if (!key.startsWith('workflo-completion:') || key.endsWith(':error')) continue
+        const command = JSON.parse(value)
+        if (command.scope !== scope) continue
+        try {
+          await this.workfloApiClient.executeAction(command.externalId, command.outputs, command.expectedVersion)
+          const current = await this.workfloApiClient.getTask(command.externalId)
+          saveServerTaskSnapshot(this.db, command.taskId, current)
+          this.db.updateTask(command.taskId, serverTaskFields(this.db, current), 'workflo-server')
+          if (current.status !== 'completed') throw new Error('The server has not confirmed completion.')
+          this.db.deleteSetting(key)
+          this.db.deleteSetting(`${key}:error`)
+        } catch (error) {
+          this.db.setSetting(`${key}:error`, error instanceof Error ? error.message : String(error))
+        }
+      }
+    } finally { this.completionInFlight = false }
   }
 
   async executeAction(
@@ -164,6 +331,25 @@ export class SyncManager {
 
     const plugin = this.pluginRegistry.get(source.plugin_id)
     if (!plugin) return { success: false, error: `Plugin "${source.plugin_id}" not found` }
+
+    if (source.plugin_id === 'peakflo') {
+      const scope = this.taskUploadScope()
+      const snapshot = serverTaskSnapshot(this.db, task.id)
+      if (!scope || !snapshot?.version) return {success:false,error:'Sync this task with Workflo before completing it.'}
+      const key = `workflo-completion:${task.id}`
+      if (!this.db.getSetting(key)) {
+        const outputs: Record<string, unknown> = Object.fromEntries((task.output_fields ?? [])
+          .filter(field => field.value !== undefined && field.value !== null && field.value !== '')
+          .map(field => [field.id, field.value]))
+        outputs.action = actionId
+        if (input) outputs.reason = input
+        this.db.setSetting(key, JSON.stringify({scope,taskId:task.id,externalId:task.external_id,expectedVersion:snapshot.version,outputs}))
+      }
+      await this.flushTaskCompletions()
+      return this.db.getSetting(key)
+        ? {success:false,error:this.db.getSetting(`${key}:error`) || 'Completion is pending. Workflo must confirm it.'}
+        : {success:true}
+    }
 
     const ctx = this.buildContext(source.mcp_server_id || undefined, sourceId)
     const config = this.getConfig(source)

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -119,8 +119,9 @@ export class SyncManager {
     // Merge legacy columns into config for backward compat
     const config = this.getConfig(source)
 
-    // Phase 2.4: re-sync agents/skills/MCP servers before each task import
-    if (this.enterpriseSyncManager && this.enterpriseUserId) {
+    // Canonical task snapshots are self-contained. Resource uploads must not
+    // block task commands/imports when an unrelated skill sync is slow or fails.
+    if (source.plugin_id !== 'peakflo' && this.enterpriseSyncManager && this.enterpriseUserId) {
       try {
         console.log('[sync] Running enterprise resource sync before task import...')
         await this.enterpriseSyncManager.syncAll(this.enterpriseUserId)

--- a/src/main/task-api-server.test.ts
+++ b/src/main/task-api-server.test.ts
@@ -5,7 +5,7 @@ import { join } from 'path'
 import { createTestDb } from '../../test/helpers/db-test-helper'
 import { makeTask, makeAgent } from '../../test/helpers/task-fixtures'
 import type { DatabaseManager } from './database'
-import { setTaskApiAgentController, setTaskApiNotifier, setTaskAutomationTrigger, startTaskApiServer, stopTaskApiServer } from './task-api-server'
+import { handleRoute, setTaskApiAgentController, setTaskApiNotifier, setTaskAutomationTrigger, startTaskApiServer, stopTaskApiServer } from './task-api-server'
 import { TaskStatus } from '../shared/constants'
 
 /**
@@ -119,18 +119,14 @@ describe('/update_task - triage status guard', () => {
     expect(updatedTask.agent_id).toBe(agent!.id) // Agent assigned
   })
 
-  it('allows status update when task is not in triaging status', () => {
+  it('refuses direct completion even when a task is not triaging', async () => {
     const task = db.createTask(makeTask({ title: 'Normal task' }))!
     expect(task.status).toBe('not_started')
-
-    // Simulate handleRoute status guard
-    const currentTask = rawDb.prepare('SELECT status FROM tasks WHERE id = ?').get(task.id) as { status: string }
-    expect(currentTask.status).not.toBe('triaging')
-
-    // Status update should proceed normally
-    db.updateTask(task.id, { status: 'completed' as unknown as Parameters<typeof db.updateTask>[1]['status'] })
-    const updatedTask = db.getTask(task.id)!
-    expect(updatedTask.status).toBe('completed')
+    const update = vi.spyOn(db, 'updateTask')
+    expect(await handleRoute(db, '/update_task', { task_id: task.id, status: 'completed' })).toEqual({ error: 'Workflo must confirm completion. Agents submit results for review.' })
+    expect(update).not.toHaveBeenCalled()
+    expect(db.getTask(task.id)!.status).toBe('not_started')
+    expect(rawDb.prepare('SELECT status FROM tasks WHERE id = ?').get(task.id)).toEqual({ status: 'not_started' })
   })
 })
 

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -347,6 +347,7 @@ export async function handleRoute(db: DatabaseManager, route: string, params: Re
     }
 
     case '/create_task': {
+      if (params.status === 'completed') return { error: 'Create the task in Workflo before completing it.' }
       if (!params.title) return { error: 'Title is required' }
 
       const id = `task_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
@@ -428,6 +429,11 @@ export async function handleRoute(db: DatabaseManager, route: string, params: Re
     }
 
     case '/update_task': {
+      if (params.status === 'completed') return { error: 'Workflo must confirm completion. Agents submit results for review.' }
+      if (params.status && params.status !== 'in_progress') {
+        try { db.updateTask(params.task_id as string, { status: params.status as never }) }
+        catch (error) { return { error: error instanceof Error ? error.message : 'Task status refused' } }
+      }
       const updates: string[] = []
       const qParams: unknown[] = []
 

--- a/src/main/task-automation-scheduler.test.ts
+++ b/src/main/task-automation-scheduler.test.ts
@@ -288,7 +288,7 @@ describe('TaskAutomationScheduler — parents and subtasks', () => {
         sort_order: index,
         agent_id: child.agent_id === undefined ? agentId : child.agent_id,
         ...(child.status ? { status: child.status } : {})
-      })
+      }, 'workflo-server')
       return created.id
     })
     return { parentId: parent.id, childIds }
@@ -317,7 +317,9 @@ describe('TaskAutomationScheduler — parents and subtasks', () => {
 
     await new TaskAutomationScheduler(db, agentManager).runNow()
 
+    expect(agentManager.completeTaskWithoutReview).toHaveBeenCalledTimes(1)
     expect(agentManager.completeTaskWithoutReview).toHaveBeenCalledWith(parentId)
+    expect(db.getTask(parentId)?.status).toBe(TaskStatus.ReadyForReview)
   })
 
   it('waiting for a child does not burn a completion attempt', async () => {
@@ -333,10 +335,12 @@ describe('TaskAutomationScheduler — parents and subtasks', () => {
     for (let i = 0; i < 5; i++) await scheduler.runNow()
     expect(agentManager.completeTaskWithoutReview).not.toHaveBeenCalled()
 
-    db.updateTask(childIds[0], { status: TaskStatus.Completed })
+    db.updateTask(childIds[0], { status: TaskStatus.Completed }, 'workflo-server')
     await scheduler.runNow()
 
+    expect(agentManager.completeTaskWithoutReview).toHaveBeenCalledTimes(1)
     expect(agentManager.completeTaskWithoutReview).toHaveBeenCalledWith(parentId)
+    expect(db.getTask(parentId)?.status).toBe(TaskStatus.ReadyForReview)
   })
 
   it('starts the first child of a parent that created children and stopped', async () => {
@@ -368,7 +372,7 @@ describe('TaskAutomationScheduler — parents and subtasks', () => {
     await scheduler.runNow()
     expect(agentManager.startTask).not.toHaveBeenCalled()
 
-    db.updateTask(childIds[0], { status: TaskStatus.Completed })
+    db.updateTask(childIds[0], { status: TaskStatus.Completed }, 'workflo-server')
     await scheduler.runNow()
     expect(agentManager.startTask).toHaveBeenCalledWith(childIds[1])
   })

--- a/src/main/task-automation-scheduler.ts
+++ b/src/main/task-automation-scheduler.ts
@@ -1,3 +1,4 @@
+import { isWorkfloLinkedTask } from './workflo-task-sync'
 import type { DatabaseManager, TaskRecord } from './database'
 import type { AgentManager } from './agent-manager'
 import { TaskStatus } from '../shared/constants'
@@ -182,7 +183,7 @@ export class TaskAutomationScheduler {
     return candidateIds
       .filter((id) => (this.failedStarts.get(id) ?? 0) < this.MAX_START_ATTEMPTS)
       .map((id) => this.dbManager.getTask(id))
-      .filter((task): task is TaskRecord => !!task)
+      .filter((task): task is TaskRecord => !!task && !isWorkfloLinkedTask(this.dbManager, task))
   }
 
   private hasSubtasks(taskId: string): boolean {
@@ -253,6 +254,8 @@ export class TaskAutomationScheduler {
     console.log(`[TaskAutomation] Found ${candidates.length} task(s) to auto-complete`)
 
     for (const row of candidates) {
+      const task = this.dbManager.getTask(row.id)
+      if (task && isWorkfloLinkedTask(this.dbManager, task)) continue
       if (this.inFlight.has(row.id)) continue
       if (this.agentManager.hasActiveSessionForTask(row.id)) {
         console.log(`[TaskAutomation] Skipping auto-complete of ${row.id} — agent session still active`)

--- a/src/main/workflo-api-client.ts
+++ b/src/main/workflo-api-client.ts
@@ -1,3 +1,5 @@
+const TASK_WRITE_HEADERS = { 'x-task-contract-version': '2', 'x-task-actor': 'human' }
+
 /**
  * WorkfloApiClient — Phase 2.1
  *
@@ -22,6 +24,16 @@ export interface WorkfloTask {
   title: string
   description: string | null
   status: string
+  deletedAt?: string | null
+  version?: number
+  agentId?: string | null
+  skillIds?: string[]
+  cron?: string | null
+  timezone?: string
+  isRecurring?: boolean
+  recurrenceParentId?: string | null
+  executionMode?: 'human' | 'autonomous'
+  autoCompleteWithoutReview?: boolean
   communicationChannel: string
   dueDate: string | null
   priority: string | null
@@ -121,6 +133,7 @@ export interface WorkfloSkill {
   description: string
   content: string
   confidence?: number
+  deletedAt?: string | null
   version?: number
   uses?: number
   lastUsed?: string | null
@@ -196,8 +209,19 @@ export class WorkfloApiClient {
   /**
    * Get a single task by ID
    */
+  async listTaskCache(cursor?: string): Promise<{tasks: WorkfloTask[]; nextCursor: string | null}> {
+    return await this.auth.apiRequest('GET', `/api/tasks/cache${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''}`) as {tasks:WorkfloTask[];nextCursor:string|null}
+  }
+
   async getTask(taskId: string): Promise<WorkfloTask> {
     const result = (await this.auth.apiRequest('GET', `/api/tasks/${taskId}`)) as { task: WorkfloTask }
+    return result.task
+  }
+
+
+
+  async createTask(data: { clientRequestId: string; title: string; description: string; agentId?: string; skillIds?: string[]; assignees?: Array<{ assigneeType: string; assigneeValue: string }>; cron?: string; timezone?: string; autoCompleteWithoutReview?: boolean }): Promise<WorkfloTask> {
+    const result = await this.auth.apiRequest('POST', '/api/tasks', data, TASK_WRITE_HEADERS) as { task: WorkfloTask }
     return result.task
   }
 
@@ -207,6 +231,9 @@ export class WorkfloApiClient {
   async updateTask(
     taskId: string,
     data: {
+      expectedVersion?: number
+      agentId?: string | null
+      skillIds?: string[]
       title?: string
       description?: string | null
       priority?: string | null
@@ -215,7 +242,7 @@ export class WorkfloApiClient {
       assignees?: Array<{ assigneeType: string; assigneeValue: string }>
     }
   ): Promise<void> {
-    await this.auth.apiRequest('PATCH', `/api/tasks/${taskId}`, data)
+    await this.auth.apiRequest('PATCH', `/api/tasks/${taskId}`, data, TASK_WRITE_HEADERS)
   }
 
   /**
@@ -223,11 +250,13 @@ export class WorkfloApiClient {
    */
   async executeAction(
     taskId: string,
-    outputs: Record<string, unknown>
+    outputs: Record<string, unknown>,
+    expectedVersion?: number
   ): Promise<void> {
+    const version = expectedVersion ?? (await this.getTask(taskId)).version
     await this.auth.apiRequest('POST', `/api/tasks/${taskId}/action`, {
-      outputs
-    })
+      outputs, expectedVersion: version
+    }, TASK_WRITE_HEADERS)
   }
 
   // ── Org Nodes ─────────────────────────────────────────────────────────

--- a/src/main/workflo-api-client.ts
+++ b/src/main/workflo-api-client.ts
@@ -1,4 +1,4 @@
-const TASK_WRITE_HEADERS = { 'x-task-contract-version': '2', 'x-task-actor': 'human' }
+import { TASK_WRITE_HEADERS, taskCompletionCommand } from '../shared/task-write-contract'
 
 /**
  * WorkfloApiClient — Phase 2.1
@@ -254,9 +254,9 @@ export class WorkfloApiClient {
     expectedVersion?: number
   ): Promise<void> {
     const version = expectedVersion ?? (await this.getTask(taskId)).version
-    await this.auth.apiRequest('POST', `/api/tasks/${taskId}/action`, {
-      outputs, expectedVersion: version
-    }, TASK_WRITE_HEADERS)
+    if (version === undefined) throw new Error('Sync this task with Workflo contract v2 before completing it.')
+    const command = taskCompletionCommand(taskId, outputs, version)
+    await this.auth.apiRequest(command.method, command.path, command.body, command.headers)
   }
 
   // ── Org Nodes ─────────────────────────────────────────────────────────

--- a/src/main/workflo-task-sync.test.ts
+++ b/src/main/workflo-task-sync.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestDb } from '../../test/helpers/db-test-helper'
+import { makeTask } from '../../test/helpers/task-fixtures'
+import type { DatabaseManager } from './database'
+import type { WorkfloApiClient, WorkfloTask } from './workflo-api-client'
+import type { PluginContext } from './plugins/types'
+import { PeakfloPlugin } from './plugins/peakflo-plugin'
+import { TaskAutomationScheduler } from './task-automation-scheduler'
+import type { AgentManager } from './agent-manager'
+import { SyncManager } from './sync-manager'
+import { serverTaskFields } from './workflo-task-sync'
+
+let db: DatabaseManager
+let sourceId: string
+const remote = (status = 'not_started'): WorkfloTask => ({
+  id: 'remote-1', tenantId: 'tenant-1', title: 'Server task', description: '', status,
+  version: 3, agentId: null, skillIds: [], cron: '* * * * *', isRecurring: true,
+  executionMode: 'human', assignees: [], taskData: null
+} as unknown as WorkfloTask)
+
+beforeEach(() => {
+  db = createTestDb().db
+  sourceId = db.createTaskSource({ name: 'Workflo', plugin_id: 'peakflo', mcp_server_id: null,
+    config: { enterprise_mode: true }, list_tool: '', list_tool_args: {}, update_tool: '', update_tool_args: {} })!.id
+})
+
+function context(api: Partial<WorkfloApiClient>): PluginContext {
+  return { db, workfloApiClient: api as WorkfloApiClient } as PluginContext
+}
+
+it('refuses local completion and unlink, but accepts a server completion', () => {
+  const task = db.createTask(makeTask({ external_id: 'remote-1', source_id: sourceId, complete_at_source: false }))!
+  expect(() => db.updateTask(task.id, { status: 'completed' })).toThrow('Workflo controls')
+  expect(db.getTask(task.id)?.status).toBe('not_started')
+  expect(() => db.updateTask(task.id, { source_id: null })).toThrow('Only the sync service')
+  db.updateTask(task.id, { status: 'completed' }, 'workflo-server')
+  expect(db.getTask(task.id)?.status).toBe('completed')
+})
+
+it('does not close after action success when the server still reports open', async () => {
+  const task = db.createTask(makeTask({ external_id: 'remote-1', source_id: sourceId }))!
+  const api = { executeAction: vi.fn().mockResolvedValue(undefined), getTask: vi.fn().mockResolvedValue(remote('ready_for_review')) }
+  const result = await new PeakfloPlugin().executeAction('complete', task, undefined, {}, context(api))
+  expect(result.success).toBe(false)
+  expect(db.getTask(task.id)?.status).toBe('ready_for_review')
+  api.getTask.mockResolvedValue(remote('completed'))
+  expect((await new PeakfloPlugin().executeAction('complete', task, undefined, {}, context(api))).success).toBe(true)
+  expect(db.getTask(task.id)?.status).toBe('completed')
+})
+
+it('pulls canonical status and never installs a second schedule', async () => {
+  const local = db.createTask(makeTask({ external_id: 'remote-1', source_id: sourceId, status: 'completed' }))!
+  const listTaskCache = vi.fn().mockResolvedValue({ tasks: [remote('ready_for_review')], pagination: { totalPages: 1 } })
+  await new PeakfloPlugin().importTasks(sourceId, { status_filter: 'pending' }, context({ listTaskCache }))
+  expect(db.getTask(local.id)).toMatchObject({ status: 'ready_for_review', server_managed: true, is_recurring: false, auto_start_agent: false })
+  expect(listTaskCache).toHaveBeenCalledWith(undefined)
+  expect(JSON.parse(db.getSetting(`workflo-task:${local.id}`)!)).toMatchObject({ cron: '* * * * *', version: 3 })
+})
+
+it('does not start or complete a server task from stale local automation flags', async () => {
+  db.createTask(makeTask({ external_id: 'remote-1', source_id: sourceId, auto_start_agent: true }))!
+  db.createTask(makeTask({ external_id: 'remote-2', source_id: sourceId, status: 'ready_for_review', auto_complete_without_review: true }))!
+  const manager = { startTask: vi.fn(), completeTaskWithoutReview: vi.fn(), hasActiveSessionForTask: vi.fn().mockReturnValue(false) }
+  await new TaskAutomationScheduler(db, manager as unknown as AgentManager).runNow()
+  expect(manager.startTask).not.toHaveBeenCalled()
+  expect(manager.completeTaskWithoutReview).not.toHaveBeenCalled()
+})
+
+it('maps enterprise agent and skill IDs without changing published agent data', () => {
+  const agent = db.createAgent({ name: 'Agent', config: { enterprise_agent_id: 'agent-remote' } as never })!
+  const skill = db.createSkill({ name: 'Skill', description: '', content: '', enterprise_skill_id: 'skill-remote' })!
+  expect(serverTaskFields(db, { ...remote(), agentId: 'agent-remote', skillIds: ['skill-remote'] })).toMatchObject({ agent_id: agent.id, skill_ids: [skill.id] })
+})
+
+describe('durable upload', () => {
+  function setup() {
+    db.setSetting('enterprise_tenant_id', 'tenant-1')
+    const api = { getDomain: () => 'api.test', createTask: vi.fn().mockRejectedValue(new Error('offline')) }
+    const sync = new SyncManager(db, {} as never, { get: () => undefined } as never)
+    // Set connection state directly so this test controls when retries run.
+    Object.assign(sync, { workfloApiClient: api, enterpriseUserId: 'user-1' })
+    return { api, sync }
+  }
+
+  it('keeps one request ID across offline retry and binds the same local task', async () => {
+    const { api, sync } = setup()
+    const task = db.createTask(makeTask())!
+    expect(await sync.uploadTask(task.id)).toEqual({ queued: true })
+    const first = api.createTask.mock.calls[0][0]
+    expect(first.assignees).toEqual([{ assigneeType: 'user', assigneeValue: 'user-1' }])
+    api.createTask.mockResolvedValue(remote() as never)
+    await sync.flushTaskUploads()
+    expect(api.createTask.mock.calls[1][0].clientRequestId).toBe(first.clientRequestId)
+    expect(db.getTask(task.id)?.external_id).toBe('remote-1')
+    expect(db.getSetting(`workflo-upload:${task.id}`)).toBeUndefined()
+    expect(db.getTasks()).toHaveLength(1)
+  })
+
+  it('does not replay an upload into a different tenant', async () => {
+    const { api, sync } = setup()
+    const task = db.createTask(makeTask())!
+    await sync.uploadTask(task.id)
+    db.setSetting('enterprise_tenant_id', 'tenant-2')
+    api.createTask.mockClear()
+    await sync.flushTaskUploads()
+    expect(api.createTask).not.toHaveBeenCalled()
+    expect(db.getSetting(`workflo-upload:${task.id}`)).toBeDefined()
+  })
+})
+
+it('does not fire local recurrence for an old Workflo task with a stale schedule', async () => {
+  const { RecurrenceScheduler } = await import('./recurrence-scheduler')
+  const task = db.createTask(makeTask({ external_id: 'remote-1', source_id: sourceId,
+    is_recurring: true, recurrence_pattern: '* * * * *' }))!
+  db.updateTask(task.id, { next_occurrence_at: new Date(Date.now() - 120000).toISOString() })
+  const scheduler = new RecurrenceScheduler(db, 'UTC')
+  await (scheduler as unknown as { checkAndCreateDueInstances(): Promise<void> }).checkAndCreateDueInstances()
+  expect(db.getTasks()).toHaveLength(1)
+})
+
+it('refuses a successful legacy action without a completed task read', async () => {
+  const task = db.createTask(makeTask({ external_id: 'remote-1', source_id: sourceId }))!
+  const ctx = { db, mcpServer: { id: 'mcp' }, toolCaller: { callTool: vi.fn().mockResolvedValue({ success: true,
+    result: { content: [{ type: 'text', text: JSON.stringify({ status: 'pending' }) }] } }) } } as unknown as PluginContext
+  expect((await new PeakfloPlugin().executeAction('complete', task, undefined, {}, ctx)).success).toBe(false)
+  expect(db.getTask(task.id)?.status).toBe('not_started')
+})
+
+it('keeps offline metadata and original version across conflict and pull', async () => {
+  db.setSetting('enterprise_tenant_id', 'tenant-1')
+  const local = db.createTask(makeTask({ title: 'Old title', external_id: 'remote-1', source_id: sourceId }))!
+  db.setSetting(`workflo-task:${local.id}`, JSON.stringify(remote()))
+  const api = {
+    getDomain: () => 'api.test',
+    updateTask: vi.fn().mockRejectedValue(new Error('409: Task changed on the server')),
+    getTask: vi.fn().mockResolvedValue({ ...remote(), version: 4 }),
+    listTaskCache: vi.fn().mockResolvedValue({ tasks: [{ ...remote(), title: 'Someone else changed this', version: 4 }], pagination: { totalPages: 1 } })
+  }
+  const plugin = new PeakfloPlugin()
+  const sync = new SyncManager(db, {} as never, { get: () => plugin } as never)
+  Object.assign(sync, { workfloApiClient: api, enterpriseUserId: 'user-1' })
+  db.updateTask(local.id, { title: 'My pending title' })
+  await sync.exportTaskUpdate(local.id, { title: 'My pending title', status: 'completed' })
+  expect(api.updateTask).toHaveBeenCalledWith('remote-1', { title: 'My pending title', expectedVersion: 3 })
+  await plugin.importTasks(sourceId, {}, context(api))
+  expect(db.getTask(local.id)).toMatchObject({ title: 'Someone else changed this', server_sync_pending: true, server_sync_error: '409: Task changed on the server' })
+  await sync.flushTaskUpdates()
+  expect(api.updateTask.mock.calls[1][1]).toMatchObject({ expectedVersion: 3 })
+  expect(JSON.parse(db.getSetting(`workflo-task:${local.id}`)!)).toMatchObject({ version: 4 })
+})
+
+it('a desktop helper cannot send status with the human credential', () => {
+  const local = db.createTask(makeTask({ external_id: 'remote-1', source_id: sourceId }))!
+  expect(() => db.updateTask(local.id, {status:'ready_for_review'})).toThrow('Workflo controls')
+  expect(db.getTask(local.id)?.status).toBe('not_started')
+  expect(db.getSetting(`workflo-progress:${local.id}`)).toBeUndefined()
+})
+
+it('refuses local progress for autonomous and completed server tasks', () => {
+  const local = db.createTask(makeTask({ external_id: 'remote-1', source_id: sourceId }))!
+  db.setSetting(`workflo-task:${local.id}`, JSON.stringify({ ...remote(), executionMode: 'autonomous' }))
+  expect(() => db.updateTask(local.id, { status: 'ready_for_review' })).toThrow('Workflo controls')
+  db.setSetting(`workflo-task:${local.id}`, JSON.stringify(remote('completed')))
+  expect(() => db.updateTask(local.id, { status: 'agent_working' })).toThrow('Workflo controls')
+})
+
+it('stores an offline human completion with its original version until the server confirms it',async()=>{
+  db.setSetting('enterprise_tenant_id','tenant-1')
+  const local=db.createTask(makeTask({external_id:'remote-1',source_id:sourceId}))!
+  db.setSetting(`workflo-task:${local.id}`,JSON.stringify(remote()))
+  const api={getDomain:()=> 'api.test',executeAction:vi.fn().mockRejectedValue(new Error('offline')),getTask:vi.fn().mockResolvedValue(remote('completed'))}
+  const sync=new SyncManager(db,{} as never,{get:()=>new PeakfloPlugin()} as never)
+  Object.assign(sync,{workfloApiClient:api,enterpriseUserId:'user-1'})
+  expect((await sync.executeAction('complete',local,undefined,sourceId)).success).toBe(false)
+  expect(db.getTask(local.id)?.status).toBe('not_started')
+  expect(JSON.parse(db.getSetting(`workflo-completion:${local.id}`)!)).toMatchObject({expectedVersion:3})
+  api.executeAction.mockResolvedValue(undefined)
+  await sync.flushTaskCompletions()
+  expect(api.executeAction).toHaveBeenLastCalledWith('remote-1',{action:'complete'},3)
+  expect(db.getTask(local.id)?.status).toBe('completed')
+  expect(db.getSetting(`workflo-completion:${local.id}`)).toBeUndefined()
+})
+
+it('a local draft cannot become completed without server acceptance',()=>{
+  const draft=db.createTask(makeTask())!
+  expect(()=>db.updateTask(draft.id,{status:'completed'})).toThrow('Workflo must confirm')
+  expect(db.getTask(draft.id)?.status).toBe('not_started')
+})

--- a/src/main/workflo-task-sync.ts
+++ b/src/main/workflo-task-sync.ts
@@ -1,0 +1,50 @@
+import type { DatabaseManager, TaskRecord, UpdateTaskData } from './database'
+import type { WorkfloTask } from './workflo-api-client'
+import { TaskStatus } from '../shared/constants'
+
+/** The server snapshot is a cache. No local status can grant completion. */
+export function isWorkfloLinkedTask(db: DatabaseManager, task: TaskRecord): boolean {
+  return !!task.external_id && !!task.source_id &&
+    db.getTaskSource(task.source_id)?.plugin_id === 'peakflo'
+}
+
+export function serverTaskSnapshot(db: DatabaseManager, id: string): WorkfloTask | undefined {
+  const value = db.getSetting(`workflo-task:${id}`)
+  return value ? JSON.parse(value) as WorkfloTask : undefined
+}
+
+export function saveServerTaskSnapshot(db: DatabaseManager, id: string, task: WorkfloTask): void {
+  db.setSetting(`workflo-task:${id}`, JSON.stringify(task))
+}
+
+export function pendingServerTaskFields(db: DatabaseManager, id: string): UpdateTaskData {
+  const value = db.getSetting(`workflo-update:${id}`)
+  return value ? JSON.parse(value).fields : {}
+}
+
+export function serverTaskStatus(status: string): TaskStatus {
+  if (Object.values(TaskStatus).includes(status as TaskStatus)) return status as TaskStatus
+  return status === 'in_progress' ? TaskStatus.Triaging : TaskStatus.NotStarted
+}
+
+/** Resolve server IDs through the existing enterprise resource links. */
+export function serverTaskFields(db: DatabaseManager, task: WorkfloTask): UpdateTaskData {
+  const result: UpdateTaskData = {
+    status: serverTaskStatus(task.status),
+    auto_start_agent: false,
+    auto_complete_without_review: false,
+    // The server owns the schedule. Keep it in the snapshot for display;
+    // never give it to the local recurrence scheduler.
+    is_recurring: false,
+    recurrence_pattern: null,
+    next_occurrence_at: null
+  }
+  if (task.agentId !== undefined) {
+    result.agent_id = db.getAgents().find(a =>
+      (a.config as Record<string, unknown>).enterprise_agent_id === task.agentId)?.id ?? null
+  }
+  if (task.skillIds !== undefined) {
+    result.skill_ids = db.getSkills().filter(s => s.enterprise_skill_id && task.skillIds!.includes(s.enterprise_skill_id)).map(s => s.id)
+  }
+  return result
+}

--- a/src/mobile/api/client.ts
+++ b/src/mobile/api/client.ts
@@ -57,8 +57,8 @@ export const api = {
     get: (id: string) => get<unknown>(`/api/tasks/${encodeURIComponent(id)}`),
     create: (data: unknown) => post<unknown>('/api/tasks', data),
     update: (id: string, data: unknown) => post<unknown>(`/api/tasks/${encodeURIComponent(id)}`, data),
-    complete: (id: string, completeAtSource: boolean) =>
-      post<{ completed: boolean; status?: string }>(`/api/tasks/${encodeURIComponent(id)}/complete`, { completeAtSource }),
+    complete: (id: string) =>
+      post<{ completed: boolean; status?: string }>(`/api/tasks/${encodeURIComponent(id)}/complete`, {}),
     reorderSubtasks: (parentId: string, orderedIds: string[]) =>
       post<{ success: boolean }>('/api/tasks/reorder-subtasks', { parentId, orderedIds })
   },

--- a/src/mobile/pages/TaskDetailPage.test.tsx
+++ b/src/mobile/pages/TaskDetailPage.test.tsx
@@ -341,36 +341,13 @@ describe('TaskDetailPage', () => {
     unmount()
   })
 
-  it('asks a source-backed task which completion to use instead of completing directly', () => {
-    const task = makeTask({ source_id: 'src-1', source: 'Notion' })
-    useTaskStore.setState({ tasks: [task], isLoading: false })
-
-    const { getByTestId, getByText, queryByTestId } = render(
-      <TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />
-    )
-
-    // The completion choice must be shown, not a direct completion
-    fireEvent.click(getByTestId('main-cta-complete'))
-    expect(getByText('Complete in Notion?')).toBeTruthy()
-
-    // Cancel leaves the task open
-    fireEvent.click(getByText('Cancel'))
-    expect(queryByTestId('main-cta-complete')).toBeTruthy()
-  })
-
-  it('completes a source-backed task locally via /complete when the user picks manual', () => {
+  it.each([null, 'src-1'])('requests server completion for source %s without a local choice', (sourceId) => {
     completeMock.mockClear()
-    const task = makeTask({ source_id: 'src-1', source: 'Notion' })
+    const task = makeTask({ source_id: sourceId, complete_at_source: false })
     useTaskStore.setState({ tasks: [task], isLoading: false })
-
-    const { getByTestId, getByText } = render(
-      <TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />
-    )
-
+    const { getByTestId, queryByText } = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
     fireEvent.click(getByTestId('main-cta-complete'))
-    // "I'll do it manually" routes to the source-honouring completion endpoint
-    // with completeAtSource=false, so the ticket is not closed at the source.
-    fireEvent.click(getByText("I'll do it manually"))
-    expect(completeMock).toHaveBeenCalledWith('task-1', false)
+    expect(completeMock).toHaveBeenCalledWith('task-1')
+    expect(queryByText("I'll do it manually")).toBeNull()
   })
 })

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -170,100 +170,31 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
     if (session?.sessionId) _stopSession(session.sessionId)
   }, [session?.sessionId, _stopSession])
 
-  // Display name of the source this task came from, when it has one. Shown in
-  // the completion choice, mirroring the desktop dialog.
-  const completeSourceName = useMemo(() => {
-    if (!task?.source_id) return undefined
-    return task.source || 'the task source'
-  }, [task?.source_id, task?.source])
-
-  // Completes a task the way the desktop does: a source-backed task honours
-  // the recorded answer — closing the ticket at the source when the user chose
-  // to, local-only otherwise. Tasks without a source just mark Completed.
-  const completeTaskNow = useCallback(
-    async (t: Task, completeAtSource: boolean) => {
-      if (t.source_id) {
-        await api.tasks.complete(t.id, completeAtSource)
-      } else {
-        await updateTask(t.id, { status: TaskStatus.Completed })
-      }
-    },
-    [updateTask]
-  )
+  const completeTaskNow = useCallback(async (t: Task) => {
+    try {
+      await api.tasks.complete(t.id)
+    } catch (error) {
+      window.alert(error instanceof Error ? error.message : 'Workflo has not confirmed completion.')
+    }
+  }, [])
 
   const handleCompleteTask = useCallback(async () => {
     if (!task) return
-    // Always show feedback when an agent is assigned (there may be a session to learn from)
-    if (task.agent_id) {
-      setCompleteModal({ withFeedback: true })
-    } else if (task.source_id && task.complete_at_source == null) {
-      // A source-backed task with no recorded answer asks which to use — reuse
-      // the same modal, without the rating/comment section.
-      setCompleteModal({ withFeedback: false })
-    } else {
-      await completeTaskNow(task, task.complete_at_source !== false)
-    }
+    if (task.agent_id) setCompleteModal({ withFeedback: true })
+    else await completeTaskNow(task)
   }, [task, completeTaskNow])
 
-  const handleCompleteAtSource = useCallback(async () => {
+  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string) => {
     if (!task) return
     setCompleteModal(null)
-    await completeTaskNow(task, true)
-  }, [task, completeTaskNow])
+    await updateTask(task.id, { feedback_rating: rating, feedback_comment: comment || null })
+    await completeTaskNow(task)
+  }, [task, updateTask, completeTaskNow])
 
-  const handleCompleteManually = useCallback(async () => {
+  const handleFeedbackSkip = useCallback(async () => {
     if (!task) return
     setCompleteModal(null)
-    await completeTaskNow(task, false)
-  }, [task, completeTaskNow])
-
-  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string, completeAtSource: boolean) => {
-    if (!task || !task.agent_id) return
-    setCompleteModal(null)
-
-    // 1. Set task to AgentLearning status with feedback (matches desktop flow).
-    //    complete_at_source records the answer for the backend completion, which
-    //    honours it when the learning session finishes.
-    await updateTask(task.id, {
-      status: TaskStatus.AgentLearning,
-      feedback_rating: rating,
-      feedback_comment: comment || null,
-      ...(task.source_id ? { complete_at_source: completeAtSource } : {})
-    })
-
-    // 2. Build the same feedback prompt as desktop
-    const commentPart = comment ? ` Comment: "${comment}".` : ''
-    const today = new Date().toISOString().split('T')[0]
-    const prompt = `User rated this session ${rating}/5.${commentPart}\n\nReview the session and update skills in .agents/skills/:\n\n**For skills you used:**\nUpdate the YAML frontmatter:\n- confidence: ${rating >= 4 ? '+0.05 (was helpful)' : rating <= 2 ? '-0.10 (was wrong/outdated)' : 'no change'}\n- uses: increment by 1\n- lastUsed: ${today}\n- tags: add relevant keywords if missing\n\n**If you discovered a new reusable pattern:**\nCreate a new skill file.\n\nUpdate existing skills that were helpful or create new ones for patterns worth reusing.`
-
-    // 3. Resume the session (or start fresh if none) and send feedback prompt
-    try {
-      let activeSessionId = session?.sessionId
-      if (!activeSessionId && task.session_id) {
-        // Resume existing session from task record
-        const { sessionId } = await api.sessions.resume(task.session_id, task.agent_id, task.id)
-        activeSessionId = sessionId
-        initSession(task.id, sessionId, task.agent_id)
-      }
-      if (activeSessionId) {
-        await api.sessions.send(activeSessionId, prompt, task.id, task.agent_id)
-        // Backend agent-manager will sync skills and auto-transition to Completed
-        // when the session becomes idle (via transitionToIdle AgentLearning check)
-      } else {
-        // No session at all — just complete, honouring the source choice
-        await completeTaskNow(task, completeAtSource)
-      }
-    } catch (e) {
-      console.error('Failed to send feedback to agent:', e)
-      // Fallback: complete the task even if learning session fails
-      await completeTaskNow(task, completeAtSource)
-    }
-  }, [task, session, updateTask, initSession, completeTaskNow])
-
-  const handleFeedbackSkip = useCallback(async (completeAtSource: boolean) => {
-    if (!task) return
-    setCompleteModal(null)
-    await completeTaskNow(task, completeAtSource)
+    await completeTaskNow(task)
   }, [task, completeTaskNow])
 
   // Skills available for this agent — must be before conditional return (Rules of Hooks)
@@ -883,13 +814,9 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
         completion choice — one modal, no separate dialog. */}
       {completeModal && (
         <FeedbackModal
-          withFeedback={completeModal.withFeedback}
-          sourceName={completeSourceName}
           onSubmit={handleFeedbackSubmit}
           onSkip={handleFeedbackSkip}
           onCancel={() => setCompleteModal(null)}
-          onCompleteAtSource={handleCompleteAtSource}
-          onCompleteManually={handleCompleteManually}
         />
       )}
     </div>
@@ -1012,190 +939,29 @@ function SubtasksSection({ subtasks, onNavigateToTask, onReorderSubtasks }: { su
   )
 }
 
-function FeedbackModal({
-  withFeedback,
-  sourceName,
-  onSubmit,
-  onSkip,
-  onCancel,
-  onCompleteAtSource,
-  onCompleteManually
-}: {
-  /** True for an agent completion (shows 5-star rating + comment). False for a plain source completion. */
-  withFeedback: boolean
-  sourceName?: string | null
-  onSubmit: (rating: number, comment: string, completeAtSource: boolean) => void
-  onSkip: (completeAtSource: boolean) => void
+function FeedbackModal({ onSubmit, onSkip, onCancel }: {
+  onSubmit: (rating: number, comment: string) => void
+  onSkip: () => void
   onCancel: () => void
-  onCompleteAtSource: () => void
-  onCompleteManually: () => void
 }) {
   const [rating, setRating] = useState(0)
   const [comment, setComment] = useState('')
-  // Defaults to closing the task at the source, which is what 20x did before
-  // the choice existed (matches desktop).
-  const [completeAtSource, setCompleteAtSource] = useState(true)
-
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
-      {/* Backdrop */}
-      <div className="fixed inset-0 bg-black/60" onClick={onCancel} />
-
-      {/* Modal */}
-      <div className="relative z-50 w-full max-w-md mx-4 mb-4 bg-card border border-border rounded-xl shadow-xl animate-in slide-in-from-bottom-4 duration-200">
-        <div className="px-5 pt-5 pb-2">
-          {withFeedback ? (
-            <>
-              <h2 className="text-base font-semibold text-foreground">Session Feedback</h2>
-              <p className="text-xs text-muted-foreground mt-1">Rate this session to help the agent improve</p>
-            </>
-          ) : (
-            <>
-              <h2 className="text-base font-semibold text-foreground">
-                {sourceName ? `Complete in ${sourceName}?` : 'Complete this task?'}
-              </h2>
-              <p className="text-xs text-muted-foreground mt-1">
-                {sourceName
-                  ? `20x can close it there for you, or you can mark it complete here only and update ${sourceName} yourself.`
-                  : 'Choose how this task completes.'}
-              </p>
-            </>
-          )}
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div role="dialog" aria-label="Session feedback" className="mx-4 w-full max-w-md rounded-xl border bg-card p-5 space-y-4">
+        <h2>Session feedback</h2>
+        <p className="text-sm text-muted-foreground">Workflo confirms task completion.</p>
+        <div className="flex gap-2">
+          {[1, 2, 3, 4, 5].map(value => <button key={value} aria-label={`Rate ${value}`} aria-pressed={rating === value} onClick={() => setRating(value)}>{value}</button>)}
         </div>
-
-        {/* Star rating + comment — only for a feedback completion */}
-        {withFeedback && (
-          <>
-            <div className="flex gap-2 justify-center py-4">
-              {[1, 2, 3, 4, 5].map((star) => (
-                <button
-                  key={star}
-                  type="button"
-                  onClick={() => setRating(star)}
-                  className="p-1 active:scale-110 transition-transform"
-                >
-                  <svg
-                    className={`h-8 w-8 transition-colors ${
-                      star <= rating
-                        ? 'fill-amber-400 text-amber-400'
-                        : 'text-muted-foreground/30 fill-none'
-                    }`}
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-                  </svg>
-                </button>
-              ))}
-            </div>
-            <div className="px-5">
-              <textarea
-                placeholder="Optional feedback..."
-                value={comment}
-                onChange={(e) => setComment(e.target.value)}
-                rows={3}
-                className="w-full bg-transparent border border-input rounded-md px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-ring focus:ring-1 focus:ring-ring/30 resize-none"
-              />
-            </div>
-          </>
-        )}
-
-        {/* Source completion choice (mirrors desktop FeedbackDialog). Shown only
-        alongside the rating form — a plain completion uses the action buttons
-        below. */}
-        {withFeedback && sourceName && (
-          <div className="mx-5 rounded-lg border border-border/50 p-3 space-y-2">
-            <span className="block text-xs font-medium text-foreground">
-              This task came from {sourceName}
-            </span>
-            <div className="flex gap-2">
-              <ChoiceButton
-                selected={completeAtSource}
-                onClick={() => setCompleteAtSource(true)}
-                label={`Close it in ${sourceName}`}
-              />
-              <ChoiceButton
-                selected={!completeAtSource}
-                onClick={() => setCompleteAtSource(false)}
-                label="I'll do it manually"
-              />
-            </div>
-          </div>
-        )}
-
-        {/* Actions */}
-        <div className="flex gap-2 justify-end px-5 py-4">
-          {withFeedback ? (
-            <>
-              <button
-                onClick={() => onSkip(completeAtSource)}
-                className="h-9 px-4 text-sm text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
-              >
-                Skip
-              </button>
-              <button
-                onClick={() => { if (rating > 0) onSubmit(rating, comment, completeAtSource) }}
-                disabled={rating === 0}
-                className="h-9 px-4 text-sm font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                Submit Feedback
-              </button>
-            </>
-          ) : (
-            <>
-              <button
-                onClick={onCancel}
-                className="h-9 px-4 text-sm text-muted-foreground hover:text-foreground rounded-md transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={onCompleteManually}
-                className="h-9 px-4 text-sm font-medium border border-border text-foreground rounded-md hover:bg-accent/60 transition-colors"
-              >
-                I'll do it manually
-              </button>
-              <button
-                onClick={onCompleteAtSource}
-                className="h-9 px-4 text-sm font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
-              >
-                Complete at source
-              </button>
-            </>
-          )}
+        <textarea aria-label="Feedback" placeholder="Optional feedback..." value={comment} onChange={event => setComment(event.target.value)} />
+        <div className="flex gap-3">
+          <button onClick={onCancel}>Cancel</button>
+          <button onClick={onSkip}>Skip</button>
+          <button disabled={!rating} onClick={() => onSubmit(rating, comment)}>Submit Feedback</button>
         </div>
       </div>
     </div>
-  )
-}
-
-function ChoiceButton({
-  selected,
-  onClick,
-  label
-}: {
-  selected: boolean
-  onClick: () => void
-  label: string
-}) {
-  return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={selected}
-      onClick={onClick}
-      className={cn(
-        'flex-1 rounded-md border px-2.5 py-1.5 text-[11px] transition-colors',
-        selected
-          ? 'border-ring bg-accent/60 text-foreground'
-          : 'border-border/50 text-muted-foreground active:bg-accent/30'
-      )}
-    >
-      {label}
-    </button>
   )
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -256,6 +256,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('taskSource:update', id, data),
     delete: (id: string): Promise<boolean> => ipcRenderer.invoke('taskSource:delete', id),
     sync: (sourceId: string): Promise<unknown> => ipcRenderer.invoke('taskSource:sync', sourceId),
+    upload: (taskId: string, autonomous?: boolean): Promise<{ queued: boolean }> => ipcRenderer.invoke('taskSource:upload', taskId, autonomous),
     exportUpdate: (taskId: string, fields: Record<string, unknown>): Promise<void> =>
       ipcRenderer.invoke('taskSource:exportUpdate', taskId, fields),
     getUsers: (sourceId: string): Promise<unknown[]> =>

--- a/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
@@ -1,3 +1,4 @@
+import { taskCompletionCommand } from '../../../../shared/task-write-contract'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { TaskPanelContent } from './TaskPanelContent'
@@ -101,6 +102,7 @@ vi.mock('@/stores/task-store', () => {
   useTaskStore.getState = () => ({
     tasks: taskList,
     selectTask: selectTaskMock,
+    fetchTasks: async () => undefined,
   })
 
   return { useTaskStore }
@@ -183,25 +185,26 @@ describe('TaskPanelContent', () => {
     expect(addEdgeMock).not.toHaveBeenCalled()
   })
 
-  it('completes a task with no source directly from the canvas panel', async () => {
+  it.each([null, 'src-1'])('issues server completion for source %s without writing local completion', async (sourceId) => {
+    taskList[0].source_id = sourceId
+    const apiRequest = vi.fn()
+    const upload = vi.fn(async () => { taskList[0].source_id = 'src-1'; return { queued: false } })
+    window.electronAPI.taskSources.upload = upload
+    // Bridge the renderer command to the real API encoder. Credentials stay in main.
+    executeActionMock.mockImplementation(async () => {
+      const command = taskCompletionCommand('remote-1', { action: 'complete' }, 7)
+      apiRequest(command.method, command.path, command.body, command.headers)
+      return { success: true }
+    })
     render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
-
     fireEvent.click(screen.getByText('Complete task'))
-
-    await waitFor(() =>
-      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: 'completed' })
-    )
-    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
-  })
-
-  it('asks how to complete a source-backed task from the canvas panel', async () => {
-    taskList[0].source_id = 'src-1'
-    render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
-
-    fireEvent.click(screen.getByText('Complete task'))
-
-    expect(await screen.findByTestId('complete-at-source-dialog')).toBeTruthy()
+    await waitFor(() => expect(apiRequest).toHaveBeenCalledWith('POST', '/api/tasks/remote-1/action',
+      { outputs: { action: 'complete' }, expectedVersion: 7 },
+      { 'x-task-contract-version': '2', 'x-task-actor': 'human' }))
+    expect(executeActionMock).toHaveBeenCalledExactlyOnceWith('complete', 'task-1', 'src-1')
     expect(updateTaskMock).not.toHaveBeenCalled()
-    expect(executeActionMock).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
+    if (sourceId === null) expect(upload).toHaveBeenCalledExactlyOnceWith('task-1')
+    else expect(upload).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, fireEvent, within, cleanup } from '@testing-library/rea
 import { FeedbackDialog } from './FeedbackDialog'
 
 describe('FeedbackDialog', () => {
-  const onSubmit = vi.fn<(rating: number, comment: string, completeAtSource: boolean) => void>()
-  const onSkip = vi.fn<(completeAtSource: boolean) => void>()
+  const onSubmit = vi.fn<(rating: number, comment: string) => void>()
+  const onSkip = vi.fn<() => void>()
   const onCancel = vi.fn<() => void>()
 
   beforeEach(() => {
@@ -14,6 +14,13 @@ describe('FeedbackDialog', () => {
   // Without this the previous test's dialog stays in the DOM and testid
   // lookups match more than one element.
   afterEach(cleanup)
+
+  it('does not offer local-only completion for a Workflo task', () => {
+    render(<FeedbackDialog open sourceName="Workflo" serverManaged onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    expect(screen.queryByTestId('choice-complete-manually')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('Skip'))
+    expect(onSkip).toHaveBeenCalledWith()
+  })
 
   function getDialog() {
     return screen.getByRole('dialog')
@@ -62,7 +69,7 @@ describe('FeedbackDialog', () => {
 
     // Submit
     fireEvent.click(within(dialog).getByText('Submit Feedback'))
-    expect(onSubmit).toHaveBeenCalledWith(4, 'Great session!', true)
+    expect(onSubmit).toHaveBeenCalledWith(4, 'Great session!')
   })
 
   // ── Source completion choice ──────────────────────────────
@@ -72,34 +79,10 @@ describe('FeedbackDialog', () => {
     expect(screen.queryByTestId('source-completion-choice')).toBeNull()
   })
 
-  it('shows the source choice, defaulting to closing it at the source', () => {
-    render(<FeedbackDialog open={true} sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
-    expect(screen.getByTestId('source-completion-choice')).toBeInTheDocument()
-    expect(screen.getByText('This task came from Notion')).toBeInTheDocument()
-    expect(screen.getByTestId('choice-complete-at-source')).toHaveAttribute('aria-checked', 'true')
-    expect(screen.getByTestId('choice-complete-manually')).toHaveAttribute('aria-checked', 'false')
-  })
-
-  it('passes completeAtSource=false to onSubmit after picking the manual option', () => {
-    render(<FeedbackDialog open={true} sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
-    const dialog = getDialog()
-
-    fireEvent.click(screen.getByTestId('choice-complete-manually'))
-    expect(screen.getByTestId('choice-complete-manually')).toHaveAttribute('aria-checked', 'true')
-
-    const starButtons = within(dialog).getAllByRole('button').filter(btn =>
-      btn.getAttribute('type') === 'button' && btn.querySelector('svg')
-    )
-    fireEvent.click(starButtons[4])
-    fireEvent.click(within(dialog).getByText('Submit Feedback'))
-
-    expect(onSubmit).toHaveBeenCalledWith(5, '', false)
-  })
-
-  it('passes the choice to onSkip too, so Skip does not ask again', () => {
-    render(<FeedbackDialog open={true} sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
-    fireEvent.click(screen.getByTestId('choice-complete-manually'))
-    fireEvent.click(within(getDialog()).getByText('Skip'))
-    expect(onSkip).toHaveBeenCalledWith(false)
+  it('never offers local-only completion for any source', () => {
+    render(<FeedbackDialog open sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    expect(screen.queryByTestId('choice-complete-manually')).toBeNull()
+    fireEvent.click(screen.getByText('Skip'))
+    expect(onSkip).toHaveBeenCalledWith()
   })
 })

--- a/src/renderer/src/components/tasks/FeedbackDialog.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.tsx
@@ -3,7 +3,6 @@ import { Star } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogBody, DialogTitle, DialogDescription } from '@/components/ui/Dialog'
 import { Button } from '@/components/ui/Button'
 import { Textarea } from '@/components/ui/Textarea'
-import { cn } from '@/lib/utils'
 
 interface FeedbackDialogProps {
   open: boolean
@@ -12,18 +11,18 @@ interface FeedbackDialogProps {
    * show the completion choice; leave it undefined for a local task.
    */
   sourceName?: string | null
-  onSubmit: (rating: number, comment: string, completeAtSource: boolean) => void
-  onSkip: (completeAtSource: boolean) => void
+  serverManaged?: boolean
+  onSubmit: (rating: number, comment: string) => void
+  onSkip: () => void
   onCancel: () => void
 }
 
-export function FeedbackDialog({ open, sourceName, onSubmit, onSkip, onCancel }: FeedbackDialogProps) {
+export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDialogProps) {
   const [rating, setRating] = useState(0)
   const [hoveredStar, setHoveredStar] = useState(0)
   const [comment, setComment] = useState('')
   // Defaults to closing the task at the source, which is what 20x did before
   // the choice existed.
-  const [completeAtSource, setCompleteAtSource] = useState(true)
 
   // Reset state when dialog opens
   useEffect(() => {
@@ -31,12 +30,11 @@ export function FeedbackDialog({ open, sourceName, onSubmit, onSkip, onCancel }:
       setRating(0)
       setHoveredStar(0)
       setComment('')
-      setCompleteAtSource(true)
     }
   }, [open])
 
   const handleSubmit = () => {
-    if (rating > 0) onSubmit(rating, comment, completeAtSource)
+    if (rating > 0) onSubmit(rating, comment)
   }
 
   return (
@@ -76,30 +74,10 @@ export function FeedbackDialog({ open, sourceName, onSubmit, onSkip, onCancel }:
             rows={3}
           />
 
-          {sourceName && (
-            <div className="flex flex-col gap-2 rounded-lg border border-border/50 p-3" data-testid="source-completion-choice">
-              <span className="text-xs font-medium text-foreground">
-                This task came from {sourceName}
-              </span>
-              <div className="flex gap-2">
-                <ChoiceButton
-                  selected={completeAtSource}
-                  onClick={() => setCompleteAtSource(true)}
-                  testId="choice-complete-at-source"
-                  label={`Close it in ${sourceName}`}
-                />
-                <ChoiceButton
-                  selected={!completeAtSource}
-                  onClick={() => setCompleteAtSource(false)}
-                  testId="choice-complete-manually"
-                  label="I'll do it manually"
-                />
-              </div>
-            </div>
-          )}
+          <p>Workflo confirms task completion.</p>
 
           <div className="flex gap-2 justify-end">
-            <Button variant="ghost" size="sm" onClick={() => onSkip(completeAtSource)}>
+            <Button variant="ghost" size="sm" onClick={() => onSkip()}>
               Skip
             </Button>
             <Button size="sm" disabled={rating === 0} onClick={handleSubmit}>
@@ -109,35 +87,5 @@ export function FeedbackDialog({ open, sourceName, onSubmit, onSkip, onCancel }:
         </DialogBody>
       </DialogContent>
     </Dialog>
-  )
-}
-
-function ChoiceButton({
-  selected,
-  onClick,
-  label,
-  testId
-}: {
-  selected: boolean
-  onClick: () => void
-  label: string
-  testId: string
-}) {
-  return (
-    <button
-      type="button"
-      role="radio"
-      aria-checked={selected}
-      data-testid={testId}
-      onClick={onClick}
-      className={cn(
-        'flex-1 rounded-md border px-2.5 py-1.5 text-[11px] transition-colors',
-        selected
-          ? 'border-ring bg-accent/60 text-foreground'
-          : 'border-border/50 text-muted-foreground hover:bg-accent/30'
-      )}
-    >
-      {label}
-    </button>
   )
 }

--- a/src/renderer/src/components/tasks/TaskHeaderBar.tsx
+++ b/src/renderer/src/components/tasks/TaskHeaderBar.tsx
@@ -1,3 +1,5 @@
+import { useEnterpriseStore } from '@/stores/enterprise-store'
+import { useTaskStore } from '@/stores/task-store'
 import { useEffect, useRef, useState } from 'react'
 import { ArrowLeft, Bot, Check, ChevronDown, ExternalLink, FolderOpen, Layers, Menu, MoreHorizontal, Pencil, Play, RotateCcw, Sparkles, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
@@ -68,6 +70,18 @@ export function TaskHeaderBar({
   const [editing, setEditing] = useState(false)
   const [title, setTitle] = useState(task.title)
   const [menuOpen, setMenuOpen] = useState(false)
+  const enterpriseConnected = useEnterpriseStore(s => s.isAuthenticated)
+  const [uploadMessage, setUploadMessage] = useState<string | null>(null)
+  const uploadToWorkflo = async (autonomous = false) => {
+    try {
+      const result = await window.electronAPI.taskSources.upload(task.id, autonomous)
+      setUploadMessage(result.queued ? 'Waiting for Workflo. Retry is saved.' : 'Task sent to Workflo.')
+      await useTaskStore.getState().fetchTasks()
+    } catch (error) {
+      setUploadMessage(error instanceof Error ? error.message : String(error))
+    }
+  }
+
   const [statusMenuOpen, setStatusMenuOpen] = useState(false)
   const [agentMenuOpen, setAgentMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -237,7 +251,7 @@ export function TaskHeaderBar({
           </span>
         )}
       </div>
-      {actionMeta && onAction && (
+      {actionMeta && onAction && task.server_execution_mode !== 'autonomous' && (
         <Button size="sm" onClick={onAction} className="h-8 gap-1.5 px-3" data-testid={`header-cta-${action}`}>
           {ActionIcon && <ActionIcon className="h-3.5 w-3.5" />}
           {actionMeta.label}
@@ -268,6 +282,8 @@ export function TaskHeaderBar({
         {menuOpen && (
           <div className="absolute right-0 top-9 z-50 w-44 overflow-hidden rounded-lg border border-border/50 bg-popover p-1 shadow-xl">
             {[
+              { label: 'Send to Workflo', icon: ExternalLink, action: enterpriseConnected && !task.source_id ? () => uploadToWorkflo(false) : undefined },
+              { label: 'Run agent in Workflo', icon: Bot, action: enterpriseConnected && !task.source_id && task.agent_id ? () => uploadToWorkflo(true) : undefined },
               { label: 'Edit task', icon: Pencil, action: onEdit },
               { label: 'Snooze', icon: ChevronDown, action: onSnooze },
               { label: 'Open in canvas', icon: Layers, action: onOpenCanvas },
@@ -285,6 +301,11 @@ export function TaskHeaderBar({
           </div>
         )}
       </div>
+      {task.server_execution_mode === 'autonomous' && <span className="text-xs">Agent runs in Workflo</span>}
+      {task.server_cron && <span className="text-xs">Workflo schedule: {task.server_cron}</span>}
+      {task.server_pending_edits && <details className="text-xs"><summary>Unsaved edits</summary><pre className="whitespace-pre-wrap">{JSON.stringify(task.server_pending_edits, null, 2)}</pre></details>}
+      {task.server_sync_pending && <span role="status" className="text-xs">{task.server_sync_error ? `Edits not saved in Workflo: ${task.server_sync_error}` : 'Waiting to sync with Workflo'}</span>}
+      {uploadMessage && <span role="status" className="text-xs">{uploadMessage}</span>}
     </header>
   )
 }

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -660,13 +660,17 @@ function TaskWorkspaceComponent({
     }
   }, [session.sessionId, session.messages.length, task?.session_id, onCompleteTask])
 
-  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string, completeAtSource: boolean) => {
+  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string) => {
     if (!task?.agent_id || !task?.id) return
     setShowFeedback(false)
 
+    if (task.server_managed) {
+      await taskApi.update(task.id, {feedback_rating:rating,feedback_comment:comment || null})
+      await onCompleteTask()
+      return
+    }
+
     // Persist feedback + set task to Learning status - prevents auto-stop useEffect.
-    // `complete_at_source` records the user's answer here, because the learning
-    // session finishes in the main process, where no dialog can be shown.
     console.log('[TaskWorkspace] Setting task status to AgentLearning:', task.id)
     let updatedTask: WorkfloTask | null | undefined
     try {
@@ -674,7 +678,6 @@ function TaskWorkspaceComponent({
         status: TaskStatus.AgentLearning,
         feedback_rating: rating,
         feedback_comment: comment || null,
-        ...(task.source_id ? { complete_at_source: completeAtSource } : {})
       })
     } catch (error) {
       // The dialog is already closed at this point, so a rejected write left the
@@ -757,7 +760,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
     }
   }, [ensureChatSession, sendMessage, session.sessionId, task?.id])
 
-  const handleFeedbackSkip = useCallback(async (completeAtSource: boolean) => {
+  const handleFeedbackSkip = useCallback(async () => {
     if (!task?.id) return
     setShowFeedback(false)
     // Record the answer first so the completion path does not ask a second
@@ -765,7 +768,6 @@ Update existing skills that were helpful or create new ones for patterns worth r
     // source-backed tasks before setting the local status to Completed.
     // updateTaskInStore persists through the API and syncs the store, so the
     // completion path below reads the answer back.
-    if (task.source_id) await updateTaskInStore(task.id, { complete_at_source: completeAtSource })
     await onCompleteTask()
   }, [task?.id, task?.source_id, onCompleteTask, updateTaskInStore])
 
@@ -1246,6 +1248,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
       <FeedbackDialog
         open={showFeedback}
         sourceName={feedbackSourceName}
+        serverManaged={task.server_managed || taskSources.find(s => s.id === task.source_id)?.plugin_id === 'peakflo'}
         onSubmit={handleFeedbackSubmit}
         onSkip={handleFeedbackSkip}
         onCancel={() => setShowFeedback(false)}

--- a/src/renderer/src/hooks/use-agent-auto-start.ts
+++ b/src/renderer/src/hooks/use-agent-auto-start.ts
@@ -171,7 +171,7 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
       return allTasks
         .filter((task) => {
           // Skip recurring parent template tasks — they are templates, not actionable tasks
-          if (isRecurringTemplate(task)) return false
+          if (task.server_managed || isRecurringTemplate(task)) return false
 
           // Skip subtasks — they are managed by sequential subtask orchestration
           if (task.parent_task_id) return false
@@ -244,7 +244,7 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
 
       allTasks.forEach((task) => {
         // Skip recurring parent template tasks — they are templates, not actionable tasks
-        if (isRecurringTemplate(task)) return
+        if (task.server_managed || isRecurringTemplate(task)) return
 
         // Skip parent tasks that have subtasks — subtasks will run sequentially instead
         const hasChildren = allTasks.some((t) => t.parent_task_id === task.id)
@@ -392,7 +392,7 @@ export function useAgentAutoStart({ tasks, agents, showToast }: UseAgentAutoStar
 
       // Verify task is still eligible
       if (
-        isRecurringTemplate(task) ||
+        task.server_managed || isRecurringTemplate(task) ||
         task.status !== TaskStatus.NotStarted ||
         task.agent_id !== agentId ||
         isSnoozed(task.snoozed_until) ||

--- a/src/renderer/src/hooks/use-task-completion.test.tsx
+++ b/src/renderer/src/hooks/use-task-completion.test.tsx
@@ -97,8 +97,9 @@ describe('server completion', () => {
     expect(screen.queryByRole('dialog')).toBeNull()
   })
   it('requires a server task before completion',async()=>{
+    window.electronAPI.taskSources.upload = vi.fn().mockResolvedValue({queued:true})
     storeState.tasks=[makeTask()];render(<Harness />);fireEvent.click(screen.getByText('Complete'))
-    await waitFor(()=>expect(onToast).toHaveBeenCalledWith(expect.stringContaining('Send this task'),true))
+    await waitFor(()=>expect(onToast).toHaveBeenCalledWith(expect.stringContaining('Task creation is pending'),true))
     expect(updateTaskMock).not.toHaveBeenCalled();expect(executeActionMock).not.toHaveBeenCalled();expect(onCompleted).not.toHaveBeenCalled()
   })
   it('keeps a refused completion open',async()=>{

--- a/src/renderer/src/hooks/use-task-completion.test.tsx
+++ b/src/renderer/src/hooks/use-task-completion.test.tsx
@@ -16,7 +16,7 @@ const { updateTaskMock, executeActionMock, storeState } = vi.hoisted(() => ({
 }))
 
 vi.mock('@/stores/task-store', () => {
-  const getState = () => ({ tasks: storeState.tasks, updateTask: updateTaskMock })
+  const getState = () => ({ tasks: storeState.tasks, updateTask: updateTaskMock, fetchTasks: async()=>undefined })
   const useTaskStore = (selector: (s: ReturnType<typeof getState>) => unknown) => selector(getState())
   useTaskStore.getState = getState
   return { useTaskStore }
@@ -85,169 +85,26 @@ function Harness({ taskId = 'task-1' }: { taskId?: string }) {
   )
 }
 
-describe('useTaskCompletion', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    executeActionMock.mockResolvedValue({ success: true })
-    storeState.tasks = []
-    storeState.sources = []
-  })
-
+describe('server completion', () => {
+  beforeEach(() => { vi.clearAllMocks(); executeActionMock.mockResolvedValue({success:true}); storeState.tasks=[] })
   afterEach(cleanup)
-
-  it('completes a task with no source immediately, without asking', async () => {
-    storeState.tasks = [makeTask({ source_id: null })]
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-
-    await waitFor(() =>
-      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
-    )
-    expect(executeActionMock).not.toHaveBeenCalled()
-    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
-    expect(onCompleted).toHaveBeenCalled()
-  })
-
-  it('asks before completing a task that came from a source', async () => {
-    storeState.tasks = [makeTask({ source_id: 'src-1' })]
-    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-
-    expect(await screen.findByTestId('complete-at-source-dialog')).toBeTruthy()
-    // Nothing happens until the user answers.
-    expect(executeActionMock).not.toHaveBeenCalled()
+  it('always calls the source and never writes local completion', async () => {
+    storeState.tasks=[makeTask({source_id:'src-1',complete_at_source:false})]
+    render(<Harness />); fireEvent.click(screen.getByText('Complete'))
+    await waitFor(()=>expect(onCompleted).toHaveBeenCalled())
+    expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete,'task-1','src-1')
     expect(updateTaskMock).not.toHaveBeenCalled()
-    expect(screen.getByText('Complete in Linear?')).toBeTruthy()
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
-
-  it('pushes the completion to the source when the user picks "complete at source"', async () => {
-    storeState.tasks = [makeTask({ source_id: 'src-1' })]
-    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-    fireEvent.click(await screen.findByTestId('complete-at-source'))
-
-    await waitFor(() =>
-      expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete, 'task-1', 'src-1')
-    )
-    expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
-      status: TaskStatus.Completed,
-      complete_at_source: true
-    })
-    await waitFor(() => expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull())
+  it('requires a server task before completion',async()=>{
+    storeState.tasks=[makeTask()];render(<Harness />);fireEvent.click(screen.getByText('Complete'))
+    await waitFor(()=>expect(onToast).toHaveBeenCalledWith(expect.stringContaining('Send this task'),true))
+    expect(updateTaskMock).not.toHaveBeenCalled();expect(executeActionMock).not.toHaveBeenCalled();expect(onCompleted).not.toHaveBeenCalled()
   })
-
-  it('skips the source call when the user picks "I\'ll do it manually"', async () => {
-    storeState.tasks = [makeTask({ source_id: 'src-1' })]
-    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-    fireEvent.click(await screen.findByTestId('complete-manually'))
-
-    await waitFor(() =>
-      expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
-        status: TaskStatus.Completed,
-        complete_at_source: false
-      })
-    )
-    expect(executeActionMock).not.toHaveBeenCalled()
-    expect(onToast).toHaveBeenCalledWith('"Fix the login bug" completed in 20x only')
-  })
-
-  it('uses the action output field as the source action id', async () => {
-    storeState.tasks = [
-      makeTask({
-        source_id: 'src-1',
-        output_fields: [{ id: 'action', value: PluginActionId.Approve }] as WorkfloTask['output_fields']
-      })
-    ]
-    storeState.sources = [{ id: 'src-1', name: 'Peakflo' }]
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-    fireEvent.click(await screen.findByTestId('complete-at-source'))
-
-    await waitFor(() =>
-      expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Approve, 'task-1', 'src-1')
-    )
-  })
-
-  it('keeps the task open and reports the error when the source call fails', async () => {
-    storeState.tasks = [makeTask({ source_id: 'src-1' })]
-    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
-    executeActionMock.mockResolvedValue({ success: false, error: 'Linear rejected the update' })
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-    fireEvent.click(await screen.findByTestId('complete-at-source'))
-
-    await waitFor(() =>
-      expect(onToast).toHaveBeenCalledWith('Linear rejected the update', true)
-    )
-    expect(updateTaskMock).not.toHaveBeenCalled()
-    // The dialog stays open so the user can retry or complete manually.
-    expect(screen.getByTestId('complete-at-source-dialog')).toBeTruthy()
-  })
-
-  it('completes nothing when the user cancels', async () => {
-    storeState.tasks = [makeTask({ source_id: 'src-1' })]
-    storeState.sources = [{ id: 'src-1', name: 'Linear' }]
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-    fireEvent.click(await screen.findByText('Cancel'))
-
-    await waitFor(() => expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull())
-    expect(executeActionMock).not.toHaveBeenCalled()
-    expect(updateTaskMock).not.toHaveBeenCalled()
-  })
-
-  it('does not ask again when the feedback dialog already recorded the answer', async () => {
-    storeState.tasks = [makeTask({ source_id: 'src-1', complete_at_source: false })]
-    storeState.sources = [{ id: 'src-1', name: 'Notion' }]
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-
-    await waitFor(() =>
-      expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
-        status: TaskStatus.Completed,
-        complete_at_source: false
-      })
-    )
-    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
-    expect(executeActionMock).not.toHaveBeenCalled()
-  })
-
-  it('honours a recorded "close it at the source" answer without asking', async () => {
-    storeState.tasks = [makeTask({ source_id: 'src-1', complete_at_source: true })]
-    storeState.sources = [{ id: 'src-1', name: 'Notion' }]
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-
-    await waitFor(() =>
-      expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete, 'task-1', 'src-1')
-    )
-    expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
-      status: TaskStatus.Completed,
-      complete_at_source: true
-    })
-    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
-  })
-
-  it('falls back to the task source label when the source record is not loaded', async () => {
-    storeState.tasks = [makeTask({ source_id: 'src-1', source: 'jira' })]
-    storeState.sources = []
-    render(<Harness />)
-
-    fireEvent.click(screen.getByText('Complete'))
-
-    expect(await screen.findByText('Complete in jira?')).toBeTruthy()
+  it('keeps a refused completion open',async()=>{
+    executeActionMock.mockResolvedValue({success:false,error:'Review required'})
+    storeState.tasks=[makeTask({source_id:'src-1'})];render(<Harness />);fireEvent.click(screen.getByText('Complete'))
+    await waitFor(()=>expect(onToast).toHaveBeenCalledWith('Review required',true))
+    expect(updateTaskMock).not.toHaveBeenCalled();expect(onCompleted).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -15,10 +15,16 @@ export interface CompleteTaskRequestOptions {
 export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
   const executeAction = useTaskSourceStore(s => s.executeAction)
   const requestComplete = useCallback(async (taskId: string, options?: CompleteTaskRequestOptions) => {
-    const task = useTaskStore.getState().tasks.find(t => t.id === taskId)
+    let task = useTaskStore.getState().tasks.find(t => t.id === taskId)
     if (!task) return
     try {
-      if (!task.source_id) throw new Error('Send this task to Workflo before completing it.')
+      if (!task.source_id) {
+        const upload = await window.electronAPI.taskSources.upload(task.id)
+        if (upload.queued) throw new Error('Task creation is pending in Workflo. Completion has not been accepted.')
+        await useTaskStore.getState().fetchTasks()
+        task = useTaskStore.getState().tasks.find(t => t.id === taskId)
+        if (!task?.source_id) throw new Error('Send this task to Workflo before completing it.')
+      }
       const action = task.output_fields.find(f => f.id === 'action')?.value
       const result = await executeAction(action ? String(action) : PluginActionId.Complete, task.id, task.source_id)
       if (!result.success) throw new Error(result.error || 'The server did not confirm completion.')

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -1,162 +1,33 @@
-import { useCallback, useMemo, useState, type ReactNode } from 'react'
-import { CompleteAtSourceDialog } from '@/components/tasks/CompleteAtSourceDialog'
+import { useCallback } from 'react'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { useTaskStore } from '@/stores/task-store'
-import { TaskStatus, PluginActionId } from '@/types'
+import { PluginActionId } from '@/types'
 import type { WorkfloTask } from '@/types'
 
 export interface UseTaskCompletionOptions {
-  /** Shows a short message to the user. Optional. */
   onToast?: (message: string, isError?: boolean) => void
 }
-
 export interface CompleteTaskRequestOptions {
-  /** Runs after the task is completed. */
   onCompleted?: (task: WorkfloTask) => void
 }
 
-interface PendingCompletion {
-  taskId: string
-  options?: CompleteTaskRequestOptions
-}
-
-/**
- * Single completion path for tasks.
- *
- * A task that came from an external source (Linear, Jira, GitHub, ...) has two
- * valid completions: close it in the source system, or close it only in 20x
- * because the user updates the source. This hook asks the user which one to
- * use, instead of always pushing the completion to the source.
- *
- * Tasks without a source complete immediately — there is nothing to ask.
- */
+/** Completion is confirmed by the server. Local dismissal is a view action. */
 export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
-  const updateTask = useTaskStore((s) => s.updateTask)
-  const executeAction = useTaskSourceStore((s) => s.executeAction)
-  const sources = useTaskSourceStore((s) => s.sources)
-
-  const [pending, setPending] = useState<PendingCompletion | null>(null)
-  const [isBusy, setIsBusy] = useState(false)
-
-  // The dialog reads the task through the store, so an import that arrives
-  // while the dialog is open cannot make the prompt act on stale data.
-  const tasks = useTaskStore((s) => s.tasks)
-  const pendingTask = useMemo(
-    () => (pending ? tasks.find((t) => t.id === pending.taskId) : undefined),
-    [pending, tasks]
-  )
-
-  const sourceName = useMemo(() => {
-    if (!pendingTask?.source_id) return 'the task source'
-    const source = sources.find((s) => s.id === pendingTask.source_id)
-    return source?.name || pendingTask.source || 'the task source'
-  }, [pendingTask, sources])
-
-  /**
-   * Applies the completion. When `atSource` is true the plugin action runs
-   * first; a failure leaves the task open so the two systems stay in sync.
-   */
-  const runCompletion = useCallback(
-    async (
-      task: WorkfloTask,
-      options: CompleteTaskRequestOptions | undefined,
-      atSource: boolean
-    ): Promise<boolean> => {
-      try {
-        if (atSource && task.source_id) {
-          const actionField = task.output_fields.find((f) => f.id === 'action')
-          const actionValue = actionField?.value
-            ? String(actionField.value)
-            : PluginActionId.Complete
-          const result = await executeAction(actionValue, task.id, task.source_id)
-          if (!result.success) {
-            onToast?.(result.error || 'Failed to complete task', true)
-            return false
-          }
-        }
-        await updateTask(task.id, {
-          status: TaskStatus.Completed,
-          // Record the user's completion choice so a later update does not push
-          // a source completion against it (see SyncManager.exportTaskUpdate).
-          ...(task.source_id ? { complete_at_source: atSource } : {})
-        })
-      } catch (err) {
-        console.error('Failed to complete task:', err)
-        onToast?.('Failed to complete task', true)
-        return false
-      }
-
+  const executeAction = useTaskSourceStore(s => s.executeAction)
+  const requestComplete = useCallback(async (taskId: string, options?: CompleteTaskRequestOptions) => {
+    const task = useTaskStore.getState().tasks.find(t => t.id === taskId)
+    if (!task) return
+    try {
+      if (!task.source_id) throw new Error('Send this task to Workflo before completing it.')
+      const action = task.output_fields.find(f => f.id === 'action')?.value
+      const result = await executeAction(action ? String(action) : PluginActionId.Complete, task.id, task.source_id)
+      if (!result.success) throw new Error(result.error || 'The server did not confirm completion.')
+      await useTaskStore.getState().fetchTasks()
       options?.onCompleted?.(task)
-      onToast?.(
-        atSource
-          ? `"${task.title}" completed`
-          : `"${task.title}" completed in 20x only`
-      )
-      return true
-    },
-    [executeAction, onToast, updateTask]
-  )
-
-  /**
-   * Entry point for every user-triggered completion. Reads the task from the
-   * store so callers cannot pass a stale copy.
-   */
-  const requestComplete = useCallback(
-    async (taskId: string, options?: CompleteTaskRequestOptions) => {
-      const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
-      if (!task) return
-      if (task.source_id) {
-        // The feedback dialog asks the same question for tasks that ran an
-        // agent, and records the answer on the task. Honour it instead of
-        // asking a second time.
-        if (task.complete_at_source != null) {
-          await runCompletion(task, options, task.complete_at_source)
-          return
-        }
-        setPending({ taskId, options })
-        return
-      }
-      await runCompletion(task, options, false)
-    },
-    [runCompletion]
-  )
-
-  const resolvePending = useCallback(
-    async (atSource: boolean) => {
-      if (!pending || isBusy) return
-      const task = useTaskStore.getState().tasks.find((t) => t.id === pending.taskId)
-      if (!task) {
-        setPending(null)
-        return
-      }
-      setIsBusy(true)
-      try {
-        const done = await runCompletion(task, pending.options, atSource)
-        if (done) setPending(null)
-      } finally {
-        setIsBusy(false)
-      }
-    },
-    [isBusy, pending, runCompletion]
-  )
-
-  const handleCompleteAtSource = useCallback(() => resolvePending(true), [resolvePending])
-  const handleCompleteManually = useCallback(() => resolvePending(false), [resolvePending])
-  const handleCancel = useCallback(() => {
-    if (!isBusy) setPending(null)
-  }, [isBusy])
-
-  const completionDialog: ReactNode = (
-    <CompleteAtSourceDialog
-      isOpen={pending !== null}
-      taskTitle={pendingTask?.title || ''}
-      sourceName={sourceName}
-      isBusy={isBusy}
-      onCompleteAtSource={handleCompleteAtSource}
-      onCompleteManually={handleCompleteManually}
-      onCancel={handleCancel}
-    />
-  )
-
-  return { requestComplete, completionDialog }
+      onToast?.(`"${task.title}" completed`)
+    } catch (error) {
+      onToast?.(error instanceof Error ? error.message : 'Task completion failed.', true)
+    }
+  }, [executeAction, onToast])
+  return { requestComplete, completionDialog: null }
 }

--- a/src/renderer/src/stores/task-source-store.test.ts
+++ b/src/renderer/src/stores/task-source-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Mock } from 'vitest'
 import { useTaskSourceStore } from './task-source-store'
+import { useTaskStore } from './task-store'
 import type { TaskSource, CreateTaskSourceDTO, UpdateTaskSourceDTO } from '@/types'
 
 const mockElectronAPI = window.electronAPI
@@ -97,6 +98,27 @@ describe('useTaskSourceStore', () => {
   })
 
   describe('syncAllEnabled', () => {
+    it('refreshes canonical tasks while another source remains pending', async () => {
+      let finishSlow!: (value: unknown) => void
+      const slow = new Promise((resolve) => { finishSlow = resolve })
+      const result = { source_id: 'canonical', imported: 0, updated: 1, errors: [] }
+      useTaskSourceStore.setState({ sources: [
+        { id: 'canonical', enabled: true }, { id: 'slow', enabled: true }
+      ] as TaskSource[] })
+      const refresh = vi.spyOn(useTaskStore.getState(), 'fetchTasks').mockResolvedValue()
+      ;(mockElectronAPI.taskSources.sync as unknown as Mock).mockImplementation((id) =>
+        id === 'slow' ? slow : Promise.resolve(result))
+      const all = useTaskSourceStore.getState().syncAllEnabled()
+      try {
+        await vi.waitFor(() => expect(refresh).toHaveBeenCalledOnce())
+        expect(useTaskSourceStore.getState().syncingIds.has('slow')).toBe(true)
+      } finally {
+        finishSlow(result)
+        await all
+        refresh.mockRestore()
+      }
+    })
+
     it('syncs all enabled sources', async () => {
       useTaskSourceStore.setState({
         sources: [

--- a/src/renderer/src/stores/task-source-store.ts
+++ b/src/renderer/src/stores/task-source-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { useTaskStore } from './task-store'
 import type { TaskSource, CreateTaskSourceDTO, UpdateTaskSourceDTO, SyncResult, ActionResult } from '@/types'
 import { taskSourceApi, pluginApi } from '@/lib/ipc-client'
 
@@ -85,6 +86,8 @@ export const useTaskSourceStore = create<TaskSourceState>((set, get) => ({
 
     try {
       const result = await taskSourceApi.sync(sourceId)
+      // Show each canonical import even while another source is still syncing.
+      await useTaskStore.getState().fetchTasks()
       set((state) => {
         const next = new Set(state.syncingIds)
         next.delete(sourceId)

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -330,6 +330,7 @@ interface ElectronAPI {
     update: (id: string, data: UpdateTaskSourceDTO) => Promise<TaskSource | undefined>
     delete: (id: string) => Promise<boolean>
     sync: (sourceId: string) => Promise<SyncResult>
+    upload: (taskId: string, autonomous?: boolean) => Promise<{ queued: boolean }>
     exportUpdate: (taskId: string, fields: Record<string, unknown>) => Promise<void>
     getUsers: (sourceId: string) => Promise<SourceUser[]>
     reassign: (taskId: string, userIds: string[], assigneeDisplay: string) => Promise<ReassignResult>

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -292,6 +292,12 @@ export interface RecurrencePatternObject {
 export type RecurrencePattern = RecurrencePatternObject | string
 
 export interface WorkfloTask {
+  server_pending_edits?: Record<string, unknown>
+  server_managed?: boolean
+  server_execution_mode?: 'human' | 'autonomous'
+  server_cron?: string | null
+  server_sync_pending?: boolean
+  server_sync_error?: string
   id: string
   title: string
   description: string

--- a/src/shared/task-write-contract.ts
+++ b/src/shared/task-write-contract.ts
@@ -1,0 +1,11 @@
+/** Human intent is explicit; the main process supplies the actual user credential. */
+export const TASK_WRITE_HEADERS = { 'x-task-contract-version': '2', 'x-task-actor': 'human' } as const
+
+export function taskCompletionCommand(taskId: string, outputs: Record<string, unknown>, expectedVersion: number) {
+  return {
+    method: 'POST' as const,
+    path: `/api/tasks/${taskId}/action`,
+    body: { outputs, expectedVersion },
+    headers: TASK_WRITE_HEADERS
+  }
+}


### PR DESCRIPTION
Task completion now requires server confirmation. 20x is a cache with a durable command outbox: creates use stable idempotency keys, edits carry revisions, and conflicts preserve the rejected edit while displaying the canonical server snapshot. Local-only completion and its two-minute preservation are removed. Contract v2 requires 20x 0.0.146.

Local 20x agents assist human-owned tasks and cannot change their canonical status or reuse the human JWT for agent completion. Agent-owned work runs through agent-harness. Server-owned recurrence templates are excluded from local spawning. Imports refresh the UI without waiting for unrelated source uploads.

Companion server PR: https://github.com/peakflo/workflow-builder/pull/1687. Coordinate rollout; old task writes deliberately receive an upgrade refusal. This does not include the separate S8 cloud transcript adapter.

Validation at 2b7afaf: CI verify green, 172 files, 2712 tests passed / 2 skipped (2714 total). Full macOS verification: 172 files, 2705 passed / 4 skipped; lint, typecheck and production build passed. Mutation checks discriminate actor, revision, local-write, ownership, recurrence, server-confirmation and child-wait guards.

Live local acceptance is demonstrated: web→20x import, 20x→web creation, durable retry through API downtime, revision conflict with visible rejected edits, and actual 20x Codex assistance returning DESKTOP HELP VERIFIED while the canonical task remains not_started and human-assigned. The companion server's real recurring runner/model result, overlap skip, workflow resume, normal MCP completion refusal and automatic-completion positive case are also demonstrated. Temporary acceptance runner credentials were revoked. No production/staging deployment or merge was performed.

Human review is required before merge; all current CI checks are green.
