### PR TITLE
Fix Workflo task upload routes and reviewed-session guard

### DIFF
--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -153,7 +153,11 @@ export class SyncManager {
   async uploadTask(taskId: string, autonomous = false): Promise<{ queued: boolean }> {
     const task = this.db.getTask(taskId)
     if (!task || task.source_id || task.external_id) throw new Error('Only a local task can be sent to Workflo.')
-    if (task.session_id || !['not_started', 'ready_for_review'].includes(task.status)) {
+    // A finished local agent run remains resumable for review, so
+    // ready_for_review tasks may legitimately retain their session_id. The
+    // status transition is the execution boundary; only an untouched task
+    // with a persisted session can still represent active/resumable work.
+    if ((task.status === 'not_started' && task.session_id) || !['not_started', 'ready_for_review'].includes(task.status)) {
       throw new Error('Stop the local session before sending this task to Workflo.')
     }
     const scope = this.taskUploadScope()

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -9,6 +9,7 @@ import type { PluginContext, PluginSyncResult, ActionResult } from './plugins/ty
 import type { WorkfloApiClient } from './workflo-api-client'
 import type { EnterpriseSyncManager } from './enterprise-sync'
 import type { SourceUser, ReassignResult } from '../shared/types'
+import { TaskStatus } from '../shared/constants'
 
 export interface SyncResult {
   source_id: string
@@ -157,7 +158,10 @@ export class SyncManager {
     // ready_for_review tasks may legitimately retain their session_id. The
     // status transition is the execution boundary; only an untouched task
     // with a persisted session can still represent active/resumable work.
-    if ((task.status === 'not_started' && task.session_id) || !['not_started', 'ready_for_review'].includes(task.status)) {
+    if (
+      (task.status === TaskStatus.NotStarted && task.session_id)
+      || (task.status !== TaskStatus.NotStarted && task.status !== TaskStatus.ReadyForReview)
+    ) {
       throw new Error('Stop the local session before sending this task to Workflo.')
     }
     const scope = this.taskUploadScope()

--- a/src/main/workflo-api-client.test.ts
+++ b/src/main/workflo-api-client.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+import { TASK_WRITE_HEADERS } from '../shared/task-write-contract'
+import type { EnterpriseAuth } from './enterprise-auth'
+import { WorkfloApiClient, type WorkfloTask } from './workflo-api-client'
+
+describe('WorkfloApiClient task writes', () => {
+  it('uses the strict collection-command route when creating a task', async () => {
+    const task = { id: 'remote-task' } as WorkfloTask
+    const apiRequest = vi.fn().mockResolvedValue({ task })
+    const client = new WorkfloApiClient({ apiRequest } as unknown as EnterpriseAuth)
+    const data = {
+      clientRequestId: '20x:request-1',
+      title: 'Fix task upload',
+      description: 'Use the registered Workflo route'
+    }
+
+    await expect(client.createTask(data)).resolves.toBe(task)
+    expect(apiRequest).toHaveBeenCalledWith('POST', '/api/tasks/', data, TASK_WRITE_HEADERS)
+  })
+})

--- a/src/main/workflo-api-client.ts
+++ b/src/main/workflo-api-client.ts
@@ -221,7 +221,11 @@ export class WorkfloApiClient {
 
 
   async createTask(data: { clientRequestId: string; title: string; description: string; agentId?: string; skillIds?: string[]; assignees?: Array<{ assigneeType: string; assigneeValue: string }>; cron?: string; timezone?: string; autoCompleteWithoutReview?: boolean }): Promise<WorkfloTask> {
-    const result = await this.auth.apiRequest('POST', '/api/tasks', data, TASK_WRITE_HEADERS) as { task: WorkfloTask }
+    // The Workflo task command is registered as `POST /` under the
+    // `/api/tasks` Fastify prefix. Workflo uses strict trailing-slash routing,
+    // so `/api/tasks` is only the collection read endpoint while the create
+    // command lives at `/api/tasks/`.
+    const result = await this.auth.apiRequest('POST', '/api/tasks/', data, TASK_WRITE_HEADERS) as { task: WorkfloTask }
     return result.task
   }
 

--- a/src/main/workflo-task-sync.test.ts
+++ b/src/main/workflo-task-sync.test.ts
@@ -106,6 +106,26 @@ describe('durable upload', () => {
     expect(api.createTask).not.toHaveBeenCalled()
     expect(db.getSetting(`workflo-upload:${task.id}`)).toBeDefined()
   })
+
+  it('uploads a reviewed local task while retaining its resumable session', async () => {
+    const { api, sync } = setup()
+    api.createTask.mockResolvedValue(remote() as never)
+    const task = db.createTask(makeTask({ status: 'ready_for_review' }))!
+    db.updateTask(task.id, { session_id: 'completed-local-session' })
+
+    await expect(sync.uploadTask(task.id)).resolves.toEqual({ queued: false })
+    expect(api.createTask).toHaveBeenCalledOnce()
+    expect(db.getTask(task.id)).toMatchObject({ external_id: 'remote-1' })
+  })
+
+  it('still blocks an untouched task with a resumable local session', async () => {
+    const { api, sync } = setup()
+    const task = db.createTask(makeTask())!
+    db.updateTask(task.id, { session_id: 'active-local-session' })
+
+    await expect(sync.uploadTask(task.id)).rejects.toThrow('Stop the local session')
+    expect(api.createTask).not.toHaveBeenCalled()
+  })
 })
 
 it('does not fire local recurrence for an old Workflo task with a stale schedule', async () => {


### PR DESCRIPTION
## Summary
- use Workflo's strict trailing-slash task creation route
- allow ready-for-review local tasks to upload while retaining a resumable session
- keep blocking untouched tasks with active/resumable local sessions
- add regression coverage for both failures

## Verification
- pnpm test:run --project main src/main/workflo-api-client.test.ts src/main/workflo-task-sync.test.ts
- pnpm typecheck
- full pre-commit suite: 173 files passed, 2723 tests passed, 4 skipped