### PR TITLE
fix: restore feedback learning and independent source completion choices

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1396,6 +1396,29 @@ describe('AgentManager transitionToIdle — enterprise task completion after fee
     return { mgr, session }
   }
 
+  it.each([true, false])('completes only after learning and honors the user source choice %s', async completeAtSource => {
+    const mockDb = createEnterpriseTaskDb({complete_at_source: completeAtSource})
+    const {mgr, session} = setupManager(mockDb)
+    const task = mockDb.getTask('task-1')!
+    vi.mocked(mockDb.getSetting).mockImplementation(key => key === 'session-feedback-completion:task-1' ? JSON.stringify({completeAtSource}) : undefined)
+    mockDb.deleteSetting = vi.fn()
+    vi.mocked(mockDb.updateTask).mockImplementation((_id, updates) => Object.assign(task, updates))
+    let finishSkills!: () => void
+    const syncSkills = vi.spyOn(mgr as any, 'syncSkillsFromWorkspace').mockImplementation(() => new Promise(resolve => {
+      finishSkills = () => resolve({created: [], updated: [], unchanged: []})
+    }))
+    const executeAction = vi.fn().mockResolvedValue({success: true})
+    mgr.setSyncManager({executeAction} as never)
+    const idle = (mgr as any).transitionToIdle('session-1', session)
+    await vi.waitFor(() => expect(syncSkills).toHaveBeenCalled())
+    expect(task.status).toBe(TaskStatus.AgentLearning)
+    expect(executeAction).not.toHaveBeenCalled()
+    finishSkills()
+    await idle
+    expect(task.status).toBe(TaskStatus.Completed)
+    expect(executeAction).toHaveBeenCalledTimes(completeAtSource ? 1 : 0)
+  })
+
   it('learning never completes with the human credential',async()=>{
     const mockDb=createEnterpriseTaskDb();const {mgr,session}=setupManager(mockDb)
     const executeAction=vi.fn();mgr.setSyncManager({executeAction} as never)

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -1,3 +1,4 @@
+import { finishSessionFeedback, updateTaskFromUser } from './session-feedback'
 import { serverTaskSnapshot } from './workflo-task-sync'
 import { EventEmitter } from 'events'
 import { spawn } from 'child_process'
@@ -567,8 +568,10 @@ export class AgentManager extends EventEmitter {
    * Set the sync manager for executing enterprise actions (e.g. completing tasks on Workflo).
    * Called after both AgentManager and SyncManager are created.
    */
+  private syncManager?: import('./sync-manager').SyncManager
+
   setSyncManager(syncManager: import('./sync-manager').SyncManager): void {
-    void syncManager
+    this.syncManager = syncManager
   }
 
   setMainWindow(window: BrowserWindow): void {
@@ -3100,7 +3103,7 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
   /** Local help can save its session and results, but cannot set canonical status. */
   private updateTaskFromLocalAgent(taskId: string, updates: Parameters<DatabaseManager['updateTask']>[1]): TaskRecord | undefined {
     const fields = { ...updates }
-    if (serverTaskSnapshot(this.db, taskId)) delete fields.status
+    if (serverTaskSnapshot(this.db, taskId) || (fields.status === TaskStatus.AgentWorking && this.db.getTask(taskId)?.status === TaskStatus.AgentLearning)) delete fields.status
     if (Object.keys(fields).length === 0) return this.db.getTask(taskId)
     return this.db.updateTask(taskId, fields)
   }
@@ -3892,10 +3895,23 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         await this.syncSkillsFromWorkspace(sessionId)
       } catch (err) {
         console.error(`[AgentManager] Skill sync error:`, err)
+        updateTaskFromUser(this.db, session.taskId, {status: TaskStatus.ReadyForReview})
+        this.sendToRenderer('task:updated', {taskId: session.taskId, updates: this.db.getTask(session.taskId)})
+        this.sendToRenderer('agent:status', {sessionId, agentId: session.agentId, taskId: session.taskId, status: 'idle'})
+        return
       }
       await yieldEventLoop()
 
-      if (this.db.getTask(session.taskId)?.status !== TaskStatus.Completed) this.updateTaskFromLocalAgent(session.taskId, { status: TaskStatus.ReadyForReview })
+      try {
+        const completed = await finishSessionFeedback(this.db, this.syncManager, session.taskId)
+        if (completed?.parent_task_id) {
+          await this.notifyParentOfSubtaskCompletion(completed.parent_task_id, session.taskId)
+        }
+        if (!completed && this.db.getTask(session.taskId)?.status !== TaskStatus.Completed) this.updateTaskFromLocalAgent(session.taskId, {status: TaskStatus.ReadyForReview})
+      } catch (error) {
+        this.sendToRenderer('task:source-action-failed', {taskId: session.taskId, taskTitle: task.title, error: error instanceof Error ? error.message : String(error)})
+      }
+      this.sendToRenderer('task:updated', {taskId: session.taskId, updates: this.db.getTask(session.taskId)})
       this.sendToRenderer('agent:status', {
         sessionId, agentId: session.agentId, taskId: session.taskId, status: 'idle'
       })

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2367,17 +2367,21 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
     return this.getTask(id)
   }
 
-  updateTask(id: string, data: UpdateTaskData, origin?: 'workflo-server'): TaskRecord | undefined {
+  updateTask(id: string, data: UpdateTaskData, origin?: 'workflo-server' | 'session-feedback' | 'task-source'): TaskRecord | undefined {
     if (origin !== 'workflo-server' && ('external_id' in data || 'source_id' in data || 'source' in data)) {
       throw new Error('Only the sync service can change a task source link.')
     }
     const currentTask = this.getTask(id)
+    const approvedStatusWrite = origin === 'session-feedback' || origin === 'task-source'
+    if (!approvedStatusWrite && currentTask?.status === TaskStatus.AgentLearning && this.getSetting(`session-feedback-completion:${id}`) && !(data.status === TaskStatus.Completed && data.complete_at_source === false)) {
+      data = { ...data, status: TaskStatus.AgentLearning }
+    }
     const manualCompletion = data.status === TaskStatus.Completed && data.complete_at_source === false
     // A source refresh must not reopen a task the user closed only in 20x.
     if (currentTask?.source_id && currentTask.status === TaskStatus.Completed && currentTask.complete_at_source === false && data.complete_at_source !== true) {
       data = { ...data, status: TaskStatus.Completed }
     }
-    if (data.status && origin !== 'workflo-server' && !manualCompletion) {
+    if (data.status && origin !== 'workflo-server' && !manualCompletion && !approvedStatusWrite) {
       const task = this.getTask(id)
       const snapshot = this.getSetting(`workflo-task:${id}`)
       const remote = snapshot ? JSON.parse(snapshot) : undefined
@@ -2388,7 +2392,7 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
         throw new Error('This task is completed in Workflo.')
       }
     }
-    if (data.status === TaskStatus.Completed && origin !== 'workflo-server' && !manualCompletion) {
+    if (data.status === TaskStatus.Completed && origin !== 'workflo-server' && !manualCompletion && !approvedStatusWrite) {
       const task = this.getTask(id)
       if (task?.source_id && task.status !== TaskStatus.Completed) {
         throw new Error('Workflo must confirm completion before this task can close in 20x.')

--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -2371,7 +2371,13 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
     if (origin !== 'workflo-server' && ('external_id' in data || 'source_id' in data || 'source' in data)) {
       throw new Error('Only the sync service can change a task source link.')
     }
-    if (data.status && origin !== 'workflo-server') {
+    const currentTask = this.getTask(id)
+    const manualCompletion = data.status === TaskStatus.Completed && data.complete_at_source === false
+    // A source refresh must not reopen a task the user closed only in 20x.
+    if (currentTask?.source_id && currentTask.status === TaskStatus.Completed && currentTask.complete_at_source === false && data.complete_at_source !== true) {
+      data = { ...data, status: TaskStatus.Completed }
+    }
+    if (data.status && origin !== 'workflo-server' && !manualCompletion) {
       const task = this.getTask(id)
       const snapshot = this.getSetting(`workflo-task:${id}`)
       const remote = snapshot ? JSON.parse(snapshot) : undefined
@@ -2382,7 +2388,7 @@ Remember: Be helpful, concise, and proactive. Learn from history, but adapt to c
         throw new Error('This task is completed in Workflo.')
       }
     }
-    if (data.status === TaskStatus.Completed && origin !== 'workflo-server') {
+    if (data.status === TaskStatus.Completed && origin !== 'workflo-server' && !manualCompletion) {
       const task = this.getTask(id)
       if (task?.source_id && task.status !== TaskStatus.Completed) {
         throw new Error('Workflo must confirm completion before this task can close in 20x.')

--- a/src/main/enterprise-state-sync.test.ts
+++ b/src/main/enterprise-state-sync.test.ts
@@ -34,6 +34,13 @@ describe('EnterpriseStateSync', () => {
   })
 
   describe('event recording', () => {
+    it('does not send a manual completion through the event queue', async () => {
+      stateSync.recordTaskCompleted(makeTask({complete_at_source: false}), {action: 'approve'})
+      await stateSync.flush()
+      expect(mockApiClient.sendSyncEvents).not.toHaveBeenCalled()
+      expect(stateSync.pendingCount).toBe(0)
+    })
+
     it('records task status change events', () => {
       const task = makeTask()
       stateSync.recordTaskStatusChange(task, 'not_started', 'agent_working')

--- a/src/main/enterprise-state-sync.ts
+++ b/src/main/enterprise-state-sync.ts
@@ -104,6 +104,8 @@ export class EnterpriseStateSync {
     task: TaskRecord,
     opts?: { action?: string; outputs?: Record<string, unknown> }
   ): void {
+    // A manual completion must not reach the source through the event queue.
+    if (task.complete_at_source === false) return
     this.pendingEvents.push({
       eventType: 'task_completed',
       entityType: 'task',

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -191,6 +191,7 @@ describe('db:updateTask coordinator wake-up', () => {
     const agentManager = { notifyParentOfSubtaskCompletion: notifyParent } as unknown as Parameters<typeof registerIpcHandlers>[1]
     const db = {
       getTask: vi.fn(() => existing),
+      getSetting: vi.fn(() => undefined),
       updateTask: vi.fn(() => updated)
     } as unknown as Parameters<typeof registerIpcHandlers>[0]
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,3 +1,4 @@
+import { updateTaskFromUser } from './session-feedback'
 import { ipcMain, dialog, shell, Notification, app, session } from 'electron'
 import * as childProcess from 'child_process'
 import { copyFileSync, existsSync, unlinkSync, readdirSync, statSync, readFileSync, rmSync } from 'fs'
@@ -146,7 +147,7 @@ export function registerIpcHandlers(
       }
     }
 
-    const updated = db.updateTask(id, data)
+    const updated = updateTaskFromUser(db, id, data)
 
     // Initialize recurring task schedule when recurrence is added or changed
     if (recurrenceScheduler && updated && updated.is_recurring && updated.recurrence_pattern) {

--- a/src/main/mobile-api-server.test.ts
+++ b/src/main/mobile-api-server.test.ts
@@ -1,3 +1,5 @@
+import { SyncManager } from './sync-manager'
+import { finishSessionFeedback } from './session-feedback'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createHash } from 'crypto'
 import { createTestDb } from '../../test/helpers/db-test-helper'
@@ -258,6 +260,47 @@ describe('mobile-api-server: source completion action', () => {
     })
     expect(response.status).toBe(200)
     expect(executeAction).toHaveBeenCalledWith(action || 'complete', expect.objectContaining({ id: task.id }), undefined, source.id)
+    db.close()
+  })
+})
+
+
+describe('mobile API: all four feedback/source combinations', () => {
+  afterEach(() => { stopMobileApiServer(); vi.restoreAllMocks() })
+  it.each([
+    ['submit', true], ['submit', false], ['skip', true], ['skip', false]
+  ] as const)('%s with source action %s', async (feedback, completeAtSource) => {
+    const {db} = createTestDb()
+    const source = db.createTaskSource({name: 'dmitry ai tasks', plugin_id: 'notion', mcp_server_id: null})!
+    const agent = db.createAgent({name: 'Learning agent', server_url: '', config: {}, is_default: false})!
+    const task = db.createTask(makeTask({source_id: source.id, external_id: 'notion-page', source: 'Notion', status: 'ready_for_review'}))!
+    db.updateTask(task.id, {agent_id: agent.id})
+    const notionRecord = {status: 'open'}
+    const sourceAction = vi.fn(async () => {
+      notionRecord.status = 'closed'
+      return {success: true, taskUpdate: {status: 'completed'}}
+    })
+    const sync = new SyncManager(db, {} as never, {get: () => ({executeAction: sourceAction})} as never)
+    const token = 'four-cases-token'
+    db.createMobileSession('four-cases-session', createHash('sha256').update(token).digest('hex'), 'test-device')
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const port = await startMobileApiServer(db, {} as never, {} as never,
+      21000 + Math.floor(Math.random() * 40000), sync)
+    const response = await fetch(`http://127.0.0.1:${port}/api/tasks/${task.id}${feedback === 'skip' ? '/complete' : ''}`, {
+      method: 'POST', headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
+      body: JSON.stringify(feedback === 'skip' ? {completeAtSource} : {
+        status: 'agent_learning', feedback_rating: 4, feedback_comment: 'Useful', complete_at_source: completeAtSource
+      })
+    })
+    expect(response.status).toBe(200)
+    if (feedback === 'submit') {
+      expect(db.getTask(task.id)?.status).toBe('agent_learning')
+      expect(sourceAction).not.toHaveBeenCalled()
+      await finishSessionFeedback(db, sync, task.id)
+    }
+    expect(db.getTask(task.id)?.status).toBe('completed')
+    expect(sourceAction).toHaveBeenCalledTimes(completeAtSource ? 1 : 0)
+    expect(notionRecord.status).toBe(completeAtSource ? 'closed' : 'open')
     db.close()
   })
 })

--- a/src/main/mobile-api-server.test.ts
+++ b/src/main/mobile-api-server.test.ts
@@ -220,6 +220,28 @@ describe('mobile-api-server: source completion action', () => {
     vi.restoreAllMocks()
   })
 
+  it('completes manually without calling the source and preserves the choice after a refresh', async () => {
+    const { db } = createTestDb()
+    const source = db.createTaskSource({ name: 'Session Feedback', plugin_id: 'peakflo', mcp_server_id: null })!
+    const task = db.createTask(makeTask({ source_id: source.id, external_id: 'remote-feedback', source: 'Session Feedback' }))!
+    const executeAction = vi.fn()
+    const token = 'test-manual-token'
+    db.createMobileSession('manual-session', createHash('sha256').update(token).digest('hex'), 'test-device')
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const port = await startMobileApiServer(db, {} as never, {} as never,
+      21000 + Math.floor(Math.random() * 40000), { executeAction } as never)
+    const response = await fetch(`http://127.0.0.1:${port}/api/tasks/${task.id}/complete`, {
+      method: 'POST', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ completeAtSource: false })
+    })
+    expect(response.status).toBe(200)
+    expect(db.getTask(task.id)).toMatchObject({status: 'completed', complete_at_source: false})
+    expect(executeAction).not.toHaveBeenCalled()
+    db.updateTask(task.id, {status: 'not_started', title: 'Refreshed title'}, 'workflo-server')
+    expect(db.getTask(task.id)).toMatchObject({status: 'completed', title: 'Refreshed title', complete_at_source: false})
+    db.close()
+  })
+
   it.each(['approve', undefined])('sends the selected action %s to the source', async (action) => {
     const { db } = createTestDb()
     const source = db.createTaskSource({ name: 'Session Feedback', plugin_id: 'peakflo', mcp_server_id: null })!

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -735,17 +735,25 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
     const taskId = taskCompleteMatch[1]
     const task = db.getTask(taskId)
     if (!task) throw Object.assign(new Error('Task not found'), { status: 404 })
-    if (!task.source_id) {
-      const fresh = db.updateTask(taskId, { status: TaskStatus.Completed })
+    const completeAtSource = (params as { completeAtSource?: boolean }).completeAtSource !== false
+    if (!task.source_id || !completeAtSource) {
+      const fresh = db.updateTask(taskId, { status: TaskStatus.Completed, ...(task.source_id ? { complete_at_source: false } : {}) })
       if (fresh) {
         broadcastToMobileClients('task:updated', { taskId, updates: fresh })
         if (notifyDesktop) notifyDesktop('task:updated', { taskId, updates: fresh })
+        triggerTaskAutomation()
+        if (fresh.parent_task_id && task.status !== TaskStatus.Completed) {
+          agent.notifyParentOfSubtaskCompletion(fresh.parent_task_id, taskId).catch(err => {
+            console.error('[MobileAPI] Failed to wake parent after local completion:', err)
+          })
+        }
       }
       return { completed: true, status: fresh?.status }
     }
     if (!syncManagerRef || db.getTaskSource(task.source_id)?.plugin_id !== 'peakflo') {
       throw Object.assign(new Error('Sync this task with Workflo before completing it.'), { status: 409 })
     }
+    db.updateTask(taskId, { complete_at_source: true })
     const result = await syncManagerRef.executeAction(getTaskCompletionAction(task.output_fields), task, undefined, task.source_id)
     if (!result.success) throw Object.assign(new Error(result.error || 'Completion is pending.'), { status: 409 })
     const completed = true

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -1,3 +1,4 @@
+import { updateTaskFromUser } from './session-feedback'
 import { getTaskCompletionAction } from '../shared/task-completion'
 /**
  * Mobile API server — HTTP + WebSocket for controlling 20x from a mobile device.
@@ -750,7 +751,7 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
       }
       return { completed: true, status: fresh?.status }
     }
-    if (!syncManagerRef || db.getTaskSource(task.source_id)?.plugin_id !== 'peakflo') {
+    if (!syncManagerRef) {
       throw Object.assign(new Error('Sync this task with Workflo before completing it.'), { status: 409 })
     }
     db.updateTask(taskId, { complete_at_source: true })
@@ -770,7 +771,7 @@ async function routePost(pathname: string, params: Record<string, unknown>, req?
     const taskId = taskUpdateMatch[1]
     const existing = db.getTask(taskId)
     if (!existing) throw Object.assign(new Error('Task not found'), { status: 404 })
-    const updated = db.updateTask(taskId, params as Parameters<DatabaseManager['updateTask']>[1])
+    const updated = updateTaskFromUser(db, taskId, params as Parameters<DatabaseManager['updateTask']>[1])
     if (updated) {
       broadcastToMobileClients('task:updated', { taskId, updates: updated })
       if (notifyDesktop) notifyDesktop('task:updated', { taskId, updates: updated })

--- a/src/main/session-feedback.test.ts
+++ b/src/main/session-feedback.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestDb } from '../../test/helpers/db-test-helper'
+import { makeTask } from '../../test/helpers/task-fixtures'
+import type { DatabaseManager } from './database'
+import { updateTaskFromUser, finishSessionFeedback } from './session-feedback'
+
+describe('session feedback completion', () => {
+  let db: DatabaseManager
+  let taskId: string
+  beforeEach(() => {
+    db = createTestDb().db
+    const agent = db.createAgent({name: 'Learning agent', server_url: '', config: {}, is_default: false})!
+    const source = db.createTaskSource({name: 'dmitry ai tasks', plugin_id: 'peakflo', mcp_server_id: null})!
+    taskId = db.createTask(makeTask({source_id: source.id, external_id: 'remote-1', source: 'Notion',
+      status: 'ready_for_review', output_fields: [{id: 'action', name: 'Action', type: 'text', value: 'approve'}]}))!.id
+    db.updateTask(taskId, {agent_id: agent.id})
+  })
+  afterEach(() => db.close())
+
+  it.each([true, false])('starts learning and honors source choice %s after learning', async completeAtSource => {
+    const executeAction = vi.fn().mockResolvedValue({success: true})
+    updateTaskFromUser(db, taskId, {status: 'agent_learning', feedback_rating: 4, feedback_comment: 'Useful', complete_at_source: completeAtSource})
+    expect(db.getTask(taskId)).toMatchObject({status: 'agent_learning', complete_at_source: completeAtSource})
+    expect(executeAction).not.toHaveBeenCalled()
+    db.updateTask(taskId, {status: 'ready_for_review'}, 'workflo-server')
+    expect(db.getTask(taskId)?.status).toBe('agent_learning')
+    db.updateTask(taskId, {status: 'ready_for_review'})
+    expect(db.getTask(taskId)?.status).toBe('agent_learning')
+    await finishSessionFeedback(db, {executeAction} as never, taskId)
+    expect(db.getTask(taskId)?.status).toBe('completed')
+    if (completeAtSource) expect(executeAction).toHaveBeenCalledWith('approve', expect.objectContaining({id: taskId}), undefined, expect.any(String))
+    else expect(executeAction).not.toHaveBeenCalled()
+    await finishSessionFeedback(db, {executeAction} as never, taskId)
+    expect(executeAction).toHaveBeenCalledTimes(completeAtSource ? 1 : 0)
+  })
+
+  it('does not authorize completion without a user feedback request', async () => {
+    const executeAction = vi.fn()
+    expect(() => db.updateTask(taskId, {status: 'agent_learning', feedback_rating: 4})).toThrow()
+    await finishSessionFeedback(db, {executeAction} as never, taskId)
+    expect(executeAction).not.toHaveBeenCalled()
+    expect(db.getTask(taskId)?.status).toBe('ready_for_review')
+  })
+
+  it('leaves the task open if the source action fails after learning', async () => {
+    updateTaskFromUser(db, taskId, {status: 'agent_learning', feedback_rating: 4, complete_at_source: true})
+    const executeAction = vi.fn().mockResolvedValue({success: false, error: 'Notion unavailable'})
+    await expect(finishSessionFeedback(db, {executeAction} as never, taskId)).rejects.toThrow('Notion unavailable')
+    expect(db.getTask(taskId)?.status).toBe('ready_for_review')
+  })
+
+  it('cancels pending completion if learning cannot start', async () => {
+    updateTaskFromUser(db, taskId, {status: 'agent_learning', feedback_rating: 4, complete_at_source: true})
+    updateTaskFromUser(db, taskId, {status: 'ready_for_review'})
+    const executeAction = vi.fn()
+    await finishSessionFeedback(db, {executeAction} as never, taskId)
+    expect(executeAction).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/session-feedback.ts
+++ b/src/main/session-feedback.ts
@@ -1,0 +1,51 @@
+import type { DatabaseManager, UpdateTaskData } from './database'
+import type { SyncManager } from './sync-manager'
+import { TaskStatus } from '../shared/constants'
+import { getTaskCompletionAction } from '../shared/task-completion'
+
+const feedbackKey = (taskId: string) => `session-feedback-completion:${taskId}`
+
+/** Called only by the desktop/mobile user write routes, not the agent task API. */
+export function updateTaskFromUser(db: DatabaseManager, taskId: string, data: UpdateTaskData) {
+  if (data.status === TaskStatus.AgentLearning && data.feedback_rating !== undefined) {
+    if (!Number.isInteger(data.feedback_rating) || data.feedback_rating! < 1 || data.feedback_rating! > 5) {
+      throw new Error('Select a rating from 1 to 5.')
+    }
+    const task = db.getTask(taskId)
+    if (!task?.agent_id) throw new Error('An agent is required for session learning.')
+    if (task.status === TaskStatus.Completed) throw new Error('This task is already completed.')
+    if (task.source_id && typeof data.complete_at_source !== 'boolean') throw new Error('Select a source completion option.')
+    const result = db.updateTask(taskId, data, 'session-feedback')
+    db.setSetting(feedbackKey(taskId), JSON.stringify({ completeAtSource: data.complete_at_source !== false }))
+    return result
+  }
+  if (data.status === TaskStatus.ReadyForReview && db.getSetting(feedbackKey(taskId))) {
+    db.deleteSetting(feedbackKey(taskId))
+    return db.updateTask(taskId, data, 'session-feedback')
+  }
+  return db.updateTask(taskId, data)
+}
+
+/** Consume the user's choice only after the learning session and skill sync finish. */
+export async function finishSessionFeedback(db: DatabaseManager, sync: SyncManager | undefined, taskId: string) {
+  const pending = db.getSetting(feedbackKey(taskId))
+  if (!pending) return undefined
+  const task = db.getTask(taskId)
+  if (!task || task.status !== TaskStatus.AgentLearning) return undefined
+  const { completeAtSource } = JSON.parse(pending) as { completeAtSource: boolean }
+  db.deleteSetting(feedbackKey(taskId))
+  try {
+    if (db.getSubtasks(taskId).some(child => child.status !== TaskStatus.Completed && child.status !== TaskStatus.ReadyForReview)) {
+      throw new Error('Subtasks must finish before this task can complete.')
+    }
+    if (task.source_id && completeAtSource) {
+      if (!sync) throw new Error('Task source is unavailable.')
+      const result = await sync.executeAction(getTaskCompletionAction(task.output_fields), task, undefined, task.source_id)
+      if (!result.success) throw new Error(result.error || 'Source completion failed.')
+    }
+    return db.updateTask(taskId, { status: TaskStatus.Completed }, 'session-feedback')
+  } catch (error) {
+    db.updateTask(taskId, { status: TaskStatus.ReadyForReview }, 'session-feedback')
+    throw error
+  }
+}

--- a/src/main/sync-manager.test.ts
+++ b/src/main/sync-manager.test.ts
@@ -243,7 +243,7 @@ describe('SyncManager', () => {
       const result = await syncManager.executeAction('approve', task, undefined, 'src-1')
 
       expect(result.success).toBe(true)
-      expect(db.updateTask).toHaveBeenCalledWith('t1', { status: TaskStatus.Completed })
+      expect(db.updateTask).toHaveBeenCalledWith('t1', { status: TaskStatus.Completed }, 'task-source')
     })
   })
 })

--- a/src/main/sync-manager.test.ts
+++ b/src/main/sync-manager.test.ts
@@ -161,7 +161,7 @@ describe('SyncManager', () => {
       ;(db.getMcpServer as unknown as ReturnType<typeof vi.fn>).mockReturnValue({ id: 'srv-1' })
 
       await syncManager.exportTaskUpdate('t1', { status: 'completed', complete_at_source: false })
-      expect(plugin.exportUpdate).toHaveBeenCalledWith(expect.anything(), {status:'completed'}, {}, expect.anything())
+      expect(plugin.exportUpdate).not.toHaveBeenCalled()
     })
 
     it('still syncs non-status edits when the user chose "I\'ll do it manually"', async () => {
@@ -178,7 +178,7 @@ describe('SyncManager', () => {
       await syncManager.exportTaskUpdate('t1', { title: 'New', status: 'in_progress' })
       expect(plugin.exportUpdate).toHaveBeenCalledWith(
         expect.objectContaining({ id: 't1' }),
-        { title: 'New', status: 'in_progress' },
+        { title: 'New' },
         {},
         expect.anything()
       )

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -265,6 +265,7 @@ export class SyncManager {
     const fields = { ...changedFields }
     // Internal completion control — never a source field.
     delete fields.complete_at_source
+    if (task.complete_at_source === false) delete fields.status
     if (Object.keys(fields).length === 0) return
 
     const ctx = this.buildContext(source.mcp_server_id || undefined, task.source_id || undefined)
@@ -329,6 +330,11 @@ export class SyncManager {
         if (!key.startsWith('workflo-completion:') || key.endsWith(':error')) continue
         const command = JSON.parse(value)
         if (command.scope !== scope) continue
+        if (this.db.getTask(command.taskId)?.complete_at_source === false) {
+          this.db.deleteSetting(key)
+          this.db.deleteSetting(`${key}:error`)
+          continue
+        }
         try {
           await this.workfloApiClient.executeAction(command.externalId, command.outputs, command.expectedVersion)
           const current = await this.workfloApiClient.getTask(command.externalId)

--- a/src/main/sync-manager.ts
+++ b/src/main/sync-manager.ts
@@ -388,7 +388,7 @@ export class SyncManager {
 
     // Apply local task updates if action succeeded
     if (result.success && result.taskUpdate && Object.keys(result.taskUpdate).length > 0) {
-      this.db.updateTask(task.id, result.taskUpdate)
+      this.db.updateTask(task.id, result.taskUpdate, 'task-source')
     }
 
     return result

--- a/src/main/workflo-task-sync.test.ts
+++ b/src/main/workflo-task-sync.test.ts
@@ -228,3 +228,30 @@ it('a source-less local task completes without server acceptance',()=>{
   const draft=db.createTask(makeTask())!
   expect(db.updateTask(draft.id,{status:'completed'})?.status).toBe('completed')
 })
+
+ it('allows explicit manual completion but keeps source status in the server snapshot', () => {
+  const local = db.createTask(makeTask({ external_id: 'remote-1', source_id: sourceId }))!
+  db.setSetting(`workflo-task:${local.id}`, JSON.stringify(remote()))
+  expect(() => db.updateTask(local.id, {status: 'completed'})).toThrow()
+  expect(db.updateTask(local.id, {status: 'completed', complete_at_source: false})).toMatchObject({status: 'completed', complete_at_source: false})
+  db.updateTask(local.id, {status: 'ready_for_review'}, 'workflo-server')
+  expect(db.getTask(local.id)?.status).toBe('completed')
+  expect(JSON.parse(db.getSetting(`workflo-task:${local.id}`)!).status).toBe('not_started')
+ })
+
+ it('does not retry a queued source completion after the user chooses manual completion', async () => {
+  db.setSetting('enterprise_tenant_id', 'tenant-1')
+  const local = db.createTask(makeTask({external_id: 'remote-1', source_id: sourceId}))!
+  db.setSetting(`workflo-task:${local.id}`, JSON.stringify(remote()))
+  const api = {getDomain: () => 'api.test', executeAction: vi.fn().mockRejectedValue(new Error('offline')), getTask: vi.fn()}
+  const sync = new SyncManager(db, {} as never, {get: () => new PeakfloPlugin()} as never)
+  Object.assign(sync, {workfloApiClient: api, enterpriseUserId: 'user-1'})
+  await sync.executeAction('complete', local, undefined, sourceId)
+  expect(api.executeAction).toHaveBeenCalledTimes(1)
+  expect(db.getSetting(`workflo-completion:${local.id}`)).toBeTruthy()
+  db.updateTask(local.id, {status: 'completed', complete_at_source: false})
+  api.executeAction.mockClear()
+  await sync.flushTaskCompletions()
+  expect(api.executeAction).not.toHaveBeenCalled()
+  expect(db.getSetting(`workflo-completion:${local.id}`)).toBeUndefined()
+ })

--- a/src/mobile/api/client.ts
+++ b/src/mobile/api/client.ts
@@ -57,8 +57,8 @@ export const api = {
     get: (id: string) => get<unknown>(`/api/tasks/${encodeURIComponent(id)}`),
     create: (data: unknown) => post<unknown>('/api/tasks', data),
     update: (id: string, data: unknown) => post<unknown>(`/api/tasks/${encodeURIComponent(id)}`, data),
-    complete: (id: string) =>
-      post<{ completed: boolean; status?: string }>(`/api/tasks/${encodeURIComponent(id)}/complete`, {}),
+    complete: (id: string, completeAtSource = true) =>
+      post<{ completed: boolean; status?: string }>(`/api/tasks/${encodeURIComponent(id)}/complete`, { completeAtSource }),
     reorderSubtasks: (parentId: string, orderedIds: string[]) =>
       post<{ success: boolean }>('/api/tasks/reorder-subtasks', { parentId, orderedIds })
   },

--- a/src/mobile/pages/TaskDetailPage.test.tsx
+++ b/src/mobile/pages/TaskDetailPage.test.tsx
@@ -1,3 +1,4 @@
+import { api } from '../api/client'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, cleanup, fireEvent, waitFor, within } from '@testing-library/react'
 import { ArtifactType } from '@shared/artifacts'
@@ -84,22 +85,34 @@ afterEach(() => {
 })
 
 describe('TaskDetailPage', () => {
-  it.each(['Skip', 'Submit Feedback'])('sends the manual choice through %s', async (button) => {
-    const task = makeTask({agent_id: 'agent-1', source_id: 'feedback', source: 'Session Feedback'})
+  it.each([
+    ['Submit Feedback', true], ['Submit Feedback', false], ['Skip', true], ['Skip', false]
+  ] as const)('%s with source completion %s', async (button, completeAtSource) => {
+    const task = makeTask({agent_id: 'agent-1', source_id: 'feedback', source: 'Notion', session_id: 'persisted'})
     const originalUpdate = useTaskStore.getState().updateTask
-    const updateTask = vi.fn().mockResolvedValue(undefined)
+    const updateTask = vi.fn().mockResolvedValue(true)
+    const resume = vi.spyOn(api.sessions, 'resume').mockResolvedValue({sessionId: 'persisted'})
+    const send = vi.spyOn(api.sessions, 'send').mockResolvedValue({success: true})
     useTaskStore.setState({tasks: [task], isLoading: false, updateTask})
     try {
       const view = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
       fireEvent.click(view.getByTestId('main-cta-complete'))
-      fireEvent.click(view.getByRole('radio', {name: "I'll do it manually"}))
+      if (!completeAtSource) fireEvent.click(view.getByRole('radio', {name: "I'll do it manually"}))
       fireEvent.click(view.getByRole('button', {name: 'Rate 4'}))
-      expect(completeMock).not.toHaveBeenCalled()
       fireEvent.click(view.getByRole('button', {name: button}))
-      await waitFor(() => expect(completeMock).toHaveBeenCalledWith(task.id, false))
+      if (button === 'Submit Feedback') {
+        await waitFor(() => expect(send).toHaveBeenCalledWith('persisted', expect.stringContaining('Review the session and update skills'), task.id, task.agent_id))
+        expect(updateTask).toHaveBeenCalledWith(task.id, {status: 'agent_learning', feedback_rating: 4, feedback_comment: null, complete_at_source: completeAtSource})
+        expect(completeMock).not.toHaveBeenCalled()
+      } else {
+        await waitFor(() => expect(completeMock).toHaveBeenCalledWith(task.id, completeAtSource))
+        expect(send).not.toHaveBeenCalled()
+      }
     } finally {
       cleanup()
       useTaskStore.setState({updateTask: originalUpdate})
+      resume.mockRestore()
+      send.mockRestore()
     }
   })
 

--- a/src/mobile/pages/TaskDetailPage.test.tsx
+++ b/src/mobile/pages/TaskDetailPage.test.tsx
@@ -84,6 +84,25 @@ afterEach(() => {
 })
 
 describe('TaskDetailPage', () => {
+  it.each(['Skip', 'Submit Feedback'])('sends the manual choice through %s', async (button) => {
+    const task = makeTask({agent_id: 'agent-1', source_id: 'feedback', source: 'Session Feedback'})
+    const originalUpdate = useTaskStore.getState().updateTask
+    const updateTask = vi.fn().mockResolvedValue(undefined)
+    useTaskStore.setState({tasks: [task], isLoading: false, updateTask})
+    try {
+      const view = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
+      fireEvent.click(view.getByTestId('main-cta-complete'))
+      fireEvent.click(view.getByRole('radio', {name: "I'll do it manually"}))
+      fireEvent.click(view.getByRole('button', {name: 'Rate 4'}))
+      expect(completeMock).not.toHaveBeenCalled()
+      fireEvent.click(view.getByRole('button', {name: button}))
+      await waitFor(() => expect(completeMock).toHaveBeenCalledWith(task.id, false))
+    } finally {
+      cleanup()
+      useTaskStore.setState({updateTask: originalUpdate})
+    }
+  })
+
   it.each(['approve', undefined])('shows the Session Feedback action %s before Skip completes', async (action) => {
     const task = makeTask({ agent_id: 'agent-1', source_id: 'session-feedback', source: 'Session Feedback',
       output_fields: action ? [{ id: 'action', value: action }] : [] })
@@ -94,7 +113,7 @@ describe('TaskDetailPage', () => {
     expect(dialog.getByText(`Action at Session Feedback: ${action || 'complete'}. Completion sends this action and the task outputs to the source.`)).toBeTruthy()
     expect(completeMock).not.toHaveBeenCalled()
     fireEvent.click(dialog.getByRole('button', { name: 'Skip' }))
-    await waitFor(() => expect(completeMock).toHaveBeenCalledWith(task.id))
+    await waitFor(() => expect(completeMock).toHaveBeenCalledWith(task.id, true))
   })
 
   it('cancels source feedback without completing', () => {
@@ -371,13 +390,20 @@ describe('TaskDetailPage', () => {
     unmount()
   })
 
-  it.each([null, 'src-1'])('requests server completion for source %s without a local choice', (sourceId) => {
+  it.each([null, 'src-1'])('asks before completing source %s', (sourceId) => {
     completeMock.mockClear()
     const task = makeTask({ source_id: sourceId, complete_at_source: false })
     useTaskStore.setState({ tasks: [task], isLoading: false })
-    const { getByTestId, queryByText } = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
+    const { getByTestId, getByRole, queryByText } = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
     fireEvent.click(getByTestId('main-cta-complete'))
-    expect(completeMock).toHaveBeenCalledWith('task-1')
-    expect(queryByText("I'll do it manually")).toBeNull()
+    if (sourceId) {
+      expect(completeMock).not.toHaveBeenCalled()
+      fireEvent.click(getByRole('radio', { name: "I'll do it manually" }))
+      fireEvent.click(getByRole('button', { name: 'Complete' }))
+      expect(completeMock).toHaveBeenCalledWith('task-1', false)
+    } else {
+      expect(completeMock).toHaveBeenCalledWith('task-1', true)
+      expect(queryByText("I'll do it manually")).toBeNull()
+    }
   })
 })

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -169,9 +169,9 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
     if (session?.sessionId) _stopSession(session.sessionId)
   }, [session?.sessionId, _stopSession])
 
-  const completeTaskNow = useCallback(async (t: Task) => {
+  const completeTaskNow = useCallback(async (t: Task, completeAtSource = true) => {
     try {
-      await api.tasks.complete(t.id)
+      await api.tasks.complete(t.id, completeAtSource)
     } catch (error) {
       window.alert(error instanceof Error ? error.message : 'Workflo has not confirmed completion.')
     }
@@ -179,21 +179,21 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
 
   const handleCompleteTask = useCallback(async () => {
     if (!task) return
-    if (task.agent_id) setCompleteModal({ withFeedback: true })
+    if (task.agent_id || task.source_id) setCompleteModal({ withFeedback: !!task.agent_id })
     else await completeTaskNow(task)
   }, [task, completeTaskNow])
 
-  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string) => {
+  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string, completeAtSource: boolean) => {
     if (!task) return
     setCompleteModal(null)
     await updateTask(task.id, { feedback_rating: rating, feedback_comment: comment || null })
-    await completeTaskNow(task)
+    await completeTaskNow(task, completeAtSource)
   }, [task, updateTask, completeTaskNow])
 
-  const handleFeedbackSkip = useCallback(async () => {
+  const handleFeedbackSkip = useCallback(async (completeAtSource: boolean) => {
     if (!task) return
     setCompleteModal(null)
-    await completeTaskNow(task)
+    await completeTaskNow(task, completeAtSource)
   }, [task, completeTaskNow])
 
   // Skills available for this agent — must be before conditional return (Rules of Hooks)
@@ -812,6 +812,8 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
       {completeModal && (
         <FeedbackModal
           completionDescription={getSourceCompletionDescription(task)}
+          sourceName={task.source_id ? task.source || 'the task source' : undefined}
+          withFeedback={completeModal.withFeedback}
           onSubmit={handleFeedbackSubmit}
           onSkip={handleFeedbackSkip}
           onCancel={() => setCompleteModal(null)}
@@ -937,32 +939,40 @@ function SubtasksSection({ subtasks, onNavigateToTask, onReorderSubtasks }: { su
   )
 }
 
-function FeedbackModal({ onSubmit, onSkip, onCancel, completionDescription }: {
+function FeedbackModal({ onSubmit, onSkip, onCancel, completionDescription, sourceName, withFeedback }: {
   completionDescription?: string
-  onSubmit: (rating: number, comment: string) => void
-  onSkip: () => void
+  sourceName?: string
+  withFeedback: boolean
+  onSubmit: (rating: number, comment: string, completeAtSource: boolean) => void
+  onSkip: (completeAtSource: boolean) => void
   onCancel: () => void
 }) {
   const [rating, setRating] = useState(0)
   const [comment, setComment] = useState('')
+  const [completeAtSource, setCompleteAtSource] = useState(true)
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div role="dialog" aria-label="Session feedback" className="mx-4 w-full max-w-md rounded-xl border bg-card p-5 space-y-4">
-        <h2>Session feedback</h2>
-        {completionDescription && (
+      <div role="dialog" aria-label={withFeedback ? 'Session feedback' : 'Complete task'} className="mx-4 w-full max-w-md rounded-xl border bg-card p-5 space-y-4">
+        <h2>{withFeedback ? 'Session feedback' : 'Complete task'}</h2>
+        {sourceName && (
           <div className="rounded-md border p-3 text-sm space-y-2">
-            <p>{completionDescription}</p>
-            <p>Skip omits only the session rating and comment.</p>
+            <p>{completeAtSource ? completionDescription : 'Complete in 20x only. The source record will not change.'}</p>
+            <div className="flex gap-2">
+              <button className={`flex-1 rounded-md border px-2 py-2 ${completeAtSource ? 'border-ring bg-accent' : 'border-border text-muted-foreground'}`} role="radio" aria-checked={completeAtSource} onClick={() => setCompleteAtSource(true)}>Close it in {sourceName}</button>
+              <button className={`flex-1 rounded-md border px-2 py-2 ${!completeAtSource ? 'border-ring bg-accent' : 'border-border text-muted-foreground'}`} role="radio" aria-checked={!completeAtSource} onClick={() => setCompleteAtSource(false)}>I'll do it manually</button>
+            </div>
           </div>
         )}
-        <div className="flex gap-2">
-          {[1, 2, 3, 4, 5].map(value => <button key={value} aria-label={`Rate ${value}`} aria-pressed={rating === value} onClick={() => setRating(value)}>{value}</button>)}
-        </div>
-        <textarea aria-label="Feedback" placeholder="Optional feedback..." value={comment} onChange={event => setComment(event.target.value)} />
+        {withFeedback && <>
+          <div className="flex gap-2">
+            {[1, 2, 3, 4, 5].map(value => <button key={value} aria-label={`Rate ${value}`} aria-pressed={rating === value} onClick={() => setRating(value)}>{value}</button>)}
+          </div>
+          <textarea aria-label="Feedback" placeholder="Optional feedback..." value={comment} onChange={event => setComment(event.target.value)} />
+        </>}
         <div className="flex gap-3">
           <button onClick={onCancel}>Cancel</button>
-          <button onClick={onSkip}>Skip</button>
-          <button disabled={!rating} onClick={() => onSubmit(rating, comment)}>Submit Feedback</button>
+          <button onClick={() => onSkip(completeAtSource)}>{withFeedback ? 'Skip' : 'Complete'}</button>
+          {withFeedback && <button disabled={!rating} onClick={() => onSubmit(rating, comment, completeAtSource)}>Submit Feedback</button>}
         </div>
       </div>
     </div>

--- a/src/mobile/pages/TaskDetailPage.tsx
+++ b/src/mobile/pages/TaskDetailPage.tsx
@@ -1,4 +1,4 @@
-import { getSourceCompletionDescription } from '@shared/task-completion'
+import { getSourceCompletionDescription, getTaskSourceName } from '@shared/task-completion'
 import { useMemo, useCallback, useEffect, useState, useRef } from 'react'
 import { TaskStatus } from '@shared/constants'
 import { isAgentConfigured, getAgentConfigIssue } from '@shared/agent-utils'
@@ -184,11 +184,26 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
   }, [task, completeTaskNow])
 
   const handleFeedbackSubmit = useCallback(async (rating: number, comment: string, completeAtSource: boolean) => {
-    if (!task) return
+    if (!task?.agent_id) return
+    const saved = await updateTask(task.id, {status: TaskStatus.AgentLearning, feedback_rating: rating,
+      feedback_comment: comment || null, complete_at_source: completeAtSource})
+    if (!saved) return
     setCompleteModal(null)
-    await updateTask(task.id, { feedback_rating: rating, feedback_comment: comment || null })
-    await completeTaskNow(task, completeAtSource)
-  }, [task, updateTask, completeTaskNow])
+    try {
+      let sessionId = session?.sessionId
+      if (!sessionId && task.session_id) {
+        sessionId = (await api.sessions.resume(task.session_id, task.agent_id, task.id)).sessionId
+      }
+      if (!sessionId) sessionId = (await api.sessions.start(task.agent_id, task.id, true)).sessionId
+      initSession(task.id, sessionId, task.agent_id)
+      await api.sessions.send(sessionId,
+        `User rated this session ${rating}/5. Comment: "${comment}". Review the session and update skills in .agents/skills/. Update confidence, uses, lastUsed, and tags for useful skills. Create skills for new reusable patterns.`,
+        task.id, task.agent_id)
+    } catch (error) {
+      await updateTask(task.id, {status: TaskStatus.ReadyForReview})
+      window.alert(error instanceof Error ? error.message : 'Could not start the learning session.')
+    }
+  }, [task, session, updateTask, initSession])
 
   const handleFeedbackSkip = useCallback(async (completeAtSource: boolean) => {
     if (!task) return
@@ -812,7 +827,7 @@ export function TaskDetailPage({ taskId, onNavigate }: { taskId: string; onNavig
       {completeModal && (
         <FeedbackModal
           completionDescription={getSourceCompletionDescription(task)}
-          sourceName={task.source_id ? task.source || 'the task source' : undefined}
+          sourceName={task.source_id ? getTaskSourceName(task) : undefined}
           withFeedback={completeModal.withFeedback}
           onSubmit={handleFeedbackSubmit}
           onSkip={handleFeedbackSkip}

--- a/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.test.tsx
@@ -212,12 +212,14 @@ describe('TaskPanelContent', () => {
     })
     render(<TaskPanelContent panelId="panel-1" taskId="task-1" panelLayout="both" />)
     fireEvent.click(screen.getByText('Complete task'))
+    expect(executeActionMock).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByTestId('complete-at-source'))
     await waitFor(() => expect(apiRequest).toHaveBeenCalledWith('POST', '/api/tasks/remote-1/action',
       { outputs: { action: 'complete' }, expectedVersion: 7 },
       { 'x-task-contract-version': '2', 'x-task-actor': 'human' }))
     expect(executeActionMock).toHaveBeenCalledExactlyOnceWith('complete', 'task-1', 'src-1')
-    expect(updateTaskMock).not.toHaveBeenCalled()
-    // A single shared confirmation exists for every source — no source dialog.
+    expect(updateTaskMock).toHaveBeenCalledWith('task-1', {complete_at_source: true})
+    // The dialog closes after the source confirms completion.
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 })

--- a/src/renderer/src/components/canvas/TaskPanelContent.tsx
+++ b/src/renderer/src/components/canvas/TaskPanelContent.tsx
@@ -32,7 +32,7 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
   const openEditModal = useUIStore((s) => s.openEditModal)
   const openDeleteModal = useUIStore((s) => s.openDeleteModal)
   // Completion is server-confirmed through the shared hook (same for every source).
-  const { requestComplete } = useTaskCompletion()
+  const { requestComplete, completionDialog } = useTaskCompletion()
 
   const handleEdit = useCallback(() => {
     if (task) openEditModal(task.id)
@@ -56,8 +56,8 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
     [task, updateTask]
   )
 
-  const handleCompleteTask = useCallback(async () => {
-    if (task) await requestComplete(task.id)
+  const handleCompleteTask = useCallback(async (completeAtSource?: boolean) => {
+    if (task) await requestComplete(task.id, { completeAtSource })
   }, [task, requestComplete])
 
   const handleAssignAgent = useCallback(
@@ -135,6 +135,7 @@ export function TaskPanelContent({ panelId, taskId, panelLayout = 'both' }: Task
 
   return (
     <div className="h-full select-text">
+      {completionDialog}
       <TaskWorkspace
         task={task}
         agents={agents}

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -158,7 +158,7 @@ export function AppLayout() {
   useEffect(() => onShortcutFeedback(({ message, isError }) => showToast(message, isError)), [showToast])
 
   // Completion is server-confirmed through the shared hook (same for every source).
-  const { requestComplete } = useTaskCompletion({ onToast: showToast })
+  const { requestComplete, completionDialog } = useTaskCompletion({ onToast: showToast })
 
   // A completion that the main process could not push to the source sends the
   // task back to review. Without this the user sees the task reappear with no
@@ -180,8 +180,9 @@ export function AppLayout() {
   )
 
   const completeTask = useCallback(
-    async (taskId: string, options?: { selectNextTask?: boolean }) => {
+    async (taskId: string, options?: { selectNextTask?: boolean; completeAtSource?: boolean }) => {
       await requestComplete(taskId, {
+        completeAtSource: options?.completeAtSource,
         onCompleted: options?.selectNextTask
           ? (task) => selectNextActiveTask(task.id)
           : undefined
@@ -209,8 +210,8 @@ export function AppLayout() {
     },
     [selectedTaskId, updateTask]
   )
-  const handleCompleteSelectedTask = useCallback(async () => {
-    if (selectedTaskId) await completeTask(selectedTaskId, { selectNextTask: true })
+  const handleCompleteSelectedTask = useCallback(async (completeAtSource?: boolean) => {
+    if (selectedTaskId) await completeTask(selectedTaskId, { selectNextTask: true, completeAtSource })
   }, [completeTask, selectedTaskId])
 
   const handleAssignAgent = useCallback(async (taskId: string, agentId: string | null) => {
@@ -239,8 +240,8 @@ export function AppLayout() {
     },
     [dashboardPreviewTaskId, updateTask]
   )
-  const handleCompleteDashboardPreviewTask = useCallback(async () => {
-    if (dashboardPreviewTaskId) await completeTask(dashboardPreviewTaskId)
+  const handleCompleteDashboardPreviewTask = useCallback(async (completeAtSource?: boolean) => {
+    if (dashboardPreviewTaskId) await completeTask(dashboardPreviewTaskId, { completeAtSource })
   }, [completeTask, dashboardPreviewTaskId])
 
   const activeTaskId = dashboardPreviewTaskId || selectedTaskId || null
@@ -643,6 +644,7 @@ export function AppLayout() {
 
   return (
     <>
+      {completionDialog}
       {/* ── Top bar: drag region with logo (left) + nav switcher (center) + actions (right) ── */}
       <div className="app-chrome drag-region bg-background h-8 flex-shrink-0 flex items-center justify-center px-3 pt-2.5 windows-titlebar-pad">
         {/* Logo + wordmark + update indicator — pinned left. The white logo mark

--- a/src/renderer/src/components/tasks/CompleteAtSourceDialog.tsx
+++ b/src/renderer/src/components/tasks/CompleteAtSourceDialog.tsx
@@ -1,0 +1,73 @@
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel
+} from '@/components/ui/AlertDialog'
+import { Button } from '@/components/ui/Button'
+
+export interface CompleteAtSourceDialogProps {
+  isOpen: boolean
+  /** Title of the task being completed. */
+  taskTitle: string
+  /** Display name of the task source, e.g. "Linear — Engineering". */
+  sourceName: string
+  /** True while one of the two completion paths runs. */
+  isBusy?: boolean
+  /** Complete the task in the external source, then locally. */
+  onCompleteAtSource: () => void
+  /** Complete the task locally only — the user updates the source. */
+  onCompleteManually: () => void
+  onCancel: () => void
+}
+
+/**
+ * Asks the user how a task that came from an external source must be completed:
+ * in the source system, or locally only.
+ */
+export function CompleteAtSourceDialog({
+  isOpen,
+  taskTitle,
+  sourceName,
+  isBusy = false,
+  onCompleteAtSource,
+  onCompleteManually,
+  onCancel
+}: CompleteAtSourceDialogProps) {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={(open) => !open && !isBusy && onCancel()}>
+      <AlertDialogContent data-testid="complete-at-source-dialog">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Complete in {sourceName}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            "{taskTitle}" came from {sourceName}. 20x can close it there for you, or you can
+            mark it complete here only and update {sourceName} yourself.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-col-reverse sm:flex-row sm:justify-end">
+          <AlertDialogCancel disabled={isBusy} onClick={onCancel}>
+            Cancel
+          </AlertDialogCancel>
+          <Button
+            variant="outline"
+            disabled={isBusy}
+            onClick={onCompleteManually}
+            data-testid="complete-manually"
+          >
+            I'll do it manually
+          </Button>
+          <Button
+            disabled={isBusy}
+            onClick={onCompleteAtSource}
+            data-testid="complete-at-source"
+          >
+            Complete at source
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, fireEvent, within, cleanup } from '@testing-library/rea
 import { FeedbackDialog } from './FeedbackDialog'
 
 describe('FeedbackDialog', () => {
-  const onSubmit = vi.fn<(rating: number, comment: string) => void>()
-  const onSkip = vi.fn<() => void>()
+  const onSubmit = vi.fn<(rating: number, comment: string, completeAtSource: boolean) => void>()
+  const onSkip = vi.fn<(completeAtSource: boolean) => void>()
   const onCancel = vi.fn<() => void>()
 
   beforeEach(() => {
@@ -15,9 +15,8 @@ describe('FeedbackDialog', () => {
   // lookups match more than one element.
   afterEach(cleanup)
 
-  // Completion is identical for every source (Workflo, Notion, …): the dialog
-  // never offers a source-specific or local-only choice.
-  it('never offers source-specific completion choices', () => {
+  // Local tasks do not need a source choice.
+  it('does not offer source choices for local tasks', () => {
     render(<FeedbackDialog open={true} onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
     expect(screen.queryByTestId('source-completion-choice')).toBeNull()
     expect(screen.queryByTestId('choice-complete-manually')).toBeNull()
@@ -56,7 +55,7 @@ describe('FeedbackDialog', () => {
   })
 
   it('calls onSubmit with rating and comment when submitted', () => {
-    render(<FeedbackDialog open={true} completionDescription="Action at Session Feedback: approve." onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
+    render(<FeedbackDialog open={true} sourceName="Session Feedback" completionDescription="Action at Session Feedback: approve." onSubmit={onSubmit} onSkip={onSkip} onCancel={onCancel} />)
     const dialog = getDialog()
     expect(within(dialog).getByText('Action at Session Feedback: approve.')).toBeInTheDocument()
     expect(onSubmit).not.toHaveBeenCalled()
@@ -73,6 +72,22 @@ describe('FeedbackDialog', () => {
 
     // Submit
     fireEvent.click(within(dialog).getByText('Submit Feedback'))
-    expect(onSubmit).toHaveBeenCalledWith(4, 'Great session!')
+    expect(onSubmit).toHaveBeenCalledWith(4, 'Great session!', true)
+  })
+})
+
+describe('manual feedback completion', () => {
+  afterEach(cleanup)
+  it.each(['Skip', 'Submit Feedback'])('keeps the manual choice through %s', (button) => {
+    const onSubmit = vi.fn()
+    const onSkip = vi.fn()
+    render(<FeedbackDialog open sourceName="Session Feedback" onSubmit={onSubmit} onSkip={onSkip} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: "I'll do it manually" }))
+    expect(screen.getByText('Complete in 20x only. The source record will not change.')).toBeInTheDocument()
+    const stars = within(screen.getByRole('dialog')).getAllByRole('button').filter(button => button.querySelector('svg'))
+    fireEvent.click(stars[3])
+    fireEvent.click(screen.getByRole('button', { name: button }))
+    if (button === 'Skip') expect(onSkip).toHaveBeenCalledWith(false)
+    else expect(onSubmit).toHaveBeenCalledWith(4, '', false)
   })
 })

--- a/src/renderer/src/components/tasks/FeedbackDialog.tsx
+++ b/src/renderer/src/components/tasks/FeedbackDialog.tsx
@@ -3,19 +3,28 @@ import { Star } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogBody, DialogTitle, DialogDescription } from '@/components/ui/Dialog'
 import { Button } from '@/components/ui/Button'
 import { Textarea } from '@/components/ui/Textarea'
+import { cn } from '@/lib/utils'
 
 interface FeedbackDialogProps {
   completionDescription?: string
   open: boolean
-  onSubmit: (rating: number, comment: string) => void
-  onSkip: () => void
+  /**
+   * Display name of the external source, when the task came from one. Set it to
+   * show the completion choice; leave it undefined for a local task.
+   */
+  sourceName?: string | null
+  onSubmit: (rating: number, comment: string, completeAtSource: boolean) => void
+  onSkip: (completeAtSource: boolean) => void
   onCancel: () => void
 }
 
-export function FeedbackDialog({ open, onSubmit, onSkip, onCancel, completionDescription }: FeedbackDialogProps) {
+export function FeedbackDialog({ open, sourceName, onSubmit, onSkip, onCancel, completionDescription }: FeedbackDialogProps) {
   const [rating, setRating] = useState(0)
   const [hoveredStar, setHoveredStar] = useState(0)
   const [comment, setComment] = useState('')
+  // Defaults to closing the task at the source, which is what 20x did before
+  // the choice existed.
+  const [completeAtSource, setCompleteAtSource] = useState(true)
 
   // Reset state when dialog opens
   useEffect(() => {
@@ -23,11 +32,12 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel, completionDes
       setRating(0)
       setHoveredStar(0)
       setComment('')
+      setCompleteAtSource(true)
     }
   }, [open])
 
   const handleSubmit = () => {
-    if (rating > 0) onSubmit(rating, comment)
+    if (rating > 0) onSubmit(rating, comment, completeAtSource)
   }
 
   return (
@@ -40,12 +50,6 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel, completionDes
           </DialogDescription>
         </DialogHeader>
         <DialogBody className="flex flex-col gap-4">
-          {completionDescription && (
-            <div className="rounded-md border p-3 text-sm space-y-2">
-              <p>{completionDescription}</p>
-              <p>Skip omits only the session rating and comment.</p>
-            </div>
-          )}
           <div className="flex gap-1 justify-center">
             {[1, 2, 3, 4, 5].map((star) => (
               <button
@@ -73,8 +77,33 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel, completionDes
             rows={3}
           />
 
+          {sourceName && (
+            <div className="flex flex-col gap-2 rounded-lg border border-border/50 p-3" data-testid="source-completion-choice">
+              <p className="text-xs text-muted-foreground">
+                {completeAtSource ? completionDescription : 'Complete in 20x only. The source record will not change.'}
+              </p>
+              <span className="text-xs font-medium text-foreground">
+                This task came from {sourceName}
+              </span>
+              <div className="flex gap-2">
+                <ChoiceButton
+                  selected={completeAtSource}
+                  onClick={() => setCompleteAtSource(true)}
+                  testId="choice-complete-at-source"
+                  label={`Close it in ${sourceName}`}
+                />
+                <ChoiceButton
+                  selected={!completeAtSource}
+                  onClick={() => setCompleteAtSource(false)}
+                  testId="choice-complete-manually"
+                  label="I'll do it manually"
+                />
+              </div>
+            </div>
+          )}
+
           <div className="flex gap-2 justify-end">
-            <Button variant="ghost" size="sm" onClick={() => onSkip()}>
+            <Button variant="ghost" size="sm" onClick={() => onSkip(completeAtSource)}>
               Skip
             </Button>
             <Button size="sm" disabled={rating === 0} onClick={handleSubmit}>
@@ -84,5 +113,35 @@ export function FeedbackDialog({ open, onSubmit, onSkip, onCancel, completionDes
         </DialogBody>
       </DialogContent>
     </Dialog>
+  )
+}
+
+function ChoiceButton({
+  selected,
+  onClick,
+  label,
+  testId
+}: {
+  selected: boolean
+  onClick: () => void
+  label: string
+  testId: string
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      data-testid={testId}
+      onClick={onClick}
+      className={cn(
+        'flex-1 rounded-md border px-2.5 py-1.5 text-[11px] transition-colors',
+        selected
+          ? 'border-ring bg-accent/60 text-foreground'
+          : 'border-border/50 text-muted-foreground hover:bg-accent/30'
+      )}
+    >
+      {label}
+    </button>
   )
 }

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -138,6 +138,18 @@ describe('clampTranscriptWidth', () => {
 })
 
 describe('TaskWorkspace keyboard actions', () => {
+  it.each([true, false])('passes source choice %s after submitting feedback', async (completeAtSource) => {
+    const task = makeRendererTask({status: TaskStatus.ReadyForReview, session_id: 'persisted', source_id: 'feedback', source: 'Session Feedback'})
+    renderWorkspace(task)
+    act(() => dispatchTaskShortcut({ action: TaskShortcutAction.COMPLETE, taskId: task.id }))
+    if (!completeAtSource) fireEvent.click(screen.getByRole('radio', {name: "I'll do it manually"}))
+    const stars = screen.getAllByRole('button').filter(button => button.querySelector('svg.lucide-star'))
+    fireEvent.click(stars[3])
+    fireEvent.click(screen.getByRole('button', {name: 'Submit Feedback'}))
+    await waitFor(() => expect(noopFn).toHaveBeenCalledWith(completeAtSource))
+    expect(window.electronAPI.db.updateTask).toHaveBeenCalledWith(task.id, {feedback_rating: 4, feedback_comment: null})
+  })
+
   it.each(['approve', undefined])('shows the Session Feedback source action %s before completion', async (action) => {
     const task = makeRendererTask({
       status: TaskStatus.ReadyForReview,
@@ -149,10 +161,11 @@ describe('TaskWorkspace keyboard actions', () => {
     renderWorkspace(task)
     act(() => dispatchTaskShortcut({ action: TaskShortcutAction.COMPLETE, taskId: task.id }))
     expect(screen.getByText(`Action at Session Feedback: ${action || 'complete'}. Completion sends this action and the task outputs to the source.`)).toBeInTheDocument()
-    expect(screen.getByText('Skip omits only the session rating and comment.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('radio', { name: "I'll do it manually" }))
+    expect(screen.getByText('Complete in 20x only. The source record will not change.')).toBeInTheDocument()
     expect(noopFn).not.toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
-    await waitFor(() => expect(noopFn).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(noopFn).toHaveBeenCalledWith(false))
   })
 
   it('opens session feedback instead of completing immediately', () => {

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -1,3 +1,4 @@
+import { useTaskSourceStore } from '@/stores/task-source-store'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, act, fireEvent, screen, waitFor, cleanup } from '@testing-library/react'
 import { clampTranscriptWidth, TaskWorkspace } from './TaskWorkspace'
@@ -109,6 +110,7 @@ afterEach(() => {
 })
 
 beforeEach(() => {
+  useTaskSourceStore.setState({sources: []})
   useAgentStore.setState({
     agents: [],
     isLoading: false,
@@ -138,16 +140,43 @@ describe('clampTranscriptWidth', () => {
 })
 
 describe('TaskWorkspace keyboard actions', () => {
-  it.each([true, false])('passes source choice %s after submitting feedback', async (completeAtSource) => {
-    const task = makeRendererTask({status: TaskStatus.ReadyForReview, session_id: 'persisted', source_id: 'feedback', source: 'Session Feedback'})
+  it('uses Notion for both the feedback button and action description', () => {
+    useTaskSourceStore.setState({sources: [{id: 'src-notion', name: 'dmitry ai tasks', plugin_id: 'notion',
+      mcp_server_id: '', config: {}, list_tool: '', list_tool_args: {}, update_tool: '', update_tool_args: {},
+      enabled: true, last_synced_at: null, created_at: '', updated_at: ''}]})
+    const task = makeRendererTask({source_id: 'src-notion', source: 'Notion', session_id: 'persisted', status: TaskStatus.ReadyForReview})
+    renderWorkspace(task)
+    act(() => dispatchTaskShortcut({action: TaskShortcutAction.COMPLETE, taskId: task.id}))
+    expect(screen.getByRole('radio', {name: 'Close it in Notion'})).toBeInTheDocument()
+    expect(screen.getByText('Action at Notion: complete. Completion sends this action and the task outputs to the source.')).toBeInTheDocument()
+    expect(screen.queryByRole('radio', {name: 'Close it in dmitry ai tasks'})).toBeNull()
+  })
+
+  it.each([
+    ['Submit Feedback', true], ['Submit Feedback', false], ['Skip', true], ['Skip', false]
+  ] as const)('%s with source completion %s', async (button, completeAtSource) => {
+    const task = makeRendererTask({status: TaskStatus.ReadyForReview, session_id: 'persisted', source_id: 'feedback', source: 'Notion'})
+    useAgentStore.getState().initSession(task.id, 'persisted', 'agent-1')
+    useAgentStore.setState(state => ({sessions: new Map(state.sessions).set(task.id, {
+      ...state.sessions.get(task.id)!, status: SessionStatus.IDLE,
+      messages: [{id: 'previous', role: 'assistant', content: 'Task done', timestamp: new Date()}]
+    })}))
     renderWorkspace(task)
     act(() => dispatchTaskShortcut({ action: TaskShortcutAction.COMPLETE, taskId: task.id }))
     if (!completeAtSource) fireEvent.click(screen.getByRole('radio', {name: "I'll do it manually"}))
     const stars = screen.getAllByRole('button').filter(button => button.querySelector('svg.lucide-star'))
     fireEvent.click(stars[3])
-    fireEvent.click(screen.getByRole('button', {name: 'Submit Feedback'}))
-    await waitFor(() => expect(noopFn).toHaveBeenCalledWith(completeAtSource))
-    expect(window.electronAPI.db.updateTask).toHaveBeenCalledWith(task.id, {feedback_rating: 4, feedback_comment: null})
+    fireEvent.click(screen.getByRole('button', {name: button}))
+    if (button === 'Submit Feedback') {
+      await waitFor(() => expect(window.electronAPI.agentSession.send).toHaveBeenCalledWith('persisted', expect.stringContaining('Review the session and update skills'), task.id, 'agent-1', undefined))
+      expect(window.electronAPI.db.updateTask).toHaveBeenCalledWith(task.id, {
+        status: TaskStatus.AgentLearning, feedback_rating: 4, feedback_comment: null, complete_at_source: completeAtSource
+      })
+      expect(noopFn).not.toHaveBeenCalled()
+    } else {
+      await waitFor(() => expect(noopFn).toHaveBeenCalledWith(completeAtSource))
+      expect(window.electronAPI.agentSession.send).not.toHaveBeenCalled()
+    }
   })
 
   it.each(['approve', undefined])('shows the Session Feedback source action %s before completion', async (action) => {

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -1,4 +1,4 @@
-import { getSourceCompletionDescription } from '@shared/task-completion'
+import { getSourceCompletionDescription, getTaskSourceName } from '@shared/task-completion'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { LayoutList, Send, Sparkles } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
@@ -658,18 +658,13 @@ function TaskWorkspaceComponent({
     if (!task?.agent_id || !task?.id) return
     setShowFeedback(false)
 
-    if (task.source_id || task.server_managed) {
-      await taskApi.update(task.id, {feedback_rating:rating,feedback_comment:comment || null})
-      await onCompleteTask(completeAtSource)
-      return
-    }
-
     // Persist feedback + set task to Learning status - prevents auto-stop useEffect.
     console.log('[TaskWorkspace] Setting task status to AgentLearning:', task.id)
     let updatedTask: WorkfloTask | null | undefined
     try {
       updatedTask = await taskApi.update(task.id, {
         status: TaskStatus.AgentLearning,
+        complete_at_source: completeAtSource,
         feedback_rating: rating,
         feedback_comment: comment || null,
       })
@@ -724,7 +719,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
     try {
       if (!session.sessionId) {
         const readySessionId = await ensureChatSession()
-        if (!readySessionId) return
+        if (!readySessionId) throw new Error('Could not start the learning session.')
 
         // Wait for messages to load (poll for session to be ready)
         await new Promise<void>((resolve) => {
@@ -1237,7 +1232,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
 
       <FeedbackDialog
         open={showFeedback}
-        sourceName={task?.source_id ? taskSources.find(source => source.id === task.source_id)?.name || task.source || 'the task source' : undefined}
+        sourceName={task?.source_id ? getTaskSourceName(task, taskSources.find(source => source.id === task.source_id)?.name) : undefined}
         completionDescription={task ? getSourceCompletionDescription(task, taskSources.find(source => source.id === task.source_id)?.name) : undefined}
         onSubmit={handleFeedbackSubmit}
         onSkip={handleFeedbackSkip}

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -76,7 +76,7 @@ interface TaskWorkspaceProps {
   onDelete: () => void
   onUpdateAttachments: (attachments: FileAttachment[]) => void
   onUpdateOutputFields: (fields: OutputField[]) => void
-  onCompleteTask: () => void
+  onCompleteTask: (completeAtSource?: boolean) => void
   onAssignAgent: (taskId: string, agentId: string | null) => void
   onUpdateTask?: (taskId: string, data: Record<string, unknown>) => Promise<void>
   onNavigateToTask?: (taskId: string) => void
@@ -654,13 +654,13 @@ function TaskWorkspaceComponent({
     }
   }, [session.sessionId, session.messages.length, task?.session_id, onCompleteTask])
 
-  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string) => {
+  const handleFeedbackSubmit = useCallback(async (rating: number, comment: string, completeAtSource: boolean) => {
     if (!task?.agent_id || !task?.id) return
     setShowFeedback(false)
 
-    if (task.server_managed) {
+    if (task.source_id || task.server_managed) {
       await taskApi.update(task.id, {feedback_rating:rating,feedback_comment:comment || null})
-      await onCompleteTask()
+      await onCompleteTask(completeAtSource)
       return
     }
 
@@ -752,13 +752,13 @@ Update existing skills that were helpful or create new ones for patterns worth r
       console.error('Failed to send feedback:', error)
       await taskApi.update(task.id, { status: TaskStatus.ReadyForReview })
     }
-  }, [ensureChatSession, sendMessage, session.sessionId, task?.id])
+  }, [ensureChatSession, sendMessage, session.sessionId, task, onCompleteTask])
 
-  const handleFeedbackSkip = useCallback(async () => {
+  const handleFeedbackSkip = useCallback(async (completeAtSource: boolean) => {
     if (!task?.id) return
     setShowFeedback(false)
-    // Completion is server-confirmed through the shared path for every source.
-    await onCompleteTask()
+    // Preserve the source choice when feedback is skipped.
+    await onCompleteTask(completeAtSource)
   }, [task?.id, onCompleteTask])
 
   const handleSnooze = useCallback(async (isoString: string) => {
@@ -1237,6 +1237,7 @@ Update existing skills that were helpful or create new ones for patterns worth r
 
       <FeedbackDialog
         open={showFeedback}
+        sourceName={task?.source_id ? taskSources.find(source => source.id === task.source_id)?.name || task.source || 'the task source' : undefined}
         completionDescription={task ? getSourceCompletionDescription(task, taskSources.find(source => source.id === task.source_id)?.name) : undefined}
         onSubmit={handleFeedbackSubmit}
         onSkip={handleFeedbackSkip}

--- a/src/renderer/src/hooks/use-task-completion.test.tsx
+++ b/src/renderer/src/hooks/use-task-completion.test.tsx
@@ -86,8 +86,16 @@ function Harness({ taskId = 'task-1' }: { taskId?: string }) {
 }
 
 describe('server completion', () => {
-  beforeEach(() => { vi.clearAllMocks(); executeActionMock.mockResolvedValue({success:true}); storeState.tasks=[] })
+  beforeEach(() => { vi.clearAllMocks(); executeActionMock.mockResolvedValue({success:true}); storeState.tasks=[]; storeState.sources=[] })
   afterEach(cleanup)
+  it('names Notion instead of the custom connection in the completion dialog', () => {
+    storeState.tasks = [makeTask({source_id: 'src-1', source: 'Notion'})]
+    storeState.sources = [{id: 'src-1', name: 'dmitry ai tasks'}]
+    render(<Harness />)
+    fireEvent.click(screen.getByText('Complete'))
+    expect(screen.getByText('Complete in Notion?')).toBeInTheDocument()
+    expect(screen.queryByText(/dmitry ai tasks/)).toBeNull()
+  })
   it('waits for the source choice before sending completion', async () => {
     storeState.tasks=[makeTask({source_id:'src-1',complete_at_source:false})]
     render(<Harness />); fireEvent.click(screen.getByText('Complete'))

--- a/src/renderer/src/hooks/use-task-completion.test.tsx
+++ b/src/renderer/src/hooks/use-task-completion.test.tsx
@@ -74,9 +74,10 @@ const onToast = vi.fn()
 const onCompleted = vi.fn()
 
 function Harness({ taskId = 'task-1' }: { taskId?: string }) {
-  const { requestComplete } = useTaskCompletion({ onToast })
+  const { requestComplete, completionDialog } = useTaskCompletion({ onToast })
   return (
     <>
+      {completionDialog}
       <button type="button" onClick={() => void requestComplete(taskId, { onCompleted })}>
         Complete
       </button>
@@ -87,12 +88,14 @@ function Harness({ taskId = 'task-1' }: { taskId?: string }) {
 describe('server completion', () => {
   beforeEach(() => { vi.clearAllMocks(); executeActionMock.mockResolvedValue({success:true}); storeState.tasks=[] })
   afterEach(cleanup)
-  it('always calls the source and never writes local completion', async () => {
+  it('waits for the source choice before sending completion', async () => {
     storeState.tasks=[makeTask({source_id:'src-1',complete_at_source:false})]
     render(<Harness />); fireEvent.click(screen.getByText('Complete'))
+    expect(executeActionMock).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByTestId('complete-at-source'))
     await waitFor(()=>expect(onCompleted).toHaveBeenCalled())
     expect(executeActionMock).toHaveBeenCalledWith(PluginActionId.Complete,'task-1','src-1')
-    expect(updateTaskMock).not.toHaveBeenCalled()
+    expect(updateTaskMock).toHaveBeenCalledWith('task-1', { complete_at_source: true })
     expect(screen.queryByRole('dialog')).toBeNull()
   })
   it('completes a source-less 20x task locally without uploading it',async()=>{
@@ -106,7 +109,28 @@ describe('server completion', () => {
   it('keeps a refused completion open',async()=>{
     executeActionMock.mockResolvedValue({success:false,error:'Review required'})
     storeState.tasks=[makeTask({source_id:'src-1'})];render(<Harness />);fireEvent.click(screen.getByText('Complete'))
+    fireEvent.click(screen.getByTestId('complete-at-source'))
     await waitFor(()=>expect(onToast).toHaveBeenCalledWith('Review required',true))
-    expect(updateTaskMock).not.toHaveBeenCalled();expect(onCompleted).not.toHaveBeenCalled()
+    expect(updateTaskMock).not.toHaveBeenCalledWith('task-1', expect.objectContaining({status: TaskStatus.Completed}));expect(onCompleted).not.toHaveBeenCalled()
+  })
+
+  it('cancels without a local write or a source request', () => {
+    storeState.tasks = [makeTask({source_id: 'src-1'})]
+    render(<Harness />)
+    fireEvent.click(screen.getByText('Complete'))
+    fireEvent.click(screen.getByRole('button', {name: 'Cancel'}))
+    expect(updateTaskMock).not.toHaveBeenCalled()
+    expect(executeActionMock).not.toHaveBeenCalled()
+  })
+
+  it('completes manually without a source request' , async () => {
+    vi.clearAllMocks()
+    storeState.tasks = [makeTask({ source_id: 'src-1', source: 'Session Feedback' })]
+    render(<Harness />)
+    fireEvent.click(screen.getByText('Complete'))
+    fireEvent.click(screen.getByTestId('complete-manually'))
+    await waitFor(() => expect(updateTaskMock).toHaveBeenCalledWith('task-1', {status: TaskStatus.Completed, complete_at_source: false}))
+    expect(executeActionMock).not.toHaveBeenCalled()
+    expect(onCompleted).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -1,5 +1,6 @@
+import { CompleteAtSourceDialog } from '@/components/tasks/CompleteAtSourceDialog'
 import { getTaskCompletionAction } from '@shared/task-completion'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { useTaskStore } from '@/stores/task-store'
 import { TaskStatus } from '@/types'
@@ -9,32 +10,57 @@ export interface UseTaskCompletionOptions {
   onToast?: (message: string, isError?: boolean) => void
 }
 export interface CompleteTaskRequestOptions {
+  completeAtSource?: boolean
   onCompleted?: (task: WorkfloTask) => void
 }
 
-/** Sourced completion is confirmed externally; source-less 20x tasks stay local. */
+/** Ask before a source write; a manual completion changes only the local task. */
 export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
+  const [pending, setPending] = useState<{ taskId: string; options?: CompleteTaskRequestOptions } | null>(null)
+  const [isBusy, setIsBusy] = useState(false)
+  const sources = useTaskSourceStore(s => s.sources)
+  const tasks = useTaskStore(s => s.tasks)
   const executeAction = useTaskSourceStore(s => s.executeAction)
   const requestComplete = useCallback(async (taskId: string, options?: CompleteTaskRequestOptions) => {
     const task = useTaskStore.getState().tasks.find(t => t.id === taskId)
     if (!task) return
+    if (task.source_id && options?.completeAtSource === undefined) {
+      setPending({ taskId, options })
+      return
+    }
+    setIsBusy(true)
     try {
-      if (!task.source_id) {
-        await useTaskStore.getState().updateTask(task.id, { status: TaskStatus.Completed })
+      if (!task.source_id || options?.completeAtSource === false) {
+        await useTaskStore.getState().updateTask(task.id, { status: TaskStatus.Completed, ...(task.source_id ? { complete_at_source: false } : {}) })
         const completedTask = { ...task, status: TaskStatus.Completed }
+        setPending(null)
         options?.onCompleted?.(completedTask)
         onToast?.(`"${task.title}" completed`)
         return
       }
+      await useTaskStore.getState().updateTask(task.id, { complete_at_source: true })
       const action = getTaskCompletionAction(task.output_fields)
       const result = await executeAction(action, task.id, task.source_id)
       if (!result.success) throw new Error(result.error || 'The server did not confirm completion.')
       await useTaskStore.getState().fetchTasks()
+      setPending(null)
       options?.onCompleted?.(task)
       onToast?.(`"${task.title}" completed`)
     } catch (error) {
       onToast?.(error instanceof Error ? error.message : 'Task completion failed.', true)
+    } finally {
+      setIsBusy(false)
     }
   }, [executeAction, onToast])
-  return { requestComplete }
+  const pendingTask = tasks.find(task => task.id === pending?.taskId)
+  const completionDialog = pendingTask && pending ? <CompleteAtSourceDialog
+    isOpen={true}
+    taskTitle={pendingTask.title}
+    sourceName={sources.find(source => source.id === pendingTask.source_id)?.name || pendingTask.source || 'the task source'}
+    isBusy={isBusy}
+    onCompleteAtSource={() => void requestComplete(pending.taskId, { ...pending.options, completeAtSource: true })}
+    onCompleteManually={() => void requestComplete(pending.taskId, { ...pending.options, completeAtSource: false })}
+    onCancel={() => setPending(null)}
+  /> : null
+  return { requestComplete, completionDialog }
 }

--- a/src/renderer/src/hooks/use-task-completion.tsx
+++ b/src/renderer/src/hooks/use-task-completion.tsx
@@ -1,5 +1,5 @@
 import { CompleteAtSourceDialog } from '@/components/tasks/CompleteAtSourceDialog'
-import { getTaskCompletionAction } from '@shared/task-completion'
+import { getTaskCompletionAction, getTaskSourceName } from '@shared/task-completion'
 import { useCallback, useState } from 'react'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { useTaskStore } from '@/stores/task-store'
@@ -56,7 +56,7 @@ export function useTaskCompletion({ onToast }: UseTaskCompletionOptions = {}) {
   const completionDialog = pendingTask && pending ? <CompleteAtSourceDialog
     isOpen={true}
     taskTitle={pendingTask.title}
-    sourceName={sources.find(source => source.id === pendingTask.source_id)?.name || pendingTask.source || 'the task source'}
+    sourceName={getTaskSourceName(pendingTask, sources.find(source => source.id === pendingTask.source_id)?.name)}
     isBusy={isBusy}
     onCompleteAtSource={() => void requestComplete(pending.taskId, { ...pending.options, completeAtSource: true })}
     onCompleteManually={() => void requestComplete(pending.taskId, { ...pending.options, completeAtSource: false })}

--- a/src/shared/task-completion.test.ts
+++ b/src/shared/task-completion.test.ts
@@ -4,11 +4,14 @@ import { getSourceCompletionDescription, getTaskCompletionAction } from './task-
 const task = { source_id: 'feedback', source: 'Session Feedback', output_fields: [] }
 
 describe('source completion description', () => {
-  it('uses the loaded source name before the task label', () => {
-    expect(getSourceCompletionDescription(task, 'Feedback Inbox')).toContain('Action at Feedback Inbox: complete.')
+  it('uses the source system instead of the connection name', () => {
+    expect(getSourceCompletionDescription({...task, source: 'Notion'}, 'dmitry ai tasks')).toContain('Action at Notion: complete.')
   })
-  it('falls back to the task source label', () => {
+  it('uses the task source label without a loaded connection', () => {
     expect(getSourceCompletionDescription(task)).toContain('Action at Session Feedback: complete.')
+  })
+  it('uses the connection name when the source label is missing', () => {
+    expect(getSourceCompletionDescription({...task, source: ' '}, 'Feedback Inbox')).toContain('Action at Feedback Inbox: complete.')
   })
   it('uses a readable fallback for an empty source label', () => {
     expect(getSourceCompletionDescription({ ...task, source: '' })).toContain('Action at the task source: complete.')

--- a/src/shared/task-completion.ts
+++ b/src/shared/task-completion.ts
@@ -8,12 +8,17 @@ export function getTaskCompletionAction(outputFields: readonly unknown[]): strin
   return field?.value ? String(field.value) : PluginActionId.Complete
 }
 
+/** The task label identifies the source system; a connection can have a custom name. */
+export function getTaskSourceName(task: { source: string }, connectionName?: string): string {
+  return task.source?.trim() || connectionName?.trim() || 'the task source'
+}
+
 export function getSourceCompletionDescription(task: {
   source_id: string | null
   source: string
   output_fields: readonly unknown[]
 }, sourceName?: string): string | undefined {
   if (!task.source_id) return undefined
-  const name = sourceName?.trim() || task.source?.trim() || 'the task source'
+  const name = getTaskSourceName(task, sourceName)
   return `Action at ${name}: ${getTaskCompletionAction(task.output_fields)}. Completion sends this action and the task outputs to the source.`
 }


### PR DESCRIPTION
Restore the two independent choices in Session Feedback on desktop and mobile. The feedback option controls learning; the source option controls whether the source record changes.

| Feedback action | Source choice | Result |
|---|---|---|
| Submit Feedback | Close in Notion | Save feedback, start Agent Learning, sync skills when learning finishes, then complete at the source and in 20x. |
| Submit Feedback | I'll do it manually | Save feedback, start Agent Learning, sync skills when learning finishes, then complete only in 20x. |
| Skip | Close in Notion | Skip learning and complete at the source and in 20x. |
| Skip | I'll do it manually | Skip learning and complete only in 20x. |

Selecting an option does not complete the task. Cancel changes neither record. The source label takes priority over the connection name, so the button says “Close it in Notion”, not “Close it in dmitry ai tasks”.

The desktop and mobile user routes record an explicit pending feedback completion. The agent idle handler consumes it only after skill sync. Unattended agents still cannot accept their own work. Source refreshes preserve Agent Learning while feedback is pending. A failed learning start or source action leaves the task open for review.

Manual completion blocks source actions, status exports, enterprise completion events, and queued completion retries. The local completed state survives source refreshes. Successful source plugin actions can confirm local completion; mobile supports the Notion source path as well as Workflo.

Validation:
- Four-case UI tests on desktop and mobile verify learning requests, saved source choices, and the absence of immediate completion on Submit.
- Four-case HTTP tests use the real mobile route, database, and SyncManager; only the external source plugin action is simulated.
- Agent idle tests verify source completion occurs only after skill sync and honors the recorded choice.
- Tests cover source refreshes, failed source actions, cancelled learning, manual exports/events/retries, and the Notion label.
- Restoring the prior source causes 16 regression tests to fail, including both Submit cases, learning completion, Notion source completion, and source labels.
- Full local verification passes: lint, type checking, desktop/mobile builds, and 177 test files (2,803 tests passed; four skipped).
