### PR TITLE
fix: let a source plugin's confirmed completion close a sourced task in 20x

### DIFF
--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -689,3 +689,46 @@ describe('transcript_parts.rev migration on a legacy DB (no rev column)', () => 
     expect(after).toBe(before)
   })
 })
+
+describe('updateTask completion guard for sourced tasks', () => {
+  function makeSourcedTask(pluginId = 'notion', externalId = 'page-1') {
+    const server = db.createMcpServer({ name: 'Src Server' })!
+    const source = db.createTaskSource({ mcp_server_id: server.id, name: 'Src', plugin_id: pluginId })!
+    const task = db.createTask(makeTask({
+      title: 'Sourced', status: 'ready_for_review', external_id: externalId, source_id: source.id, source: 'Src'
+    }))!
+    return { source, task }
+  }
+
+  it('refuses a local completion of a sourced task', () => {
+    const { task } = makeSourcedTask()
+    expect(() => db.updateTask(task.id, { status: 'completed' as never }))
+      .toThrow('The task source must confirm completion before this task can close in 20x.')
+    expect(db.getTask(task.id)!.status).toBe('ready_for_review')
+  })
+
+  it('completes a sourced task when the source plugin confirms it', () => {
+    const { task } = makeSourcedTask()
+    const updated = db.updateTask(task.id, { status: 'completed' as never }, 'source-plugin')
+    expect(updated!.status).toBe('completed')
+    expect(db.getTask(task.id)!.status).toBe('completed')
+  })
+
+  it('source-plugin origin cannot change the source link', () => {
+    const { task } = makeSourcedTask()
+    expect(() => db.updateTask(task.id, { external_id: 'other' }, 'source-plugin'))
+      .toThrow('Only the sync service can change a task source link.')
+  })
+
+  it('source-plugin origin cannot change the status of a Workflo-owned task', () => {
+    const { task } = makeSourcedTask('peakflo', 'wf-1')
+    expect(() => db.updateTask(task.id, { status: 'completed' as never }, 'source-plugin'))
+      .toThrow('Workflo controls task status. Use a server task action.')
+    expect(db.getTask(task.id)!.status).toBe('ready_for_review')
+  })
+
+  it('still completes a source-less local task without an origin', () => {
+    const task = db.createTask(makeTask({ status: 'ready_for_review' }))!
+    expect(db.updateTask(task.id, { status: 'completed' as never })!.status).toBe('completed')
+  })
+})

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -421,6 +421,8 @@ export interface CreateTaskData {
   cron?: string
 }
 
+export type TaskUpdateOrigin = 'workflo-server' | 'source-plugin'
+
 export interface UpdateTaskData {
   external_id?: string | null
   source_id?: string | null
@@ -2362,7 +2364,18 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
     return this.getTask(id)
   }
 
-  updateTask(id: string, data: UpdateTaskData, origin?: 'workflo-server'): TaskRecord | undefined {
+  /**
+   * `origin` names who vouches for this write:
+   * - `'workflo-server'`: the Workflo sync service. It may change the source
+   *   link and the status of a Workflo-owned task.
+   * - `'source-plugin'`: a task-source plugin whose `executeAction` succeeded
+   *   at the source (Notion, Linear, YouTrack, GitHub, HubSpot). The source
+   *   has confirmed the change, so the local completion guard is satisfied.
+   *   It may not touch the source link or a Workflo-owned task.
+   * - `undefined`: a local caller (renderer, agent, API). Sourced tasks may
+   *   not be completed locally; they close through the source.
+   */
+  updateTask(id: string, data: UpdateTaskData, origin?: TaskUpdateOrigin): TaskRecord | undefined {
     if (origin !== 'workflo-server' && ('external_id' in data || 'source_id' in data || 'source' in data)) {
       throw new Error('Only the sync service can change a task source link.')
     }
@@ -2377,10 +2390,10 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
         throw new Error('This task is completed in Workflo.')
       }
     }
-    if (data.status === TaskStatus.Completed && origin !== 'workflo-server') {
+    if (data.status === TaskStatus.Completed && origin === undefined) {
       const task = this.getTask(id)
       if (task?.source_id && task.status !== TaskStatus.Completed) {
-        throw new Error('Workflo must confirm completion before this task can close in 20x.')
+        throw new Error('The task source must confirm completion before this task can close in 20x.')
       }
     }
     const setClauses: string[] = []

--- a/src/main/sync-manager.test.ts
+++ b/src/main/sync-manager.test.ts
@@ -5,6 +5,8 @@ import type { DatabaseManager, TaskRecord } from './database'
 import type { McpToolCaller } from './mcp-tool-caller'
 import type { PluginRegistry } from './plugins/registry'
 import type { TaskSourcePlugin } from './plugins/types'
+import { createTestDb } from '../../test/helpers/db-test-helper'
+import { makeTask } from '../../test/helpers/task-fixtures'
 
 function makeMockDb(): DatabaseManager {
   return {
@@ -243,7 +245,27 @@ describe('SyncManager', () => {
       const result = await syncManager.executeAction('approve', task, undefined, 'src-1')
 
       expect(result.success).toBe(true)
-      expect(db.updateTask).toHaveBeenCalledWith('t1', { status: TaskStatus.Completed })
+      expect(db.updateTask).toHaveBeenCalledWith('t1', { status: TaskStatus.Completed }, 'source-plugin')
+    })
+
+    it('closes a Notion-style sourced task locally once the plugin confirms completion (real db)', async () => {
+      // Regression: the sourced-task completion guard in Database.updateTask
+      // rejected the plugin's own confirmed taskUpdate, so the source was
+      // marked done while 20x threw "must confirm completion".
+      const { db: realDb } = createTestDb()
+      const server = realDb.createMcpServer({ name: 'Notion' })!
+      const source = realDb.createTaskSource({ mcp_server_id: server.id, name: 'Notion', plugin_id: 'notion' })!
+      const task = realDb.createTask(makeTask({
+        title: 'Notion page', status: TaskStatus.ReadyForReview, external_id: 'page-1', source_id: source.id, source: 'Notion'
+      }))!
+      const plugin = makeMockPlugin({ id: 'notion' })
+      ;(registry.get as unknown as ReturnType<typeof vi.fn>).mockReturnValue(plugin)
+      const realSync = new SyncManager(realDb, toolCaller, registry)
+
+      const result = await realSync.executeAction('complete', task, undefined, source.id)
+
+      expect(result).toEqual({ success: true, taskUpdate: { status: TaskStatus.Completed } })
+      expect(realDb.getTask(task.id)!.status).toBe(TaskStatus.Completed)
     })
   })
 })

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -380,9 +380,11 @@ export class SyncManager {
 
     const result = await plugin.executeAction(actionId, task, input, config, ctx)
 
-    // Apply local task updates if action succeeded
+    // Apply local task updates if action succeeded. The plugin has already
+    // written the change at the source, so the source has confirmed it; the
+    // 'source-plugin' origin lets a completion pass the local sourced-task guard.
     if (result.success && result.taskUpdate && Object.keys(result.taskUpdate).length > 0) {
-      this.db.updateTask(task.id, result.taskUpdate)
+      this.db.updateTask(task.id, result.taskUpdate, 'source-plugin')
     }
 
     return result


### PR DESCRIPTION
## Summary
- **Symptom:** Completing a Notion-sourced task on desktop fails with `Error invoking remote method 'plugin:executeAction': Error: Workflo must confirm completion before this task can close in 20x.` The Notion page is already moved to Done, but the 20x task stays open. The same applies to Linear, YouTrack, GitHub Issues and HubSpot sources.
- **Root cause:** `SyncManager.executeAction` (generic, non-Workflo path) calls the plugin, which writes the status at the source and returns `taskUpdate: { status: 'completed' }`. SyncManager then applies it via `db.updateTask(task.id, taskUpdate)` with no origin. The sourced-task completion guard in `Database.updateTask` (added in #521, widened to every `source_id` in #531) only accepts `origin === 'workflo-server'`, so it throws. The error is a 20x-side message; workflow-builder is not involved.
- **Fix:**
  - `Database.updateTask` gets a new origin `'source-plugin'`. It satisfies only the local completion guard. It still cannot change the source link fields and still cannot change the status of a Workflo-owned task.
  - `SyncManager.executeAction` applies the plugin `taskUpdate` with origin `'source-plugin'`.
  - The guard message is now source-neutral ("The task source must confirm completion…") because non-Workflo sources reach it.

## Scope check
- Desktop IPC `plugin:executeAction` → `SyncManager.executeAction` is the only main-process path that applied a plugin `taskUpdate`. The Workflo (`peakflo`) branch in `executeAction` never reaches this write, so Workflo behaviour is unchanged.
- `mobile-api-server` `/api/tasks/:id/complete` already returns 409 for every non-Workflo source before calling the plugin; that is a separate mobile limit, not this bug.

## Follow-up (not in this PR)
- Mobile completion for non-Workflo sources still returns `Sync this task with Workflo before completing it.` (409).

## Test plan
- [x] `database.test.ts`: guard matrix — local completion of a sourced task is refused; `'source-plugin'` completes it; `'source-plugin'` cannot change the source link; `'source-plugin'` cannot change a Workflo-owned task's status; source-less tasks still complete locally.
- [x] `sync-manager.test.ts`: real-DB regression — a Notion-style sourced task ends `completed` after the plugin confirms. This test fails on `main` without the fix (verified by stashing the production change).
- [x] `pnpm test:main --run`: 89 files, 1746 passed, 4 skipped.
- [x] `pnpm typecheck` and `eslint` on changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)