### PR TITLE
fix: remove 'Workflo confirms task completion.' from feedback dialogs

### DIFF
--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -950,7 +950,6 @@ function FeedbackModal({ onSubmit, onSkip, onCancel }: {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
       <div role="dialog" aria-label="Session feedback" className="mx-4 w-full max-w-md rounded-xl border bg-card p-5 space-y-4">
         <h2>Session feedback</h2>
-        <p className="text-sm text-muted-foreground">Workflo confirms task completion.</p>
         <div className="flex gap-2">
           {[1, 2, 3, 4, 5].map(value => <button key={value} aria-label={`Rate ${value}`} aria-pressed={rating === value} onClick={() => setRating(value)}>{value}</button>)}
         </div>

--- a/src/renderer/src/components/tasks/FeedbackDialog.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.tsx
@@ -74,8 +74,6 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDia
             rows={3}
           />
 
-          <p>Workflo confirms task completion.</p>
-
           <div className="flex gap-2 justify-end">
             <Button variant="ghost" size="sm" onClick={() => onSkip()}>
               Skip


### PR DESCRIPTION
## Summary
- Removes the stale `Workflo confirms task completion.` line from the desktop `FeedbackDialog` (`src/renderer/src/components/tasks/FeedbackDialog.tsx`) and the mobile `FeedbackModal` (`src/mobile/pages/TaskDetailPage.tsx`), keeping both platforms in sync.
- Grep confirms no remaining occurrences of the string in the repo.

## Test plan
- [x] `npx eslint` on both touched files — clean
- [x] `npx tsc --build --noEmit` — passes
- [x] FeedbackDialog suite (8 tests) passes via Electron vitest runtime
- [ ] CI `verify` check passes