### PR TITLE
fix: wait for concurrent SQLite transcript writers

### DIFF
--- a/src/main/database.test.ts
+++ b/src/main/database.test.ts
@@ -1,3 +1,8 @@
+import { spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, it, expect, beforeEach } from 'vitest'
 import RawDatabase from 'better-sqlite3'
 import { createTestDb } from '../../test/helpers/db-test-helper'
@@ -480,6 +485,69 @@ describe('Closed database behavior', () => {
 })
 
 describe('Durable transcript projection', () => {
+  it('waits for a concurrent writer before calculating transcript sequence and revision', async () => {
+    const dir = mkdtempSync(join(tmpdir(), '20x-transcript-lock-'))
+    const dbPath = join(dir, 'transcript.db')
+    const rawDb = new RawDatabase(dbPath)
+    rawDb.pragma('journal_mode = WAL')
+    rawDb.pragma('busy_timeout = 1000')
+    rawDb.exec(`
+      CREATE TABLE transcript_parts (
+        task_id TEXT NOT NULL,
+        part_id TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        role TEXT NOT NULL DEFAULT 'system',
+        content TEXT NOT NULL DEFAULT '',
+        part_type TEXT,
+        tool TEXT,
+        payload TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        rev INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (task_id, part_id)
+      )
+    `)
+    const manager = new RealDatabaseManager()
+    manager.db = rawDb
+
+    const lockHolder = spawn(process.execPath, ['-e', `
+      const Database = require('better-sqlite3')
+      const db = new Database(process.argv[1])
+      db.pragma('journal_mode = WAL')
+      db.exec('BEGIN IMMEDIATE')
+      db.prepare('INSERT INTO transcript_parts (task_id, part_id, seq, role, content, created_at, updated_at, rev) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')
+        .run('task-1', 'other-process', 1, 'assistant', 'concurrent write', 1, 1, 1)
+      process.stdout.write('locked\\n')
+      setTimeout(() => {
+        db.exec('COMMIT')
+        db.close()
+      }, 200)
+    `, dbPath], {
+      cwd: process.cwd(),
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+
+    try {
+      await once(lockHolder.stdout!, 'data')
+
+      expect(() => manager.upsertTranscriptParts('task-1', [
+        { id: 'p1', role: 'assistant', content: 'persisted after contention' }
+      ])).not.toThrow()
+
+      if (lockHolder.exitCode === null) await once(lockHolder, 'exit')
+      expect(manager.getTranscriptParts('task-1').map((part) => [part.partId, part.seq, part.rev]))
+        .toEqual([
+          ['other-process', 1, 1],
+          ['p1', 2, 2]
+        ])
+    } finally {
+      if (lockHolder.exitCode === null) lockHolder.kill()
+      rawDb.close()
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('assigns monotonic per-task seq to new parts', () => {
     db.upsertTranscriptParts('task-1', [
       { id: 'p1', role: 'user', content: 'hello' },

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2192,7 +2192,12 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
       }
       maxRev = rev
     })
-    txn()
+    // Reserve the WAL writer slot before reading seq/rev. A deferred
+    // transaction can take a read snapshot while another connection is
+    // writing, then fail immediately with SQLITE_BUSY when it tries to upgrade
+    // that stale snapshot. BEGIN IMMEDIATE lets busy_timeout wait for the
+    // writer and only calculates the counters after the lock is acquired.
+    txn.immediate()
     return { maxRev, changedPartIds }
   }
 


### PR DESCRIPTION
## Summary
- start transcript upserts with BEGIN IMMEDIATE so SQLite acquires or waits for the WAL writer slot before reading the next sequence and global revision
- prevent deferred read snapshots from failing with SQLITE_BUSY during the later read-to-write upgrade
- add a two-process, file-backed regression test that holds a concurrent transcript write, then verifies the second write waits and receives the next sequence and revision

## Root cause
The database already used WAL mode and a 5-second busy timeout. However, upsertTranscriptParts opened a deferred transaction and read MAX(seq) and MAX(rev) before its first write. When another 20x process held the WAL writer slot, this connection created a read snapshot and then could not promote that stale snapshot to a writer. SQLite returned SQLITE_BUSY instead of applying the intended wait at transaction start.

## Test plan
- [x] Regression test fails on the original deferred transaction with SqliteError: database is locked
- [x] Database suite: 63 passed
- [x] Related AgentManager and migration suites: 144 passed
- [x] Full main-process suite: 1,741 passed, 4 skipped
- [x] TypeScript typecheck
- [x] ESLint on changed files
- [x] Production build

Generated with Codex.