### PR TITLE
fix(pi): use bundled Node runtime

### DIFF
--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -100,12 +100,18 @@ describe('PiAdapter', () => {
     })
 
     expect(id).toBe('/sessions/native-session.jsonl')
+    expect(spawnMock.mock.calls[0][0]).toBe(process.execPath)
     const args = spawnMock.mock.calls[0][1] as string[]
+    expect(args[0]).toBe('/usr/local/bin/pi')
     expect(args).toContain('--mode')
     expect(args).toContain('--extension')
     expect(args).not.toContain('--session-dir')
     expect(args).not.toContain('--provider')
     expect(args).not.toContain('--model')
+    expect(spawnMock.mock.calls[0][2]).toMatchObject({
+      env: expect.objectContaining({ ELECTRON_RUN_AS_NODE: '1' }),
+      shell: false,
+    })
     expect(command).toHaveBeenLastCalledWith(
       expect.anything(),
       { type: 'set_model', provider: 'peakflo', modelId: 'model-one' },
@@ -146,7 +152,18 @@ describe('PiAdapter', () => {
       ],
       default: { peakflo: 'model-one' },
     })
-    expect(spawnMock.mock.calls[0][1]).toEqual(['--mode', 'rpc', '--no-session', '--approve'])
+    expect(spawnMock.mock.calls[0][0]).toBe(process.execPath)
+    expect(spawnMock.mock.calls[0][1]).toEqual([
+      '/usr/local/bin/pi',
+      '--mode',
+      'rpc',
+      '--no-session',
+      '--approve',
+    ])
+    expect(spawnMock.mock.calls[0][2]).toMatchObject({
+      env: expect.objectContaining({ ELECTRON_RUN_AS_NODE: '1' }),
+      shell: false,
+    })
   })
 
   it('waits for agent_settled instead of agent_end', () => {

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -268,6 +268,32 @@ export class PiAdapter implements CodingAgentAdapter {
     return env
   }
 
+  /**
+   * Pi's npm launcher uses `#!/usr/bin/env node`. Launching it directly would
+   * therefore make Pi depend on whichever Node happens to be first on the
+   * desktop app's PATH. Recent Pi releases require Node >=22.19 and use zstd
+   * APIs that are absent from older runtimes. On macOS/Linux, run the launcher
+   * with Electron's bundled Node so Pi uses the same known runtime as 20x.
+   *
+   * Windows npm launchers are .cmd files, so they must continue to run through
+   * the shell.
+   */
+  private piInvocation(
+    executable: string,
+    args: string[],
+    env: NodeJS.ProcessEnv,
+  ): { command: string; args: string[]; env: NodeJS.ProcessEnv; shell: boolean } {
+    if (process.platform === 'win32') {
+      return { command: executable, args, env, shell: true }
+    }
+    return {
+      command: process.execPath,
+      args: [executable, ...args],
+      env: { ...env, ELECTRON_RUN_AS_NODE: '1' },
+      shell: false,
+    }
+  }
+
   private createSessionState(
     id: string,
     child: ChildProcessWithoutNullStreams,
@@ -333,12 +359,13 @@ export class PiAdapter implements CodingAgentAdapter {
     if (resumeId) args.push('--session', resumeId)
     if (mcpConfigPath) args.push('--mcp-config', mcpConfigPath)
 
-    const child = spawn(executable, args, {
+    const invocation = this.piInvocation(executable, args, this.processEnv(config, gateway))
+    const child = spawn(invocation.command, invocation.args, {
       cwd: config.workspaceDir,
-      env: this.processEnv(config, gateway),
+      env: invocation.env,
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
-      shell: process.platform === 'win32',
+      shell: invocation.shell,
       detached: process.platform !== 'win32',
     })
 
@@ -1027,8 +1054,11 @@ export class PiAdapter implements CodingAgentAdapter {
   async checkHealth(): Promise<{ available: boolean; reason?: string }> {
     try {
       const executable = await this.findPiExecutable()
-      const { stdout, stderr } = await execFileAsync(executable, ['--version'], {
+      const invocation = this.piInvocation(executable, ['--version'], { ...process.env })
+      const { stdout, stderr } = await execFileAsync(invocation.command, invocation.args, {
+        env: invocation.env,
         timeout: 10_000,
+        shell: invocation.shell,
         windowsHide: true,
       })
       const match = `${stdout}\n${stderr}`.match(/(\d+)\.(\d+)\.(\d+)/)
@@ -1061,12 +1091,17 @@ export class PiAdapter implements CodingAgentAdapter {
       workspaceDir: directory || process.cwd(),
       permissionMode: 'allow',
     }
-    const child = spawn(executable, ['--mode', 'rpc', '--no-session', '--approve'], {
+    const invocation = this.piInvocation(
+      executable,
+      ['--mode', 'rpc', '--no-session', '--approve'],
+      this.processEnv(config, gateway),
+    )
+    const child = spawn(invocation.command, invocation.args, {
       cwd: config.workspaceDir,
-      env: this.processEnv(config, gateway),
+      env: invocation.env,
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
-      shell: process.platform === 'win32',
+      shell: invocation.shell,
       detached: process.platform !== 'win32',
     })
     const session = this.createSessionState(`pi-discovery-${randomUUID()}`, child, config)


### PR DESCRIPTION
## Summary
- launch Pi with the Electron-bundled Node runtime on macOS and Linux
- preserve shell-based npm launcher handling on Windows
- apply the runtime selection to sessions, model discovery, and health checks
- add regression assertions for the Pi command, entrypoint, environment, and shell mode

## Root cause
Pi 0.84.3 requires Node >=22.19 and uses the Zstandard decompression API. Its npm launcher uses `/usr/bin/env node`, so launching it directly from the desktop app could select an older Node from the inherited PATH and crash with `zlib.createZstdDecompress is not a function`.

## Verification
- full lint completed with 0 errors (existing warnings only)
- TypeScript typecheck passed
- production build passed
- full suite: 171 files passed, 2712 tests passed, 4 skipped
- Electron 44 bundled Node reports `createZstdDecompress` as available
- Pi 0.84.3 `--version` succeeds through the Electron Node invocation