### PR TITLE
fix: show source action in session feedback on desktop and mobile

### DIFF
--- a/src/main/mobile-api-server.test.ts
+++ b/src/main/mobile-api-server.test.ts
@@ -213,3 +213,29 @@ describe('mobile-api-server: POST /api/tasks/:id coordinator wake-up', () => {
     expect(notifyParent).not.toHaveBeenCalled()
   })
 })
+
+describe('mobile-api-server: source completion action', () => {
+  afterEach(() => {
+    stopMobileApiServer()
+    vi.restoreAllMocks()
+  })
+
+  it.each(['approve', undefined])('sends the selected action %s to the source', async (action) => {
+    const { db } = createTestDb()
+    const source = db.createTaskSource({ name: 'Session Feedback', plugin_id: 'peakflo', mcp_server_id: null })!
+    const task = db.createTask(makeTask({ source_id: source.id, source: 'Session Feedback',
+      output_fields: action ? [{ id: 'action', name: 'Action', type: 'text', value: action }] : [] }))!
+    const executeAction = vi.fn().mockResolvedValue({ success: true })
+    const token = 'test-completion-token'
+    db.createMobileSession('completion-session', createHash('sha256').update(token).digest('hex'), 'test-device')
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const port = await startMobileApiServer(db, {} as never, {} as never,
+      21000 + Math.floor(Math.random() * 40000), { executeAction } as never)
+    const response = await fetch(`http://127.0.0.1:${port}/api/tasks/${task.id}/complete`, {
+      method: 'POST', headers: { Authorization: `Bearer ${token}` }
+    })
+    expect(response.status).toBe(200)
+    expect(executeAction).toHaveBeenCalledWith(action || 'complete', expect.objectContaining({ id: task.id }), undefined, source.id)
+    db.close()
+  })
+})

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -1,3 +1,4 @@
+import { getTaskCompletionAction } from '../shared/task-completion'
 /**
  * Mobile API server — HTTP + WebSocket for controlling 20x from a mobile device.
  * Runs inside the Electron main process, shares DatabaseManager and AgentManager.
@@ -745,7 +746,7 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
     if (!syncManagerRef || db.getTaskSource(task.source_id)?.plugin_id !== 'peakflo') {
       throw Object.assign(new Error('Sync this task with Workflo before completing it.'), { status: 409 })
     }
-    const result = await syncManagerRef.executeAction('complete', task, undefined, task.source_id)
+    const result = await syncManagerRef.executeAction(getTaskCompletionAction(task.output_fields), task, undefined, task.source_id)
     if (!result.success) throw Object.assign(new Error(result.error || 'Completion is pending.'), { status: 409 })
     const completed = true
     const fresh = db.getTask(taskId)

--- a/src/mobile/pages/TaskDetailPage.test.tsx
+++ b/src/mobile/pages/TaskDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, cleanup, fireEvent } from '@testing-library/react'
+import { render, cleanup, fireEvent, waitFor, within } from '@testing-library/react'
 import { ArtifactType } from '@shared/artifacts'
 import { TaskDetailPage } from './TaskDetailPage'
 import { useTaskStore, type Task } from '../stores/task-store'
@@ -84,6 +84,28 @@ afterEach(() => {
 })
 
 describe('TaskDetailPage', () => {
+  it.each(['approve', undefined])('shows the Session Feedback action %s before Skip completes', async (action) => {
+    const task = makeTask({ agent_id: 'agent-1', source_id: 'session-feedback', source: 'Session Feedback',
+      output_fields: action ? [{ id: 'action', value: action }] : [] })
+    useTaskStore.setState({ tasks: [task], isLoading: false })
+    const view = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
+    fireEvent.click(view.getByTestId('main-cta-complete'))
+    const dialog = within(view.getByRole('dialog'))
+    expect(dialog.getByText(`Action at Session Feedback: ${action || 'complete'}. Completion sends this action and the task outputs to the source.`)).toBeTruthy()
+    expect(completeMock).not.toHaveBeenCalled()
+    fireEvent.click(dialog.getByRole('button', { name: 'Skip' }))
+    await waitFor(() => expect(completeMock).toHaveBeenCalledWith(task.id))
+  })
+
+  it('cancels source feedback without completing', () => {
+    useTaskStore.setState({ tasks: [makeTask({ agent_id: 'agent-1', source_id: 'session-feedback', source: 'Session Feedback' })], isLoading: false })
+    const view = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
+    fireEvent.click(view.getByTestId('main-cta-complete'))
+    fireEvent.click(view.getByRole('button', { name: 'Cancel' }))
+    expect(completeMock).not.toHaveBeenCalled()
+    expect(view.queryByRole('dialog')).toBeNull()
+  })
+
   it('switches to the artifacts segment and opens an artifact viewer', () => {
     const task = makeTask({ id: 'task-1' })
     useTaskStore.setState({ tasks: [task], isLoading: false })

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -1,3 +1,4 @@
+import { getSourceCompletionDescription } from '@shared/task-completion'
 import { useMemo, useCallback, useEffect, useState, useRef } from 'react'
 import { TaskStatus } from '@shared/constants'
 import { isAgentConfigured, getAgentConfigIssue } from '@shared/agent-utils'
@@ -84,9 +85,7 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
   const initSession = useAgentStore((s) => s.initSession)
   const endSession = useAgentStore((s) => s.endSession)
 
-  // Single modal is reused for both a feedback completion (agent session) and a
-  // plain source completion (no agent): the shared FeedbackModal shows the
-  // 5-star rating/comment only when withFeedback is true.
+  // Session feedback is collected before the completion request.
   const [completeModal, setCompleteModal] = useState<{ withFeedback: boolean } | null>(null)
   const [activeSection, setActiveSection] = useState<'details' | 'artifacts'>('details')
   const [agentMenuOpen, setAgentMenuOpen] = useState(false)
@@ -809,11 +808,10 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
         )}
       </div>
 
-      {/* Shared feedback / completion modal. Shows the 5-star rating and comment
-        only for a feedback completion (withFeedback), otherwise the plain
-        completion choice — one modal, no separate dialog. */}
+      {/* Show the source action before submitting or skipping session feedback. */}
       {completeModal && (
         <FeedbackModal
+          completionDescription={getSourceCompletionDescription(task)}
           onSubmit={handleFeedbackSubmit}
           onSkip={handleFeedbackSkip}
           onCancel={() => setCompleteModal(null)}
@@ -939,7 +937,8 @@ function SubtasksSection({ subtasks, onNavigateToTask, onReorderSubtasks }: { su
   )
 }
 
-function FeedbackModal({ onSubmit, onSkip, onCancel }: {
+function FeedbackModal({ onSubmit, onSkip, onCancel, completionDescription }: {
+  completionDescription?: string
   onSubmit: (rating: number, comment: string) => void
   onSkip: () => void
   onCancel: () => void
@@ -950,6 +949,12 @@ function FeedbackModal({ onSubmit, onSkip, onCancel }: {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
       <div role="dialog" aria-label="Session feedback" className="mx-4 w-full max-w-md rounded-xl border bg-card p-5 space-y-4">
         <h2>Session feedback</h2>
+        {completionDescription && (
+          <div className="rounded-md border p-3 text-sm space-y-2">
+            <p>{completionDescription}</p>
+            <p>Skip omits only the session rating and comment.</p>
+          </div>
+        )}
         <div className="flex gap-2">
           {[1, 2, 3, 4, 5].map(value => <button key={value} aria-label={`Rate ${value}`} aria-pressed={rating === value} onClick={() => setRating(value)}>{value}</button>)}
         </div>

--- a/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
@@ -56,8 +56,10 @@ describe('FeedbackDialog', () => {
   })
 
   it('calls onSubmit with rating and comment when submitted', () => {
-    render(<FeedbackDialog open={true} onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    render(<FeedbackDialog open={true} completionDescription="Action at Session Feedback: approve." onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
     const dialog = getDialog()
+    expect(within(dialog).getByText('Action at Session Feedback: approve.')).toBeInTheDocument()
+    expect(onSubmit).not.toHaveBeenCalled()
 
     // Click the 4th star
     const starButtons = within(dialog).getAllByRole('button').filter(btn =>

--- a/src/renderer/src/components/tasks/FeedbackDialog.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.tsx
@@ -5,13 +5,14 @@ import { Button } from '@/components/ui/Button'
 import { Textarea } from '@/components/ui/Textarea'
 
 interface FeedbackDialogProps {
+  completionDescription?: string
   open: boolean
   onSubmit: (rating: number, comment: string) => void
   onSkip: () => void
   onCancel: () => void
 }
 
-export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDialogProps) {
+export function FeedbackDialog({ open, onSubmit, onSkip, onCancel, completionDescription }: FeedbackDialogProps) {
   const [rating, setRating] = useState(0)
   const [hoveredStar, setHoveredStar] = useState(0)
   const [comment, setComment] = useState('')
@@ -39,6 +40,12 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel }: FeedbackDia
           </DialogDescription>
         </DialogHeader>
         <DialogBody className="flex flex-col gap-4">
+          {completionDescription && (
+            <div className="rounded-md border p-3 text-sm space-y-2">
+              <p>{completionDescription}</p>
+              <p>Skip omits only the session rating and comment.</p>
+            </div>
+          )}
           <div className="flex gap-1 justify-center">
             {[1, 2, 3, 4, 5].map((star) => (
               <button

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -138,6 +138,23 @@ describe('clampTranscriptWidth', () => {
 })
 
 describe('TaskWorkspace keyboard actions', () => {
+  it.each(['approve', undefined])('shows the Session Feedback source action %s before completion', async (action) => {
+    const task = makeRendererTask({
+      status: TaskStatus.ReadyForReview,
+      session_id: 'persisted-session-1',
+      source_id: 'session-feedback',
+      source: 'Session Feedback',
+      output_fields: action ? [{ id: 'action', name: 'Action', type: 'text', value: action }] : []
+    })
+    renderWorkspace(task)
+    act(() => dispatchTaskShortcut({ action: TaskShortcutAction.COMPLETE, taskId: task.id }))
+    expect(screen.getByText(`Action at Session Feedback: ${action || 'complete'}. Completion sends this action and the task outputs to the source.`)).toBeInTheDocument()
+    expect(screen.getByText('Skip omits only the session rating and comment.')).toBeInTheDocument()
+    expect(noopFn).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+    await waitFor(() => expect(noopFn).toHaveBeenCalledTimes(1))
+  })
+
   it('opens session feedback instead of completing immediately', () => {
     const task = makeRendererTask({
       status: TaskStatus.ReadyForReview,

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -1,3 +1,5 @@
+import { getSourceCompletionDescription } from '@shared/task-completion'
+import { useTaskSourceStore } from '@/stores/task-source-store'
 import { LayoutList, Send, Sparkles } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { EmptyState } from '@/components/ui/EmptyState'
@@ -124,6 +126,7 @@ function TaskWorkspaceComponent({
   const [editingAgentId, setEditingAgentId] = useState<string | null>(null)
   const [orgProvider, setOrgProvider] = useState<GitProvider>('github')
   const [isSettingUpWorktree, setIsSettingUpWorktree] = useState(false)
+  const taskSources = useTaskSourceStore(state => state.sources)
   const [showFeedback, setShowFeedback] = useState(false)
   const [showSnooze, setShowSnooze] = useState(false)
   const [showIncompatibleSession, setShowIncompatibleSession] = useState(false)
@@ -1234,6 +1237,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
 
       <FeedbackDialog
         open={showFeedback}
+        completionDescription={task ? getSourceCompletionDescription(task, taskSources.find(source => source.id === task.source_id)?.name) : undefined}
         onSubmit={handleFeedbackSubmit}
         onSkip={handleFeedbackSkip}
         onCancel={() => setShowFeedback(false)}

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -1,7 +1,8 @@
+import { getTaskCompletionAction } from '@shared/task-completion'
 import { useCallback } from 'react'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { useTaskStore } from '@/stores/task-store'
-import { PluginActionId, TaskStatus } from '@/types'
+import { TaskStatus } from '@/types'
 import type { WorkfloTask } from '@/types'
 
 export interface UseTaskCompletionOptions {
@@ -25,8 +26,8 @@ export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
         onToast?.(`"${task.title}" completed`)
         return
       }
-      const action = task.output_fields.find(f => f.id === 'action')?.value
-      const result = await executeAction(action ? String(action) : PluginActionId.Complete, task.id, task.source_id)
+      const action = getTaskCompletionAction(task.output_fields)
+      const result = await executeAction(action, task.id, task.source_id)
       if (!result.success) throw new Error(result.error || 'The server did not confirm completion.')
       await useTaskStore.getState().fetchTasks()
       options?.onCompleted?.(task)

--- a/src/shared/task-completion.test.ts
+++ b/src/shared/task-completion.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { getSourceCompletionDescription, getTaskCompletionAction } from './task-completion'
+
+const task = { source_id: 'feedback', source: 'Session Feedback', output_fields: [] }
+
+describe('source completion description', () => {
+  it('uses the loaded source name before the task label', () => {
+    expect(getSourceCompletionDescription(task, 'Feedback Inbox')).toContain('Action at Feedback Inbox: complete.')
+  })
+  it('falls back to the task source label', () => {
+    expect(getSourceCompletionDescription(task)).toContain('Action at Session Feedback: complete.')
+  })
+  it('uses a readable fallback for an empty source label', () => {
+    expect(getSourceCompletionDescription({ ...task, source: '' })).toContain('Action at the task source: complete.')
+  })
+  it('does not describe a source write for a local task', () => {
+    expect(getSourceCompletionDescription({ ...task, source_id: null })).toBeUndefined()
+  })
+  it('selects the action output and defaults empty actions to complete', () => {
+    expect(getTaskCompletionAction([{ id: 'other', value: 'reject' }, { id: 'action', value: 'approve' }])).toBe('approve')
+    expect(getTaskCompletionAction([{ id: 'action', value: '' }])).toBe('complete')
+  })
+})

--- a/src/shared/task-completion.ts
+++ b/src/shared/task-completion.ts
@@ -1,0 +1,19 @@
+import { PluginActionId } from './constants'
+
+/** Use the same action for the completion preview and the source write. */
+export function getTaskCompletionAction(outputFields: readonly unknown[]): string {
+  const field = outputFields.find((field): field is { id: string; value?: unknown } =>
+    typeof field === 'object' && field !== null && 'id' in field && field.id === 'action'
+  )
+  return field?.value ? String(field.value) : PluginActionId.Complete
+}
+
+export function getSourceCompletionDescription(task: {
+  source_id: string | null
+  source: string
+  output_fields: readonly unknown[]
+}, sourceName?: string): string | undefined {
+  if (!task.source_id) return undefined
+  const name = sourceName?.trim() || task.source?.trim() || 'the task source'
+  return `Action at ${name}: ${getTaskCompletionAction(task.output_fields)}. Completion sends this action and the task outputs to the source.`
+}


### PR DESCRIPTION
Session feedback did not show the source action before the user submitted or skipped feedback. For example, a task from Session Feedback with action `approve` showed only rating and comment controls.

Both feedback dialogs now show the source name, selected action, and the effect of completion. They explain that Skip omits only the session rating and comment. Desktop uses the loaded source name when available, with the task label as a fallback. Tasks without a source do not show a source write description.

A shared action selector keeps the description and source request consistent. The mobile completion route now uses the task's action output, as desktop does, instead of always sending `complete`. The default remains `complete`.

The current flow replaced CompleteAtSourceDialog after #459 and #473. This change follows that current flow. Desktop task views share TaskWorkspace; mobile uses TaskDetailPage. Completion without a feedback dialog is outside this display fix.

Validation:
- 63 focused tests pass, including rendered desktop and mobile flows and a real HTTP request to the mobile completion route.
- Restoring the original source causes six regression tests to fail. All pass after the fix is restored.
- Type checking, lint, and desktop/mobile builds pass. Lint has 131 existing warnings and no errors.
- Full test suite: 176 files passed; 2,773 tests passed and four skipped.
