### PR TITLE
fix(pi): shorten MCP server names to fit provider 64-char tool limit, surface real send errors

### DIFF
--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -17,7 +17,7 @@ vi.mock('../enterprise-ai-gateway', () => ({
   readEnterpriseAiGatewayConfig: vi.fn(() => null),
 }))
 
-import { PiAdapter } from './pi-adapter'
+import { PiAdapter, sanitizePiMcpServerName, sanitizePiSessionName, withProviderNameLimitHint } from './pi-adapter'
 import { MessagePartType } from './coding-agent-adapter'
 
 function fakeProcess() {
@@ -506,5 +506,37 @@ describe('PiAdapter', () => {
     )
     expect(session.pendingUiRequests.size).toBe(0)
     expect(session.status).toBe('idle')
+  })
+
+  it('keeps Pi session names within the provider 64-char limit', () => {
+    expect(sanitizePiSessionName('task-1')).toBe('task-1')
+    const long = `task_${'a'.repeat(100)}`
+    const slug = sanitizePiSessionName(long)
+    expect(slug.length).toBeLessThanOrEqual(64)
+    expect(slug).not.toMatch(/-$/)
+  })
+
+  it('shortens MCP server names so combined tool names fit the 64-char limit', () => {
+    // Reproduction of the reported failure: a long display name such as
+    // "[Workflo] Organisation Workspace" plus a long tool name overflows the
+    // provider limit ("name must be at most 64 characters, got 76").
+    const longTool = `mcp__[Workflo] Organisation Workspace__${'t'.repeat(40)}`
+    expect(longTool.length).toBeGreaterThan(64)
+
+    const used = new Set<string>()
+    // Canonical alias: "[Workflo] Organisation Workspace" → "workflo"
+    expect(sanitizePiMcpServerName('[Workflo] Organisation Workspace', used)).toBe('workflo')
+    const shortened = `mcp__workflo__${'t'.repeat(25)}`
+    expect(shortened.length).toBeLessThanOrEqual(64)
+    // Second use dedupes instead of colliding
+    expect(sanitizePiMcpServerName('[Workflo] Organisation Workspace', used)).not.toBe('workflo')
+    // Generic bracket rule: "[Workflo] My tasks" → "workflo-my-tasks"
+    expect(sanitizePiMcpServerName('[Workflo] My tasks', new Set())).toBe('workflo-my-tasks')
+  })
+
+  it('adds a retry hint to provider 64-char name errors', () => {
+    const hinted = withProviderNameLimitHint('Error from provider (Console): name must be at most 64 characters, got 76')
+    expect(hinted).toContain('continue')
+    expect(withProviderNameLimitHint('Provider unavailable')).toBe('Provider unavailable')
   })
 })

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -35,6 +35,85 @@ const MAX_BUFFERED_PARTS = 1_000
 const MINIMUM_PI_VERSION = [0, 80, 5] as const
 const PI_PERMISSION_MODE_ENV = 'TWENTYX_PI_PERMISSION_MODE'
 const TERMINAL_ERROR_SETTLE_GRACE_MS = 1_000
+/**
+ * Most model providers cap function/tool `name` at 64 characters. Pi forwards
+ * MCP tools as `<server>_<tool>`-style names, so a long MCP server name (e.g.
+ * "[Workflo] Organisation Workspace") plus a long tool name overflows the
+ * limit and the whole turn fails with "name must be at most 64 characters".
+ * Keep server slugs short to leave room for the tool suffix.
+ */
+export const MAX_PI_NAME_LENGTH = 64
+export const MAX_PI_MCP_SERVER_SLUG_LENGTH = 24
+
+/**
+ * Short Pi-side aliases for MCP servers whose display names are too long to
+ * fit the provider 64-char tool-name limit. The alias is only used in the
+ * Pi `--mcp-config` file — display names in settings, docs, and other
+ * backends are untouched.
+ */
+export const PI_MCP_SERVER_ALIASES: Record<string, string> = {
+  '[Workflo] Organisation Workspace': 'workflo',
+  '[Workflo] MCP Dev Server': 'workflo-dev',
+}
+
+function slugifyPiName(value: string, maxLength: number): string {
+  return (value
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '')
+    .slice(0, maxLength)
+    .replace(/-+$/g, '') || 'mcp')
+}
+
+/**
+ * Generic rule for bracket-prefixed servers ("[Workflo] My tasks" →
+ * "workflo-my-tasks"). Returns null when the name has no bracket prefix so
+ * the caller falls back to plain slugification.
+ */
+function slugifyBracketPrefix(name: string): string | null {
+  const match = /^\[([^\]]+)\]\s*(.*)$/.exec(name)
+  if (!match) return null
+  const combined = `${match[1]}-${match[2]}`.trim()
+  if (!combined.replace(/-/g, '')) return null
+  return slugifyPiName(combined, MAX_PI_MCP_SERVER_SLUG_LENGTH)
+}
+
+export function sanitizePiSessionName(taskId: string): string {
+  const slug = taskId
+    .replace(/[^a-zA-Z0-9-_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-_]+|[-_]+$/g, '')
+    .slice(0, MAX_PI_NAME_LENGTH)
+    .replace(/-+$/g, '')
+  return slug || 'pi-session'
+}
+
+export function sanitizePiMcpServerName(name: string, used: Set<string>): string {
+  // Exact aliases first (e.g. "[Workflo] Organisation Workspace" → "workflo").
+  const alias = PI_MCP_SERVER_ALIASES[name]
+  const base = alias ?? slugifyBracketPrefix(name) ?? slugifyPiName(name, MAX_PI_MCP_SERVER_SLUG_LENGTH)
+  if (!used.has(base)) {
+    used.add(base)
+    return base
+  }
+  for (let index = 2; index < 1000; index++) {
+    const suffix = `-${index}`
+    const candidate = `${base.slice(0, MAX_PI_MCP_SERVER_SLUG_LENGTH - suffix.length)}${suffix}`
+    if (!used.has(candidate)) {
+      used.add(candidate)
+      return candidate
+    }
+  }
+  const fallback = `mcp-${used.size + 1}`
+  used.add(fallback)
+  return fallback
+}
+
+export function withProviderNameLimitHint(error: string): string {
+  if (!/name must be at most 64/i.test(error)) return error
+  return `${error}\n\nHint: a tool name exceeded the provider 64-character limit. 20x now shortens MCP server names automatically — retry with "continue". If it persists, rename the long MCP server in settings.`
+}
 
 const PI_PERMISSION_EXTENSION_SOURCE = `\
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -219,16 +298,24 @@ export class PiAdapter implements CodingAgentAdapter {
     if (!config.mcpServers || Object.keys(config.mcpServers).length === 0) return undefined
     const dir = join(homedir(), '.20x', 'pi-mcp')
     mkdirSync(dir, { recursive: true })
-    const path = join(dir, `${config.taskId}-${randomUUID()}.json`)
+    const path = join(dir, `${sanitizePiSessionName(config.taskId)}-${randomUUID()}.json`)
+    // Pi forwards MCP tools to the model as <server>_<tool> names, which most
+    // providers cap at 64 characters. Sanitize server keys so a long display
+    // name (e.g. "[Workflo] Organisation Workspace") cannot overflow the limit.
+    const usedSlugs = new Set<string>()
     const mcpServers = Object.fromEntries(Object.entries(config.mcpServers).map(([name, server]) => {
+      const slug = sanitizePiMcpServerName(name, usedSlugs)
+      if (slug !== name) {
+        console.warn(`[PiAdapter] Renamed MCP server "${name}" to "${slug}" to fit the provider 64-char tool name limit`)
+      }
       if (server.type === 'stdio') {
-        return [name, {
+        return [slug, {
           command: server.command,
           args: server.args ?? [],
           env: server.env ?? {},
         }]
       }
-      return [name, {
+      return [slug, {
         url: server.url,
         headers: server.headers ?? {},
       }]
@@ -352,7 +439,7 @@ export class PiAdapter implements CodingAgentAdapter {
     const mcpConfigPath = this.buildMcpConfig(config)
     const permissionExtension = this.installPermissionExtension()
 
-    const args = ['--mode', 'rpc', '--approve', '--name', config.taskId, '--extension', permissionExtension]
+    const args = ['--mode', 'rpc', '--approve', '--name', sanitizePiSessionName(config.taskId), '--extension', permissionExtension]
     if (config.systemPrompt?.trim()) {
       args.push('--append-system-prompt', config.systemPrompt.trim())
     }
@@ -814,7 +901,7 @@ export class PiAdapter implements CodingAgentAdapter {
 
   private settlePendingTurnError(session: PiSession): void {
     if (!session.pendingTurnError) return
-    const error = session.pendingTurnError
+    const error = withProviderNameLimitHint(session.pendingTurnError)
     session.pendingTurnError = null
     session.pendingTurnErrorMonotonicTime = null
     session.lastError = error

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -4238,11 +4238,26 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
 
   /**
    * Handles errors from fire-and-forget doSendAdapterMessage calls.
-   * Sends error status to the renderer so the UI reflects the failure.
+   * Sends error status AND the real message to the renderer so the transcript
+   * shows why the send failed (instead of a generic "session did not start")
+   * and the user can retry with "continue". The session stays recoverable:
+   * the next send clears the error state (see doSendAdapterMessage).
    */
   private handleSessionError(sessionId: string, session: AgentSession, err: unknown): void {
-    console.error(`[AgentManager] Session ${sessionId} error:`, err instanceof Error ? err.message : err)
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[AgentManager] Session ${sessionId} error:`, message)
     session.status = 'error'
+    this.sendToRenderer('agent:output', {
+      sessionId,
+      taskId: session.taskId,
+      type: 'message',
+      data: {
+        id: `send-error-${Date.now()}`,
+        role: 'system',
+        content: `Could not send the message: ${message}\n\nThe session is still here — fix the issue and retry with "continue".`,
+        partType: 'error'
+      }
+    })
     this.sendToRenderer('agent:status', {
       sessionId,
       agentId: session.agentId,

--- a/src/mobile/pages/TaskDetailPage.test.tsx
+++ b/src/mobile/pages/TaskDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, cleanup, fireEvent } from '@testing-library/react'
 import { ArtifactType } from '@shared/artifacts'
 import { TaskDetailPage } from './TaskDetailPage'
@@ -73,6 +73,14 @@ beforeEach(() => {
     sessions: new Map()
   })
   useArtifactStore.setState({ artifactsByTask: new Map(), loadingTaskIds: new Set() })
+})
+
+// Unmount after each test, not just before the next one: the completion tests
+// leave async store/API continuations in flight, and a still-mounted tree lets
+// React schedule render work after vitest tears down the DOM environment
+// ("ReferenceError: window is not defined" unhandled error, flaky in CI).
+afterEach(() => {
+  cleanup()
 })
 
 describe('TaskDetailPage', () => {

--- a/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
+++ b/src/renderer/src/components/agents/AgentTranscriptPanel.tsx
@@ -1132,7 +1132,14 @@ export function AgentTranscriptPanel({
         console.error('[AgentTranscriptPanel] Message send failed:', error)
         if (inputRef.current && !inputRef.current.value) inputRef.current.value = value
         setPendingAttachments(attachmentsAtSend)
-        dispatchShortcutFeedback('Could not send the message — the agent session did not start', true)
+        const detail = error instanceof Error && error.message ? error.message.trim() : String(error ?? '').trim()
+        // Surface the real failure (e.g. provider "name must be at most 64
+        // characters") instead of a generic "session did not start" — the text
+        // is restored above so nothing is lost and the user can retry.
+        const feedback = detail && detail !== 'No taskId'
+          ? `Could not send the message — ${detail.slice(0, 280)}`
+          : 'Could not send the message — the agent session did not start'
+        dispatchShortcutFeedback(feedback, true)
       })
     }
   }


### PR DESCRIPTION
Fixes the Pi provider failure `name must be at most 64 characters, got 76` and the generic `agent session did not start` dead-end that followed it.

**Root cause:** Pi forwards MCP tools as `mcp__<server>__<tool>` names. A long server display name (e.g. `[Workflo] Organisation Workspace`) plus a long tool name overflows the provider 64-char function-name limit and the whole turn fails.

**Changes:**
- `src/main/adapters/pi-adapter.ts`: sanitize Pi `--name` (≤64) and MCP server keys in `--mcp-config` (alias map: `[Workflo] Organisation Workspace` → `workflo`, legacy dev server → `workflo-dev`; generic `[X] Y` → `x-y` rule; dedupe suffixes). 64-char provider errors now include a retry hint.
- `src/main/agent-manager.ts`: `handleSessionError` posts the real error text as an error transcript part; session stays recoverable via existing error-clear on next send.
- `src/renderer/.../AgentTranscriptPanel.tsx`: composer failure toast shows the actual error instead of the hardcoded message; draft text still restored.
- Tests for the sanitizers, alias, and hint.

**Verification:** pi-adapter 19/19, agent-manager 141/141, AgentTranscriptPanel 10/10, typecheck clean, eslint clean, full pre-commit suite 2727 passed.