### PR TITLE
fix(pi): proxy MCP tools to respect provider name limits

### DIFF
--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -17,7 +17,13 @@ vi.mock('../enterprise-ai-gateway', () => ({
   readEnterpriseAiGatewayConfig: vi.fn(() => null),
 }))
 
-import { PiAdapter, sanitizePiMcpServerName, sanitizePiSessionName, withProviderNameLimitHint } from './pi-adapter'
+import {
+  PiAdapter,
+  buildPiMcpConfigDocument,
+  sanitizePiMcpServerName,
+  sanitizePiSessionName,
+  withProviderNameLimitHint,
+} from './pi-adapter'
 import { MessagePartType } from './coding-agent-adapter'
 
 function fakeProcess() {
@@ -516,27 +522,53 @@ describe('PiAdapter', () => {
     expect(slug).not.toMatch(/-$/)
   })
 
-  it('shortens MCP server names so combined tool names fit the 64-char limit', () => {
-    // Reproduction of the reported failure: a long display name such as
-    // "[Workflo] Organisation Workspace" plus a long tool name overflows the
-    // provider limit ("name must be at most 64 characters, got 76").
-    const longTool = `mcp__[Workflo] Organisation Workspace__${'t'.repeat(40)}`
-    expect(longTool.length).toBeGreaterThan(64)
+  it('keeps long generated workflow tools behind a short MCP namespace proxy', () => {
+    // Real Workflo workflow tools can be 50 characters. A 24-character server
+    // slug plus separator plus this tool is the reported 76-character failure.
+    const workflowTool = 'wf_peakflo_travels_voice_agent_call_summary_peakfl'
+    expect(workflowTool).toHaveLength(50)
+    expect(`${'s'.repeat(24)}__${workflowTool}`).toHaveLength(76)
 
     const used = new Set<string>()
     // Canonical alias: "[Workflo] Organisation Workspace" → "workflo"
     expect(sanitizePiMcpServerName('[Workflo] Organisation Workspace', used)).toBe('workflo')
-    const shortened = `mcp__workflo__${'t'.repeat(25)}`
-    expect(shortened.length).toBeLessThanOrEqual(64)
     // Second use dedupes instead of colliding
     expect(sanitizePiMcpServerName('[Workflo] Organisation Workspace', used)).not.toBe('workflo')
     // Generic bracket rule: "[Workflo] My tasks" → "workflo-my-tasks"
     expect(sanitizePiMcpServerName('[Workflo] My tasks', new Set())).toBe('workflo-my-tasks')
+
+    const document = buildPiMcpConfigDocument({
+      '[Workflo] Organisation Workspace': {
+        type: 'http',
+        url: 'https://example.com/mcp',
+      },
+    }) as {
+      settings: { directTools: boolean }
+      mcpServers: Record<string, unknown>
+    }
+    expect(document.settings.directTools).toBe(false)
+    expect(Object.keys(document.mcpServers)).toEqual(['workflo'])
+    // With direct tools disabled, this is the only server-specific tool name
+    // registered with the provider; the 50-character suffix stays in MCP.
+    expect('mcp__workflo').toHaveLength(12)
+  })
+
+  it('prevents the parent environment from forcing direct MCP tools back on', () => {
+    const previous = process.env.MCP_DIRECT_TOOLS
+    process.env.MCP_DIRECT_TOOLS = '*'
+    try {
+      const adapter = new PiAdapter({ getSetting: vi.fn(() => null) } as any)
+      const env = (adapter as any).processEnv({ permissionMode: 'ask' }, null)
+      expect(env.MCP_DIRECT_TOOLS).toBeUndefined()
+    } finally {
+      if (previous === undefined) delete process.env.MCP_DIRECT_TOOLS
+      else process.env.MCP_DIRECT_TOOLS = previous
+    }
   })
 
   it('adds a retry hint to provider 64-char name errors', () => {
     const hinted = withProviderNameLimitHint('Error from provider (Console): name must be at most 64 characters, got 76')
-    expect(hinted).toContain('continue')
+    expect(hinted).toContain('Stop and start the agent')
     expect(withProviderNameLimitHint('Provider unavailable')).toBe('Provider unavailable')
   })
 })

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -112,7 +112,47 @@ export function sanitizePiMcpServerName(name: string, used: Set<string>): string
 
 export function withProviderNameLimitHint(error: string): string {
   if (!/name must be at most 64/i.test(error)) return error
-  return `${error}\n\nHint: a tool name exceeded the provider 64-character limit. 20x now shortens MCP server names automatically — retry with "continue". If it persists, rename the long MCP server in settings.`
+  return `${error}\n\nHint: a tool name exceeded the provider 64-character limit. 20x now keeps MCP tools behind short namespace proxies. Stop and start the agent to rebuild its tool list.`
+}
+
+/**
+ * Build the pi-mcp-adapter document used by 20x sessions.
+ *
+ * Keep MCP servers behind namespace proxy tools (`mcp__<server>`). Direct MCP
+ * tools concatenate the server and tool names; a 24-character server slug and
+ * a 50-character generated workflow tool already produce a 76-character name.
+ * Providers commonly reject the entire request when any tool exceeds 64
+ * characters, before the model can call a tool.
+ */
+export function buildPiMcpConfigDocument(
+  servers: NonNullable<SessionConfig['mcpServers']>,
+  onRename?: (name: string, slug: string) => void,
+): Record<string, unknown> {
+  const usedSlugs = new Set<string>()
+  const mcpServers = Object.fromEntries(Object.entries(servers).map(([name, server]) => {
+    const slug = sanitizePiMcpServerName(name, usedSlugs)
+    if (slug !== name) onRename?.(name, slug)
+    if (server.type === 'stdio') {
+      return [slug, {
+        command: server.command,
+        args: server.args ?? [],
+        env: server.env ?? {},
+      }]
+    }
+    return [slug, {
+      url: server.url,
+      headers: server.headers ?? {},
+    }]
+  }))
+
+  return {
+    settings: {
+      // This must be explicit because MCP_DIRECT_TOOLS and user-level Pi
+      // settings can otherwise expose every `<server>_<tool>` directly.
+      directTools: false,
+    },
+    mcpServers,
+  }
 }
 
 const PI_PERMISSION_EXTENSION_SOURCE = `\
@@ -302,25 +342,10 @@ export class PiAdapter implements CodingAgentAdapter {
     // Pi forwards MCP tools to the model as <server>_<tool> names, which most
     // providers cap at 64 characters. Sanitize server keys so a long display
     // name (e.g. "[Workflo] Organisation Workspace") cannot overflow the limit.
-    const usedSlugs = new Set<string>()
-    const mcpServers = Object.fromEntries(Object.entries(config.mcpServers).map(([name, server]) => {
-      const slug = sanitizePiMcpServerName(name, usedSlugs)
-      if (slug !== name) {
-        console.warn(`[PiAdapter] Renamed MCP server "${name}" to "${slug}" to fit the provider 64-char tool name limit`)
-      }
-      if (server.type === 'stdio') {
-        return [slug, {
-          command: server.command,
-          args: server.args ?? [],
-          env: server.env ?? {},
-        }]
-      }
-      return [slug, {
-        url: server.url,
-        headers: server.headers ?? {},
-      }]
-    }))
-    writeFileSync(path, `${JSON.stringify({ mcpServers }, null, 2)}\n`, { mode: 0o600 })
+    const document = buildPiMcpConfigDocument(config.mcpServers, (name, slug) => {
+      console.warn(`[PiAdapter] Renamed MCP server "${name}" to "${slug}" to fit the provider 64-char tool name limit`)
+    })
+    writeFileSync(path, `${JSON.stringify(document, null, 2)}\n`, { mode: 0o600 })
     chmodSync(path, 0o600)
     return path
   }
@@ -352,6 +377,10 @@ export class PiAdapter implements CodingAgentAdapter {
     } as NodeJS.ProcessEnv
     delete env.AI_AGENT
     delete env.PI_CODING_AGENT
+    // A parent shell may set this globally. pi-mcp-adapter gives the variable
+    // precedence over its config, which would undo `directTools: false` and
+    // recreate overlong provider-facing names.
+    delete env.MCP_DIRECT_TOOLS
     return env
   }
 


### PR DESCRIPTION
## Summary
- keep Pi MCP servers behind namespace proxy tools instead of registering every combined server/tool name
- prevent inherited `MCP_DIRECT_TOOLS` from overriding the safe session config
- cover the real 50-character Workflo workflow tool that produced a 76-character provider name
- update recovery guidance to restart the agent so its tool list is rebuilt

## Root cause
PR #528 capped server slugs at 24 characters, but Workflo exposes generated workflow tools up to 50 characters. A 24-character namespace plus the separator and a 50-character tool still produces the reported 76-character name, causing providers with a 64-character limit to reject the entire request before any tool runs.

## Verification
- `pnpm test:main --run src/main/adapters/pi-adapter.test.ts` — 20 passed
- `pnpm typecheck`
- `pnpm exec eslint src/main/adapters/pi-adapter.ts src/main/adapters/pi-adapter.test.ts`
- pre-commit suite — 173 files passed, 2733 tests passed, 4 skipped
- production build passed