### PR TITLE
feat: prune idle node_modules across workspaces after 7 days of inactivity

### DIFF
--- a/src/main/workspace-cleanup-scheduler.test.ts
+++ b/src/main/workspace-cleanup-scheduler.test.ts
@@ -112,6 +112,7 @@ describe('WorkspaceCleanupScheduler', () => {
 
       expect(result.cleaned).toBe(0)
       expect(result.errors).toEqual([])
+      expect(result.nodeModulesCleaned).toBe(0)
     })
 
     it('does not clean tasks that are not completed', async () => {

--- a/src/main/workspace-cleanup-scheduler.ts
+++ b/src/main/workspace-cleanup-scheduler.ts
@@ -6,6 +6,22 @@ import type { WorktreeManager } from './worktree-manager'
 import { TaskStatus } from '../shared/constants'
 import { WORKSPACES_DIR, listWorkspaceDirs } from './workspace-paths'
 import { terminateProcessesInWorkspaces, readDiskSpace, workspacePressureWarning } from './workspace-process-cleanup'
+import {
+  NODE_MODULES_GC_DAYS_KEY,
+  NODE_MODULES_GC_ENABLED_KEY,
+  NODE_MODULES_GC_LAST_RUN_KEY,
+  DEFAULT_NODE_MODULES_GC_DAYS,
+  activeStatusWorkspaceIds,
+  findWorkspacesWithLiveProcesses,
+  pruneStaleNodeModules
+} from './workspace-node-modules-gc'
+
+/** Combined outcome of a cleanup run: whole workspaces plus pruned dependency dirs. */
+export interface CleanupResult {
+  cleaned: number
+  errors: string[]
+  nodeModulesCleaned: number
+}
 
 /**
  * WorkspaceCleanupScheduler - Automatic cleanup of old completed task workspaces
@@ -15,10 +31,14 @@ import { terminateProcessesInWorkspaces, readDiskSpace, workspacePressureWarning
  * 2. Queries completed tasks where `updated_at` is older than the configured retention period
  * 3. Cleans up worktrees and workspace directories for those tasks
  * 4. Also removes orphaned workspace directories (no matching task in DB)
+ * 5. Prunes idle `node_modules` directories at any depth, for tasks in ANY status
+ *    (own enable flag + retention, on by default — deps reinstall from package.json)
  *
  * Settings:
  * - `workspace_autocleanup_enabled` — "true"/"false" (default: "false")
  * - `workspace_autocleanup_days` — number of days after completion (default: 7)
+ * - `workspace_nodemodules_gc_enabled` — "true"/"false" (default: "true")
+ * - `workspace_nodemodules_gc_days` — days of node_modules inactivity before pruning (default: 7)
  */
 export class WorkspaceCleanupScheduler {
   private dbManager: DatabaseManager
@@ -60,25 +80,33 @@ export class WorkspaceCleanupScheduler {
   }
 
   /**
-   * Manually trigger a cleanup run. Returns the number of workspaces cleaned.
+   * Manually trigger a cleanup run. Returns the number of workspaces cleaned
+   * plus the number of idle node_modules directories pruned.
    * Rejects if a cleanup is already in progress (prevents concurrent runs).
    */
-  async runNow(): Promise<{ cleaned: number; errors: string[] }> {
+  async runNow(): Promise<CleanupResult> {
     if (this.isRunning) {
-      return { cleaned: 0, errors: ['Cleanup is already in progress'] }
+      return { cleaned: 0, errors: ['Cleanup is already in progress'], nodeModulesCleaned: 0 }
     }
     this.isRunning = true
     this.sendToRenderer('workspace:cleanup-progress', { phase: 'starting', current: 0, total: 0 })
     try {
       const result = await this.doCleanup(true)
+      const nm = await this.runNodeModulesPhase(true)
+      const combined: CleanupResult = {
+        cleaned: result.cleaned,
+        errors: [...result.errors, ...nm.errors],
+        nodeModulesCleaned: nm.pruned
+      }
       this.sendToRenderer('workspace:cleanup-progress', {
         phase: 'done',
-        current: result.cleaned,
-        total: result.cleaned,
-        cleaned: result.cleaned,
-        errors: result.errors
+        current: combined.cleaned,
+        total: combined.cleaned,
+        cleaned: combined.cleaned,
+        nodeModulesCleaned: combined.nodeModulesCleaned,
+        errors: combined.errors
       })
-      return result
+      return combined
     } finally {
       this.isRunning = false
     }
@@ -90,6 +118,11 @@ export class WorkspaceCleanupScheduler {
     if (this.isRunning) return
 
     try {
+      // Idle node_modules pruning has its own flag and schedule: it is safe for
+      // every task status (only regenerable deps go), so it runs whether or not
+      // whole-workspace auto-cleanup is enabled.
+      await this.runNodeModulesGcAuto()
+
       // Check if auto-cleanup is enabled
       const enabled = this.dbManager.getSetting('workspace_autocleanup_enabled')
       if (enabled !== 'true') {
@@ -297,6 +330,99 @@ export class WorkspaceCleanupScheduler {
       if (!isNaN(parsed) && parsed >= 1) return parsed
     }
     return this.DEFAULT_RETENTION_DAYS
+  }
+
+  // ── Idle node_modules GC ──────────────────────────────
+
+  private isNodeModulesGcEnabled(): boolean {
+    const setting = this.dbManager.getSetting(NODE_MODULES_GC_ENABLED_KEY)
+    if (setting === undefined || setting === null) return true
+    return setting === 'true'
+  }
+
+  private getNodeModulesGcDays(): number {
+    const setting = this.dbManager.getSetting(NODE_MODULES_GC_DAYS_KEY)
+    if (setting) {
+      const parsed = parseInt(setting, 10)
+      if (!isNaN(parsed) && parsed >= 1) return parsed
+    }
+    return DEFAULT_NODE_MODULES_GC_DAYS
+  }
+
+  /**
+   * Automatic (scheduled) node_modules pass: own enable flag, at most once per day.
+   * Runs independently of whole-workspace auto-cleanup.
+   */
+  private async runNodeModulesGcAuto(): Promise<void> {
+    if (!this.isNodeModulesGcEnabled()) return
+    const lastRun = this.dbManager.getSetting(NODE_MODULES_GC_LAST_RUN_KEY)
+    if (lastRun) {
+      const hoursSinceLastRun = (Date.now() - new Date(lastRun).getTime()) / (1000 * 60 * 60)
+      if (hoursSinceLastRun < 23) return
+    }
+    const nm = await this.runNodeModulesPhase(false)
+    this.dbManager.setSetting(NODE_MODULES_GC_LAST_RUN_KEY, new Date().toISOString())
+    if (nm.pruned > 0) {
+      console.log(`[WorkspaceCleanup] Pruned ${nm.pruned} idle node_modules`)
+    }
+    if (nm.errors.length > 0) {
+      console.warn(`[WorkspaceCleanup] node_modules prune errors: ${nm.errors.join('; ')}`)
+    }
+  }
+
+  /**
+   * One node_modules pruning pass over every workspace on disk, regardless of
+   * task status. Workspaces with a live process rooted in them are skipped; when
+   * liveness cannot be observed (Windows, unreadable process table), tasks in an
+   * active status are skipped instead — a build lock inside node_modules must
+   * never be pulled out from under a running agent.
+   */
+  private async runNodeModulesPhase(reportProgress: boolean): Promise<{ pruned: number; errors: string[] }> {
+    if (!this.isNodeModulesGcEnabled()) return { pruned: 0, errors: [] }
+    const days = this.getNodeModulesGcDays()
+    const dirs = listWorkspaceDirs() ?? []
+    const allTasks = this.dbManager.getTasks()
+
+    let skip = findWorkspacesWithLiveProcesses(WORKSPACES_DIR, dirs)
+    if (skip === null) skip = activeStatusWorkspaceIds(allTasks)
+
+    if (reportProgress) {
+      this.sendToRenderer('workspace:cleanup-progress', {
+        phase: 'pruning',
+        current: 0,
+        total: dirs.length,
+        message: `Pruning idle node_modules (inactive > ${days} day${days !== 1 ? 's' : ''})...`
+      })
+    }
+
+    const result = pruneStaleNodeModules({
+      workspacesRoot: WORKSPACES_DIR,
+      inactiveDays: days,
+      skipWorkspaceIds: skip,
+      onProgress: reportProgress
+        ? (processed, total, currentPath) => {
+            this.sendToRenderer('workspace:cleanup-progress', {
+              phase: 'pruning',
+              current: processed,
+              total,
+              message: currentPath ? `Pruning idle node_modules...` : `Pruned idle node_modules`
+            })
+          }
+        : undefined
+    })
+
+    if (reportProgress) {
+      this.sendToRenderer('workspace:cleanup-progress', {
+        phase: 'pruning',
+        current: dirs.length,
+        total: dirs.length,
+        message: result.pruned.length > 0
+          ? `Pruned ${result.pruned.length} idle node_modules`
+          : 'No idle node_modules to prune'
+      })
+    }
+
+    return { pruned: result.pruned.length, errors: result.errors }
   }
 
   private sendToRenderer(channel: string, data: unknown): void {

--- a/src/main/workspace-node-modules-gc.test.ts
+++ b/src/main/workspace-node-modules-gc.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, utimesSync, statSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, basename } from 'node:path'
+import {
+  activeStatusWorkspaceIds,
+  findTopLevelNodeModules,
+  findWorkspacesWithLiveProcesses,
+  isInactive,
+  pruneStaleNodeModules
+} from './workspace-node-modules-gc'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function makeRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'nm-gc-test-'))
+}
+
+/** Creates dir (with a file inside) and backdates the dir's own mtime by `ageDays`. */
+function makeAgedDir(path: string, ageDays: number): void {
+  mkdirSync(path, { recursive: true })
+  writeFileSync(join(path, 'marker.txt'), 'x')
+  const t = new Date(Date.now() - ageDays * DAY_MS)
+  utimesSync(path, t, t)
+}
+
+describe('isInactive', () => {
+  it('is true when mtime is older than the threshold', () => {
+    expect(isInactive(Date.now() - 8 * DAY_MS, Date.now(), 7)).toBe(true)
+  })
+
+  it('is false when mtime is within the threshold', () => {
+    expect(isInactive(Date.now() - 6 * DAY_MS, Date.now(), 7)).toBe(false)
+  })
+})
+
+describe('findTopLevelNodeModules', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = makeRoot()
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('finds node_modules at any depth', () => {
+    const ws = join(root, 'task-1')
+    for (const p of [
+      join(ws, '.opencode', 'node_modules'),
+      join(ws, '20x', 'node_modules'),
+      join(ws, 'peakflo-web', 'functions', 'node_modules'),
+      join(ws, 'workflow-builder', 'packages', 'ui', 'node_modules')
+    ]) {
+      mkdirSync(p, { recursive: true })
+    }
+
+    const found = findTopLevelNodeModules(ws).sort()
+
+    expect(found).toEqual(
+      [
+        join(ws, '.opencode', 'node_modules'),
+        join(ws, '20x', 'node_modules'),
+        join(ws, 'peakflo-web', 'functions', 'node_modules'),
+        join(ws, 'workflow-builder', 'packages', 'ui', 'node_modules')
+      ].sort()
+    )
+  })
+
+  it('reports a nested node_modules only once and never descends into it', () => {
+    const ws = join(root, 'task-1')
+    const outer = join(ws, 'repo', 'node_modules')
+    mkdirSync(join(outer, 'some-pkg', 'node_modules'), { recursive: true })
+    mkdirSync(join(outer, 'deeply', 'nested', 'dir'), { recursive: true })
+
+    expect(findTopLevelNodeModules(ws)).toEqual([outer])
+  })
+
+  it('skips .git directories', () => {
+    const ws = join(root, 'task-1')
+    mkdirSync(join(ws, '.git', 'node_modules'), { recursive: true })
+    mkdirSync(join(ws, 'repo', 'node_modules'), { recursive: true })
+
+    expect(findTopLevelNodeModules(ws)).toEqual([join(ws, 'repo', 'node_modules')])
+  })
+
+  it('returns empty for a missing directory', () => {
+    expect(findTopLevelNodeModules(join(root, 'nope'))).toEqual([])
+  })
+})
+
+describe('pruneStaleNodeModules', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = makeRoot()
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('prunes idle node_modules but keeps recent ones and all source files', () => {
+    const oldWs = join(root, 'task-old')
+    const newWs = join(root, 'task-new')
+    makeAgedDir(join(oldWs, '.opencode', 'node_modules'), 10)
+    writeFileSync(join(oldWs, '.opencode', 'package.json'), '{}')
+    makeAgedDir(join(oldWs, 'repo', 'node_modules'), 30)
+    writeFileSync(join(oldWs, 'repo', 'index.ts'), 'code')
+    mkdirSync(join(newWs, 'repo', 'node_modules'), { recursive: true })
+
+    const result = pruneStaleNodeModules({ workspacesRoot: root, inactiveDays: 7 })
+
+    expect(result.errors).toEqual([])
+    expect(result.pruned.sort()).toEqual(
+      [join(oldWs, '.opencode', 'node_modules'), join(oldWs, 'repo', 'node_modules')].sort()
+    )
+    expect(existsSync(join(oldWs, '.opencode', 'node_modules'))).toBe(false)
+    expect(existsSync(join(oldWs, 'repo', 'node_modules'))).toBe(false)
+    // Source files survive the prune.
+    expect(existsSync(join(oldWs, '.opencode', 'package.json'))).toBe(true)
+    expect(existsSync(join(oldWs, 'repo', 'index.ts'))).toBe(true)
+    // Recent install is kept.
+    expect(existsSync(join(newWs, 'repo', 'node_modules'))).toBe(true)
+  })
+
+  it('respects skipWorkspaceIds (live activity)', () => {
+    const ws = join(root, 'task-busy')
+    makeAgedDir(join(ws, 'repo', 'node_modules'), 30)
+
+    const result = pruneStaleNodeModules({
+      workspacesRoot: root,
+      inactiveDays: 7,
+      skipWorkspaceIds: new Set(['task-busy'])
+    })
+
+    expect(result.pruned).toEqual([])
+    expect(existsSync(join(ws, 'repo', 'node_modules'))).toBe(true)
+  })
+
+  it('refuses an invalid threshold instead of pruning everything', () => {
+    const ws = join(root, 'task-1')
+    mkdirSync(join(ws, 'node_modules'), { recursive: true })
+
+    const result = pruneStaleNodeModules({ workspacesRoot: root, inactiveDays: 0 })
+
+    expect(result.pruned).toEqual([])
+    expect(result.errors.length).toBe(1)
+    expect(existsSync(join(ws, 'node_modules'))).toBe(true)
+  })
+
+  it('returns empty when the workspaces root is missing', () => {
+    const result = pruneStaleNodeModules({ workspacesRoot: join(root, 'nope'), inactiveDays: 7 })
+
+    expect(result).toEqual({ pruned: [], errors: [] })
+  })
+
+  it('reports progress per workspace', () => {
+    makeAgedDir(join(root, 'a', 'node_modules'), 10)
+    mkdirSync(join(root, 'b'), { recursive: true })
+    const seen: Array<[number, number]> = []
+
+    pruneStaleNodeModules({
+      workspacesRoot: root,
+      inactiveDays: 7,
+      onProgress: (processed, total) => {
+        seen.push([processed, total])
+      }
+    })
+
+    expect(seen.length).toBeGreaterThan(0)
+    expect(seen[seen.length - 1]).toEqual([2, 2])
+  })
+
+  it('ignores workspaces that vanish before the prune while cleaning the rest', () => {
+    const ws1 = join(root, 'task-1')
+    const ws2 = join(root, 'task-2')
+    makeAgedDir(join(ws1, 'node_modules'), 10)
+    makeAgedDir(join(ws2, 'node_modules'), 10)
+    // Deleting the parent first turns the child stat into a failure path.
+    rmSync(ws1, { recursive: true, force: true })
+
+    const result = pruneStaleNodeModules({ workspacesRoot: root, inactiveDays: 7 })
+
+    expect(result.pruned).toEqual([join(ws2, 'node_modules')])
+  })
+})
+
+describe('activeStatusWorkspaceIds', () => {
+  it('selects only active statuses', () => {
+    const ids = activeStatusWorkspaceIds([
+      { id: 'a', status: 'agent_working' },
+      { id: 'b', status: 'triaging' },
+      { id: 'c', status: 'agent_learning' },
+      { id: 'd', status: 'ready_for_review' },
+      { id: 'e', status: 'completed' },
+      { id: 'f', status: 'not_started' }
+    ])
+
+    expect([...ids].sort()).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('findWorkspacesWithLiveProcesses', () => {
+  it('returns an empty set when there is nothing to check', () => {
+    expect(findWorkspacesWithLiveProcesses('/nonexistent-root', [])).toEqual(new Set())
+  })
+
+  it('sees the current process when it runs inside a workspace dir', () => {
+    if (process.platform === 'win32') return
+    // process.cwd() is the repo checkout, not a workspace — use a fake root that
+    // cannot match, and assert the shape (a Set) rather than membership.
+    const result = findWorkspacesWithLiveProcesses('/nonexistent-root', ['task-1'])
+    expect(result === null || result instanceof Set).toBe(true)
+  })
+
+  it('marks the real cwd workspace as active', () => {
+    if (process.platform === 'win32') return
+    const cwd = process.cwd()
+    // Derive a fake workspaces root one level above cwd so cwd looks like a workspace.
+    void statSync(cwd)
+    const result = findWorkspacesWithLiveProcesses(dirname(cwd), [basename(cwd)])
+    // The current process (vitest/electron) has cwd inside it, so it must be active —
+    // unless the platform cannot report cwds, in which case null is the honest answer.
+    if (result !== null) expect(result.has(basename(cwd))).toBe(true)
+  })
+})

--- a/src/main/workspace-node-modules-gc.ts
+++ b/src/main/workspace-node-modules-gc.ts
@@ -1,0 +1,197 @@
+import { existsSync, readdirSync, rmSync, statSync } from 'fs'
+import { join } from 'path'
+import {
+  ACTIVE_TASK_STATUSES,
+  canReadProcessCwd,
+  readProcessSnapshot,
+  resolveWorkspacesRoot,
+  workspaceIdForCwd
+} from './workspace-process-cleanup'
+
+/**
+ * Age-based pruning of idle `node_modules` directories inside task workspaces.
+ *
+ * Whole-workspace cleanup only handles `completed` tasks, so review-pending and
+ * other live workspaces accumulate dependency directories forever (measured:
+ * 175 stale `node_modules` holding ~23 GB). Dependencies are regenerable from
+ * `package.json`, so deleting just them is safe for every task status — source
+ * files, worktrees and review state are left untouched.
+ *
+ * Inactivity is the `node_modules` directory's own mtime: installing, adding
+ * or removing a top-level entry refreshes it, while reads (builds, typechecks)
+ * do not. A directory untouched for longer than the threshold is pruned.
+ *
+ * Settings:
+ * - `workspace_nodemodules_gc_enabled` — "true"/"false" (default: "true")
+ * - `workspace_nodemodules_gc_days` — days of inactivity before pruning (default: 7)
+ * - `workspace_nodemodules_gc_last_run` — ISO timestamp of the last automatic run
+ */
+
+export const NODE_MODULES_GC_ENABLED_KEY = 'workspace_nodemodules_gc_enabled'
+export const NODE_MODULES_GC_DAYS_KEY = 'workspace_nodemodules_gc_days'
+export const NODE_MODULES_GC_LAST_RUN_KEY = 'workspace_nodemodules_gc_last_run'
+
+export const DEFAULT_NODE_MODULES_GC_DAYS = 7
+
+export interface NodeModulesPruneResult {
+  /** Absolute paths of the `node_modules` directories that were removed. */
+  pruned: string[]
+  errors: string[]
+}
+
+/** True when `mtimeMs` is older than `inactiveDays` measured from `nowMs`. */
+export function isInactive(mtimeMs: number, nowMs: number, inactiveDays: number): boolean {
+  return mtimeMs < nowMs - inactiveDays * 24 * 60 * 60 * 1000
+}
+
+/**
+ * Every top-level `node_modules` directory under `workspaceDir`, at any depth:
+ * `.opencode/node_modules`, `<repo>/node_modules`, `<repo>/functions/node_modules`,
+ * `<pkg>/packages/<name>/node_modules`, …
+ *
+ * A `node_modules` that contains another `node_modules` is reported once — the
+ * walk does not descend into it, since removing the outer one removes the inner.
+ * `.git` directories are never descended into (worktree metadata, not deps).
+ * Unreadable subdirectories are skipped silently; they are retried on the next run.
+ */
+export function findTopLevelNodeModules(workspaceDir: string): string[] {
+  const found: string[] = []
+  const stack: string[] = [workspaceDir]
+  while (stack.length > 0) {
+    const dir = stack.pop() as string
+    let entries
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      if (entry.name === 'node_modules') {
+        found.push(join(dir, entry.name))
+        continue
+      }
+      // Symbolic links to directories are not followed: a linked `node_modules`
+      // (e.g. pnpm-style) is either reported by name above or left alone, and
+      // following links could escape the workspace or loop.
+      if (entry.isSymbolicLink()) continue
+      if (entry.name === '.git') continue
+      stack.push(join(dir, entry.name))
+    }
+  }
+  return found
+}
+
+/**
+ * Workspace ids that currently have at least one process rooted in them.
+ *
+ * Returns NULL when that cannot be determined — on Windows (no cheap cwd query)
+ * or when the process table yields no cwd rows at all. A NULL must fall back to
+ * a conservative rule (e.g. skipping `ACTIVE_TASK_STATUSES`); it must never be
+ * read as "nothing is running". An empty set is the real, readable answer.
+ *
+ * Deliberately unguarded: unlike the kill paths, our own processes also count
+ * as activity here. Skipping a workspace we happen to run from is the safe side.
+ */
+export function findWorkspacesWithLiveProcesses(
+  workspacesRoot: string,
+  dirNames: readonly string[]
+): Set<string> | null {
+  if (!canReadProcessCwd()) return null
+  if (dirNames.length === 0) return new Set()
+  let snapshot: { cwdRows: { pid: number; cwd: string }[] }
+  try {
+    snapshot = readProcessSnapshot()
+  } catch {
+    return null
+  }
+  if (snapshot.cwdRows.length === 0) return null
+  const wanted = new Set(dirNames)
+  const root = resolveWorkspacesRoot(workspacesRoot)
+  const active = new Set<string>()
+  for (const { cwd } of snapshot.cwdRows) {
+    const id = workspaceIdForCwd(cwd, root)
+    if (id !== null && wanted.has(id)) active.add(id)
+  }
+  return active
+}
+
+/**
+ * Workspace ids to spare when liveness cannot be observed. A task an agent is
+ * actively working on may hold a build lock inside `node_modules`; without a
+ * process snapshot there is no way to tell it apart from a stuck one, so every
+ * task in an active status is skipped. Stuck-but-idle tasks are still pruned on
+ * platforms where the snapshot works, because there the live-process check ran.
+ */
+export function activeStatusWorkspaceIds(
+  tasks: readonly { id: string; status: string }[]
+): Set<string> {
+  const active = new Set<string>()
+  for (const task of tasks) {
+    if ((ACTIVE_TASK_STATUSES as readonly string[]).includes(task.status)) active.add(task.id)
+  }
+  return active
+}
+
+/**
+ * Removes every top-level `node_modules` under `workspacesRoot` whose own mtime
+ * is older than `inactiveDays`, except in skipped workspaces.
+ *
+ * Never throws: per-directory failures are collected in `errors` and the run
+ * continues. Rejects a threshold below 1 day rather than pruning everything.
+ */
+export function pruneStaleNodeModules(input: {
+  workspacesRoot: string
+  inactiveDays: number
+  now?: number
+  skipWorkspaceIds?: ReadonlySet<string>
+  onProgress?: (processed: number, total: number, currentPath: string) => void
+}): NodeModulesPruneResult {
+  const pruned: string[] = []
+  const errors: string[] = []
+  const { workspacesRoot, skipWorkspaceIds, onProgress } = input
+  const now = input.now ?? Date.now()
+  const inactiveDays = input.inactiveDays
+
+  if (!Number.isFinite(inactiveDays) || inactiveDays < 1) {
+    return { pruned, errors: [`Refusing node_modules prune with invalid threshold: ${String(inactiveDays)}`] }
+  }
+
+  let dirNames: string[]
+  try {
+    if (!existsSync(workspacesRoot)) return { pruned, errors }
+    dirNames = readdirSync(workspacesRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+  } catch (err) {
+    return { pruned, errors: [`Could not list workspaces directory: ${err instanceof Error ? err.message : String(err)}`] }
+  }
+
+  const candidates = dirNames.filter((name) => !(skipWorkspaceIds?.has(name) ?? false))
+  let processed = 0
+  for (const name of candidates) {
+    const workspaceDir = join(workspacesRoot, name)
+    onProgress?.(processed, candidates.length, workspaceDir)
+    for (const nmPath of findTopLevelNodeModules(workspaceDir)) {
+      let mtimeMs: number
+      try {
+        mtimeMs = statSync(nmPath).mtimeMs
+      } catch (err) {
+        errors.push(`Could not stat ${nmPath}: ${err instanceof Error ? err.message : String(err)}`)
+        continue
+      }
+      if (!isInactive(mtimeMs, now, inactiveDays)) continue
+      try {
+        rmSync(nmPath, { recursive: true, force: true })
+        pruned.push(nmPath)
+        console.log(`[NodeModulesGC] Pruned idle node_modules: ${nmPath}`)
+      } catch (err) {
+        errors.push(`Failed to prune ${nmPath}: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
+    processed++
+  }
+  onProgress?.(processed, candidates.length, '')
+
+  return { pruned, errors }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -244,7 +244,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('worktree:files', taskId, repos),
     readFile: (taskId: string, repoFullName: string | null, filePath: string): Promise<{ content: string; size: number; binary: boolean; truncated: boolean } | null> =>
       ipcRenderer.invoke('worktree:readFile', taskId, repoFullName, filePath),
-    runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> =>
+    runCleanupNow: (): Promise<{ cleaned: number; errors: string[]; nodeModulesCleaned: number }> =>
       ipcRenderer.invoke('workspace:runCleanupNow')
   },
   taskSources: {

--- a/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
@@ -11,6 +11,18 @@ import { OnboardingWizard } from '@/components/onboarding/OnboardingWizard'
 import { settingsApi, mobileApi, updaterApi, worktreeApi, onWorkspaceCleanupProgress } from '@/lib/ipc-client'
 import { MASTERMIND_PREWARM_SETTING } from '@/components/orchestrator/OrchestratorPanel'
 
+/** Human-readable summary of a cleanup run, or null when there is nothing to report. */
+function describeCleanupOutcome(cleaned: number | undefined, nodeModulesCleaned: number | undefined): string | null {
+  const parts: string[] = []
+  if (cleaned !== undefined && cleaned > 0) {
+    parts.push(`Cleaned ${cleaned} workspace${cleaned !== 1 ? 's' : ''}`)
+  }
+  if (nodeModulesCleaned !== undefined && nodeModulesCleaned > 0) {
+    parts.push(`pruned ${nodeModulesCleaned} idle node_modules`)
+  }
+  return parts.length > 0 ? parts.join(', ') : null
+}
+
 export function GeneralSettings() {
   const [setupDialogOpen, setSetupDialogOpen] = useState(false)
   const [launchAtStartup, setLaunchAtStartup] = useState(false)
@@ -53,8 +65,9 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
       if (event.phase === 'done') {
         setCleanupRunning(false)
         setCleanupProgress(null)
-        if (event.cleaned !== undefined && event.cleaned > 0) {
-          setCleanupResult(`Cleaned ${event.cleaned} workspace${event.cleaned !== 1 ? 's' : ''}`)
+        const summary = describeCleanupOutcome(event.cleaned, event.nodeModulesCleaned)
+        if (summary) {
+          setCleanupResult(summary)
         } else if (event.errors && event.errors.length > 0) {
           setCleanupResult(`Cleanup finished with ${event.errors.length} error${event.errors.length !== 1 ? 's' : ''}`)
         } else {
@@ -71,6 +84,8 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
   // Workspace cleanup settings
   const [autocleanEnabled, setAutocleanEnabled] = useState(false)
   const [autocleanDays, setAutocleanDays] = useState('7')
+  const [nodeModulesGcEnabled, setNodeModulesGcEnabled] = useState(true)
+  const [nodeModulesGcDays, setNodeModulesGcDays] = useState('7')
   const [cleanupRunning, setCleanupRunning] = useState(false)
   const [cleanupResult, setCleanupResult] = useState<string | null>(null)
   const [cleanupProgress, setCleanupProgress] = useState<{ current: number; total: number; message?: string } | null>(null)
@@ -119,6 +134,12 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
 
         const cleanupDays = await settingsApi.get('workspace_autocleanup_days')
         if (cleanupDays) setAutocleanDays(cleanupDays)
+
+        const nmGcEnabled = await settingsApi.get('workspace_nodemodules_gc_enabled')
+        if (nmGcEnabled !== null) setNodeModulesGcEnabled(nmGcEnabled !== 'false')
+
+        const nmGcDays = await settingsApi.get('workspace_nodemodules_gc_days')
+        if (nmGcDays) setNodeModulesGcDays(nmGcDays)
       } catch (error) {
         console.error('Failed to load workspace cleanup settings:', error)
       }
@@ -623,12 +644,56 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
           </select>
         </div>
 
+        <div className="flex items-center justify-between py-2 border-b border-border">
+          <div className="space-y-0.5">
+            <Label htmlFor="nodemodules-gc-enabled">Prune idle node_modules</Label>
+            <p className="text-xs text-muted-foreground">
+              Delete dependency folders untouched for more than the configured days, in every workspace.
+              Source files are kept — dependencies reinstall on the next run.
+            </p>
+          </div>
+          <Switch
+            id="nodemodules-gc-enabled"
+            checked={nodeModulesGcEnabled}
+            onCheckedChange={async (checked) => {
+              setNodeModulesGcEnabled(checked)
+              await settingsApi.set('workspace_nodemodules_gc_enabled', checked ? 'true' : 'false')
+            }}
+            disabled={loading}
+          />
+        </div>
+
+        <div className="flex items-center justify-between py-2 border-b border-border">
+          <div className="space-y-0.5">
+            <Label htmlFor="nodemodules-gc-days">Dependency inactivity period</Label>
+            <p className="text-xs text-muted-foreground">
+              Days without changes before a node_modules folder is pruned
+            </p>
+          </div>
+          <select
+            id="nodemodules-gc-days"
+            value={nodeModulesGcDays}
+            onChange={async (e) => {
+              setNodeModulesGcDays(e.target.value)
+              await settingsApi.set('workspace_nodemodules_gc_days', e.target.value)
+            }}
+            disabled={loading || !nodeModulesGcEnabled}
+            className="bg-transparent border rounded px-2 py-1 text-sm disabled:opacity-50"
+          >
+            <option value="1">1 day</option>
+            <option value="3">3 days</option>
+            <option value="7">7 days</option>
+            <option value="14">14 days</option>
+            <option value="30">30 days</option>
+          </select>
+        </div>
+
         <div className="py-2">
           <div className="flex items-center justify-between">
             <div className="space-y-0.5">
               <Label>Manual cleanup</Label>
               <p className="text-xs text-muted-foreground">
-                Run workspace cleanup now for all eligible completed tasks
+                Run workspace cleanup and idle dependency pruning now
               </p>
             </div>
             <div className="flex items-center gap-2">
@@ -648,8 +713,9 @@ const [currentVersion, setCurrentVersion] = useState<string | null>(null)
                     // The progress listener handles the final state via the 'done' event,
                     // but also handle the IPC response as a fallback
                     if (!cleanupProgress) {
-                      if (result.cleaned > 0) {
-                        setCleanupResult(`Cleaned ${result.cleaned} workspace${result.cleaned !== 1 ? 's' : ''}`)
+                      const summary = describeCleanupOutcome(result.cleaned, result.nodeModulesCleaned)
+                      if (summary) {
+                        setCleanupResult(summary)
                       } else if (result.errors.length > 0 && result.errors[0] === 'Cleanup is already in progress') {
                         setCleanupResult('Cleanup already in progress')
                       } else {

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -586,7 +586,7 @@ export const worktreeApi = {
     }
     return readFile(taskId, repoFullName, filePath)
   },
-  runCleanupNow: (): Promise<{ cleaned: number; errors: string[] }> => {
+  runCleanupNow: (): Promise<{ cleaned: number; errors: string[]; nodeModulesCleaned: number }> => {
     return window.electronAPI.worktree.runCleanupNow()
   }
 }

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -178,11 +178,12 @@ export interface WorktreeProgressEvent {
 }
 
 export interface WorkspaceCleanupProgressEvent {
-  phase: 'starting' | 'scanning' | 'cleaning' | 'done'
+  phase: 'starting' | 'scanning' | 'cleaning' | 'pruning' | 'done'
   current: number
   total: number
   message?: string
   cleaned?: number
+  nodeModulesCleaned?: number
   errors?: string[]
 }
 
@@ -321,7 +322,7 @@ interface ElectronAPI {
     changes: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; diff: string; allFiles?: string[]; workspace?: boolean; error?: string; noWorktree?: boolean; path?: string; branch?: string; pushed?: boolean; prNumber?: number; prUrl?: string; prState?: string; prTitle?: string; ciStatus?: 'passing' | 'failing' | 'pending' | 'none' }>>
     files: (taskId: string, repos: { fullName: string }[]) => Promise<Array<{ repo: string; allFiles: string[]; workspace?: boolean; error?: string; noWorktree?: boolean; path?: string }>>
     readFile: (taskId: string, repoFullName: string | null, filePath: string) => Promise<{ content: string; size: number; binary: boolean; truncated: boolean } | null>
-    runCleanupNow: () => Promise<{ cleaned: number; errors: string[] }>
+    runCleanupNow: () => Promise<{ cleaned: number; errors: string[]; nodeModulesCleaned: number }>
   }
   taskSources: {
     getAll: () => Promise<TaskSource[]>


### PR DESCRIPTION
## Why

Manual cleanup on 2026-09-06 removed 175 stale `node_modules` dirs under `…/20x/workspaces`, freeing ~23 GB. Investigation (task_1788676171272_drk5nwn) found whole-workspace GC only handles `completed` tasks, so review-pending and other live workspaces accumulate dependency dirs forever — and no `node_modules`-only pruning existed anywhere.

## What

Age-based, dependency-only GC that automates exactly that manual cleanup:

- New `src/main/workspace-node-modules-gc.ts`: finds top-level `node_modules` at any depth (`.opencode/`, repo roots, `functions/`, `packages/*/`), prunes those whose own mtime is older than the threshold. Source files, worktrees and review state are untouched — deps reinstall from `package.json` on next run.
- Safety: workspaces with a live process rooted in them are skipped; when liveness can't be observed (Windows/unreadable table) tasks in active statuses are skipped instead. Never throws; invalid threshold refuses to run.
- Scheduler: own flag `workspace_nodemodules_gc_enabled` (**default ON**) + `workspace_nodemodules_gc_days` (**default 7**) with its own daily stamp. Runs even when whole-workspace auto-cleanup is off; manual Clean Now always includes it with a live `pruning` progress phase.
- Settings UI: switch + inactivity-period dropdown, combined result line ("Cleaned N workspaces, pruned M idle node_modules").
- IPC result gains additive `nodeModulesCleaned` field.

## Verification

- 16 new unit tests (real temp dirs) + scheduler contract assertion.
- Full suites green via pre-commit hook: 2740 passed, 4 skipped; `typecheck` + `eslint` clean.
- Walk-shape validated against the pre-cleanup scan (930 dirs): same population reproduced.