### PR TITLE
feat: ask whether to update the task source too or complete only in 20x

### DIFF
--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -731,4 +731,32 @@ describe('updateTask completion guard for sourced tasks', () => {
     const task = db.createTask(makeTask({ status: 'ready_for_review' }))!
     expect(db.updateTask(task.id, { status: 'completed' as never })!.status).toBe('completed')
   })
+
+  // ── 'user-local': the user chose "Only in 20x" ────────────────────────────
+
+  it('user-local origin completes a Notion-style sourced task without the source', () => {
+    const { task } = makeSourcedTask()
+    const updated = db.updateTask(task.id, { status: 'completed' as never, complete_at_source: false }, 'user-local')
+    expect(updated!.status).toBe('completed')
+    const stored = db.getTask(task.id)!
+    expect(stored.status).toBe('completed')
+    expect(stored.complete_at_source).toBe(false)
+    // The source link is untouched.
+    expect(stored.source_id).toBe(task.source_id)
+    expect(stored.external_id).toBe('page-1')
+  })
+
+  it('user-local origin is still refused for a Workflo-owned task', () => {
+    const { task } = makeSourcedTask('peakflo', 'wf-1')
+    expect(() => db.updateTask(task.id, { status: 'completed' as never }, 'user-local'))
+      .toThrow('Workflo controls task status. Use a server task action.')
+    expect(db.getTask(task.id)!.status).toBe('ready_for_review')
+  })
+
+  it('user-local origin cannot change the source link', () => {
+    const { task } = makeSourcedTask()
+    expect(() => db.updateTask(task.id, { source_id: null }, 'user-local'))
+      .toThrow('Only the sync service can change a task source link.')
+    expect(db.getTask(task.id)!.source_id).toBe(task.source_id)
+  })
 })

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -421,7 +421,7 @@ export interface CreateTaskData {
   cron?: string
 }
 
-export type TaskUpdateOrigin = 'workflo-server' | 'source-plugin'
+export type TaskUpdateOrigin = 'workflo-server' | 'source-plugin' | 'user-local'
 
 export interface UpdateTaskData {
   external_id?: string | null
@@ -2372,6 +2372,11 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
    *   at the source (Notion, Linear, YouTrack, GitHub, HubSpot). The source
    *   has confirmed the change, so the local completion guard is satisfied.
    *   It may not touch the source link or a Workflo-owned task.
+   * - `'user-local'`: the user chose "Only in 20x" for a non-Workflo sourced
+   *   task. Only the main-process `task:completeLocally` handler passes it, so
+   *   the renderer cannot forge it through `UpdateTaskData`. It satisfies only
+   *   the local completion guard; the source link and Workflo-owned status
+   *   guards still apply.
    * - `undefined`: a local caller (renderer, agent, API). Sourced tasks may
    *   not be completed locally; they close through the source.
    */

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -252,3 +252,98 @@ describe('db:updateTask coordinator wake-up', () => {
     expect(notifyParent).not.toHaveBeenCalled()
   })
 })
+
+describe('task:completeLocally ("Only in 20x")', () => {
+  function setup(task: Record<string, unknown> | undefined, source: Record<string, unknown> | undefined) {
+    const notifyParent = vi.fn().mockResolvedValue(undefined)
+    const agentManager = { notifyParentOfSubtaskCompletion: notifyParent } as unknown as Parameters<typeof registerIpcHandlers>[1]
+    const updateTask = vi.fn((_id: string, data: Record<string, unknown>) => (task ? { ...task, ...data } : undefined))
+    const db = {
+      getTask: vi.fn(() => task),
+      getTaskSource: vi.fn(() => source),
+      updateTask
+    } as unknown as Parameters<typeof registerIpcHandlers>[0]
+    const disableHeartbeat = vi.fn()
+    const heartbeatScheduler = { disableHeartbeat } as unknown as NonNullable<Parameters<typeof registerIpcHandlers>[11]>
+    const recordTaskCompleted = vi.fn()
+    const enterpriseStateSync = {
+      recordTaskCompleted,
+      recordTaskStatusChange: vi.fn(),
+      recordFeedbackSubmitted: vi.fn()
+    } as unknown as NonNullable<Parameters<typeof registerIpcHandlers>[13]>
+
+    registerIpcHandlers(
+      db, agentManager, {} as never, {} as never, {} as never, {} as never,
+      undefined, undefined, undefined, undefined, undefined,
+      heartbeatScheduler, undefined, enterpriseStateSync
+    )
+
+    const handleCalls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls as [string, (...args: unknown[]) => unknown][]
+    const completeLocally = handleCalls.filter((call) => call[0] === 'task:completeLocally').pop()?.[1]
+    expect(completeLocally).toBeDefined()
+    return { completeLocally: completeLocally!, updateTask, notifyParent, disableHeartbeat, recordTaskCompleted }
+  }
+
+  it('completes a Notion-style sourced task with origin user-local and complete_at_source=false', async () => {
+    const task = {
+      id: 'task-1', status: 'ready_for_review', source_id: 'src-notion', external_id: 'page-1',
+      parent_task_id: 'parent-1', heartbeat_enabled: true, type: 'general', priority: 'medium'
+    }
+    const { completeLocally, updateTask, notifyParent, disableHeartbeat, recordTaskCompleted } =
+      setup(task, { id: 'src-notion', plugin_id: 'notion' })
+
+    const result = await completeLocally({}, 'task-1')
+
+    expect(updateTask).toHaveBeenCalledExactlyOnceWith(
+      'task-1', { status: 'completed', complete_at_source: false }, 'user-local'
+    )
+    expect(result).toMatchObject({ status: 'completed', complete_at_source: false })
+    // The shared post-update side effects run exactly like for db:updateTask.
+    expect(disableHeartbeat).toHaveBeenCalledWith('task-1')
+    expect(recordTaskCompleted).toHaveBeenCalledWith(expect.objectContaining({ id: 'task-1', status: 'completed' }))
+    expect(notifyParent).toHaveBeenCalledWith('parent-1', 'task-1')
+  })
+
+  it('refuses a Workflo task (plugin peakflo) so the server keeps status ownership', async () => {
+    const task = { id: 'task-2', status: 'ready_for_review', source_id: 'src-wf', external_id: 'wf-1' }
+    const { completeLocally, updateTask } = setup(task, { id: 'src-wf', plugin_id: 'peakflo' })
+
+    await expect(async () => completeLocally({}, 'task-2')).rejects.toThrow('Workflo controls task status')
+    expect(updateTask).not.toHaveBeenCalled()
+  })
+
+  it('refuses a server-managed task even without a source record', async () => {
+    const task = { id: 'task-2b', status: 'ready_for_review', source_id: 'src-wf', external_id: 'wf-2', server_managed: true }
+    const { completeLocally, updateTask } = setup(task, undefined)
+
+    await expect(async () => completeLocally({}, 'task-2b')).rejects.toThrow('Workflo controls task status')
+    expect(updateTask).not.toHaveBeenCalled()
+  })
+
+  it('refuses a source-less task — those complete through db:updateTask', async () => {
+    const task = { id: 'task-3', status: 'ready_for_review', source_id: null, external_id: null }
+    const { completeLocally, updateTask } = setup(task, undefined)
+
+    await expect(async () => completeLocally({}, 'task-3')).rejects.toThrow(/task source/)
+    expect(updateTask).not.toHaveBeenCalled()
+  })
+
+  it('refuses an unknown task', async () => {
+    const { completeLocally, updateTask } = setup(undefined, undefined)
+
+    await expect(async () => completeLocally({}, 'missing')).rejects.toThrow('Task not found')
+    expect(updateTask).not.toHaveBeenCalled()
+  })
+
+  it('db:updateTask cannot reach the user-local origin', () => {
+    const task = { id: 'task-4', status: 'ready_for_review', source_id: 'src-notion', external_id: 'page-1' }
+    const { updateTask } = setup(task, { id: 'src-notion', plugin_id: 'notion' })
+    const handleCalls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls as [string, (...args: unknown[]) => unknown][]
+    const updateHandler = handleCalls.filter((call) => call[0] === 'db:updateTask').pop()?.[1]
+
+    updateHandler!({}, 'task-4', { status: 'completed', complete_at_source: false })
+
+    // The renderer's data object is passed through without any origin.
+    expect(updateTask).toHaveBeenCalledExactlyOnceWith('task-4', { status: 'completed', complete_at_source: false })
+  })
+})

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -136,18 +136,18 @@ export function registerIpcHandlers(
     return task
   })
 
-  ipcMain.handle('db:updateTask', (_, id: string, data: UpdateTaskData) => {
-    // Capture previous status before updating (for enterprise sync)
-    let previousStatus: string | undefined
-    if (data.status) {
-      const existing = db.getTask(id)
-      if (existing && existing.status !== data.status) {
-        previousStatus = existing.status
-      }
-    }
-
-    const updated = db.updateTask(id, data)
-
+  /**
+   * Everything that must happen after a task row changes, whichever handler
+   * wrote it. `db:updateTask` and `task:completeLocally` both run this so a
+   * completion chosen as "Only in 20x" behaves exactly like any other
+   * completion for schedulers, enterprise sync, analytics and coordinators.
+   */
+  const afterTaskUpdate = (
+    id: string,
+    data: UpdateTaskData,
+    previousStatus: string | undefined,
+    updated: ReturnType<DatabaseManager['updateTask']>
+  ): void => {
     // Initialize recurring task schedule when recurrence is added or changed
     if (recurrenceScheduler && updated && updated.is_recurring && updated.recurrence_pattern) {
       recurrenceScheduler.initializeRecurringTask(id)
@@ -217,7 +217,39 @@ export function registerIpcHandlers(
         hasSource: !!updated.source_id
       })
     }
+  }
 
+  ipcMain.handle('db:updateTask', (_, id: string, data: UpdateTaskData) => {
+    // Capture previous status before updating (for enterprise sync)
+    let previousStatus: string | undefined
+    if (data.status) {
+      const existing = db.getTask(id)
+      if (existing && existing.status !== data.status) {
+        previousStatus = existing.status
+      }
+    }
+
+    const updated = db.updateTask(id, data)
+    afterTaskUpdate(id, data, previousStatus, updated)
+    return updated
+  })
+
+  // "Only in 20x": close a task that came from a non-Workflo source without
+  // touching the source. The origin that lets this write past the completion
+  // guard lives here, in the main process, so a renderer cannot request it
+  // through `db:updateTask`. Workflo tasks never take this route — the server
+  // owns their status and confirms completion through a task action.
+  ipcMain.handle('task:completeLocally', (_, id: string) => {
+    const task = db.getTask(id)
+    if (!task) throw new Error('Task not found.')
+    if (!task.source_id) throw new Error('Only a task that came from a task source can be completed in 20x only.')
+    if (task.server_managed || db.getTaskSource(task.source_id)?.plugin_id === 'peakflo') {
+      throw new Error('Workflo controls task status. Use a server task action.')
+    }
+    const data: UpdateTaskData = { status: TaskStatus.Completed, complete_at_source: false }
+    const previousStatus = task.status !== TaskStatus.Completed ? task.status : undefined
+    const updated = db.updateTask(id, data, 'user-local')
+    afterTaskUpdate(id, data, previousStatus, updated)
     return updated
   })
 

--- a/src/main/sync-manager.test.ts
+++ b/src/main/sync-manager.test.ts
@@ -151,7 +151,7 @@ describe('SyncManager', () => {
       expect(plugin.exportUpdate).toHaveBeenCalled()
     })
 
-    it('does not push a status change when the user chose "I\'ll do it manually"', async () => {
+    it('does not push a status change when the user chose "Only in 20x"', async () => {
       const plugin = makeMockPlugin()
       ;(db.getTask as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
         id: 't1', source_id: 'src-1', external_id: 'ext-1', complete_at_source: false
@@ -163,10 +163,10 @@ describe('SyncManager', () => {
       ;(db.getMcpServer as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'srv-1' })
 
       await syncManager.exportTaskUpdate('t1', { status: 'completed', complete_at_source: false })
-      expect(plugin.exportUpdate).toHaveBeenCalledWith(expect.anything(), {status:'completed'}, {}, expect.anything())
+      expect(plugin.exportUpdate).not.toHaveBeenCalled()
     })
 
-    it('still syncs non-status edits when the user chose "I\'ll do it manually"', async () => {
+    it('strips status but still syncs other edits when the user chose "Only in 20x"', async () => {
       const plugin = makeMockPlugin()
       ;(db.getTask as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
         id: 't1', source_id: 'src-1', external_id: 'ext-1', complete_at_source: false
@@ -180,7 +180,7 @@ describe('SyncManager', () => {
       await syncManager.exportTaskUpdate('t1', { title: 'New', status: 'in_progress' })
       expect(plugin.exportUpdate).toHaveBeenCalledWith(
         expect.objectContaining({ id: 't1' }),
-        { title: 'New', status: 'in_progress' },
+        { title: 'New' },
         {},
         expect.anything()
       )

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -263,6 +263,12 @@ export class SyncManager {
     if (!plugin) return
 
     const fields = { ...changedFields }
+    // The user chose "Only in 20x" for this task: pushing a status (e.g. marking
+    // the Notion page done) would close it at the source against that choice.
+    // Other edits still sync.
+    if (task.complete_at_source === false && 'status' in fields) {
+      delete fields.status
+    }
     // Internal completion control — never a source field.
     delete fields.complete_at_source
     if (Object.keys(fields).length === 0) return

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,7 +16,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   tasks: {
     getWorkspaceDir: (taskId: string): Promise<string> =>
-      ipcRenderer.invoke('tasks:getWorkspaceDir', taskId)
+      ipcRenderer.invoke('tasks:getWorkspaceDir', taskId),
+    completeLocally: (taskId: string): Promise<unknown> =>
+      ipcRenderer.invoke('task:completeLocally', taskId)
   },
   artifacts: {
     scan: (taskId: string): Promise<ArtifactFileEntry[]> =>

--- a/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
@@ -34,6 +34,8 @@ const {
       parent_task_id: null,
       output_fields: [],
       source_id: null as string | null,
+      server_managed: false as boolean,
+      complete_at_source: null as boolean | null,
       repos: [],
       priority: 'medium',
       type: 'general',
@@ -122,7 +124,13 @@ vi.mock('@/stores/ui-store', () => ({
 }))
 
 vi.mock('@/stores/task-source-store', () => {
-  const state = { sources: [], executeAction: executeActionMock }
+  const state = {
+    sources: [
+      { id: 'src-1', name: 'Workflo', plugin_id: 'peakflo' },
+      { id: 'src-notion', name: 'Notion', plugin_id: 'notion' },
+    ],
+    executeAction: executeActionMock,
+  }
   const useTaskSourceStore = (selector: (value: typeof state) => unknown) => selector(state)
   useTaskSourceStore.getState = () => state
   return { useTaskSourceStore }
@@ -136,6 +144,8 @@ describe('TaskPanelContent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     taskList[0].source_id = null
+    taskList[0].server_managed = false
+    taskList[0].complete_at_source = null
     canvasState.panels = [
       { id: 'panel-1', type: 'task', refId: 'task-1', x: 100, y: 200, width: 1020, height: 780 },
     ]
@@ -198,10 +208,10 @@ describe('TaskPanelContent', () => {
     }))
     expect(upload).not.toHaveBeenCalled()
     expect(executeActionMock).not.toHaveBeenCalled()
-    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
   })
 
-  it('issues server completion for a sourced canvas task without writing local completion', async () => {
+  it('issues server completion for a Workflo canvas task without writing local completion', async () => {
     taskList[0].source_id = 'src-1'
     const apiRequest = vi.fn()
     // Bridge the renderer command to the real API encoder. Credentials stay in main.
@@ -217,7 +227,24 @@ describe('TaskPanelContent', () => {
       { 'x-task-contract-version': '2', 'x-task-actor': 'human' }))
     expect(executeActionMock).toHaveBeenCalledExactlyOnceWith('complete', 'task-1', 'src-1')
     expect(updateTaskMock).not.toHaveBeenCalled()
-    // A single shared confirmation exists for every source — no source dialog.
-    expect(screen.queryByRole('dialog')).toBeNull()
+    // Workflo owns task status: the server confirms completion, no choice is offered.
+    expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
+  })
+
+  it('asks a Notion canvas task whether to update Notion too or complete only in 20x', async () => {
+    taskList[0].source_id = 'src-notion'
+    const completeLocally = window.electronAPI.tasks.completeLocally as unknown as ReturnType<typeof vi.fn>
+    render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
+    fireEvent.click(screen.getByText('Complete task'))
+
+    expect(await screen.findByTestId('complete-at-source-dialog')).toBeInTheDocument()
+    expect(screen.getByTestId('complete-at-source')).toHaveTextContent('Update Notion too')
+    expect(executeActionMock).not.toHaveBeenCalled()
+    expect(updateTaskMock).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByTestId('complete-manually'))
+    await waitFor(() => expect(completeLocally).toHaveBeenCalledWith('task-1'))
+    expect(executeActionMock).not.toHaveBeenCalled()
+    expect(updateTaskMock).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/canvas/TaskPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.tsx
@@ -31,8 +31,8 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
   // every canvas task panel's entire TaskWorkspace tree.
   const openEditModal = useUIStore((s) => s.openEditModal)
   const openDeleteModal = useUIStore((s) => s.openDeleteModal)
-  // Completion is server-confirmed through the shared hook (same for every source).
-  const { requestComplete } = useTaskCompletion()
+  // Tasks from a non-Workflo source ask whether to update the source too.
+  const { requestComplete, completionDialog } = useTaskCompletion()
 
   const handleEdit = useCallback(() => {
     if (task) openEditModal(task.id)
@@ -149,6 +149,7 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
         onOpenSubtaskInWindow={handleOpenSubtaskInWindow}
         panelLayout={panelLayout}
       />
+      {completionDialog}
     </div>
   )
 }

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -157,8 +157,9 @@ export function AppLayout() {
 
   useEffect(() => onShortcutFeedback(({ message, isError }) => showToast(message, isError)), [showToast])
 
-  // Completion is server-confirmed through the shared hook (same for every source).
-  const { requestComplete } = useTaskCompletion({ onToast: showToast })
+  // Tasks from a non-Workflo source ask whether to update the source too or
+  // complete in 20x only. `completionDialog` renders that question.
+  const { requestComplete, completionDialog } = useTaskCompletion({ onToast: showToast })
 
   // A completion that the main process could not push to the source sends the
   // task back to review. Without this the user sees the task reappear with no
@@ -907,6 +908,9 @@ export function AppLayout() {
           </DialogBody>
         </DialogContent>
       </Dialog>
+
+      {/* Update the task source too, or only in 20x */}
+      {completionDialog}
 
       {/* Delete Confirmation */}
       <DeleteConfirmDialog

--- a/src/renderer/src/components/tasks/CompleteAtSourceDialog.tsx
+++ b/src/renderer/src/components/tasks/CompleteAtSourceDialog.tsx
@@ -1,0 +1,74 @@
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel
+} from '@/components/ui/AlertDialog'
+import { Button } from '@/components/ui/Button'
+
+export interface CompleteAtSourceDialogProps {
+  isOpen: boolean
+  /** Title of the task being completed. */
+  taskTitle: string
+  /** Display name of the task source, e.g. "Notion — Engineering". */
+  sourceName: string
+  /** True while one of the two completion paths runs. */
+  isBusy?: boolean
+  /** Complete the task at the source, then in 20x. */
+  onCompleteAtSource: () => void
+  /** Complete the task in 20x only — the user updates the source. */
+  onCompleteManually: () => void
+  onCancel: () => void
+}
+
+/**
+ * Asks how a task that came from a task source (Notion, Linear, YouTrack,
+ * GitHub Issues, HubSpot) must be completed: at the source too, or in 20x only.
+ * Workflo tasks never see this dialog — the server confirms their completion.
+ */
+export function CompleteAtSourceDialog({
+  isOpen,
+  taskTitle,
+  sourceName,
+  isBusy = false,
+  onCompleteAtSource,
+  onCompleteManually,
+  onCancel
+}: CompleteAtSourceDialogProps) {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={(open) => !open && !isBusy && onCancel()}>
+      <AlertDialogContent data-testid="complete-at-source-dialog">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Complete in {sourceName}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            "{taskTitle}" came from {sourceName}. 20x can mark it done there as well, or
+            complete it here only and leave {sourceName} for you to update.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-col-reverse sm:flex-row sm:justify-end">
+          <AlertDialogCancel disabled={isBusy} onClick={onCancel}>
+            Cancel
+          </AlertDialogCancel>
+          <Button
+            variant="outline"
+            disabled={isBusy}
+            onClick={onCompleteManually}
+            data-testid="complete-manually"
+          >
+            Only in 20x
+          </Button>
+          <Button
+            disabled={isBusy}
+            onClick={onCompleteAtSource}
+            data-testid="complete-at-source"
+          >
+            Update {sourceName} too
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, fireEvent, within, cleanup } from '@testing-library/rea
 import { FeedbackDialog } from './FeedbackDialog'
 
 describe('FeedbackDialog', () => {
-  const onSubmit = vi.fn<(rating: number, comment: string) => void>()
-  const onSkip = vi.fn<() => void>()
+  const onSubmit = vi.fn<(rating: number, comment: string, completeAtSource?: boolean) => void>()
+  const onSkip = vi.fn<(completeAtSource?: boolean) => void>()
   const onCancel = vi.fn<() => void>()
 
   beforeEach(() => {
@@ -15,18 +15,79 @@ describe('FeedbackDialog', () => {
   // lookups match more than one element.
   afterEach(cleanup)
 
-  // Completion is identical for every source (Workflo, Notion, …): the dialog
-  // never offers a source-specific or local-only choice.
-  it('never offers source-specific completion choices', () => {
-    render(<FeedbackDialog open={true} onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
-    expect(screen.queryByTestId('source-completion-choice')).toBeNull()
-    expect(screen.queryByTestId('choice-complete-manually')).toBeNull()
-    expect(screen.queryByTestId('choice-complete-at-source')).toBeNull()
-  })
-
   function getDialog() {
     return screen.getByRole('dialog')
   }
+
+  function clickStar(index: number) {
+    const starButtons = within(getDialog()).getAllByRole('button').filter(btn =>
+      btn.getAttribute('type') === 'button' && btn.querySelector('svg')
+    )
+    fireEvent.click(starButtons[index])
+  }
+
+  // ── Source completion choice ──────────────────────────────
+
+  it('hides the source choice for a task with no source', () => {
+    render(<FeedbackDialog open={true} onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    expect(screen.queryByTestId('source-completion-choice')).toBeNull()
+    fireEvent.click(within(getDialog()).getByText('Skip'))
+    expect(onSkip).toHaveBeenCalledWith()
+  })
+
+  it('hides the source choice for a Workflo task: the server confirms completion', () => {
+    render(<FeedbackDialog open sourceName="Workflo" serverManaged onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    expect(screen.queryByTestId('source-completion-choice')).toBeNull()
+    expect(screen.queryByTestId('choice-complete-manually')).toBeNull()
+    fireEvent.click(within(getDialog()).getByText('Skip'))
+    expect(onSkip).toHaveBeenCalledWith()
+    clickStar(2)
+    fireEvent.click(within(getDialog()).getByText('Submit Feedback'))
+    expect(onSubmit).toHaveBeenCalledWith(3, '')
+  })
+
+  it('shows the source choice for a Notion task, defaulting to updating the source too', () => {
+    render(<FeedbackDialog open sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    expect(screen.getByTestId('source-completion-choice')).toBeInTheDocument()
+    expect(screen.getByText('This task came from Notion')).toBeInTheDocument()
+    expect(screen.getByTestId('choice-complete-at-source')).toHaveTextContent('Update Notion too')
+    expect(screen.getByTestId('choice-complete-at-source')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('choice-complete-manually')).toHaveTextContent('Only in 20x')
+    expect(screen.getByTestId('choice-complete-manually')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('passes completeAtSource=false to onSubmit after picking "Only in 20x"', () => {
+    render(<FeedbackDialog open sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    fireEvent.click(screen.getByTestId('choice-complete-manually'))
+    expect(screen.getByTestId('choice-complete-manually')).toHaveAttribute('aria-checked', 'true')
+    clickStar(4)
+    fireEvent.click(within(getDialog()).getByText('Submit Feedback'))
+    expect(onSubmit).toHaveBeenCalledWith(5, '', false)
+  })
+
+  it('passes completeAtSource=true to onSubmit by default for a sourced task', () => {
+    render(<FeedbackDialog open sourceName="Linear" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    clickStar(3)
+    fireEvent.click(within(getDialog()).getByText('Submit Feedback'))
+    expect(onSubmit).toHaveBeenCalledWith(4, '', true)
+  })
+
+  it('passes the choice to onSkip too, so Skip does not ask again', () => {
+    render(<FeedbackDialog open sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    fireEvent.click(screen.getByTestId('choice-complete-manually'))
+    fireEvent.click(within(getDialog()).getByText('Skip'))
+    expect(onSkip).toHaveBeenCalledWith(false)
+  })
+
+  it('resets the choice to "update the source too" each time it opens', () => {
+    const { rerender } = render(<FeedbackDialog open sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    fireEvent.click(screen.getByTestId('choice-complete-manually'))
+    rerender(<FeedbackDialog open={false} sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    rerender(<FeedbackDialog open sourceName="Notion" onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    expect(screen.getByTestId('choice-complete-at-source')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  // ── Rating ────────────────────────────────────────────────
 
   it('renders when open', () => {
     render(<FeedbackDialog open={true} onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)

--- a/src/renderer/src/components/tasks/FeedbackDialog.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.tsx
@@ -3,18 +3,32 @@ import { Star } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogBody, DialogTitle, DialogDescription } from '@/components/ui/Dialog'
 import { Button } from '@/components/ui/Button'
 import { Textarea } from '@/components/ui/Textarea'
+import { cn } from '@/lib/utils'
 
 interface FeedbackDialogProps {
   open: boolean
-  onSubmit: (rating: number, comment: string) => void
-  onSkip: () => void
+  /**
+   * Display name of the task source, when the task came from one. Together with
+   * `serverManaged === false` it shows the completion choice; leave it undefined
+   * for a local task.
+   */
+  sourceName?: string | null
+  /** Workflo tasks: the server confirms completion, so no choice is offered. */
+  serverManaged?: boolean
+  /** `completeAtSource` is only passed when the choice was shown. */
+  onSubmit: (rating: number, comment: string, completeAtSource?: boolean) => void
+  onSkip: (completeAtSource?: boolean) => void
   onCancel: () => void
 }
 
-export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDialogProps) {
+export function FeedbackDialog({ open, sourceName, serverManaged = false, onSubmit, onSkip, onCancel }: FeedbackDialogProps) {
   const [rating, setRating] = useState(0)
   const [hoveredStar, setHoveredStar] = useState(0)
   const [comment, setComment] = useState('')
+  // Defaults to updating the source too, which is what 20x did before the
+  // choice existed.
+  const [completeAtSource, setCompleteAtSource] = useState(true)
+  const showSourceChoice = !!sourceName && !serverManaged
 
   // Reset state when dialog opens
   useEffect(() => {
@@ -22,11 +36,19 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDia
       setRating(0)
       setHoveredStar(0)
       setComment('')
+      setCompleteAtSource(true)
     }
   }, [open])
 
   const handleSubmit = () => {
-    if (rating > 0) onSubmit(rating, comment)
+    if (rating === 0) return
+    if (showSourceChoice) onSubmit(rating, comment, completeAtSource)
+    else onSubmit(rating, comment)
+  }
+
+  const handleSkip = () => {
+    if (showSourceChoice) onSkip(completeAtSource)
+    else onSkip()
   }
 
   return (
@@ -66,8 +88,35 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDia
             rows={3}
           />
 
+          {showSourceChoice && (
+            <div
+              className="flex flex-col gap-2 rounded-lg border border-border/50 p-3"
+              role="radiogroup"
+              aria-label={`How to complete this ${sourceName} task`}
+              data-testid="source-completion-choice"
+            >
+              <span className="text-xs font-medium text-foreground">
+                This task came from {sourceName}
+              </span>
+              <div className="flex gap-2">
+                <ChoiceButton
+                  selected={completeAtSource}
+                  onClick={() => setCompleteAtSource(true)}
+                  testId="choice-complete-at-source"
+                  label={`Update ${sourceName} too`}
+                />
+                <ChoiceButton
+                  selected={!completeAtSource}
+                  onClick={() => setCompleteAtSource(false)}
+                  testId="choice-complete-manually"
+                  label="Only in 20x"
+                />
+              </div>
+            </div>
+          )}
+
           <div className="flex gap-2 justify-end">
-            <Button variant="ghost" size="sm" onClick={() => onSkip()}>
+            <Button variant="ghost" size="sm" onClick={handleSkip}>
               Skip
             </Button>
             <Button size="sm" disabled={rating === 0} onClick={handleSubmit}>
@@ -77,5 +126,35 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDia
         </DialogBody>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function ChoiceButton({
+  selected,
+  onClick,
+  label,
+  testId
+}: {
+  selected: boolean
+  onClick: () => void
+  label: string
+  testId: string
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      data-testid={testId}
+      onClick={onClick}
+      className={cn(
+        'flex-1 rounded-md border px-2.5 py-1.5 text-[11px] transition-colors',
+        selected
+          ? 'border-ring bg-accent/60 text-foreground'
+          : 'border-border/50 text-muted-foreground hover:bg-accent/30'
+      )}
+    >
+      {label}
+    </button>
   )
 }

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -20,6 +20,7 @@ import { useAgentSession } from '@/hooks/use-agent-session'
 import { useAgentStore, SessionStatus } from '@/stores/agent-store'
 import { useSettingsStore, type GitProvider } from '@/stores/settings-store'
 import { useTaskStore } from '@/stores/task-store'
+import { useTaskSourceStore } from '@/stores/task-source-store'
 import { useProgressToastStore } from '@/stores/progress-toast-store'
 import { taskApi, worktreeApi, taskSourceApi, onAgentIncompatibleSession, onWorktreeProgress, attachmentApi } from '@/lib/ipc-client'
 import { subscribe } from '@/lib/shared-ipc-listeners'
@@ -152,8 +153,20 @@ function TaskWorkspaceComponent({
 
   const fetchTasks = useTaskStore((s) => s.fetchTasks)
   const updateTaskInStore = useTaskStore((s) => s.updateTask)
+  const taskSources = useTaskSourceStore((s) => s.sources)
   const showProgressToast = useProgressToastStore((s) => s.show)
   const failProgressToast = useProgressToastStore((s) => s.fail)
+
+  // Undefined for a local task, which hides the completion choice in the
+  // feedback dialog. Workflo tasks hide it too: the server confirms completion.
+  const feedbackSourceName = useMemo(() => {
+    if (!task?.source_id) return undefined
+    return taskSources.find((s) => s.id === task.source_id)?.name || task.source || 'the task source'
+  }, [task?.source_id, task?.source, taskSources])
+  const feedbackServerManaged = useMemo(() => {
+    if (!task) return false
+    return !!task.server_managed || taskSources.find((s) => s.id === task.source_id)?.plugin_id === 'peakflo'
+  }, [task, taskSources])
 
   // Derive subtasks reactively from the task store so status changes (e.g., from
   // mobile-initiated sessions) update immediately without needing a re-fetch.
@@ -651,7 +664,7 @@ function TaskWorkspaceComponent({
     }
   }, [session.sessionId, session.messages.length, task?.session_id, onCompleteTask])
 
-  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string) => {
+  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string, completeAtSource?: boolean) => {
     if (!task?.agent_id || !task?.id) return
     setShowFeedback(false)
 
@@ -662,6 +675,9 @@ function TaskWorkspaceComponent({
     }
 
     // Persist feedback + set task to Learning status - prevents auto-stop useEffect.
+    // `complete_at_source` records the user's answer here, because the learning
+    // session finishes in the main process, where no dialog can be shown, and
+    // the completion path must not ask a second time.
     console.log('[TaskWorkspace] Setting task status to AgentLearning:', task.id)
     let updatedTask: WorkfloTask | null | undefined
     try {
@@ -669,6 +685,7 @@ function TaskWorkspaceComponent({
         status: TaskStatus.AgentLearning,
         feedback_rating: rating,
         feedback_comment: comment || null,
+        ...(completeAtSource !== undefined && task.source_id ? { complete_at_source: completeAtSource } : {})
       })
     } catch (error) {
       // The dialog is already closed at this point, so a rejected write left the
@@ -749,14 +766,20 @@ Update existing skills that were helpful or create new ones for patterns worth r
       console.error('Failed to send feedback:', error)
       await taskApi.update(task.id, { status: TaskStatus.ReadyForReview })
     }
-  }, [ensureChatSession, sendMessage, session.sessionId, task?.id])
+  }, [ensureChatSession, sendMessage, session.sessionId, task?.id, task?.source_id])
 
-  const handleFeedbackSkip = useCallback(async () => {
+  const handleFeedbackSkip = useCallback(async (completeAtSource?: boolean) => {
     if (!task?.id) return
     setShowFeedback(false)
-    // Completion is server-confirmed through the shared path for every source.
+    // Record the answer first so the completion path does not ask a second
+    // time. updateTaskInStore persists through the API and syncs the store, so
+    // the completion path below reads the answer back. The write carries no
+    // status, so it passes the sourced-task completion guard.
+    if (completeAtSource !== undefined && task.source_id) {
+      await updateTaskInStore(task.id, { complete_at_source: completeAtSource })
+    }
     await onCompleteTask()
-  }, [task?.id, onCompleteTask])
+  }, [task?.id, task?.source_id, onCompleteTask, updateTaskInStore])
 
   const handleSnooze = useCallback(async (isoString: string) => {
     if (!task) return
@@ -1234,6 +1257,8 @@ Update existing skills that were helpful or create new ones for patterns worth r
 
       <FeedbackDialog
         open={showFeedback}
+        sourceName={feedbackSourceName}
+        serverManaged={feedbackServerManaged}
         onSubmit={handleFeedbackSubmit}
         onSkip={handleFeedbackSkip}
         onCancel={() => setShowFeedback(false)}

--- a/src/renderer/src/hooks/use-task-completion.test.tsx
+++ b/src/renderer/src/hooks/use-task-completion.test.tsx
@@ -73,40 +73,201 @@ function makeTask(overrides: Partial<WorkfloTask> = {}): WorkfloTask {
 const onToast = vi.fn()
 const onCompleted = vi.fn()
 
+function completeLocallyMock() {
+  return window.electronAPI.tasks.completeLocally as unknown as ReturnType<typeof vi.fn>
+}
+
 function Harness({ taskId = 'task-1' }: { taskId?: string }) {
-  const { requestComplete } = useTaskCompletion({ onToast })
+  const { requestComplete, completionDialog } = useTaskCompletion({ onToast })
   return (
     <>
       <button type="button" onClick={() => void requestComplete(taskId, { onCompleted })}>
         Complete
       </button>
+      {completionDialog}
     </>
   )
 }
 
-describe('server completion', () => {
-  beforeEach(() => { vi.clearAllMocks(); executeActionMock.mockResolvedValue({success:true}); storeState.tasks=[] })
+const notionSource = { id: 'src-notion', name: 'Notion', plugin_id: 'notion' }
+const workfloSource = { id: 'src-wf', name: 'Workflo', plugin_id: 'peakflo' }
+
+describe('useTaskCompletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    executeActionMock.mockResolvedValue({ success: true })
+    completeLocallyMock().mockResolvedValue({})
+    storeState.tasks = []
+    storeState.sources = [notionSource, workfloSource]
+  })
   afterEach(cleanup)
-  it('always calls the source and never writes local completion', async () => {
-    storeState.tasks=[makeTask({source_id:'src-1',complete_at_source:false})]
-    render(<Harness />); fireEvent.click(screen.getByText('Complete'))
-    await waitFor(()=>expect(onCompleted).toHaveBeenCalled())
-    expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete,'task-1','src-1')
-    expect(updateTaskMock).not.toHaveBeenCalled()
-    expect(screen.queryByRole('dialog')).toBeNull()
+
+  describe('source-less 20x task', () => {
+    it('completes locally without asking or uploading', async () => {
+      const upload = vi.fn()
+      window.electronAPI.taskSources.upload = upload
+      storeState.tasks = [makeTask()]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+
+      await waitFor(() => expect(onCompleted).toHaveBeenCalled())
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', { status: TaskStatus.Completed })
+      expect(upload).not.toHaveBeenCalled()
+      expect(executeActionMock).not.toHaveBeenCalled()
+      expect(completeLocallyMock()).not.toHaveBeenCalled()
+      expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
+    })
   })
-  it('completes a source-less 20x task locally without uploading it',async()=>{
-    const upload = vi.fn()
-    window.electronAPI.taskSources.upload = upload
-    storeState.tasks=[makeTask()];render(<Harness />);fireEvent.click(screen.getByText('Complete'))
-    await waitFor(()=>expect(onCompleted).toHaveBeenCalled())
-    expect(updateTaskMock).toHaveBeenCalledWith('task-1',{status:TaskStatus.Completed})
-    expect(upload).not.toHaveBeenCalled();expect(executeActionMock).not.toHaveBeenCalled()
+
+  describe('Workflo task', () => {
+    it.each([
+      ['source plugin peakflo', makeTask({ source_id: 'src-wf' })],
+      ['server_managed flag', makeTask({ source_id: 'src-other', server_managed: true })]
+    ])('completes through the server action with no dialog (%s)', async (_label, task) => {
+      storeState.tasks = [task]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+
+      await waitFor(() => expect(onCompleted).toHaveBeenCalled())
+      expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete, 'task-1', task.source_id)
+      expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
+      expect(completeLocallyMock()).not.toHaveBeenCalled()
+      // Workflo tasks never record a completion choice.
+      expect(updateTaskMock).not.toHaveBeenCalled()
+    })
+
+    it('keeps a refused completion open', async () => {
+      executeActionMock.mockResolvedValue({ success: false, error: 'Review required' })
+      storeState.tasks = [makeTask({ source_id: 'src-wf' })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+
+      await waitFor(() => expect(onToast).toHaveBeenCalledWith('Review required', true))
+      expect(updateTaskMock).not.toHaveBeenCalled()
+      expect(onCompleted).not.toHaveBeenCalled()
+    })
   })
-  it('keeps a refused completion open',async()=>{
-    executeActionMock.mockResolvedValue({success:false,error:'Review required'})
-    storeState.tasks=[makeTask({source_id:'src-1'})];render(<Harness />);fireEvent.click(screen.getByText('Complete'))
-    await waitFor(()=>expect(onToast).toHaveBeenCalledWith('Review required',true))
-    expect(updateTaskMock).not.toHaveBeenCalled();expect(onCompleted).not.toHaveBeenCalled()
+
+  describe('Notion-style sourced task', () => {
+    it('asks before doing anything', async () => {
+      storeState.tasks = [makeTask({ source_id: 'src-notion' })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+
+      expect(await screen.findByTestId('complete-at-source-dialog')).toBeTruthy()
+      expect(screen.getByText('Complete in Notion?')).toBeTruthy()
+      expect(screen.getByTestId('complete-at-source')).toHaveTextContent('Update Notion too')
+      expect(screen.getByTestId('complete-manually')).toHaveTextContent('Only in 20x')
+      expect(executeActionMock).not.toHaveBeenCalled()
+      expect(updateTaskMock).not.toHaveBeenCalled()
+      expect(completeLocallyMock()).not.toHaveBeenCalled()
+    })
+
+    it('"Only in 20x" goes through task:completeLocally and never touches the source', async () => {
+      storeState.tasks = [makeTask({ source_id: 'src-notion' })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+      fireEvent.click(await screen.findByTestId('complete-manually'))
+
+      await waitFor(() => expect(completeLocallyMock()).toHaveBeenCalledWith('task-1'))
+      expect(executeActionMock).not.toHaveBeenCalled()
+      // No renderer status write: the guard lives in the main process.
+      expect(updateTaskMock).not.toHaveBeenCalled()
+      expect(onCompleted).toHaveBeenCalledWith(expect.objectContaining({ id: 'task-1', status: TaskStatus.Completed }))
+      expect(onToast).toHaveBeenCalledWith('"Fix the login bug" completed in 20x only')
+      await waitFor(() => expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull())
+    })
+
+    it('"Update Notion too" runs the source action, then records the choice without a status', async () => {
+      storeState.tasks = [makeTask({ source_id: 'src-notion' })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+      fireEvent.click(await screen.findByTestId('complete-at-source'))
+
+      await waitFor(() => expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete, 'task-1', 'src-notion'))
+      await waitFor(() => expect(updateTaskMock).toHaveBeenCalledWith('task-1', { complete_at_source: true }))
+      expect(updateTaskMock).not.toHaveBeenCalledWith('task-1', expect.objectContaining({ status: TaskStatus.Completed }))
+      expect(completeLocallyMock()).not.toHaveBeenCalled()
+      expect(onToast).toHaveBeenCalledWith('"Fix the login bug" completed')
+      await waitFor(() => expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull())
+    })
+
+    it('uses the action output field as the source action id', async () => {
+      storeState.tasks = [makeTask({
+        source_id: 'src-notion',
+        output_fields: [{ id: 'action', value: PluginActionId.Approve }] as WorkfloTask['output_fields']
+      })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+      fireEvent.click(await screen.findByTestId('complete-at-source'))
+
+      await waitFor(() => expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Approve, 'task-1', 'src-notion'))
+    })
+
+    it('keeps the dialog open and reports the error when the source refuses', async () => {
+      executeActionMock.mockResolvedValue({ success: false, error: 'Notion rejected the update' })
+      storeState.tasks = [makeTask({ source_id: 'src-notion' })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+      fireEvent.click(await screen.findByTestId('complete-at-source'))
+
+      await waitFor(() => expect(onToast).toHaveBeenCalledWith('Notion rejected the update', true))
+      expect(updateTaskMock).not.toHaveBeenCalled()
+      expect(onCompleted).not.toHaveBeenCalled()
+      expect(screen.getByTestId('complete-at-source-dialog')).toBeTruthy()
+    })
+
+    it('keeps the dialog open when the main process refuses "Only in 20x"', async () => {
+      completeLocallyMock().mockRejectedValue(new Error('Workflo controls task status.'))
+      storeState.tasks = [makeTask({ source_id: 'src-notion' })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+      fireEvent.click(await screen.findByTestId('complete-manually'))
+
+      await waitFor(() => expect(onToast).toHaveBeenCalledWith('Workflo controls task status.', true))
+      expect(onCompleted).not.toHaveBeenCalled()
+      expect(screen.getByTestId('complete-at-source-dialog')).toBeTruthy()
+    })
+
+    it('completes nothing when the user cancels', async () => {
+      storeState.tasks = [makeTask({ source_id: 'src-notion' })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+      fireEvent.click(await screen.findByText('Cancel'))
+
+      await waitFor(() => expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull())
+      expect(executeActionMock).not.toHaveBeenCalled()
+      expect(updateTaskMock).not.toHaveBeenCalled()
+      expect(completeLocallyMock()).not.toHaveBeenCalled()
+    })
+
+    it('honours a stored "Only in 20x" answer without asking', async () => {
+      storeState.tasks = [makeTask({ source_id: 'src-notion', complete_at_source: false })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+
+      await waitFor(() => expect(completeLocallyMock()).toHaveBeenCalledWith('task-1'))
+      expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
+      expect(executeActionMock).not.toHaveBeenCalled()
+    })
+
+    it('honours a stored "update the source too" answer without asking', async () => {
+      storeState.tasks = [makeTask({ source_id: 'src-notion', complete_at_source: true })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+
+      await waitFor(() => expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete, 'task-1', 'src-notion'))
+      expect(screen.queryByTestId('complete-at-source-dialog')).toBeNull()
+      expect(completeLocallyMock()).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the task source label when the source record is not loaded', async () => {
+      storeState.sources = []
+      storeState.tasks = [makeTask({ source_id: 'src-linear', source: 'linear' })]
+      render(<Harness />)
+      fireEvent.click(screen.getByText('Complete'))
+
+      expect(await screen.findByText('Complete in linear?')).toBeTruthy()
+    })
   })
 })

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -1,8 +1,10 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo, useState, type ReactNode } from 'react'
+import { CompleteAtSourceDialog } from '@/components/tasks/CompleteAtSourceDialog'
+import { taskApi } from '@/lib/ipc-client'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { useTaskStore } from '@/stores/task-store'
 import { PluginActionId, TaskStatus } from '@/types'
-import type { WorkfloTask } from '@/types'
+import type { TaskSource, WorkfloTask } from '@/types'
 
 export interface UseTaskCompletionOptions {
   onToast?: (message: string, isError?: boolean) => void
@@ -11,29 +13,179 @@ export interface CompleteTaskRequestOptions {
   onCompleted?: (task: WorkfloTask) => void
 }
 
-/** Sourced completion is confirmed externally; source-less 20x tasks stay local. */
+interface PendingCompletion {
+  taskId: string
+  options?: CompleteTaskRequestOptions
+}
+
+/** Workflo owns the status of its tasks; only the server can confirm completion. */
+export function isServerManagedTask(task: WorkfloTask, sources: TaskSource[]): boolean {
+  if (task.server_managed) return true
+  return !!task.source_id && sources.find((s) => s.id === task.source_id)?.plugin_id === 'peakflo'
+}
+
+/**
+ * Single completion path for tasks.
+ *
+ * - No source: completes in 20x immediately.
+ * - Workflo (server-managed): the server confirms completion through a task
+ *   action. There is nothing to ask.
+ * - Any other source (Notion, Linear, YouTrack, GitHub, HubSpot): the user
+ *   picks "Update <source> too" or "Only in 20x". A recorded choice on the
+ *   task (`complete_at_source`, e.g. from the feedback dialog) is honoured
+ *   without asking again.
+ */
 export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
-  const executeAction = useTaskSourceStore(s => s.executeAction)
-  const requestComplete = useCallback(async (taskId: string, options?: CompleteTaskRequestOptions) => {
-    const task = useTaskStore.getState().tasks.find(t => t.id === taskId)
-    if (!task) return
-    try {
-      if (!task.source_id) {
-        await useTaskStore.getState().updateTask(task.id, { status: TaskStatus.Completed })
-        const completedTask = { ...task, status: TaskStatus.Completed }
-        options?.onCompleted?.(completedTask)
-        onToast?.(`"${task.title}" completed`)
-        return
+  const executeAction = useTaskSourceStore((s) => s.executeAction)
+  const sources = useTaskSourceStore((s) => s.sources)
+
+  const [pending, setPending] = useState<PendingCompletion | null>(null)
+  const [isBusy, setIsBusy] = useState(false)
+
+  // The dialog reads the task through the store, so an import that arrives
+  // while the dialog is open cannot make the prompt act on stale data.
+  const tasks = useTaskStore((s) => s.tasks)
+  const pendingTask = useMemo(
+    () => (pending ? tasks.find((t) => t.id === pending.taskId) : undefined),
+    [pending, tasks]
+  )
+
+  const sourceName = useMemo(() => {
+    if (!pendingTask?.source_id) return 'the task source'
+    const source = sources.find((s) => s.id === pendingTask.source_id)
+    return source?.name || pendingTask.source || 'the task source'
+  }, [pendingTask, sources])
+
+  /** Source-less 20x task: a plain local status write. */
+  const completeLocalTask = useCallback(
+    async (task: WorkfloTask, options?: CompleteTaskRequestOptions) => {
+      await useTaskStore.getState().updateTask(task.id, { status: TaskStatus.Completed })
+      options?.onCompleted?.({ ...task, status: TaskStatus.Completed })
+      onToast?.(`"${task.title}" completed`)
+    },
+    [onToast]
+  )
+
+  /**
+   * Closes the task at its source. The source plugin confirms the change and
+   * SyncManager applies the completion in 20x; a refusal leaves the task open.
+   */
+  const completeAtSource = useCallback(
+    async (task: WorkfloTask, options: CompleteTaskRequestOptions | undefined, recordChoice: boolean) => {
+      const action = task.output_fields.find((f) => f.id === 'action')?.value
+      const result = await executeAction(action ? String(action) : PluginActionId.Complete, task.id, task.source_id!)
+      if (!result.success) throw new Error(result.error || 'The task source did not confirm completion.')
+      if (recordChoice) {
+        // No status in this write, so it passes the completion guard. It records
+        // the answer so a reopened task does not ask again.
+        try {
+          await useTaskStore.getState().updateTask(task.id, { complete_at_source: true })
+        } catch (error) {
+          console.error('[useTaskCompletion] Could not record the completion choice:', error)
+        }
       }
-      const action = task.output_fields.find(f => f.id === 'action')?.value
-      const result = await executeAction(action ? String(action) : PluginActionId.Complete, task.id, task.source_id)
-      if (!result.success) throw new Error(result.error || 'The server did not confirm completion.')
       await useTaskStore.getState().fetchTasks()
       options?.onCompleted?.(task)
       onToast?.(`"${task.title}" completed`)
-    } catch (error) {
-      onToast?.(error instanceof Error ? error.message : 'Task completion failed.', true)
-    }
-  }, [executeAction, onToast])
-  return { requestComplete }
+    },
+    [executeAction, onToast]
+  )
+
+  /** "Only in 20x": the main process owns the guard that lets this close a sourced task. */
+  const completeInTwentyXOnly = useCallback(
+    async (task: WorkfloTask, options?: CompleteTaskRequestOptions) => {
+      await taskApi.completeLocally(task.id)
+      await useTaskStore.getState().fetchTasks()
+      options?.onCompleted?.({ ...task, status: TaskStatus.Completed, complete_at_source: false })
+      onToast?.(`"${task.title}" completed in 20x only`)
+    },
+    [onToast]
+  )
+
+  /** Applies a sourced completion for a non-Workflo task; returns false when it failed. */
+  const runSourcedCompletion = useCallback(
+    async (task: WorkfloTask, options: CompleteTaskRequestOptions | undefined, atSource: boolean): Promise<boolean> => {
+      try {
+        if (atSource) await completeAtSource(task, options, true)
+        else await completeInTwentyXOnly(task, options)
+        return true
+      } catch (error) {
+        onToast?.(error instanceof Error ? error.message : 'Task completion failed.', true)
+        return false
+      }
+    },
+    [completeAtSource, completeInTwentyXOnly, onToast]
+  )
+
+  /**
+   * Entry point for every user-triggered completion. Reads the task from the
+   * store so callers cannot pass a stale copy.
+   */
+  const requestComplete = useCallback(
+    async (taskId: string, options?: CompleteTaskRequestOptions) => {
+      const task = useTaskStore.getState().tasks.find((t) => t.id === taskId)
+      if (!task) return
+      try {
+        if (!task.source_id) {
+          await completeLocalTask(task, options)
+          return
+        }
+        if (isServerManagedTask(task, useTaskSourceStore.getState().sources)) {
+          await completeAtSource(task, options, false)
+          return
+        }
+      } catch (error) {
+        onToast?.(error instanceof Error ? error.message : 'Task completion failed.', true)
+        return
+      }
+      // The feedback dialog asks the same question for tasks that ran an agent
+      // and records the answer on the task. Honour it instead of asking twice.
+      if (task.complete_at_source != null) {
+        await runSourcedCompletion(task, options, task.complete_at_source)
+        return
+      }
+      setPending({ taskId, options })
+    },
+    [completeAtSource, completeLocalTask, onToast, runSourcedCompletion]
+  )
+
+  const resolvePending = useCallback(
+    async (atSource: boolean) => {
+      if (!pending || isBusy) return
+      const task = useTaskStore.getState().tasks.find((t) => t.id === pending.taskId)
+      if (!task) {
+        setPending(null)
+        return
+      }
+      setIsBusy(true)
+      try {
+        const done = await runSourcedCompletion(task, pending.options, atSource)
+        // A failure keeps the dialog open so the user can retry or pick the other option.
+        if (done) setPending(null)
+      } finally {
+        setIsBusy(false)
+      }
+    },
+    [isBusy, pending, runSourcedCompletion]
+  )
+
+  const handleCompleteAtSource = useCallback(() => void resolvePending(true), [resolvePending])
+  const handleCompleteManually = useCallback(() => void resolvePending(false), [resolvePending])
+  const handleCancel = useCallback(() => {
+    if (!isBusy) setPending(null)
+  }, [isBusy])
+
+  const completionDialog: ReactNode = (
+    <CompleteAtSourceDialog
+      isOpen={pending !== null}
+      taskTitle={pendingTask?.title || ''}
+      sourceName={sourceName}
+      isBusy={isBusy}
+      onCompleteAtSource={handleCompleteAtSource}
+      onCompleteManually={handleCompleteManually}
+      onCancel={handleCancel}
+    />
+  )
+
+  return { requestComplete, completionDialog }
 }

--- a/src/renderer/src/lib/ipc-client.ts
+++ b/src/renderer/src/lib/ipc-client.ts
@@ -49,6 +49,14 @@ export const taskApi = {
 
   reorderSubtasks: (parentId: string, orderedIds: string[]): Promise<boolean> => {
     return window.electronAPI.db.reorderSubtasks(parentId, orderedIds)
+  },
+
+  /**
+   * Completes a task that came from a non-Workflo source in 20x only, leaving
+   * the source untouched. The main process refuses source-less and Workflo tasks.
+   */
+  completeLocally: (id: string): Promise<WorkfloTask | undefined> => {
+    return window.electronAPI.tasks.completeLocally(id)
   }
 }
 

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -226,6 +226,8 @@ interface ElectronAPI {
   }
   tasks: {
     getWorkspaceDir: (taskId: string) => Promise<string>
+    /** "Only in 20x" for a non-Workflo sourced task; the main process owns the guard. */
+    completeLocally: (taskId: string) => Promise<WorkfloTask | undefined>
   }
   /** The preload bridge always exposes every artifact capability, including
    * the desktop-only file clipboard action. */

--- a/test/setup-renderer.ts
+++ b/test/setup-renderer.ts
@@ -35,6 +35,10 @@ const mockElectronAPI = {
     deleteTask: vi.fn().mockResolvedValue(true),
     getSubtasks: vi.fn().mockResolvedValue([])
   },
+  tasks: {
+    getWorkspaceDir: vi.fn().mockResolvedValue('/tmp/test-workspace'),
+    completeLocally: vi.fn().mockResolvedValue({})
+  },
   mcpServers: {
     getAll: vi.fn().mockResolvedValue([]),
     get: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
**Stacked on #536.** Review that one first. GitHub will retarget this to `main` after #536 merges.

## Summary

When a user completes a task that came from a task source (Notion, Linear, YouTrack, GitHub Issues, HubSpot), 20x now asks **"Update \<Source\> too"** (primary) / **"Only in 20x"** (outline) / **Cancel**. Workflo tasks get no choice and stay server-confirmed through `executeAction`, exactly as today. Source-less tasks complete locally with no dialog, as today.

- `TaskUpdateOrigin` gains `'user-local'` (main-process only). It satisfies only the local completion guard; the source-link guard and the Workflo-ownership guard (`isWorkfloLinkedTask`) still apply.
- New `task:completeLocally` IPC handler: loads the task, refuses source-less and Workflo (`plugin_id === 'peakflo'` or `server_managed`) tasks, then writes `{ status: completed, complete_at_source: false }` with origin `'user-local'`. The post-update side effects of `db:updateTask` (recurrence, heartbeat disable, enterprise sync, analytics, automation scheduler, coordinator wake-up, feedback) are extracted into a shared `afterTaskUpdate` closure so both handlers run them identically.
- `SyncManager.exportTaskUpdate` again strips `status` when `task.complete_at_source === false`, so later edits never push a completion to the source against the user's choice. The misnamed #521 test that asserted the opposite is flipped back.
- `CompleteAtSourceDialog` restored; `useTaskCompletion` returns `{ requestComplete, completionDialog }` and routes: no source -> local `updateTask`; server-managed -> `executeAction`; other sourced -> stored `complete_at_source`, else the dialog. "Update too" runs `executeAction`, then records `complete_at_source: true` in a status-less write. "Only in 20x" calls `taskApi.completeLocally`.
- `AppLayout` and `TaskPanelContent` render `completionDialog`. `FeedbackDialog` offers the same radio choice for sourced non-Workflo tasks; `TaskWorkspace` persists `complete_at_source` with the AgentLearning write / before `onCompleteTask`, so the hook never asks twice.

## Behaviour

| Task | Dialog | Source call | Local write |
|---|---|---|---|
| Source-less 20x task | none | none | `db:updateTask { status: completed }` (unchanged) |
| Notion-style source, "Update Notion too" | yes | `executeAction` -> plugin confirms -> SyncManager applies with origin `source-plugin` (#536) | then `{ complete_at_source: true }` (no status) |
| Notion-style source, "Only in 20x" | yes | none, now or later (`exportTaskUpdate` strips `status`) | `task:completeLocally` -> `{ status: completed, complete_at_source: false }` with origin `user-local` |
| Notion-style source, `complete_at_source` already stored (feedback dialog) | none | per stored answer | per stored answer |
| Workflo (`peakflo` / `server_managed`) | none | `executeAction` (unchanged) | server confirms; `task:completeLocally` refuses with "Workflo controls task status" |

## Security note

The `'user-local'` origin is chosen only inside the main-process `task:completeLocally` handler. `UpdateTaskData` gained no bypass flag, so a renderer cannot request the origin through `db:updateTask` (covered by a test). The handler re-checks the source's `plugin_id` and `server_managed` itself rather than trusting anything from the renderer.

## Test plan

- [x] `pnpm test:run src/main/database.test.ts src/main/ipc-handlers.test.ts src/main/sync-manager.test.ts` - 3 files, 101 tests passed
- [x] `pnpm test:run src/renderer/src/hooks/use-task-completion.test.tsx src/renderer/src/components/tasks/FeedbackDialog.test.tsx src/renderer/src/components/canvas/TaskPanelContent.test.tsx` - 3 files, 32 tests passed
- [x] `pnpm test:main --run` - 89 files, 1755 passed, 4 skipped
- [x] `pnpm test:renderer --run` - 77 files, 959 passed
- [x] `pnpm typecheck` - clean
- [x] `npx eslint` on every changed file - clean

New/updated tests:
- `database.test.ts`: `'user-local'` completes a Notion-style sourced task; still refused for a peakflo-linked task; cannot change the source link.
- `ipc-handlers.test.ts`: `task:completeLocally` completes a Notion-style task with `complete_at_source=false` and origin `'user-local'` and runs the shared side effects (heartbeat, enterprise sync, parent wake-up); refuses peakflo, `server_managed`, source-less and unknown tasks; `db:updateTask` passes no origin.
- `sync-manager.test.ts`: status is not pushed / is stripped from mixed edits when `complete_at_source === false`.
- `use-task-completion.test.tsx`: source-less local; Workflo via plugin or `server_managed` shows no dialog; Notion shows the dialog with the new labels; "Only in 20x" calls `completeLocally` and never `executeAction`; "Update too" calls `executeAction` then records the choice; refusals keep the dialog open; cancel; stored answers skip the dialog.
- `FeedbackDialog.test.tsx`: choice hidden for source-less and Workflo tasks, shown for Notion with the new labels, passed to `onSubmit` / `onSkip`, reset on reopen.
- `TaskPanelContent.test.tsx`: Workflo panel shows no source dialog; Notion panel shows it and "Only in 20x" routes to `completeLocally`.

## Follow-up

- `mobile-api-server` (`POST /api/tasks/:id/complete`) still always calls `executeAction`; the mobile client has no "Only in 20x" route yet. Left as is here; a follow-up can expose `task:completeLocally` over the mobile API with the same main-process guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
