### PR TITLE
feat(browser): expose console logs and network activity via MCP

### DIFF
--- a/src/main/mcp-servers/task-management-core.ts
+++ b/src/main/mcp-servers/task-management-core.ts
@@ -668,6 +668,35 @@ const browserTools: Tool[] = [
       },
       required: ['task_id']
     }
+  },
+  {
+    name: 'browser_console',
+    description: 'Read buffered browser console messages (log/warn/error + page errors) for a panel. Capture starts with the first command against the panel; pass clear=true to drain the buffer after reading.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: taskParam,
+        level: { type: 'string', enum: ['debug', 'info', 'warning', 'error'], description: 'Only return messages at this level' },
+        limit: { type: 'number', description: 'Max entries to return, newest last (default 100, max 200)' },
+        clear: { type: 'boolean', description: 'Drain the buffer after reading (default false)' },
+        panel_id: panelIdParam
+      },
+      required: ['task_id']
+    }
+  },
+  {
+    name: 'browser_network',
+    description: 'List recent network activity for a panel (document navigations + resource/fetch/XHR rows with URL, initiator, timing and sizes) from the page performance timeline.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task_id: taskParam,
+        filter: { type: 'string', description: 'Only return entries whose URL contains this substring' },
+        limit: { type: 'number', description: 'Max resource rows to return, most recent last (default 50, max 200)' },
+        panel_id: panelIdParam
+      },
+      required: ['task_id']
+    }
   }
 ]
 

--- a/src/main/mcp-servers/task-management-mcp-schema.test.ts
+++ b/src/main/mcp-servers/task-management-mcp-schema.test.ts
@@ -126,6 +126,37 @@ describe('browser_reload schema', () => {
   })
 })
 
+describe('browser console + network schemas', () => {
+  it('exposes browser_console with level/limit/clear for both scopes', () => {
+    for (const scope of [FULL_ACCESS_SCOPE, SCOPED]) {
+      const props = propertiesOf(scope, 'browser_console')
+      expect(Object.keys(props)).toEqual(expect.arrayContaining(['task_id', 'level', 'limit', 'clear', 'panel_id']))
+      const tool = toolByName(scope, 'browser_console')
+      expect(tool!.inputSchema.required).toEqual(['task_id'])
+    }
+  })
+
+  it('exposes browser_network with filter/limit for both scopes', () => {
+    for (const scope of [FULL_ACCESS_SCOPE, SCOPED]) {
+      const props = propertiesOf(scope, 'browser_network')
+      expect(Object.keys(props)).toEqual(expect.arrayContaining(['task_id', 'filter', 'limit', 'panel_id']))
+      const tool = toolByName(scope, 'browser_network')
+      expect(tool!.inputSchema.required).toEqual(['task_id'])
+    }
+  })
+
+  it('dispatches both tools through the shared pass-through route', async () => {
+    const calls: Array<{ route: string; params: Record<string, unknown> }> = []
+    const invoke = async (route: string, params: Record<string, unknown>): Promise<unknown> => {
+      calls.push({ route, params })
+      return { ok: true }
+    }
+    await callToolForScope('browser_console', { task_id: 't1', level: 'error' }, FULL_ACCESS_SCOPE, invoke)
+    await callToolForScope('browser_network', { task_id: 't1', filter: 'api' }, FULL_ACCESS_SCOPE, invoke)
+    expect(calls.map((c) => c.route)).toEqual(['/browser_console', '/browser_network'])
+  })
+})
+
 describe('subtask status ceiling', () => {
   it('refuses a self-completion and points at ready_for_review', async () => {
     const invoke = async (): Promise<unknown> => ({ ok: true })

--- a/src/main/panel-browser-broker.test.ts
+++ b/src/main/panel-browser-broker.test.ts
@@ -14,16 +14,23 @@ import {
   buildClickScript,
   buildGetScript,
   buildPressScript,
+  buildResourceTimingScript,
   buildScrollScript,
   buildSnapshotScript,
   buildTypeScript,
   buildWaitScript,
+  consoleLevelName,
+  filterConsoleEntries,
   normalizeRef,
   panelBrowserBroker,
+  parseResourceTimingResult,
   parseSnapshotResult,
+  pushConsoleEntry,
   resolveKeyName,
   resolvePanelForTask,
   unwrapEval,
+  CONSOLE_BUFFER_CAP,
+  type ConsoleEntry,
   type PanelRegistry
 } from './panel-browser-broker'
 
@@ -209,6 +216,156 @@ describe('reload hard flag', () => {
       expect(result).toEqual({ ok: true, url: 'https://x.io/after-soft' })
     } finally {
       panelBrowserBroker.unregisterPanel('p-soft')
+    }
+  })
+})
+
+describe('console helpers', () => {
+  it('maps Electron console-message levels to names', () => {
+    expect(consoleLevelName(0)).toBe('debug')
+    expect(consoleLevelName(1)).toBe('info')
+    expect(consoleLevelName(2)).toBe('warning')
+    expect(consoleLevelName(3)).toBe('error')
+    expect(consoleLevelName(99)).toBe('error')
+  })
+
+  it('caps the per-panel buffer at CONSOLE_BUFFER_CAP', () => {
+    const buffer: ConsoleEntry[] = []
+    for (let i = 0; i < CONSOLE_BUFFER_CAP + 10; i++) {
+      pushConsoleEntry(buffer, { level: 'info', message: `m${i}`, source: '', line: 0, at: i })
+    }
+    expect(buffer).toHaveLength(CONSOLE_BUFFER_CAP)
+    expect(buffer[0].message).toBe('m10')
+    expect(buffer[buffer.length - 1].message).toBe(`m${CONSOLE_BUFFER_CAP + 9}`)
+  })
+
+  it('filters by level and honors the limit (newest last)', () => {
+    const entries: ConsoleEntry[] = [
+      { level: 'info', message: 'a', source: '', line: 0, at: 1 },
+      { level: 'error', message: 'b', source: '', line: 0, at: 2 },
+      { level: 'error', message: 'c', source: '', line: 0, at: 3 }
+    ]
+    expect(filterConsoleEntries(entries, { level: 'error' }).map((e) => e.message)).toEqual(['b', 'c'])
+    expect(filterConsoleEntries(entries, { limit: 2 }).map((e) => e.message)).toEqual(['b', 'c'])
+    expect(filterConsoleEntries(entries, {})).toHaveLength(3)
+  })
+})
+
+describe('resource timing script', () => {
+  it('reads the performance timeline and caps rows', () => {
+    const script = buildResourceTimingScript('api', 25)
+    expect(script).toContain("getEntriesByType('navigation')")
+    expect(script).toContain("getEntriesByType('resource')")
+    expect(script).toContain('slice(-25)')
+    expect(script).toContain('"api"')
+  })
+
+  it('clamps the limit to the result cap', () => {
+    expect(buildResourceTimingScript(undefined, 999999)).toContain('slice(-200)')
+  })
+
+  it('parses a well-formed payload and rejects malformed ones', () => {
+    const payload = JSON.stringify({
+      navigation: [{ url: 'https://x.io/', initiator: 'navigation', durationMs: 1, transferSize: 2, decodedSize: 3, status: 200 }],
+      resources: []
+    })
+    expect(parseResourceTimingResult(payload)).toMatchObject({ resources: [] })
+    expect(parseResourceTimingResult({ navigation: [], resources: [] })).toMatchObject({ navigation: [] })
+    expect(parseResourceTimingResult(null)).toHaveProperty('error')
+    expect(parseResourceTimingResult('not json')).toHaveProperty('error')
+    expect(parseResourceTimingResult('{"navigation":[]}')).toHaveProperty('error')
+  })
+})
+
+describe('broker console buffering', () => {
+  type ConsoleListener = (event: unknown, level: number, message: string, line: number, sourceId: string) => void
+
+  function fakeConsoleWebContents() {
+    let consoleListener: ConsoleListener | null = null
+    return {
+      listener: () => consoleListener,
+      isDestroyed: vi.fn(() => false),
+      getURL: vi.fn(() => 'https://x.io/'),
+      on: vi.fn((event: string, cb: ConsoleListener) => {
+        if (event === 'console-message') consoleListener = cb
+      }),
+      once: vi.fn(),
+      removeListener: vi.fn(),
+      executeJavaScript: vi.fn(async () => '{}')
+    }
+  }
+
+  it('buffers console-message events per panel with level/line/source', async () => {
+    const wc = fakeConsoleWebContents()
+    electronMocks.fromId.mockReturnValue(wc)
+    panelBrowserBroker.registerPanel('p-console', 44, ['task-console'])
+    try {
+      expect(wc.on).toHaveBeenCalledWith('console-message', expect.any(Function))
+      wc.listener()?.({}, 3, 'boom', 42, 'https://x.io/app.js')
+      wc.listener()?.({}, 1, 'hello', 7, 'https://x.io/app.js')
+      const all = (await panelBrowserBroker.console('task-console', {}, 'p-console')) as unknown as {
+        entries: ConsoleEntry[]
+        count: number
+      }
+      expect(all.count).toBe(2)
+      expect(all.entries[0]).toMatchObject({ level: 'error', message: 'boom', line: 42 })
+      const errors = (await panelBrowserBroker.console('task-console', { level: 'error' }, 'p-console')) as unknown as {
+        entries: ConsoleEntry[]
+      }
+      expect(errors.entries.map((e) => e.message)).toEqual(['boom'])
+    } finally {
+      panelBrowserBroker.unregisterPanel('p-console')
+    }
+  })
+
+  it('drains the buffer when clear is set and isolates panels', async () => {
+    const wc = fakeConsoleWebContents()
+    electronMocks.fromId.mockReturnValue(wc)
+    panelBrowserBroker.registerPanel('p-console-a', 45, ['task-console-a'])
+    panelBrowserBroker.registerPanel('p-console-b', 46, ['task-console-b'])
+    try {
+      const drained = (await panelBrowserBroker.console('task-console-a', { clear: true }, 'p-console-a')) as unknown as {
+        entries: ConsoleEntry[]
+      }
+      expect(Array.isArray(drained.entries)).toBe(true)
+      // Other panels are untouched by the drain.
+      const other = (await panelBrowserBroker.console('task-console-b', {}, 'p-console-b')) as unknown as {
+        entries: ConsoleEntry[]
+      }
+      expect(Array.isArray(other.entries)).toBe(true)
+    } finally {
+      panelBrowserBroker.unregisterPanel('p-console-a')
+      panelBrowserBroker.unregisterPanel('p-console-b')
+    }
+  })
+})
+
+describe('broker network', () => {
+  it('returns parsed navigation + resource entries', async () => {
+    const payload = JSON.stringify({
+      navigation: [{ url: 'https://x.io/', initiator: 'navigation', durationMs: 10, transferSize: 5, decodedSize: 6, status: 200 }],
+      resources: [{ url: 'https://x.io/api', initiator: 'fetch', durationMs: 3, transferSize: 1, decodedSize: 2, status: 200 }]
+    })
+    const wc = {
+      isDestroyed: vi.fn(() => false),
+      getURL: vi.fn(() => 'https://x.io/'),
+      on: vi.fn(),
+      once: vi.fn(),
+      removeListener: vi.fn(),
+      executeJavaScript: vi.fn(async () => payload)
+    }
+    electronMocks.fromId.mockReturnValue(wc)
+    panelBrowserBroker.registerPanel('p-network', 47, ['task-network'])
+    try {
+      const result = (await panelBrowserBroker.network('task-network', 'api', 50, 'p-network')) as unknown as {
+        navigation: unknown[]
+        resources: Array<{ url: string }>
+      }
+      expect(result.navigation).toHaveLength(1)
+      expect(result.resources.map((r) => r.url)).toEqual(['https://x.io/api'])
+      expect(wc.executeJavaScript).toHaveBeenCalledTimes(1)
+    } finally {
+      panelBrowserBroker.unregisterPanel('p-network')
     }
   })
 })

--- a/src/main/panel-browser-broker.ts
+++ b/src/main/panel-browser-broker.ts
@@ -294,6 +294,113 @@ export function buildWaitScript(mode: 'selector' | 'text' | 'url', value: string
 })()`
 }
 
+/** A single captured browser console message for one panel. */
+export interface ConsoleEntry {
+  level: 'debug' | 'info' | 'warning' | 'error'
+  message: string
+  source: string
+  line: number
+  /** Epoch millis when the main process observed the message. */
+  at: number
+}
+
+/** Ring-buffer cap per panel — bounds memory when pages log in loops. */
+export const CONSOLE_BUFFER_CAP = 200
+
+const CONSOLE_LEVELS = ['debug', 'info', 'warning', 'error'] as const
+
+/** Maps Electron's console-message numeric level to a stable name. */
+export function consoleLevelName(level: number): ConsoleEntry['level'] {
+  return CONSOLE_LEVELS[level] ?? (level >= 3 ? 'error' : 'debug')
+}
+
+/** Pushes an entry, evicting the oldest when the buffer is full. */
+export function pushConsoleEntry(buffer: ConsoleEntry[], entry: ConsoleEntry, cap = CONSOLE_BUFFER_CAP): ConsoleEntry[] {
+  buffer.push(entry)
+  while (buffer.length > cap) buffer.shift()
+  return buffer
+}
+
+export interface ConsoleFilter {
+  level?: string
+  /** Max entries to return (newest last). Defaults to 100, clamped to the buffer cap. */
+  limit?: number
+}
+
+/** Applies level filter + limit; returns entries oldest-first. */
+export function filterConsoleEntries(entries: ConsoleEntry[], filter: ConsoleFilter = {}): ConsoleEntry[] {
+  const level = (filter.level || '').toLowerCase()
+  const scoped = level ? entries.filter((e) => e.level === level) : entries.slice()
+  const limit = Math.max(1, Math.min(filter.limit ?? 100, CONSOLE_BUFFER_CAP))
+  return scoped.slice(-limit)
+}
+
+/** A single performance-timeline entry behind browser_network. */
+export interface NetworkEntry {
+  url: string
+  initiator: string
+  durationMs: number
+  transferSize: number
+  decodedSize: number
+  /** HTTP status when Chromium exposes it (0 when unknown / failed). */
+  status: number
+}
+
+export interface ResourceTimingResult {
+  navigation: NetworkEntry[]
+  resources: NetworkEntry[]
+}
+
+/** Max resource rows a single browser_network call returns. */
+export const NETWORK_RESULT_CAP = 200
+
+/**
+ * Builds the injected script behind browser_network: reads the page's
+ * performance timeline (navigation + resource entries) — the same data
+ * agent-browser surfaces via `network requests`, but panel-scoped through
+ * executeJavaScript so no debugger attachment or CDP socket is needed.
+ */
+export function buildResourceTimingScript(filter?: string, limit?: number): string {
+  const lim = Math.max(1, Math.min(limit ?? 50, NETWORK_RESULT_CAP))
+  return `(() => {
+  const pick = (e) => ({
+    url: String(e.name || '').slice(0, 500),
+    initiator: String(e.initiatorType || e.entryType || ''),
+    durationMs: Math.round(e.duration || 0),
+    transferSize: e.transferSize || 0,
+    decodedSize: e.decodedBodySize || 0,
+    status: e.responseStatus || 0
+  });
+  const match = (u) => !${JSON.stringify(filter || '')} || u.includes(${JSON.stringify(filter || '')});
+  let nav = [];
+  let res = [];
+  try {
+    nav = performance.getEntriesByType('navigation').map(pick).filter((e) => match(e.url));
+    res = performance.getEntriesByType('resource').map(pick).filter((e) => match(e.url)).slice(-${lim});
+  } catch (err) {
+    return JSON.stringify({ error: 'Resource timing unavailable: ' + (err && err.message ? err.message : String(err)) });
+  }
+  return JSON.stringify({ navigation: nav, resources: res });
+})()`
+}
+
+/** Parses the payload returned by buildResourceTimingScript(). */
+export function parseResourceTimingResult(raw: unknown): ResourceTimingResult | { error: string } {
+  let parsed: unknown = raw
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return { error: 'Malformed network payload' }
+    }
+  }
+  const result = parsed as ResourceTimingResult | null
+  if (!result || typeof result !== 'object' || !Array.isArray(result.resources) || !Array.isArray(result.navigation)) {
+    return { error: 'Malformed network payload' }
+  }
+  return result
+}
+
 /** Parses whatever executeJavaScript resolved into a plain object. */
 export function unwrapEval(raw: unknown): Record<string, unknown> {
   if (typeof raw === 'string') {
@@ -329,9 +436,21 @@ export function withTimeout<T>(
 
 export class PanelBrowserBroker {
   private registry: PanelRegistry = new Map()
+  /**
+   * Per-panel console ring buffers. Filled from the main-process
+   * `console-message` event — page JS history cannot be re-read after the
+   * fact, so buffering at observe time is the only way to expose past logs
+   * without a debugger attachment.
+   */
+  private consoleBuffers: Map<string, ConsoleEntry[]> = new Map()
+  /** webContentsIds already carrying a console-message listener. */
+  private consoleHooked: Set<number> = new Set()
 
   registerPanel(panelId: string, webContentsId: number, taskIds: string[]): void {
     this.registry.set(panelId, { webContentsId, taskIds: new Set(taskIds) })
+    if (!this.consoleBuffers.has(panelId)) this.consoleBuffers.set(panelId, [])
+    const wc = this.getLiveWebContents(webContentsId)
+    if (wc) this.ensureConsoleHook(webContentsId, wc)
   }
 
   /** Replaces just the task linkage (edges changed), keeping the webContentsId. */
@@ -343,6 +462,7 @@ export class PanelBrowserBroker {
   }
 
   unregisterPanel(panelId: string): boolean {
+    this.consoleBuffers.delete(panelId)
     return this.registry.delete(panelId)
   }
 
@@ -362,6 +482,8 @@ export class PanelBrowserBroker {
 
   stopAll(): void {
     this.registry.clear()
+    this.consoleBuffers.clear()
+    this.consoleHooked.clear()
   }
 
   private getLiveWebContents(webContentsId: number): Electron.WebContents | null {
@@ -386,7 +508,41 @@ export class PanelBrowserBroker {
       this.registry.delete(resolved.panelId)
       return { ok: false, error: 'That browser panel was closed. Use browser_list_panels.' }
     }
+    // Late-attach: the panel may have registered before its webContents
+    // existed (first dom-ready had not fired yet).
+    this.ensureConsoleHook(entry.webContentsId, wc)
     return { ok: true, wc }
+  }
+
+  /**
+   * Attaches a single `console-message` listener per live webContents. The
+   * fan-out is by webContentsId so one listener serves every panel sharing
+   * it, and the main app window is never hooked (it never appears here —
+   * only explicitly registered panels do).
+   */
+  private ensureConsoleHook(webContentsId: number, wc: Electron.WebContents): void {
+    if (this.consoleHooked.has(webContentsId)) return
+    if (typeof (wc as { on?: unknown }).on !== 'function') return
+    try {
+      wc.on('console-message', (_event, level, message, line, sourceId) => {
+        const entry: ConsoleEntry = {
+          level: consoleLevelName(typeof level === 'number' ? level : 0),
+          message: String(message ?? '').slice(0, 2000),
+          source: String(sourceId ?? '').slice(0, 300),
+          line: typeof line === 'number' ? line : 0,
+          at: Date.now()
+        }
+        for (const [id, panel] of this.registry) {
+          if (panel.webContentsId !== webContentsId) continue
+          const buffer = this.consoleBuffers.get(id) ?? []
+          pushConsoleEntry(buffer, entry)
+          this.consoleBuffers.set(id, buffer)
+        }
+      })
+      this.consoleHooked.add(webContentsId)
+    } catch {
+      // Listener attachment is best-effort (e.g. torn-down contents).
+    }
   }
 
   private async eval(wc: Electron.WebContents, script: string): Promise<Record<string, unknown>> {
@@ -477,6 +633,45 @@ export class PanelBrowserBroker {
 
   get(taskId: string, what: string, panelId?: string | null): Promise<Record<string, unknown>> {
     return this.evalOnResolved(taskId, panelId, buildGetScript(what))
+  }
+
+  /**
+   * Returns buffered console messages for a panel (agent-browser parity for
+   * `console` / `errors`). Capture starts with the first command against the
+   * panel; messages before that are not available. Pass clear=true to drain
+   * the buffer after reading (e.g. polling for new errors in a loop).
+   */
+  async console(
+    taskId: string,
+    filter: ConsoleFilter & { clear?: boolean } = {},
+    panelId?: string | null
+  ): Promise<Record<string, unknown>> {
+    const resolved = this.resolve(taskId, panelId)
+    if (!resolved.ok) return resolved
+    const resolvedPanel = resolvePanelForTask(this.registry, taskId, panelId)
+    if (!resolvedPanel.ok) return { error: resolvedPanel.error }
+    const buffer = this.consoleBuffers.get(resolvedPanel.panelId) ?? []
+    const entries = filterConsoleEntries(buffer, filter)
+    if (filter.clear) this.consoleBuffers.set(resolvedPanel.panelId, [])
+    return { entries, count: entries.length, buffered: buffer.length } as unknown as Record<string, unknown>
+  }
+
+  /**
+   * Returns recent network activity for a panel from the page performance
+   * timeline (agent-browser parity for `network requests`): document
+   * navigations plus subresource / fetch / XHR rows with URL, initiator,
+   * timing and sizes. No request/response headers or bodies — those need a
+   * session webRequest tap (documented follow-up), deliberately out of scope
+   * here to avoid touching the shared-session handlers.
+   */
+  async network(taskId: string, filter?: string, limit?: number, panelId?: string | null): Promise<Record<string, unknown>> {
+    const resolved = this.resolve(taskId, panelId)
+    if (!resolved.ok) return resolved
+    const evalResult = await this.evalOnResolved(taskId, panelId, buildResourceTimingScript(filter, limit))
+    if (evalResult.error) return evalResult
+    const result = parseResourceTimingResult(evalResult)
+    if ('error' in result) return result
+    return result as unknown as Record<string, unknown>
   }
 
   async wait(taskId: string, mode: 'selector' | 'text' | 'url', value: string, timeoutMs?: number, panelId?: string | null): Promise<Record<string, unknown>> {

--- a/src/main/task-api-server.ts
+++ b/src/main/task-api-server.ts
@@ -1254,6 +1254,35 @@ export async function handleRoute(db: DatabaseManager, route: string, params: Re
       return panelBrowserBroker.reload(taskId, panelId, params.hard === true)
     }
 
+    case '/browser_console': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      const level = typeof params.level === 'string' ? params.level : undefined
+      if (level && !['debug', 'info', 'warning', 'error'].includes(level.toLowerCase())) {
+        return { error: 'level must be debug | info | warning | error' }
+      }
+      return panelBrowserBroker.console(
+        taskId,
+        {
+          level,
+          limit: typeof params.limit === 'number' ? params.limit : undefined,
+          clear: params.clear === true
+        },
+        str(params.panel_id)
+      )
+    }
+
+    case '/browser_network': {
+      const taskId = typeof params.task_id === 'string' ? params.task_id : ''
+      if (!taskId || !db.getTask(taskId)) return { error: 'Task not found' }
+      return panelBrowserBroker.network(
+        taskId,
+        typeof params.filter === 'string' ? params.filter : undefined,
+        typeof params.limit === 'number' ? params.limit : undefined,
+        str(params.panel_id)
+      )
+    }
+
     default:
       return { error: 'Unknown route' }
   }


### PR DESCRIPTION
Answers: can the 20x agent browser MCP expose network call details and browser console? Yes — without CDP/debugger.\n\n## What\nTwo new MCP tools on the in-app panel broker (both scopes), keeping the broker guarantees (no debugger attachment, no CDP sockets, only task-linked panels addressable):\n\n- `browser_console` — buffered `webContents` `console-message` events per panel (ring buffer 200/panel, one listener per webContentsId, fanned out to sharing panels). Args: `level` (debug/info/warning/error), `limit` (default 100, max 200), `clear` (drain after read for error-watch loops). Capture starts with the first command against a panel.\n- `browser_network` — page performance timeline via injected script: `navigation` + `resource` entries (URL, initiator, duration, transfer/decoded sizes, responseStatus where Chromium exposes it). Args: `filter` (URL substring), `limit` (default 50, max 200).\n\n## Files\n- `src/main/panel-browser-broker.ts` — pure builders/parsers/filters + broker methods.\n- `src/main/mcp-servers/task-management-core.ts` — tool schemas (both scopes pick them up automatically).\n- `src/main/task-api-server.ts` — `/browser_console`, `/browser_network` routes with validation.\n- Tests in `panel-browser-broker.test.ts` (+13) and `task-management-mcp-schema.test.ts` (+3).\n\n## Known limits / follow-ups\n- Console history before first panel command is unavailable (buffer starts at hook time).\n- Network has no request/response headers or bodies — those need a `session.webRequest.onCompleted` tap demuxed by `webContentsId`; deliberately out of scope to avoid touching the shared-session auth/UA handlers. Natural next step.\n\n## Verification\n- Targeted: 50/50 pass (broker 32, schema 18).\n- Full suite via commit hook: 172 files, 2724 passed, 4 skipped.\n- `tsc --build --noEmit` clean, eslint clean on touched files.