### PR TITLE
fix(pi): prevent macOS Dock icons for sessions

### DIFF
--- a/src/main/adapters/pi-adapter.test.ts
+++ b/src/main/adapters/pi-adapter.test.ts
@@ -20,6 +20,7 @@ vi.mock('../enterprise-ai-gateway', () => ({
 import {
   PiAdapter,
   buildPiMcpConfigDocument,
+  findPiNodeRuntime,
   sanitizePiMcpServerName,
   sanitizePiSessionName,
   withProviderNameLimitHint,
@@ -79,6 +80,26 @@ describe('PiAdapter', () => {
     vi.clearAllMocks()
   })
 
+  it('uses the LSUIElement Electron helper as the bundled Node runtime on macOS', () => {
+    const executable = '/Applications/20x.app/Contents/MacOS/20x'
+
+    expect(findPiNodeRuntime('darwin', executable, () => true)).toBe(
+      '/Applications/20x.app/Contents/Frameworks/20x Helper.app/Contents/MacOS/20x Helper',
+    )
+  })
+
+  it('does not fall back to the foreground Electron app when its macOS helper is missing', () => {
+    expect(findPiNodeRuntime(
+      'darwin',
+      '/Applications/20x.app/Contents/MacOS/20x',
+      () => false,
+    )).toBeNull()
+  })
+
+  it('uses the Electron executable as bundled Node outside macOS', () => {
+    expect(findPiNodeRuntime('linux', '/opt/20x/electron', () => false)).toBe('/opt/20x/electron')
+  })
+
   it('uses the native Pi session file and applies model selection through RPC', async () => {
     const child = fakeProcess()
     spawnMock.mockReturnValue(child)
@@ -106,7 +127,7 @@ describe('PiAdapter', () => {
     })
 
     expect(id).toBe('/sessions/native-session.jsonl')
-    expect(spawnMock.mock.calls[0][0]).toBe(process.execPath)
+    expect(spawnMock.mock.calls[0][0]).toBe(findPiNodeRuntime(process.platform, process.execPath))
     const args = spawnMock.mock.calls[0][1] as string[]
     expect(args[0]).toBe('/usr/local/bin/pi')
     expect(args).toContain('--mode')
@@ -158,7 +179,7 @@ describe('PiAdapter', () => {
       ],
       default: { peakflo: 'model-one' },
     })
-    expect(spawnMock.mock.calls[0][0]).toBe(process.execPath)
+    expect(spawnMock.mock.calls[0][0]).toBe(findPiNodeRuntime(process.platform, process.execPath))
     expect(spawnMock.mock.calls[0][1]).toEqual([
       '/usr/local/bin/pi',
       '--mode',

--- a/src/main/adapters/pi-adapter.ts
+++ b/src/main/adapters/pi-adapter.ts
@@ -10,7 +10,7 @@ import type { ChildProcessWithoutNullStreams } from 'child_process'
 import { randomUUID } from 'crypto'
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
-import { dirname, join } from 'path'
+import { basename, dirname, join } from 'path'
 import { StringDecoder } from 'string_decoder'
 import { promisify } from 'util'
 import type { DatabaseManager } from '../database'
@@ -44,6 +44,33 @@ const TERMINAL_ERROR_SETTLE_GRACE_MS = 1_000
  */
 export const MAX_PI_NAME_LENGTH = 64
 export const MAX_PI_MCP_SERVER_SLUG_LENGTH = 24
+
+/**
+ * Electron's main macOS executable belongs to the foreground application
+ * bundle. Reusing it as Node makes LaunchServices register every Pi process as
+ * another foreground 20x application, which adds a Dock icon. Electron's
+ * standard Helper.app is an LSUIElement and exposes the same bundled Node
+ * runtime without participating in the Dock.
+ */
+export function findPiNodeRuntime(
+  platform: NodeJS.Platform,
+  electronExecutable: string,
+  pathExists: (path: string) => boolean = existsSync,
+): string | null {
+  if (platform !== 'darwin') return electronExecutable
+
+  const executableName = basename(electronExecutable)
+  const contentsDirectory = dirname(dirname(electronExecutable))
+  const helperExecutable = join(
+    contentsDirectory,
+    'Frameworks',
+    `${executableName} Helper.app`,
+    'Contents',
+    'MacOS',
+    `${executableName} Helper`,
+  )
+  return pathExists(helperExecutable) ? helperExecutable : null
+}
 
 /**
  * Short Pi-side aliases for MCP servers whose display names are too long to
@@ -388,8 +415,10 @@ export class PiAdapter implements CodingAgentAdapter {
    * Pi's npm launcher uses `#!/usr/bin/env node`. Launching it directly would
    * therefore make Pi depend on whichever Node happens to be first on the
    * desktop app's PATH. Recent Pi releases require Node >=22.19 and use zstd
-   * APIs that are absent from older runtimes. On macOS/Linux, run the launcher
-   * with Electron's bundled Node so Pi uses the same known runtime as 20x.
+   * APIs that are absent from older runtimes. On Linux, run the launcher with
+   * Electron's main executable. On macOS, use Electron's LSUIElement helper;
+   * launching the foreground app executable creates another Dock icon for
+   * every Pi session. Both expose the same bundled Node runtime.
    *
    * Windows npm launchers are .cmd files, so they must continue to run through
    * the shell.
@@ -402,8 +431,16 @@ export class PiAdapter implements CodingAgentAdapter {
     if (process.platform === 'win32') {
       return { command: executable, args, env, shell: true }
     }
+
+    const nodeRuntime = findPiNodeRuntime(process.platform, process.execPath)
+    if (!nodeRuntime) {
+      // A valid Electron macOS package always contains Helper.app. If a custom
+      // package does not, prefer Pi's shebang-selected Node over spawning the
+      // foreground Electron app and reintroducing a Dock icon.
+      return { command: executable, args, env, shell: false }
+    }
     return {
-      command: process.execPath,
+      command: nodeRuntime,
       args: [executable, ...args],
       env: { ...env, ELECTRON_RUN_AS_NODE: '1' },
       shell: false,


### PR DESCRIPTION
## Summary
- launch Pi with Electron's LSUIElement helper executable on macOS instead of reusing the foreground 20x/Electron app executable
- preserve the bundled Node runtime required by recent Pi releases
- fall back to Pi's own shebang-selected runtime if a custom macOS package is missing the standard helper, avoiding a Dock regression
- add regression coverage for packaged macOS, missing-helper, and non-macOS runtime selection

## Root cause
The bundled-runtime change in c9dc76e made every Pi session spawn process.execPath with ELECTRON_RUN_AS_NODE=1. On macOS, process.execPath is still inside the foreground 20x.app or Electron.app bundle. LaunchServices therefore registered each child as a separate Foreground application even though it ran Node, producing one generic exec Dock tile per Pi session. Pi itself did not spawn a GUI process.

## macOS evidence
Before the fix, ps/lsof showed Pi PID 2398 executing /Applications/20x.app/Contents/MacOS/20x, and lsappinfo classified it as type=Foreground with bundleID=com.20x.app. Five concurrent development Pi children were likewise Foreground registrations of Electron.app.

On the post-commit build, a real Pi RPC session initialized as PID 71335. ps/lsof showed it executing Electron Helper.app/Contents/MacOS/Electron Helper; that helper's Info.plist has LSUIElement=true, and lsappinfo classified the Pi process as type=UIElement. The compiled out/main/index.js was rebuilt after commit f04bffe and contains the Helper.app path-selection logic.

## Test plan
- [x] pnpm exec eslint src/main/adapters/pi-adapter.ts src/main/adapters/pi-adapter.test.ts
- [x] pnpm test:run --project main src/main/adapters/pi-adapter.test.ts (23 tests)
- [x] pnpm typecheck
- [x] pnpm build
- [x] Launch post-commit build on macOS with isolated user data and initialize a real Pi RPC session
- [x] Verify Pi child executable with ps/lsof and LaunchServices type with lsappinfo

Generated with Codex