### PR TITLE
fix(codex): surface real app-server error text and keep retried turns alive

### DIFF
--- a/src/main/adapters/codex-app-server-adapter.test.ts
+++ b/src/main/adapters/codex-app-server-adapter.test.ts
@@ -1235,3 +1235,170 @@ describe('CodexAppServerAdapter', () => {
     }
   })
 })
+
+describe('CodexAppServerAdapter app-server error notifications', () => {
+  const capacityError = {
+    message: 'Selected model is at capacity. Please try a different model.',
+    codexErrorInfo: 'serverOverloaded'
+  }
+
+  it('surfaces the TurnError message and code instead of the generic label', () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    session.status = SessionStatusType.BUSY
+    session.activeTurnId = 'turn-1'
+    adapter.sessions.set('thread-1', session)
+
+    const notification = {
+      jsonrpc: '2.0',
+      method: 'error',
+      params: { threadId: 'thread-1', turnId: 'turn-1', willRetry: false, error: capacityError }
+    }
+    adapter.handleRpcMessage(session, notification)
+
+    expect(session.status).toBe(SessionStatusType.ERROR)
+    expect(session.lastError).toBe(
+      'Selected model is at capacity. Please try a different model. (serverOverloaded)'
+    )
+
+    const seenPartIds = new Set<string>()
+    const parts = adapter.convertEventToMessageParts(notification, new Set(), seenPartIds, new Map(), session)
+    expect(parts).toEqual([
+      expect.objectContaining({
+        id: 'error-turn-1',
+        type: MessagePartType.ERROR,
+        text: 'Selected model is at capacity. Please try a different model. (serverOverloaded)'
+      })
+    ])
+
+    // The failed turn/completed that follows carries the same TurnError and
+    // must not print a second copy.
+    const completed = {
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: { id: 'turn-1', status: 'failed', items: [], error: capacityError }
+      }
+    }
+    expect(adapter.convertEventToMessageParts(completed, new Set(), seenPartIds, new Map(), session)).toEqual([])
+  })
+
+  it('describes object-shaped codexErrorInfo with its HTTP status', () => {
+    const adapter = adapterPrivate(new CodexAppServerAdapter())
+    const session = createSession()
+
+    const parts = adapter.convertEventToMessageParts({
+      method: 'error',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-2',
+        willRetry: false,
+        error: {
+          message: 'stream disconnected before completion',
+          additionalDetails: 'upstream closed the connection',
+          codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: 502 } }
+        }
+      }
+    }, new Set(), new Set(), new Map(), session)
+
+    expect(parts).toHaveLength(1)
+    expect(parts[0].text).toBe(
+      'stream disconnected before completion\nupstream closed the connection (responseStreamDisconnected HTTP 502)'
+    )
+  })
+
+  it('keeps the session busy and emits a retry part for recoverable errors', () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    session.status = SessionStatusType.BUSY
+    session.activeTurnId = 'turn-1'
+    adapter.sessions.set('thread-1', session)
+
+    const notification = {
+      jsonrpc: '2.0',
+      method: 'error',
+      params: {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        willRetry: true,
+        error: {
+          message: 'stream disconnected before completion',
+          codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } }
+        }
+      }
+    }
+    adapter.handleRpcMessage(session, notification)
+
+    expect(session.status).toBe(SessionStatusType.BUSY)
+    expect(session.lastError).toBeNull()
+
+    const parts = adapter.convertEventToMessageParts(notification, new Set(), new Set(), new Map(), session)
+    expect(parts).toEqual([
+      expect.objectContaining({
+        type: MessagePartType.RETRY,
+        text: 'Codex is retrying after a recoverable error: stream disconnected before completion (responseStreamDisconnected)'
+      })
+    ])
+
+    // The turn is still alive: a later idle settles normally.
+    adapter.handleRpcMessage(session, {
+      jsonrpc: '2.0',
+      method: 'thread/status/changed',
+      params: { threadId: 'thread-1', status: { type: 'idle' } }
+    })
+    expect(session.status).toBe(SessionStatusType.IDLE)
+  })
+
+  it('marks the session failed from a failed turn/completed without an error notification', async () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    session.status = SessionStatusType.BUSY
+    session.activeTurnId = 'turn-3'
+    adapter.sessions.set('thread-1', session)
+
+    const completed = {
+      jsonrpc: '2.0',
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-1',
+        turn: { id: 'turn-3', status: 'failed', items: [], error: capacityError }
+      }
+    }
+    adapter.handleRpcMessage(session, completed)
+
+    const pending = Array.from(session.pendingRequests.values())[0]
+    pending.resolve({ data: [] })
+    await flushPromises()
+
+    expect(session.status).toBe(SessionStatusType.ERROR)
+    expect(session.lastError).toBe(
+      'Selected model is at capacity. Please try a different model. (serverOverloaded)'
+    )
+    expect(adapter.convertEventToMessageParts(completed, new Set(), new Set(), new Map(), session)).toEqual([
+      expect.objectContaining({ id: 'error-turn-3', type: MessagePartType.ERROR })
+    ])
+  })
+
+  it('does not treat a completed or interrupted turn as a failure', () => {
+    const adapterInstance = new CodexAppServerAdapter()
+    const adapter = adapterPrivate(adapterInstance)
+    const session = createSession()
+    session.status = SessionStatusType.BUSY
+    adapter.sessions.set('thread-1', session)
+
+    for (const status of ['completed', 'interrupted']) {
+      const completed = {
+        jsonrpc: '2.0',
+        method: 'turn/completed',
+        params: { threadId: 'thread-1', turn: { id: `turn-${status}`, status, items: [] } }
+      }
+      adapter.handleRpcMessage(session, completed)
+      expect(session.lastError).toBeNull()
+      expect(adapter.convertEventToMessageParts(completed, new Set(), new Set(), new Map(), session)).toEqual([])
+    }
+  })
+})

--- a/src/main/adapters/codex-app-server-adapter.ts
+++ b/src/main/adapters/codex-app-server-adapter.ts
@@ -182,6 +182,59 @@ function extractText(value: unknown): string {
   return ''
 }
 
+const DEFAULT_APP_SERVER_ERROR = 'Codex app-server error'
+
+/**
+ * Codex `codexErrorInfo` is either a plain enum string (`serverOverloaded`,
+ * `usageLimitExceeded`, ...) or a single-key object such as
+ * `{ responseStreamDisconnected: { httpStatusCode: 502 } }`.
+ */
+function describeCodexErrorInfo(info: unknown): string | null {
+  if (typeof info === 'string') return info || null
+  if (!isObject(info)) return null
+  const [kind] = Object.keys(info)
+  if (!kind) return null
+  const detail = isObject(info[kind]) ? info[kind] : {}
+  const httpStatus = typeof detail.httpStatusCode === 'number' ? ` HTTP ${detail.httpStatusCode}` : ''
+  return `${kind}${httpStatus}`
+}
+
+interface AppServerErrorSummary {
+  /** Human-readable message, suffixed with the Codex error code when known. */
+  message: string
+  code: string | null
+  /** Codex retries the request itself; the turn is still alive. */
+  willRetry: boolean
+}
+
+/**
+ * Codex app-server `error` notifications carry `{ error: { message,
+ * codexErrorInfo, additionalDetails }, willRetry, threadId, turnId }` and a
+ * failed `turn/completed` carries `turn.error` with the same `TurnError` shape.
+ * `extractText` does not descend into `error`, which is why every provider
+ * failure used to surface as the bare "Codex app-server error".
+ */
+function summarizeAppServerError(params: Record<string, unknown>): AppServerErrorSummary {
+  const error = isObject(params.error) ? params.error : null
+  const code = describeCodexErrorInfo(error?.codexErrorInfo ?? error?.codex_error_info)
+  const message = (error ? asString(error.message) : undefined) || extractText(params) || DEFAULT_APP_SERVER_ERROR
+  const details = error ? asString(error.additionalDetails) : undefined
+  const lines = [message.trim()]
+  if (details && details.trim() && !message.includes(details.trim())) lines.push(details.trim())
+  const text = lines.join('\n')
+  return {
+    message: code ? `${text} (${code})` : text,
+    code,
+    willRetry: params.willRetry === true || params.will_retry === true
+  }
+}
+
+function extractFailedTurnError(params: Record<string, unknown>): AppServerErrorSummary | null {
+  const turn = isObject(params.turn) ? params.turn : null
+  if (!turn || asString(turn.status) !== 'failed' || !isObject(turn.error)) return null
+  return summarizeAppServerError({ error: turn.error })
+}
+
 function extractRole(item: Record<string, unknown>): string {
   return (asString(item.role) || asString(item.author) || asString(item.sender) || '').toLowerCase()
 }
@@ -926,6 +979,14 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
 
     if (notification.method === 'turn/completed') {
       session.activeTurnId = null
+      // A failed turn reports `turn.status === 'failed'` with a `TurnError`.
+      // Codex normally sends a non-retryable `error` notification first, but
+      // this is the authoritative signal that the turn is over.
+      const failure = extractFailedTurnError(params)
+      if (failure) {
+        session.status = SessionStatusType.ERROR
+        session.lastError = failure.message
+      }
       if (session.threadId) {
         session.pendingCompletionRefreshes += 1
         void this.reconcileCompletedTurn(session)
@@ -951,8 +1012,17 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     }
 
     if (notification.method === 'error') {
-      session.status = SessionStatusType.ERROR
-      session.lastError = extractText(params) || 'Codex app-server error'
+      const failure = summarizeAppServerError(params)
+      if (failure.willRetry) {
+        // Recoverable (stream disconnect, transient 5xx, ...): Codex retries
+        // the request itself and the turn keeps running. Flipping the session
+        // to ERROR here made AgentManager stop polling and abandon a turn that
+        // usually went on to complete.
+        console.warn(`[CodexAppServerAdapter] Codex is retrying after a recoverable error: ${failure.message}`)
+      } else {
+        session.status = SessionStatusType.ERROR
+        session.lastError = failure.message
+      }
     }
 
     if (notification.method === 'serverRequest/resolved') {
@@ -1287,11 +1357,40 @@ export class CodexAppServerAdapter implements CodingAgentAdapter {
     }
 
     if (method === 'error') {
-      const partId = `error-${Date.now()}`
+      const failure = summarizeAppServerError(params)
+      const turnId = asString(params.turnId) || asString(params.turn_id) || `${Date.now()}`
+      if (failure.willRetry) {
+        return [{
+          id: `retry-${turnId}-${Date.now()}`,
+          type: MessagePartType.RETRY,
+          text: `Codex is retrying after a recoverable error: ${failure.message}`,
+          role: MessageRole.ASSISTANT
+        }]
+      }
+      // One fatal error per turn: the failed `turn/completed` that follows
+      // carries the same TurnError and must not print a second copy.
+      const partId = `error-${turnId}`
+      if (seenPartIds.has(partId)) return []
+      seenPartIds.add(partId)
       return [{
         id: partId,
         type: MessagePartType.ERROR,
-        text: extractText(params) || 'Codex app-server error',
+        text: failure.message,
+        role: MessageRole.ASSISTANT
+      }]
+    }
+
+    if (method === 'turn/completed') {
+      const failure = extractFailedTurnError(params)
+      if (!failure) return []
+      const turn = isObject(params.turn) ? params.turn : {}
+      const partId = `error-${asString(turn.id) || Date.now()}`
+      if (seenPartIds.has(partId)) return []
+      seenPartIds.add(partId)
+      return [{
+        id: partId,
+        type: MessagePartType.ERROR,
+        text: failure.message,
         role: MessageRole.ASSISTANT
       }]
     }

--- a/src/main/adapters/coding-agent-adapter.ts
+++ b/src/main/adapters/coding-agent-adapter.ts
@@ -26,6 +26,8 @@ export enum MessagePartType {
   QUESTION = 'question',
   IMAGE = 'image',
   ERROR = 'error',
+  /** Recoverable provider error: the backend is retrying the request itself. */
+  RETRY = 'retry',
   TASK_PROGRESS = 'task_progress'
 }
 


### PR DESCRIPTION
## Summary

Every Codex app-server failure appeared in 20x as the bare **"Codex app-server error"** — 26 occurrences in the last 14 days across coding tasks and heartbeat sessions, with no indication of what went wrong. The most recent flood was the *UNIFIED TASKS* task (`task_1788605525873_kexp0c1`, Codex thread `01a07169-ce83-…`), whose rollout log shows the real failure twice:

```
task_complete error: "Selected model is at capacity. Please try a different model." (codex_error_info: server_overloaded)
```

### Root cause (`src/main/adapters/codex-app-server-adapter.ts`)

- The app-server `error` notification is `{ error: { message, codexErrorInfo, additionalDetails }, willRetry, threadId, turnId }` (see `codex app-server generate-json-schema` → `ErrorNotification`/`TurnError`). Both `handleNotification` (`lastError`) and `convertEventToMessageParts` (the transcript part) called `extractText(params)`, which only looks at `text|content|delta|message|output` and never descends into `error` → the provider message was dropped and replaced by the generic label.
- `willRetry` was ignored. Recoverable errors (stream disconnects, transient 5xx) that Codex retries itself flipped the session to `ERROR`; `AgentManager` then stopped polling and reported a failure for a turn that was still running.
- `turn/completed` with `turn.status === 'failed'` / `turn.error` was not inspected at all.

### Fix

- `summarizeAppServerError()` reads `TurnError.message` + `additionalDetails` and appends the `codexErrorInfo` code (enum string or `{ kind: { httpStatusCode } }` object form).
- `willRetry: true` → keep the session `BUSY`, log a warning, emit a `retry` part ("Codex is retrying after a recoverable error: …"). The renderer already renders `partType: 'retry'`; `MessagePartType.RETRY` is now declared.
- Failed `turn/completed` is treated as the authoritative failure; the fatal error part is keyed by turn id so the preceding `error` notification and the failed turn print once.

### Tests

- 5 new cases in `codex-app-server-adapter.test.ts` (message+code surfacing, object-shaped `codexErrorInfo` with HTTP status, retry keeps session busy, failed `turn/completed` without a prior error notification, completed/interrupted turns are not failures).
- `pnpm test:run`: 171 files / 2710 tests pass. `pnpm typecheck` and eslint on the changed files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)