### PR TITLE
Keep source-less 20x tasks local

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2379,7 +2379,7 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
     }
     if (data.status === TaskStatus.Completed && origin !== 'workflo-server') {
       const task = this.getTask(id)
-      if (task && task.status !== TaskStatus.Completed) {
+      if (task?.source_id && task.status !== TaskStatus.Completed) {
         throw new Error('Workflo must confirm completion before this task can close in 20x.')
       }
     }

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -71,13 +71,13 @@ describe('registerIpcHandlers', () => {
     expect(channels).toContain('voice:selectModel')
   })
 
-  it('returns a newly created local task without waiting for Workflo upload', async () => {
+  it('keeps a newly created source-less task local', async () => {
     const task = { id: 'task-1', title: 'Instant task', status: 'not_started', source_id: null }
     const db = {
       createTask: vi.fn(() => task),
       getTask: vi.fn(() => task)
     } as unknown as Parameters<typeof registerIpcHandlers>[0]
-    const uploadTask = vi.fn(() => new Promise<never>(() => {}))
+    const uploadTask = vi.fn()
     const syncManager = {
       canUploadTasks: vi.fn(() => true),
       uploadTask
@@ -97,7 +97,7 @@ describe('registerIpcHandlers', () => {
     const sender = { send: vi.fn() }
 
     await expect(createTask!({ sender }, task)).resolves.toBe(task)
-    expect(uploadTask).toHaveBeenCalledWith(task.id)
+    expect(uploadTask).not.toHaveBeenCalled()
     expect(sender.send).toHaveBeenCalledWith('task:created', { task })
   })
 

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -71,6 +71,36 @@ describe('registerIpcHandlers', () => {
     expect(channels).toContain('voice:selectModel')
   })
 
+  it('returns a newly created local task without waiting for Workflo upload', async () => {
+    const task = { id: 'task-1', title: 'Instant task', status: 'not_started', source_id: null }
+    const db = {
+      createTask: vi.fn(() => task),
+      getTask: vi.fn(() => task)
+    } as unknown as Parameters<typeof registerIpcHandlers>[0]
+    const uploadTask = vi.fn(() => new Promise<never>(() => {}))
+    const syncManager = {
+      canUploadTasks: vi.fn(() => true),
+      uploadTask
+    } as unknown as Parameters<typeof registerIpcHandlers>[4]
+
+    registerIpcHandlers(
+      db,
+      {} as Parameters<typeof registerIpcHandlers>[1],
+      {} as Parameters<typeof registerIpcHandlers>[2],
+      {} as Parameters<typeof registerIpcHandlers>[3],
+      syncManager,
+      {} as Parameters<typeof registerIpcHandlers>[5]
+    )
+
+    const handlers = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls as [string, (...args: unknown[]) => unknown][]
+    const createTask = handlers.filter(([channel]) => channel === 'db:createTask').pop()?.[1]
+    const sender = { send: vi.fn() }
+
+    await expect(createTask!({ sender }, task)).resolves.toBe(task)
+    expect(uploadTask).toHaveBeenCalledWith(task.id)
+    expect(sender.send).toHaveBeenCalledWith('task:created', { task })
+  })
+
   it('voice handlers stay safe when the voice manager is absent', async () => {
     const db = {} as unknown as Parameters<typeof registerIpcHandlers>[0]
     const agentManager = {} as unknown as Parameters<typeof registerIpcHandlers>[1]

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -107,18 +107,6 @@ export function registerIpcHandlers(
   ipcMain.handle('db:createTask', async (event, data: CreateTaskData) => {
     if (data.status === TaskStatus.Completed) throw new Error('Workflo must confirm completion.')
     let task = db.createTask(data)
-    if (task && !task.source_id && syncManager.canUploadTasks()) {
-      const taskId = task.id
-      // Local creation is authoritative and must stay instant. Workflo upload
-      // is best-effort and reports its eventual state through task updates.
-      void syncManager.uploadTask(taskId).then(() => {
-        const syncedTask = db.getTask(taskId)
-        if (syncedTask) event.sender.send('task:updated', { taskId, updates: syncedTask })
-      }).catch((error) => {
-        console.warn('[ipc] Background Workflo task upload failed:', error)
-      })
-      task = db.getTask(task.id)
-    }
     // Initialize recurring task if it has a recurrence pattern
     if (task && !task.server_managed && task.is_recurring && recurrenceScheduler) {
       recurrenceScheduler.initializeRecurringTask(task.id)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -106,7 +106,7 @@ export function registerIpcHandlers(
 
   ipcMain.handle('db:createTask', async (event, data: CreateTaskData) => {
     if (data.status === TaskStatus.Completed) throw new Error('Workflo must confirm completion.')
-    let task = db.createTask(data)
+    const task = db.createTask(data)
     // Initialize recurring task if it has a recurrence pattern
     if (task && !task.server_managed && task.is_recurring && recurrenceScheduler) {
       recurrenceScheduler.initializeRecurringTask(task.id)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -108,8 +108,15 @@ export function registerIpcHandlers(
     if (data.status === TaskStatus.Completed) throw new Error('Workflo must confirm completion.')
     let task = db.createTask(data)
     if (task && !task.source_id && syncManager.canUploadTasks()) {
-      try { await syncManager.uploadTask(task.id) }
-      catch (error) { db.setSetting(`workflo-upload:${task.id}:error`, error instanceof Error ? error.message : String(error)) }
+      const taskId = task.id
+      // Local creation is authoritative and must stay instant. Workflo upload
+      // is best-effort and reports its eventual state through task updates.
+      void syncManager.uploadTask(taskId).then(() => {
+        const syncedTask = db.getTask(taskId)
+        if (syncedTask) event.sender.send('task:updated', { taskId, updates: syncedTask })
+      }).catch((error) => {
+        console.warn('[ipc] Background Workflo task upload failed:', error)
+      })
       task = db.getTask(task.id)
     }
     // Initialize recurring task if it has a recurrence pattern

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -719,26 +719,30 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
     if (params.status === TaskStatus.Completed) throw Object.assign(new Error('Workflo must confirm completion.'), { status: 409 })
     const { title } = params as { title?: string }
     if (!title) throw Object.assign(new Error('title is required'), { status: 400 })
-    let task = db.createTask(params as unknown as Parameters<DatabaseManager['createTask']>[0])
+    const task = db.createTask(params as unknown as Parameters<DatabaseManager['createTask']>[0])
     if (!task) throw Object.assign(new Error('Failed to create task'), { status: 500 })
-    if (!task.source_id && syncManagerRef?.canUploadTasks()) {
-      try { await syncManagerRef.uploadTask(task.id) }
-      catch (error) { db.setSetting(`workflo-upload:${task.id}:error`, error instanceof Error ? error.message : String(error)) }
-      task = db.getTask(task.id)!
-    }
     broadcastToMobileClients('task:created', { task })
     if (notifyDesktop) notifyDesktop('task:created', { task })
     if (task.auto_start_agent) triggerTaskAutomation()
     return task
   }
 
-  // Human mobile completion uses the same durable server command as desktop.
+  // Source-less tasks are local 20x records. Only sourced tasks delegate
+  // completion to their external authority.
   const taskCompleteMatch = pathname.match(/^\/api\/tasks\/([^/]+)\/complete$/)
   if (taskCompleteMatch) {
     const taskId = taskCompleteMatch[1]
     const task = db.getTask(taskId)
     if (!task) throw Object.assign(new Error('Task not found'), { status: 404 })
-    if (!syncManagerRef || !task.source_id || db.getTaskSource(task.source_id)?.plugin_id !== 'peakflo') {
+    if (!task.source_id) {
+      const fresh = db.updateTask(taskId, { status: TaskStatus.Completed })
+      if (fresh) {
+        broadcastToMobileClients('task:updated', { taskId, updates: fresh })
+        if (notifyDesktop) notifyDesktop('task:updated', { taskId, updates: fresh })
+      }
+      return { completed: true, status: fresh?.status }
+    }
+    if (!syncManagerRef || db.getTaskSource(task.source_id)?.plugin_id !== 'peakflo') {
       throw Object.assign(new Error('Sync this task with Workflo before completing it.'), { status: 409 })
     }
     const result = await syncManagerRef.executeAction('complete', task, undefined, task.source_id)

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -18,6 +18,11 @@ export interface SyncResult {
   errors: string[]
 }
 
+function isUnsupportedTaskCreateRoute(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /^Route POST:\/api\/tasks\/? not found$/i.test(message.trim())
+}
+
 export class SyncManager {
   private workfloApiClient?: WorkfloApiClient
   private enterpriseSyncManager?: EnterpriseSyncManager
@@ -230,6 +235,16 @@ export class SyncManager {
           this.db.deleteSetting(key)
           this.db.deleteSetting(`${key}:error`)
         } catch (error) {
+          // Production can temporarily lag behind the desktop task-write
+          // contract. A missing create route is a capability mismatch, not a
+          // sync failure the user can act on. Keep the task local and remove
+          // the durable command so it does not show a permanent error banner.
+          if (isUnsupportedTaskCreateRoute(error)) {
+            this.db.deleteSetting(key)
+            this.db.deleteSetting(`${key}:error`)
+            console.warn('[sync] Workflo task creation is unavailable; keeping task local.')
+            continue
+          }
           // Retain the exact command and request ID after network failures.
           this.db.setSetting(`${key}:error`, error instanceof Error ? error.message : String(error))
         }

--- a/src/main/workflo-task-sync.test.ts
+++ b/src/main/workflo-task-sync.test.ts
@@ -126,6 +126,29 @@ describe('durable upload', () => {
     await expect(sync.uploadTask(task.id)).rejects.toThrow('Stop the local session')
     expect(api.createTask).not.toHaveBeenCalled()
   })
+
+  it.each([
+    'Route POST:/api/tasks not found',
+    'Route POST:/api/tasks/ not found'
+  ])('keeps the task local without a visible sync error when Workflo lacks the create route: %s', async (message) => {
+    const { api, sync } = setup()
+    api.createTask.mockRejectedValue(new Error(message))
+    const task = db.createTask(makeTask())!
+
+    await expect(sync.uploadTask(task.id)).resolves.toEqual({ queued: false })
+    expect(db.getSetting(`workflo-upload:${task.id}`)).toBeUndefined()
+    expect(db.getSetting(`workflo-upload:${task.id}:error`)).toBeUndefined()
+    expect(db.getTask(task.id)).toMatchObject({ external_id: null, source_id: null })
+  })
+
+  it('continues to retain and display actionable transient upload failures', async () => {
+    const { sync } = setup()
+    const task = db.createTask(makeTask())!
+
+    await expect(sync.uploadTask(task.id)).resolves.toEqual({ queued: true })
+    expect(db.getSetting(`workflo-upload:${task.id}`)).toBeDefined()
+    expect(db.getSetting(`workflo-upload:${task.id}:error`)).toBe('offline')
+  })
 })
 
 it('does not fire local recurrence for an old Workflo task with a stale schedule', async () => {

--- a/src/main/workflo-task-sync.test.ts
+++ b/src/main/workflo-task-sync.test.ts
@@ -224,8 +224,7 @@ it('stores an offline human completion with its original version until the serve
   expect(db.getSetting(`workflo-completion:${local.id}`)).toBeUndefined()
 })
 
-it('a local draft cannot become completed without server acceptance',()=>{
+it('a source-less local task completes without server acceptance',()=>{
   const draft=db.createTask(makeTask())!
-  expect(()=>db.updateTask(draft.id,{status:'completed'})).toThrow('Workflo must confirm')
-  expect(db.getTask(draft.id)?.status).toBe('not_started')
+  expect(db.updateTask(draft.id,{status:'completed'})?.status).toBe('completed')
 })

--- a/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
@@ -2,6 +2,7 @@ import { taskCompletionCommand } from '../../../../shared/task-write-contract'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { TaskPanelContent } from './TaskPanelContent'
+import { TaskStatus } from '@/types'
 
 const {
   updatePanelMock,
@@ -102,6 +103,7 @@ vi.mock('@/stores/task-store', () => {
   useTaskStore.getState = () => ({
     tasks: taskList,
     selectTask: selectTaskMock,
+    updateTask: updateTaskMock,
     fetchTasks: async () => undefined,
   })
 
@@ -185,11 +187,23 @@ describe('TaskPanelContent', () => {
     expect(addEdgeMock).not.toHaveBeenCalled()
   })
 
-  it.each([null, 'src-1'])('issues server completion for source %s without writing local completion', async (sourceId) => {
-    taskList[0].source_id = sourceId
-    const apiRequest = vi.fn()
-    const upload = vi.fn(async () => { taskList[0].source_id = 'src-1'; return { queued: false } })
+  it('completes a source-less canvas task locally without uploading it', async () => {
+    const upload = vi.fn()
     window.electronAPI.taskSources.upload = upload
+    render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
+    fireEvent.click(screen.getByText('Complete task'))
+
+    await waitFor(() => expect(updateTaskMock).toHaveBeenCalledExactlyOnceWith('task-1', {
+      status: TaskStatus.Completed,
+    }))
+    expect(upload).not.toHaveBeenCalled()
+    expect(executeActionMock).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('issues server completion for a sourced canvas task without writing local completion', async () => {
+    taskList[0].source_id = 'src-1'
+    const apiRequest = vi.fn()
     // Bridge the renderer command to the real API encoder. Credentials stay in main.
     executeActionMock.mockImplementation(async () => {
       const command = taskCompletionCommand('remote-1', { action: 'complete' }, 7)
@@ -205,7 +219,5 @@ describe('TaskPanelContent', () => {
     expect(updateTaskMock).not.toHaveBeenCalled()
     // A single shared confirmation exists for every source — no source dialog.
     expect(screen.queryByRole('dialog')).toBeNull()
-    if (sourceId === null) expect(upload).toHaveBeenCalledExactlyOnceWith('task-1')
-    else expect(upload).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/hooks/use-task-completion.test.tsx
+++ b/src/renderer/src/hooks/use-task-completion.test.tsx
@@ -95,11 +95,13 @@ describe('server completion', () => {
     expect(updateTaskMock).not.toHaveBeenCalled()
     expect(screen.queryByRole('dialog')).toBeNull()
   })
-  it('requires a server task before completion',async()=>{
-    window.electronAPI.taskSources.upload = vi.fn().mockResolvedValue({queued:true})
+  it('completes a source-less 20x task locally without uploading it',async()=>{
+    const upload = vi.fn()
+    window.electronAPI.taskSources.upload = upload
     storeState.tasks=[makeTask()];render(<Harness />);fireEvent.click(screen.getByText('Complete'))
-    await waitFor(()=>expect(onToast).toHaveBeenCalledWith(expect.stringContaining('Task creation is pending'),true))
-    expect(updateTaskMock).not.toHaveBeenCalled();expect(executeActionMock).not.toHaveBeenCalled();expect(onCompleted).not.toHaveBeenCalled()
+    await waitFor(()=>expect(onCompleted).toHaveBeenCalled())
+    expect(updateTaskMock).toHaveBeenCalledWith('task-1',{status:TaskStatus.Completed})
+    expect(upload).not.toHaveBeenCalled();expect(executeActionMock).not.toHaveBeenCalled()
   })
   it('keeps a refused completion open',async()=>{
     executeActionMock.mockResolvedValue({success:false,error:'Review required'})

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { useTaskStore } from '@/stores/task-store'
-import { PluginActionId } from '@/types'
+import { PluginActionId, TaskStatus } from '@/types'
 import type { WorkfloTask } from '@/types'
 
 export interface UseTaskCompletionOptions {
@@ -11,20 +11,19 @@ export interface CompleteTaskRequestOptions {
   onCompleted?: (task: WorkfloTask) => void
 }
 
-/** Completion is confirmed by the server. Local dismissal is a view action.
- * All sources (Workflo, Notion, …) share this single confirmation path. */
+/** Sourced completion is confirmed externally; source-less 20x tasks stay local. */
 export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
   const executeAction = useTaskSourceStore(s => s.executeAction)
   const requestComplete = useCallback(async (taskId: string, options?: CompleteTaskRequestOptions) => {
-    let task = useTaskStore.getState().tasks.find(t => t.id === taskId)
+    const task = useTaskStore.getState().tasks.find(t => t.id === taskId)
     if (!task) return
     try {
       if (!task.source_id) {
-        const upload = await window.electronAPI.taskSources.upload(task.id)
-        if (upload.queued) throw new Error('Task creation is pending in Workflo. Completion has not been accepted.')
-        await useTaskStore.getState().fetchTasks()
-        task = useTaskStore.getState().tasks.find(t => t.id === taskId)
-        if (!task?.source_id) throw new Error('Send this task to Workflo before completing it.')
+        await useTaskStore.getState().updateTask(task.id, { status: TaskStatus.Completed })
+        const completedTask = { ...task, status: TaskStatus.Completed }
+        options?.onCompleted?.(completedTask)
+        onToast?.(`"${task.title}" completed`)
+        return
       }
       const action = task.output_fields.find(f => f.id === 'action')?.value
       const result = await executeAction(action ? String(action) : PluginActionId.Complete, task.id, task.source_id)


### PR DESCRIPTION
## Summary
- never upload newly created source-less desktop or mobile tasks to Workflo
- complete source-less 20x tasks locally without a network request
- retain external completion authority for tasks that have a source
- keep the explicit **Send to Workflo** action as the only opt-in upload path
- silently keep an explicitly uploaded task local when production lacks the create route

## Verification
- main-process focused suites: 102 assertions passed
- renderer completion suite: 3 assertions passed
- mobile API suite: 11 assertions passed
- TypeScript typecheck passed
- git diff check passed