### PR TITLE
fix(ui): don't render a still-streaming mermaid fence as a diagram

### DIFF
--- a/src/renderer/src/components/ui/Markdown.test.tsx
+++ b/src/renderer/src/components/ui/Markdown.test.tsx
@@ -223,6 +223,38 @@ Second paragraph.`
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mermaidCode)
       })
     })
+
+    // The mocked `mermaid.render()` above resolves `<svg data-testid="mermaid-svg">`
+    // — scoped to THAT, not a bare `svg` selector, because `CopyCodeButton`'s
+    // own icon is also an inline `<svg>` and is present from the first render.
+    const mermaidSvgSelector = 'svg[data-testid="mermaid-svg"]'
+
+    it('renders a STILL-STREAMING (unclosed) mermaid fence as a code block, never a diagram', async () => {
+      vi.mocked(mermaid).render.mockClear()
+      const streamingSnapshot = `Building a diagram:\n\n\`\`\`mermaid\n${mermaidCode}`
+      const { container } = render(<Markdown>{streamingSnapshot}</Markdown>)
+
+      // Give any pending mermaid work a chance to run, then assert it never did.
+      await new Promise(resolve => setTimeout(resolve, 0))
+      expect(container.querySelector(mermaidSvgSelector)).not.toBeInTheDocument()
+      expect(container.querySelector('pre')).toBeInTheDocument()
+      expect(container.querySelector('pre')).toHaveTextContent('A[Start] --> B[End]')
+      expect(vi.mocked(mermaid).render).not.toHaveBeenCalled()
+    })
+
+    it('renders the diagram once the SAME fence closes on a later render (simulating the next streaming tick)', async () => {
+      vi.mocked(mermaid).render.mockClear()
+      const streamingSnapshot = `Building a diagram:\n\n\`\`\`mermaid\n${mermaidCode}`
+      const finalSnapshot = `Building a diagram:\n\n\`\`\`mermaid\n${mermaidCode}\n\`\`\` `
+      const { container, rerender } = render(<Markdown>{streamingSnapshot}</Markdown>)
+      expect(container.querySelector(mermaidSvgSelector)).not.toBeInTheDocument()
+
+      rerender(<Markdown>{finalSnapshot}</Markdown>)
+
+      await waitFor(() => {
+        expect(container.querySelector(mermaidSvgSelector)).toBeInTheDocument()
+      })
+    })
   })
 
   describe('Links', () => {

--- a/src/renderer/src/components/ui/Markdown.tsx
+++ b/src/renderer/src/components/ui/Markdown.tsx
@@ -3,6 +3,15 @@
  *
  * Provides consistent markdown rendering across the application with proper styling.
  * Used in: task descriptions, agent transcripts, plugin documentation.
+ *
+ * MERMAID STREAMING GUARD: `AgentTranscriptPanel` feeds this component
+ * growing text token by token while an agent turn is in flight, with no
+ * "streaming" flag passed down. `markIncompleteMermaidFences` runs on
+ * `children` before ReactMarkdown ever sees it, so a still-open ```mermaid
+ * fence renders as an ordinary code block instead of re-running
+ * `mermaid.render()` against half-written syntax on every token. See its
+ * own header in `@/lib/mermaid-fence` for why only the trailing fence can
+ * ever need this.
  */
 
 import React, { Fragment, memo, useMemo, useState } from 'react'
@@ -10,6 +19,7 @@ import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Check, Copy } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { markIncompleteMermaidFences } from '@/lib/mermaid-fence'
 import { MermaidDiagram } from './MermaidDiagram'
 
 /** Allow the default safe protocols plus our local app-attachment:// scheme */
@@ -292,6 +302,11 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
     ),
   }), [classes, highlightQuery]) // Only recreate when rendered styling or highlight changes
 
+  // Pure string transform. `memo` above already gates re-renders of this
+  // component on `children` changing, so an unrelated parent re-render never
+  // re-scans text that has not changed.
+  const content = markIncompleteMermaidFences(children)
+
   return (
     <div className={cn('markdown-content min-w-0', classes.base, className)}>
       <ReactMarkdown
@@ -299,7 +314,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
         urlTransform={urlTransform}
         components={components}
       >
-        {children}
+        {content}
       </ReactMarkdown>
     </div>
   )

--- a/src/renderer/src/lib/mermaid-fence.test.ts
+++ b/src/renderer/src/lib/mermaid-fence.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { markIncompleteMermaidFences } from './mermaid-fence'
+
+describe('markIncompleteMermaidFences', () => {
+  it('leaves a CLOSED mermaid fence untouched', () => {
+    const source = '```mermaid\ngraph TD;\nA-->B;\n```\n'
+    expect(markIncompleteMermaidFences(source)).toBe(source)
+  })
+
+  it('marks a trailing UNCLOSED mermaid fence as pending (the streaming case)', () => {
+    const source = 'Here is a diagram:\n\n```mermaid\ngraph TD;\nA-->'
+    const out = markIncompleteMermaidFences(source)
+    expect(out).toContain('```mermaid-pending')
+    expect(out).not.toMatch(/```mermaid\n/)
+    expect(out).toContain('A-->')
+  })
+
+  it('does NOT touch an unclosed fence in a different language', () => {
+    const source = '```js\nconst x = 1;'
+    expect(markIncompleteMermaidFences(source)).toBe(source)
+  })
+
+  it('leaves an EARLIER closed mermaid fence alone even while a LATER block streams', () => {
+    const source = '```mermaid\ngraph TD;\nA-->B;\n```\n\nAnd now some more tex'
+    expect(markIncompleteMermaidFences(source)).toBe(source)
+  })
+
+  it('requires the closing fence to use at least as many backticks as the opener', () => {
+    const source = '````mermaid\ngraph TD;\n```\nnot closed yet'
+    const out = markIncompleteMermaidFences(source)
+    expect(out).toContain('````mermaid-pending')
+  })
+
+  it('is a no-op for plain prose with no fence at all', () => {
+    const source = 'Just some assistant text, streaming in.'
+    expect(markIncompleteMermaidFences(source)).toBe(source)
+  })
+})

--- a/src/renderer/src/lib/mermaid-fence.ts
+++ b/src/renderer/src/lib/mermaid-fence.ts
@@ -1,0 +1,75 @@
+/**
+ * Mermaid fence completeness — pure logic, no React.
+ *
+ * `Markdown.tsx` streams assistant text token by token (see
+ * `AgentTranscriptPanel.tsx`), so at any instant the string handed to
+ * `Markdown` may hold an OPEN ```mermaid fence whose closing ``` has not
+ * arrived yet. `MermaidDiagram` dispatches purely on the fenced block's
+ * language (`getBlockLanguage` in `Markdown.tsx`), with no notion of
+ * "still streaming" — so without this guard, every token appended to an
+ * in-progress diagram re-triggers `mermaid.render()` against invalid,
+ * half-written syntax: a flicker between the raw-source fallback and
+ * whatever partial diagram happens to parse, on every streaming tick.
+ *
+ * CommonMark's own rule is the fix: an UNCLOSED fenced code block runs to the
+ * end of the document, so the only fence that can ever be unclosed is the
+ * LAST one in the string — every earlier fence is already complete by
+ * construction. `markIncompleteMermaidFences` renames a trailing unclosed
+ * `mermaid` fence's info string to `mermaid-pending` so `getBlockLanguage`
+ * no longer matches `'mermaid'` and the block renders as an ordinary code
+ * block until the fence closes. No `streaming` prop has to travel through
+ * `AgentTranscriptPanel` → `Markdown` for this to work.
+ *
+ * Ported from the equivalent helper in workflow-builder
+ * (`packages/ui/lib/coding-agents/mermaid-fence.ts`), written for the same
+ * mermaid-in-markdown feature there.
+ */
+
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})[ \t]*(\S*)/
+
+function closingFenceRe(fenceChar: string, minLen: number): RegExp {
+  const escaped = fenceChar === '`' ? '`' : '~'
+  return new RegExp(`^ {0,3}${escaped}{${minLen},}[ \\t]*$`)
+}
+
+/**
+ * Renames the info string of a trailing UNCLOSED ```mermaid fence to
+ * `mermaid-pending`. All other text — including earlier, already-closed
+ * mermaid fences — is returned unchanged.
+ */
+export function markIncompleteMermaidFences(source: string): string {
+  const lines = source.split('\n')
+
+  let openChar: string | null = null
+  let openLen = 0
+  let openLineIndex = -1
+  let openLang = ''
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    if (openChar === null) {
+      const match = FENCE_OPEN.exec(line)
+      if (match) {
+        openChar = match[1]?.[0] ?? '`'
+        openLen = match[1]?.length ?? 3
+        openLineIndex = i
+        openLang = match[2] ?? ''
+      }
+      continue
+    }
+    if (closingFenceRe(openChar, openLen).test(line)) {
+      openChar = null
+      openLen = 0
+      openLineIndex = -1
+      openLang = ''
+    }
+  }
+
+  const stillOpen = openChar !== null
+  const isMermaid = openLang.trim().toLowerCase() === 'mermaid'
+  if (!stillOpen || !isMermaid) return source
+
+  const fenceLine = lines[openLineIndex] ?? ''
+  lines[openLineIndex] = fenceLine.replace(/mermaid/i, 'mermaid-pending')
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Context
This is the 20x half of a task whose brief assumed 20x had no mermaid support yet ("workflow-builder first, 20x parity second"). Research before writing any code found that's wrong: **mermaid rendering already shipped in 20x** in #471 — `Markdown.tsx` dispatches ` ```mermaid ` fences to `MermaidDiagram.tsx`, which lazy-loads the `mermaid` package, initialises with `securityLevel: 'strict'` + `startOnLoad: false`, and falls back to the raw source on a render error. It's tested (`Markdown.test.tsx`) and reused as-is by the mobile SPA (same `@` alias resolves to the desktop renderer's `src`) and by `MarkdownArtifactView.tsx`. None of that needed touching, and this PR does not touch it.

## What this PR actually fixes
One real gap, found by reading `AgentTranscriptPanel.tsx` against the workflow-builder companion PR's requirements: `AgentTranscriptPanel` streams growing assistant text into `Markdown` token by token, with **no "streaming" flag** passed down anywhere. `Markdown`'s `pre` renderer dispatches to `MermaidDiagram` purely on the fenced block's language (`getBlockLanguage`), which is already `"mermaid"` as soon as the opening ` ```mermaid ` line has arrived — long before the diagram's body or its closing fence exist. So on every streaming tick, `mermaid.render()` would be re-run against half-written, syntactically invalid mermaid source: a flicker between the raw-source fallback and whatever partial diagram happens to parse, repeating every ~1.5s tick until the fence closes.

## Fix
`src/renderer/src/lib/mermaid-fence.ts` — pure string logic, no React, ported from the equivalent guard written for the workflow-builder companion PR (peakflo/workflow-builder#1706), which needed the identical fix for the same reason (same `react-markdown` v10 + streaming-transcript shape in both apps). CommonMark's own rule — *an unclosed fenced code block runs to the end of the document* — means only the LAST fence in a streamed string can ever be incomplete; every earlier fence is already closed by construction. `markIncompleteMermaidFences` detects a trailing unclosed ` ```mermaid ` fence and renames its info string to `mermaid-pending`, so `getBlockLanguage` no longer matches `'mermaid'` and it renders as an ordinary code block until the fence actually closes — no prop threading required, and an earlier, already-closed mermaid block in the SAME streaming message still renders as a diagram immediately.

Wired into `Markdown.tsx`: the transform runs on `children` right before `ReactMarkdown`, inside the existing `memo`, so it only re-runs when the text itself changes.

## Tests
- `src/renderer/src/lib/mermaid-fence.test.ts` — 6 pure-logic cases (closed fence untouched, unclosed mermaid fence marked pending, unclosed non-mermaid fence left alone, an earlier closed mermaid block unaffected by a later streaming block, 4-backtick fences, plain prose no-op).
- Two new cases added to the existing `describe('Mermaid diagrams', ...)` block in `Markdown.test.tsx`, run against the real `Markdown` component (mermaid itself mocked, matching this file's existing convention): an unclosed fence never calls `mermaid.render()` and shows the `pre` fallback; the SAME fence renders the diagram on a `rerender()` once it closes (simulating the next streaming tick).
- Full `pnpm test:renderer` run: 77 suites / 941 tests passed (933 pre-existing + 8 new). `pnpm typecheck` and `eslint` clean on the changed files.

## Scope
- No migrations. Two files touched (`Markdown.tsx`, `+2` tests) plus one new pure-logic module and its test.
- Draft PR, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)