### PR TITLE
fix: open supporting files within artifact viewers

### DIFF
--- a/src/main/artifacts.test.ts
+++ b/src/main/artifacts.test.ts
@@ -79,7 +79,8 @@ describe('task artifact files', () => {
       path: 'outputs/dashboard/index.html',
       title: 'dashboard',
       type: ArtifactType.HTML,
-      workpieceKey: 'outputs/dashboard'
+      workpieceKey: 'outputs/dashboard',
+      files: ['outputs/dashboard/README.md', 'outputs/dashboard/index.html', 'outputs/dashboard/styles.css']
     }))
   })
 
@@ -107,7 +108,8 @@ describe('task artifact files', () => {
       title: 'Sales dashboard',
       type: ArtifactType.HTML,
       path: `artifacts/${registered.artifactId}/index.html`,
-      workpieceKey: registered.artifactId
+      workpieceKey: registered.artifactId,
+      files: [`artifacts/${registered.artifactId}/index.html`, `artifacts/${registered.artifactId}/styles.css`]
     }))
     await expect(listRegisteredTaskArtifacts(workspaceDir, 'task-1')).resolves.toEqual([
       expect.objectContaining({
@@ -119,9 +121,20 @@ describe('task artifact files', () => {
     await expect(listTaskArtifactEntries(workspaceDir, 'task-1')).resolves.toEqual([
       expect.objectContaining({
         path: `artifacts/${registered.artifactId}/index.html`,
-        workpieceKey: registered.artifactId
+        workpieceKey: registered.artifactId,
+      files: [`artifacts/${registered.artifactId}/index.html`, `artifacts/${registered.artifactId}/styles.css`]
       })
     ])
+  })
+
+  it('makes registered binary files available for save and copy without scanning unrelated binaries', async () => {
+    const record = await createRegisteredTaskArtifact(workspaceDir, 'task-1', { title: 'Files', type: ArtifactType.FILE })
+    const result = await writeRegisteredTaskArtifactFile(workspaceDir, 'task-1', { artifactId: record.artifactId, filename: 'bundle.zip', content: 'UEsDBA==', encoding: 'base64' })
+    expect(result.files).toEqual([`artifacts/${record.artifactId}/bundle.zip`])
+    expect(await readTaskArtifact(workspaceDir, result.path!)).toEqual({ kind: ArtifactContentKind.DATA_URL, content: 'data:application/octet-stream;base64,UEsDBA==', mimeType: 'application/octet-stream' })
+    expect(await resolveTaskArtifactFilePath(workspaceDir, result.path!)).toBeTruthy()
+    await writeFile(join(workspaceDir, 'unregistered.zip'), 'private')
+    expect(await readTaskArtifact(workspaceDir, 'unregistered.zip')).toBeNull()
   })
 
   it('reads and exact-edits registered files while enforcing task and path boundaries', async () => {

--- a/src/main/artifacts.ts
+++ b/src/main/artifacts.ts
@@ -45,6 +45,10 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
 }
 const HTML_EXTENSIONS = new Set(['.htm', '.html'])
 const TEXT_MIME_TYPES: Record<string, string> = {
+  '.py': 'text/plain',
+  '.sh': 'text/plain',
+  '.sql': 'text/plain',
+  '.ini': 'text/plain',
   '.css': 'text/css',
   '.csv': 'text/csv',
   '.js': 'text/javascript',
@@ -184,6 +188,7 @@ export function registeredArtifactToArtifact(record: RegisteredArtifact): Artifa
     type: record.type,
     title: record.title,
     path,
+    files: record.files.map((file) => `${ARTIFACT_FILES_DIRECTORY}/${record.artifactId}/${file}`),
     workpieceKey: record.artifactId,
     updatedAt: record.updatedAt,
     reloadTrigger: Math.floor(record.updatedAt)
@@ -199,7 +204,8 @@ function registeredArtifactToEntry(record: RegisteredArtifact): ArtifactFileEntr
     type: record.type,
     updatedAt: record.updatedAt,
     size: 0,
-    workpieceKey: record.artifactId
+    workpieceKey: record.artifactId,
+    files: record.files.map((file) => `${ARTIFACT_FILES_DIRECTORY}/${record.artifactId}/${file}`)
   }
 }
 
@@ -473,15 +479,17 @@ export async function scanTaskArtifacts(workspaceDir: string): Promise<ArtifactF
           workpieceKey: workpiece.key
         }
         const previous = artifacts.get(workpiece.key)
+        const files = [...(previous?.files || []), relativePath].sort()
         if (!previous || previewPriority(candidate) > previewPriority(previous)) {
           artifacts.set(workpiece.key, {
             ...candidate,
+            files,
             updatedAt: Math.max(candidate.updatedAt, previous?.updatedAt || 0)
           })
-        } else if (fileStat.mtimeMs > previous.updatedAt) {
+        } else {
           // Supporting-file edits reload the selected preview without replacing
           // its entry point or creating another top-level tab.
-          artifacts.set(workpiece.key, { ...previous, updatedAt: fileStat.mtimeMs })
+          artifacts.set(workpiece.key, { ...previous, files, updatedAt: Math.max(previous.updatedAt, fileStat.mtimeMs) })
         }
       } catch {
         // A file can disappear while an agent is replacing it. Ignore it and
@@ -494,12 +502,23 @@ export async function scanTaskArtifacts(workspaceDir: string): Promise<ArtifactF
   return [...artifacts.values()].sort((a, b) => b.updatedAt - a.updatedAt || a.path.localeCompare(b.path))
 }
 
+/** Unknown file formats are available only when explicitly owned by a
+ * registered artifact. The scanner still excludes arbitrary binary files. */
+async function isRegisteredFile(workspaceDir: string, filePath: string): Promise<boolean> {
+  const workspaceRoot = await realpath(workspaceDir)
+  const path = relative(workspaceRoot, filePath).split(sep).join('/')
+  const registry = await readArtifactRegistryFromRoot(workspaceRoot)
+  return registry.artifacts.some((artifact) => artifact.files.some((file) =>
+    path === `${ARTIFACT_FILES_DIRECTORY}/${artifact.artifactId}/${file}`
+  ))
+}
+
 /** Resolve a previewable artifact to its absolute path while enforcing
  * task-workspace containment. Used by the "copy the file" clipboard action. */
 export async function resolveTaskArtifactFilePath(workspaceDir: string, artifactPath: string): Promise<string | null> {
   const filePath = await resolveArtifactPath(workspaceDir, artifactPath)
   if (!filePath) return null
-  if (!artifactTypeForPath(filePath)) return null
+  if (!artifactTypeForPath(filePath) && !await isRegisteredFile(workspaceDir, filePath)) return null
   try {
     return (await stat(filePath)).isFile() ? filePath : null
   } catch {
@@ -513,7 +532,7 @@ export async function readTaskArtifact(workspaceDir: string, artifactPath: strin
   if (!filePath) return null
 
   const type = artifactTypeForPath(filePath)
-  if (!type) return null
+  if (!type && !await isRegisteredFile(workspaceDir, filePath)) return null
 
   let fileStat
   try {
@@ -525,6 +544,12 @@ export async function readTaskArtifact(workspaceDir: string, artifactPath: strin
 
   const extension = extname(filePath).toLowerCase()
   try {
+    if (!type) {
+      if (fileStat.size > MAX_IMAGE_BYTES) return null
+      const data = await readFile(filePath)
+      const mimeType = 'application/octet-stream'
+      return { kind: ArtifactContentKind.DATA_URL, content: `data:${mimeType};base64,${data.toString('base64')}`, mimeType }
+    }
     if (type === ArtifactType.IMAGE) {
       if (fileStat.size > MAX_IMAGE_BYTES) return null
       const data = await readFile(filePath)

--- a/src/main/mobile-api-server.ts
+++ b/src/main/mobile-api-server.ts
@@ -953,6 +953,7 @@ function artifactFromFileEntry(taskId: string, entry: ArtifactFileEntry): Artifa
     title: entry.title,
     path: entry.path,
     workpieceKey: entry.workpieceKey,
+    files: entry.files,
     updatedAt: entry.updatedAt,
     reloadTrigger: Math.floor(entry.updatedAt)
   }

--- a/src/mobile/pages/ArtifactViewerPage.test.tsx
+++ b/src/mobile/pages/ArtifactViewerPage.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { ArtifactContentKind, ArtifactType } from '@shared/artifacts'
 import { ArtifactViewerPage } from './ArtifactViewerPage'
 import { api } from '../api/client'
@@ -17,7 +17,26 @@ beforeEach(() => {
   })
 })
 
+afterEach(cleanup)
+
 describe('ArtifactViewerPage', () => {
+  it('opens nested file links and copies the selected file content', async () => {
+    const files = ['artifacts/demo/docs/start.md', 'artifacts/demo/data.csv', 'artifacts/demo/index.html']
+    useArtifactStore.setState({ artifactsByTask: new Map([['task-1', [{ id: 'demo', taskId: 'task-1', title: 'Report', type: ArtifactType.MARKDOWN, path: files[0], files, updatedAt: 1, reloadTrigger: 0 }]]]) })
+    vi.mocked(api.artifacts.content).mockImplementation(async (_task, path) => ({ kind: ArtifactContentKind.TEXT, content: path === files[0] ? '[Data](../data.csv)' : path === files[1] ? 'name,value' : '<a href="docs/start.md">Start</a>' }))
+    const view = render(<ArtifactViewerPage taskId="task-1" artifactId="demo" onNavigate={vi.fn()} />)
+    fireEvent.click(await view.findByRole('link', { name: 'Data' }))
+    await view.findByText('name,value')
+    expect((view.getByRole('combobox') as HTMLSelectElement).value).toBe(files[1])
+    fireEvent.click(view.getByRole('button', { name: 'Copy content' }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('name,value'))
+    fireEvent.change(view.getByRole('combobox'), { target: { value: files[2] } })
+    const frame = await view.findByTitle('Report') as HTMLIFrameElement
+    act(() => window.dispatchEvent(new MessageEvent('message', { origin: 'null', source: frame.contentWindow, data: { type: 'artifact:open-file', href: 'docs/start.md' } })))
+    await view.findByRole('link', { name: 'Data' })
+    expect((view.getByRole('combobox') as HTMLSelectElement).value).toBe(files[0])
+  })
+
   it('renders a URL-only image artifact without requesting workspace content', () => {
     useArtifactStore.setState({
       artifactsByTask: new Map([['task-1', [{

--- a/src/mobile/pages/ArtifactViewerPage.tsx
+++ b/src/mobile/pages/ArtifactViewerPage.tsx
@@ -1,3 +1,6 @@
+import { ArtifactFileSelector } from '@/components/artifacts/ArtifactFileSelector'
+import { useArtifactNavigation } from '@/components/artifacts/use-artifact-navigation'
+import { ArtifactHtmlFrame } from '@/components/artifacts/viewers/ArtifactHtmlFrame'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Markdown } from '@/components/ui/Markdown'
 import {
@@ -22,14 +25,6 @@ import type { Route } from '../App'
 
 const ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS = 30_000
 
-function hardenHtml(source: string): string {
-  const policy = "default-src 'none'; connect-src 'none'; img-src data: blob:; style-src 'unsafe-inline'; script-src 'unsafe-inline'"
-  const guard = `<meta http-equiv="Content-Security-Policy" content="${policy}"><base href="about:blank"><script>window.open=function(){return null};</script>`
-  return /<head[\s>]/i.test(source)
-    ? source.replace(/<head([^>]*)>/i, `<head$1>${guard}`)
-    : `<!doctype html><html><head>${guard}</head><body>${source}</body></html>`
-}
-
 function safeExternalUrl(value?: string): string | null {
   if (!value) return null
   try {
@@ -51,7 +46,9 @@ function safeImageUrl(value?: string): string | null {
 }
 
 export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId: string; artifactId: string; onNavigate: (route: Route) => void }) {
-  const artifact = useArtifactStore((state) => state.artifactsByTask.get(taskId)?.find((item) => item.id === artifactId))
+  const workpiece = useArtifactStore((state) => state.artifactsByTask.get(taskId)?.find((item) => item.id === artifactId))
+  const navigation = useArtifactNavigation(workpiece)
+  const artifact = navigation.selectedArtifact
   const hydrate = useArtifactStore((state) => state.hydrate)
   const [content, setContent] = useState<ArtifactContent | null>(null)
   const [loading, setLoading] = useState(true)
@@ -75,14 +72,15 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
   useEffect(() => {
     if (!artifact?.path || artifact.type === ArtifactType.PR) {
       if (artifact && artifact.type !== ArtifactType.PR) {
-        settledArtifactRef.current = artifact.id
+        settledArtifactRef.current = `${artifact.id}:${artifact.path || artifact.url}`
         setLoading(false)
       }
       return
     }
     let cancelled = false
-    const initialLoad = settledArtifactRef.current !== artifact.id
+    const initialLoad = settledArtifactRef.current !== `${artifact.id}:${artifact.path || artifact.url}`
     if (initialLoad) {
+      setContent(null)
       setLoading(true)
       setError(null)
     }
@@ -95,8 +93,8 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
       if (!cancelled && initialLoad) setError(reason instanceof Error ? reason.message : String(reason))
     }).finally(() => {
       if (!cancelled) {
-        settledArtifactRef.current = artifact.id
-        if (initialLoad) setLoading(false)
+        settledArtifactRef.current = `${artifact.id}:${artifact.path || artifact.url}`
+        setLoading(false)
       }
     })
     return () => { cancelled = true }
@@ -105,8 +103,9 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
   useEffect(() => {
     if (artifact?.type !== ArtifactType.PR || !artifact.url) return
     let cancelled = false
-    const initialLoad = settledArtifactRef.current !== artifact.id
+    const initialLoad = settledArtifactRef.current !== `${artifact.id}:${artifact.path || artifact.url}`
     if (initialLoad) {
+      setContent(null)
       setLoading(true)
       setError(null)
     }
@@ -119,8 +118,8 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
       if (!cancelled && initialLoad) setError(reason instanceof Error ? reason.message : String(reason))
     }).finally(() => {
       if (!cancelled) {
-        settledArtifactRef.current = artifact.id
-        if (initialLoad) setLoading(false)
+        settledArtifactRef.current = `${artifact.id}:${artifact.path || artifact.url}`
+        setLoading(false)
       }
     })
     return () => { cancelled = true }
@@ -146,31 +145,27 @@ export function ArtifactViewerPage({ taskId, artifactId, onNavigate }: { taskId:
           <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m15 18-6-6 6-6"/></svg>
         </button>
         <span className="min-w-0 flex-1 truncate text-sm font-medium">{artifact?.title || 'Artifact'}</span>
-        {artifact && <ArtifactCopyActions artifact={artifact} content={content} />}
+        {artifact && <ArtifactCopyActions key={`${artifact.id}:${artifact.path}`} artifact={artifact} content={content} />}
         {artifact?.type === ArtifactType.PR && externalUrl && (
           <a href={externalUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-primary">Open ↗</a>
         )}
       </div>
 
+      <ArtifactFileSelector files={navigation.files} path={artifact?.path} onSelect={navigation.selectFile} />
+      {navigation.linkError && <div role="alert" className="px-3 py-2 text-sm text-red-400">{navigation.linkError}</div>}
       <div className="min-h-0 flex-1 overflow-auto bg-background">
         {loading && <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Loading artifact…</div>}
         {!loading && error && <div className="flex h-full items-center justify-center p-6 text-center text-sm text-red-400">{error}</div>}
         {!loading && !error && !artifact && <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Artifact not found</div>}
+        {!loading && !error && artifact?.path && !content && <div className="p-6 text-sm text-muted-foreground">File preview is not available.</div>}
         {!loading && !error && artifact?.type === ArtifactType.MARKDOWN && content && (
-          <div className="mx-auto max-w-3xl p-5"><Markdown size="sm">{content.content}</Markdown></div>
+          <div className="mx-auto max-w-3xl p-5"><Markdown size="sm" onLinkClick={navigation.openLink}>{content.content}</Markdown></div>
         )}
         {!loading && !error && artifact?.type === ArtifactType.IMAGE && imageUrl && (
           <div className="flex min-h-full items-center justify-center p-4"><img key={artifact.reloadTrigger} src={imageUrl} alt={artifact.title} className="max-h-full max-w-full object-contain" /></div>
         )}
         {!loading && !error && artifact?.type === ArtifactType.HTML && content && (
-          <iframe
-            key={artifact.reloadTrigger}
-            title={artifact.title}
-            srcDoc={hardenHtml(content.content)}
-            sandbox="allow-scripts"
-            referrerPolicy="no-referrer"
-            className="h-full w-full border-0 bg-white"
-          />
+          <ArtifactHtmlFrame key={`${artifact.path}:${artifact.reloadTrigger}`} html={content.content} title={artifact.title} onLinkClick={navigation.openLink} />
         )}
         {!loading && !error && artifact?.type === ArtifactType.FILE && content && (
           <pre className="min-h-full whitespace-pre-wrap break-words p-4 font-mono text-xs text-foreground/80">{content.kind === ArtifactContentKind.TEXT ? content.content : 'Binary file preview is not available.'}</pre>

--- a/src/renderer/src/components/artifacts/ArtifactFileSelector.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactFileSelector.tsx
@@ -1,0 +1,15 @@
+export function ArtifactFileSelector({ files, path, onSelect }: { files: string[]; path?: string; onSelect: (path: string) => void }) {
+  if (files.length < 2) return null
+  const segments = files[0].split('/')
+  segments.pop()
+  while (segments.length && !files.every((file) => file.startsWith(`${segments.join('/')}/`))) segments.pop()
+  const prefixLength = segments.length ? segments.join('/').length + 1 : 0
+  return (
+    <label className="flex shrink-0 items-center gap-2 border-b border-border/50 px-3 py-2 text-xs text-muted-foreground">
+      File
+      <select aria-label="Artifact file" value={path} onChange={(event) => onSelect(event.target.value)} className="min-w-0 flex-1 rounded border border-border bg-background px-2 py-1 text-foreground">
+        {files.map((file) => <option key={file} value={file}>{file.slice(prefixLength)}</option>)}
+      </select>
+    </label>
+  )
+}

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ArtifactClipboardMode, ArtifactContentKind, ArtifactType, type Artifact, type ArtifactApi, type ArtifactUIState } from '@shared/artifacts'
 import { PinnedArtifactTabId } from '@/stores/artifact-store'
 import { ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS, ArtifactsPanel } from './ArtifactsPanel'
@@ -22,6 +22,29 @@ afterEach(() => {
 })
 
 describe('ArtifactsPanel', () => {
+  it('opens supporting file links, selects files, and copies the selected file', async () => {
+    const files = ['artifacts/demo/docs/start.md', 'artifacts/demo/data.csv', 'artifacts/demo/index.html']
+    const artifact: Artifact = { id: 'demo', taskId: 'task-1', title: 'Report', type: ArtifactType.MARKDOWN, path: files[0], files, updatedAt: 1, reloadTrigger: 0 }
+    const read = vi.fn().mockImplementation(async (_task, path) => ({ kind: ArtifactContentKind.TEXT, content: path === files[0] ? '[Data](../data.csv) [Missing](missing.md) [Web](https://example.com)' : path === files[1] ? 'name,value\nA,10' : '<a href="docs/start.md">Start</a>' }))
+    const copyFile = vi.fn().mockResolvedValue({ mode: ArtifactClipboardMode.FILE })
+    render(<ArtifactsPanel taskId="task-1" artifacts={[artifact]} ui={{ ...baseUi, activeTabId: 'demo' }} artifactApi={{ scan: vi.fn(), read, copyFile }} hasChanges={false} hasOutput={false} onSelectTab={vi.fn()} onCloseTab={vi.fn()} onToggleOpen={vi.fn()} onToggleRail={vi.fn()} details={null} changes={null} output={null} />)
+    fireEvent.click(await screen.findByRole('link', { name: 'Missing' }))
+    expect(screen.getByRole('alert')).toHaveTextContent('This file is not available')
+    expect(read).not.toHaveBeenCalledWith('task-1', expect.stringContaining('missing.md'))
+    expect(screen.getByRole('link', { name: 'Web' })).toHaveAttribute('href', 'https://example.com')
+    fireEvent.click(screen.getByRole('link', { name: 'Data' }))
+    await screen.findByText(/name,value/)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Artifact file' })).toHaveValue(files[1])
+    fireEvent.click(screen.getByRole('button', { name: 'Copy file' }))
+    await waitFor(() => expect(copyFile).toHaveBeenCalledWith('task-1', files[1]))
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: files[2] } })
+    const frame = await screen.findByTitle('Report') as HTMLIFrameElement
+    act(() => window.dispatchEvent(new MessageEvent('message', { origin: 'null', source: frame.contentWindow, data: { type: 'artifact:open-file', href: 'docs/start.md' } })))
+    await screen.findByRole('link', { name: 'Data' })
+    expect(screen.getByRole('combobox')).toHaveValue(files[0])
+  })
+
   it('mounts Changes only while the Changes tab is selected', () => {
     const props = {
       taskId: 'task-1',

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.tsx
@@ -1,3 +1,5 @@
+import { ArtifactFileSelector } from './ArtifactFileSelector'
+import { useArtifactNavigation } from './use-artifact-navigation'
 import { useEffect, useState, type ReactNode } from 'react'
 import { PanelRightClose } from 'lucide-react'
 import { ArtifactType, type Artifact, type ArtifactApi, type ArtifactUIState } from '@shared/artifacts'
@@ -34,6 +36,8 @@ export interface ArtifactsPanelProps {
 export function ArtifactsPanel({ artifacts, ui, artifactApi, hasChanges, hasOutput, changesCount, onSelectTab, onCloseTab, onToggleOpen, details, changes, output, className }: ArtifactsPanelProps) {
   const active = ui.activeTabId || PinnedArtifactTabId.DETAILS
   const activeArtifact = artifacts.find((artifact) => artifact.id === active)
+  const navigation = useArtifactNavigation(activeArtifact)
+  const selectedArtifact = navigation.selectedArtifact
   const [refreshTrigger, setRefreshTrigger] = useState(0)
 
   useEffect(() => {
@@ -49,17 +53,19 @@ export function ArtifactsPanel({ artifacts, ui, artifactApi, hasChanges, hasOutp
       <div className="relative">
         <ArtifactTabStrip artifacts={artifacts} activeTabId={active} hasChanges={hasChanges} hasOutput={hasOutput} changesCount={changesCount} onSelectTab={onSelectTab} onCloseTab={onCloseTab} className={activeArtifact ? 'pr-52' : 'pr-11'} />
         <div className="absolute right-2 top-1.5 flex items-center gap-1 bg-background">
-          {activeArtifact && <ArtifactCopyActions key={activeArtifact.id} artifact={activeArtifact} artifactApi={artifactApi} />}
+          {activeArtifact && <ArtifactCopyActions key={`${activeArtifact.id}:${selectedArtifact?.path}`} artifact={selectedArtifact!} artifactApi={artifactApi} />}
           <button type="button" aria-label="Close artifacts" onClick={onToggleOpen} className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"><PanelRightClose className="h-3.5 w-3.5" /></button>
         </div>
       </div>
+      <ArtifactFileSelector files={navigation.files} path={selectedArtifact?.path} onSelect={navigation.selectFile} />
+      {navigation.linkError && <div role="alert" className="px-3 py-2 text-sm text-red-400">{navigation.linkError}</div>}
       <div className="relative min-h-0 flex-1">
         <div className={active === PinnedArtifactTabId.DETAILS ? 'h-full' : 'hidden'}>{details}</div>
         {hasChanges && active === PinnedArtifactTabId.CHANGES && <div className="h-full">{changes}</div>}
         {hasOutput && <div className={active === PinnedArtifactTabId.OUTPUT ? 'h-full overflow-y-auto p-4' : 'hidden'}>{output}</div>}
         {artifacts.map((artifact) => (
           <div key={artifact.id} className={active === artifact.id ? 'h-full' : 'hidden'}>
-            {active === artifact.id ? <ArtifactViewer artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} /> : null}
+            {active === artifact.id ? <ArtifactViewer artifact={selectedArtifact!} artifactApi={artifactApi} refreshTrigger={refreshTrigger} onLinkClick={navigation.openLink} /> : null}
           </div>
         ))}
       </div>
@@ -67,11 +73,11 @@ export function ArtifactsPanel({ artifacts, ui, artifactApi, hasChanges, hasOutp
   )
 }
 
-function ArtifactViewer({ artifact, artifactApi, refreshTrigger }: { artifact: Artifact; artifactApi: ArtifactApi; refreshTrigger: number }) {
+function ArtifactViewer({ artifact, artifactApi, refreshTrigger, onLinkClick }: { artifact: Artifact; artifactApi: ArtifactApi; refreshTrigger: number; onLinkClick: (href: string) => boolean }) {
   switch (artifact.type) {
-    case ArtifactType.MARKDOWN: return <MarkdownArtifactView artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
+    case ArtifactType.MARKDOWN: return <MarkdownArtifactView onLinkClick={onLinkClick} artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
     case ArtifactType.IMAGE: return <ImageArtifactView artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
-    case ArtifactType.HTML: return <HtmlArtifactView artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
+    case ArtifactType.HTML: return <HtmlArtifactView onLinkClick={onLinkClick} artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
     case ArtifactType.PR: return <PrArtifactView artifact={artifact} refreshTrigger={refreshTrigger} />
     default: return <FileArtifactView artifact={artifact} artifactApi={artifactApi} refreshTrigger={refreshTrigger} />
   }

--- a/src/renderer/src/components/artifacts/use-artifact-navigation.ts
+++ b/src/renderer/src/components/artifacts/use-artifact-navigation.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import type { Artifact } from '@shared/artifacts'
+import { artifactFileType, isLocalArtifactLink, resolveArtifactLink } from '@shared/artifact-navigation'
+
+export function useArtifactNavigation(artifact?: Artifact) {
+  const [selection, setSelection] = useState<{ id: string; path: string } | null>(null)
+  const [failure, setFailure] = useState<{ id: string; message: string } | null>(null)
+  const files = artifact?.files || (artifact?.path ? [artifact.path] : [])
+  const selectedPath = selection?.id === artifact?.id && files.includes(selection?.path || '') ? selection?.path : artifact?.path
+  const selectedArtifact = artifact && selectedPath && selectedPath !== artifact.path
+    ? { ...artifact, path: selectedPath, type: artifactFileType(selectedPath) }
+    : artifact
+  const selectFile = (path: string) => {
+    if (!artifact || !files.includes(path)) return
+    setSelection({ id: artifact.id, path })
+    setFailure(null)
+  }
+  const openLink = (href: string): boolean => {
+    if (!artifact || !selectedPath || !isLocalArtifactLink(href)) return false
+    const path = resolveArtifactLink(selectedPath, href, files)
+    if (path) selectFile(path)
+    else setFailure({ id: artifact.id, message: 'This file is not available in this artifact.' })
+    return true
+  }
+  return { selectedArtifact, files, selectFile, openLink, linkError: failure?.id === artifact?.id ? failure?.message : null }
+}

--- a/src/renderer/src/components/artifacts/viewers/ArtifactHtmlFrame.tsx
+++ b/src/renderer/src/components/artifacts/viewers/ArtifactHtmlFrame.tsx
@@ -1,0 +1,21 @@
+import { useLayoutEffect, useMemo, useRef } from 'react'
+
+const HARDENING = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data: blob:; media-src data: blob:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; font-src data:"><base href="about:blank"><script>window.open=function(){return null};document.addEventListener('click',function(event){var a=event.target.closest&&event.target.closest('a[href]');if(!a)return;var href=a.getAttribute('href');if(!href||href.charAt(0)==='#')return;event.preventDefault();window.parent.postMessage({type:'artifact:open-file',href:href},'*')},true);</script>`
+
+/** Keep file navigation in the host. The frame cannot read local files or
+ * navigate the app, and messages from other frames are ignored. */
+export function ArtifactHtmlFrame({ html, title, onLinkClick, onMessage }: { html: string; title: string; onLinkClick?: (href: string) => boolean; onMessage?: (data: unknown) => void }) {
+  const frameRef = useRef<HTMLIFrameElement>(null)
+  const srcDoc = useMemo(() => `${HARDENING}${html}`, [html])
+  useLayoutEffect(() => {
+    const listener = (event: MessageEvent) => {
+      if (event.origin !== 'null' || !frameRef.current?.contentWindow || event.source !== frameRef.current.contentWindow) return
+      if (event.data?.type === 'artifact:open-file' && typeof event.data.href === 'string') {
+        onLinkClick?.(event.data.href)
+      } else onMessage?.(event.data)
+    }
+    window.addEventListener('message', listener)
+    return () => window.removeEventListener('message', listener)
+  }, [onLinkClick, onMessage])
+  return <iframe ref={frameRef} title={title} sandbox="allow-scripts" referrerPolicy="no-referrer" srcDoc={srcDoc} className="h-full w-full border-0 bg-white" />
+}

--- a/src/renderer/src/components/artifacts/viewers/FileArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/FileArtifactView.tsx
@@ -6,5 +6,5 @@ import { useArtifactContent } from './use-artifact-content'
 export function FileArtifactView({ artifact, artifactApi, refreshTrigger = 0 }: { artifact: Artifact; artifactApi: ArtifactApi; refreshTrigger?: number }) {
   const state = useArtifactContent(artifact, artifactApi, refreshTrigger)
   const text = state.content?.kind === ArtifactContentKind.TEXT ? state.content.content : null
-  return <ArtifactViewState loading={state.loading} error={state.error} missing={text === null}><pre className="h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs text-foreground/80">{text}</pre></ArtifactViewState>
+  return <ArtifactViewState loading={state.loading} error={state.error} missing={state.content === null}><pre className="h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs text-foreground/80">{text ?? 'Binary file preview is not available. Use Copy file to open it in another application.'}</pre></ArtifactViewState>
 }

--- a/src/renderer/src/components/artifacts/viewers/HtmlArtifactView.test.tsx
+++ b/src/renderer/src/components/artifacts/viewers/HtmlArtifactView.test.tsx
@@ -39,10 +39,11 @@ describe('HtmlArtifactView', () => {
       read: vi.fn().mockResolvedValue({ kind: ArtifactContentKind.TEXT, content: '<p>Preview</p>' })
     }
     render(<HtmlArtifactView artifact={artifact} artifactApi={artifactApi} onMessage={onMessage} />)
-    await screen.findByTitle('preview.html')
+    const frame = await screen.findByTitle('preview.html') as HTMLIFrameElement
 
     window.dispatchEvent(new MessageEvent('message', { data: 'blocked', origin: 'https://example.com' }))
-    window.dispatchEvent(new MessageEvent('message', { data: 'accepted', origin: 'null' }))
+    window.dispatchEvent(new MessageEvent('message', { data: 'accepted', origin: 'null', source: frame.contentWindow }))
+    window.dispatchEvent(new MessageEvent('message', { data: 'other frame', origin: 'null' }))
     expect(onMessage).toHaveBeenCalledTimes(1)
     expect(onMessage).toHaveBeenCalledWith('accepted')
   })

--- a/src/renderer/src/components/artifacts/viewers/HtmlArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/HtmlArtifactView.tsx
@@ -1,24 +1,11 @@
-import { useEffect, useMemo } from 'react'
 import type { Artifact, ArtifactApi } from '@shared/artifacts'
 import { ArtifactContentKind } from '@shared/artifacts'
 import { ArtifactViewState } from './ArtifactViewState'
 import { useArtifactContent } from './use-artifact-content'
+import { ArtifactHtmlFrame } from './ArtifactHtmlFrame'
 
-const HARDENING = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data: blob:; media-src data: blob:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; font-src data:"><script>window.open=function(){return null};</script>`
-
-export function HtmlArtifactView({ artifact, artifactApi, onMessage, refreshTrigger = 0 }: { artifact: Artifact; artifactApi: ArtifactApi; onMessage?: (data: unknown) => void; refreshTrigger?: number }) {
+export function HtmlArtifactView({ artifact, artifactApi, onMessage, onLinkClick, refreshTrigger = 0 }: { artifact: Artifact; artifactApi: ArtifactApi; onMessage?: (data: unknown) => void; onLinkClick?: (href: string) => boolean; refreshTrigger?: number }) {
   const state = useArtifactContent(artifact, artifactApi, refreshTrigger)
   const html = state.content?.kind === ArtifactContentKind.TEXT ? state.content.content : null
-  const srcDoc = useMemo(() => html === null ? '' : `${HARDENING}${html}`, [html])
-
-  useEffect(() => {
-    if (!onMessage) return
-    const listener = (event: MessageEvent) => {
-      if (event.origin === 'null') onMessage(event.data)
-    }
-    window.addEventListener('message', listener)
-    return () => window.removeEventListener('message', listener)
-  }, [onMessage])
-
-  return <ArtifactViewState loading={state.loading} error={state.error} missing={html === null}><iframe key={artifact.reloadTrigger} title={artifact.title} sandbox="allow-scripts" srcDoc={srcDoc} className="h-full w-full border-0 bg-white" /></ArtifactViewState>
+  return <ArtifactViewState loading={state.loading} error={state.error} missing={html === null}><ArtifactHtmlFrame key={`${artifact.path}:${artifact.reloadTrigger}`} html={html || ''} title={artifact.title} onLinkClick={onLinkClick} onMessage={onMessage} /></ArtifactViewState>
 }

--- a/src/renderer/src/components/artifacts/viewers/MarkdownArtifactView.tsx
+++ b/src/renderer/src/components/artifacts/viewers/MarkdownArtifactView.tsx
@@ -4,8 +4,8 @@ import { ArtifactContentKind } from '@shared/artifacts'
 import { ArtifactViewState } from './ArtifactViewState'
 import { useArtifactContent } from './use-artifact-content'
 
-export function MarkdownArtifactView({ artifact, artifactApi, refreshTrigger = 0 }: { artifact: Artifact; artifactApi: ArtifactApi; refreshTrigger?: number }) {
+export function MarkdownArtifactView({ artifact, artifactApi, refreshTrigger = 0, onLinkClick }: { artifact: Artifact; artifactApi: ArtifactApi; refreshTrigger?: number; onLinkClick?: (href: string) => boolean }) {
   const state = useArtifactContent(artifact, artifactApi, refreshTrigger)
   const text = state.content?.kind === ArtifactContentKind.TEXT ? state.content.content : null
-  return <ArtifactViewState loading={state.loading} error={state.error} missing={text === null}><div className="h-full overflow-y-auto px-6 py-5"><Markdown size="sm">{text || ''}</Markdown></div></ArtifactViewState>
+  return <ArtifactViewState loading={state.loading} error={state.error} missing={text === null}><div className="h-full overflow-y-auto px-6 py-5"><Markdown size="sm" onLinkClick={onLinkClick}>{text || ''}</Markdown></div></ArtifactViewState>
 }

--- a/src/renderer/src/components/artifacts/viewers/use-artifact-content.test.ts
+++ b/src/renderer/src/components/artifacts/viewers/use-artifact-content.test.ts
@@ -1,0 +1,21 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { ArtifactContentKind, ArtifactType, type Artifact, type ArtifactContent } from '@shared/artifacts'
+import { useArtifactContent } from './use-artifact-content'
+
+afterEach(cleanup)
+
+it('finishes loading when returning to a file before the next file loads', async () => {
+  let finishOther!: (value: ArtifactContent) => void
+  const other = new Promise<ArtifactContent>((resolve) => { finishOther = resolve })
+  const api = { scan: vi.fn(), read: vi.fn().mockImplementation(async (_task, path) => path === 'other.md' ? other : { kind: ArtifactContentKind.TEXT, content: 'Start' }) }
+  const artifact: Artifact = { id: 'demo', taskId: 'task', title: 'Demo', type: ArtifactType.MARKDOWN, path: 'start.md', updatedAt: 1, reloadTrigger: 0 }
+  const { result, rerender } = renderHook(({ path }) => useArtifactContent({ ...artifact, path }, api), { initialProps: { path: 'start.md' } })
+  await waitFor(() => expect(result.current.loading).toBe(false))
+  rerender({ path: 'other.md' })
+  expect(result.current.loading).toBe(true)
+  rerender({ path: 'start.md' })
+  await waitFor(() => expect(result.current.loading).toBe(false))
+  await act(async () => finishOther({ kind: ArtifactContentKind.TEXT, content: 'Other' }))
+  expect(result.current.content?.content).toBe('Start')
+})

--- a/src/renderer/src/components/artifacts/viewers/use-artifact-content.ts
+++ b/src/renderer/src/components/artifacts/viewers/use-artifact-content.ts
@@ -33,7 +33,7 @@ export function useArtifactContent(artifact: Artifact, artifactApi: ArtifactApi,
     }).finally(() => {
       if (!cancelled) {
         settledIdentityRef.current = identity
-        if (initialLoad) setLoading(false)
+        setLoading(false)
       }
     })
     return () => { cancelled = true }

--- a/src/renderer/src/components/ui/Markdown.tsx
+++ b/src/renderer/src/components/ui/Markdown.tsx
@@ -35,6 +35,7 @@ interface MarkdownProps {
   size?: MarkdownSize
   className?: string
   highlightQuery?: string
+  onLinkClick?: (href: string) => boolean
 }
 
 // Hoisted to module scope to prevent recreation on every render
@@ -195,7 +196,7 @@ const SIZE_CLASSES = {
  * (e.g., the agent transcript) where parent scrolling would otherwise trigger
  * recreation of the components config object on every frame.
  */
-export const Markdown = memo(function Markdown({ children, size = 'sm', className, highlightQuery }: MarkdownProps) {
+export const Markdown = memo(function Markdown({ children, size = 'sm', className, highlightQuery, onLinkClick }: MarkdownProps) {
   const classes = SIZE_CLASSES[size]
 
   // Memoize the components config object per `size` to avoid creating a new
@@ -267,7 +268,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
     },
     // Links
     a: ({ children, ...props }: React.ComponentPropsWithoutRef<'a'>) => (
-      <a className="text-primary hover:underline cursor-pointer" target="_blank" rel="noopener noreferrer" {...props}>{highlightReactNode(children, highlightQuery)}</a>
+      <a className="text-primary hover:underline cursor-pointer" target={props.href?.startsWith('#') ? undefined : '_blank'} rel="noopener noreferrer" {...props} onClick={(event) => { if (props.href && onLinkClick?.(props.href)) event.preventDefault() }}>{highlightReactNode(children, highlightQuery)}</a>
     ),
     // Images
     img: ({ alt, src, ...props }: React.ComponentPropsWithoutRef<'img'>) => (
@@ -300,7 +301,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
     tr: ({ children, ...props }: React.ComponentPropsWithoutRef<'tr'>) => (
       <tr className="hover:bg-muted/50 transition-colors" {...props}>{children}</tr>
     ),
-  }), [classes, highlightQuery]) // Only recreate when rendered styling or highlight changes
+  }), [classes, highlightQuery, onLinkClick]) // Only recreate when rendered styling or highlight changes
 
   // Pure string transform. `memo` above already gates re-renders of this
   // component on `children` changing, so an unrelated parent re-render never

--- a/src/renderer/src/stores/artifact-store.test.ts
+++ b/src/renderer/src/stores/artifact-store.test.ts
@@ -142,12 +142,12 @@ describe('useArtifactStore', () => {
 
   it('hydrates the registry through the artifact API without following the result', async () => {
     const api: ArtifactApi = {
-      scan: vi.fn().mockResolvedValue([{ path: 'report.md', title: 'report.md', type: ArtifactType.MARKDOWN, updatedAt: 5, size: 20 }]),
+      scan: vi.fn().mockResolvedValue([{ path: 'report.md', files: ['report.md', 'data.csv'], title: 'report.md', type: ArtifactType.MARKDOWN, updatedAt: 5, size: 20 }]),
       read: vi.fn().mockResolvedValue({ kind: ArtifactContentKind.TEXT, content: '# Report' })
     }
     await useArtifactStore.getState().hydrate('task-1', api)
     expect(api.scan).toHaveBeenCalledWith('task-1')
-    expect(useArtifactStore.getState().getArtifacts('task-1')).toEqual([expect.objectContaining({ path: 'report.md' })])
+    expect(useArtifactStore.getState().getArtifacts('task-1')).toEqual([expect.objectContaining({ path: 'report.md', files: ['report.md', 'data.csv'] })])
     expect(useArtifactStore.getState().getUI('task-1').activeTabId).toBeNull()
     expect(useArtifactStore.getState().hydratedTasks['task-1']).toBe(true)
   })

--- a/src/renderer/src/stores/artifact-store.ts
+++ b/src/renderer/src/stores/artifact-store.ts
@@ -191,6 +191,7 @@ export function artifactsFromMessage(taskId: string, message: ArtifactMessageLik
           title: typeof value.title === 'string' ? value.title : titleFromTarget(path),
           path,
           workpieceKey,
+          files: Array.isArray(value.files) ? value.files.filter((file): file is string => typeof file === 'string') : undefined,
           updatedAt: typeof value.updatedAt === 'number' ? value.updatedAt : updatedAt
         })
       }
@@ -229,6 +230,7 @@ function fromFileEntry(taskId: string, entry: ArtifactFileEntry): Omit<Artifact,
     title: entry.title || titleFromTarget(path),
     path,
     workpieceKey: entry.workpieceKey,
+    files: entry.files,
     updatedAt: entry.updatedAt
   }
 }
@@ -265,6 +267,7 @@ export const useArtifactStore = create<ArtifactState>((set, get) => ({
         && previous.path === candidate.path
         && previous.url === candidate.url
         && previous.workpieceKey === candidate.workpieceKey
+        && JSON.stringify(previous.files) === JSON.stringify(candidate.files)
         && previous.updatedAt === candidate.updatedAt
         && (!shouldFollow || (currentUI.open && currentUI.activeTabId === id))
       ) {
@@ -393,6 +396,7 @@ export const useArtifactStore = create<ArtifactState>((set, get) => ({
           && previous.path === candidate.path
           && previous.url === candidate.url
           && previous.workpieceKey === candidate.workpieceKey
+          && JSON.stringify(previous.files) === JSON.stringify(candidate.files)
           && previous.updatedAt === candidate.updatedAt
         ) continue
 

--- a/src/shared/artifact-navigation.test.ts
+++ b/src/shared/artifact-navigation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { isLocalArtifactLink, resolveArtifactLink } from './artifact-navigation'
+
+const files = ['artifacts/demo/docs/start.md', 'artifacts/demo/data/my file.csv', 'artifacts/demo/index.html']
+describe('artifact file links', () => {
+  it.each([
+    ['../data/my%20file.csv?download=1#row', files[1]],
+    ['../index.html', files[2]],
+    ['/artifacts/demo/index.html', files[2]],
+    ['artifacts/demo/index.html', files[2]]
+  ])('resolves %s against the selected file and inventory', (href, expected) => {
+    expect(resolveArtifactLink(files[0], href, files)).toBe(expected)
+  })
+  it.each(['../../../secret.txt', '../missing.md', '%zz', '%00', '..%5csecret.txt', 'https://example.com', '//example.com', 'file:///secret.txt', '#heading'])('does not read %s', (href) => {
+    expect(resolveArtifactLink(files[0], href, files)).toBeNull()
+  })
+  it.each(['https://example.com', 'mailto:a@example.com', '#heading', '//example.com'])('leaves %s to the existing link handler', (href) => {
+    expect(isLocalArtifactLink(href)).toBe(false)
+  })
+})

--- a/src/shared/artifact-navigation.ts
+++ b/src/shared/artifact-navigation.ts
@@ -1,0 +1,33 @@
+import { ArtifactType } from './artifacts'
+
+export function artifactFileType(path: string): ArtifactType {
+  const extension = path.split('.').pop()?.toLowerCase()
+  if (extension === 'md' || extension === 'mdx') return ArtifactType.MARKDOWN
+  if (extension === 'html' || extension === 'htm') return ArtifactType.HTML
+  if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'].includes(extension || '')) return ArtifactType.IMAGE
+  return ArtifactType.FILE
+}
+
+export function isLocalArtifactLink(href: string): boolean {
+  return !!href && !href.startsWith('#') && !href.startsWith('//') && !/^[a-z][a-z\d+.-]*:/i.test(href)
+}
+
+/** Resolve only files in the workpiece inventory. Never turn a link into an
+ * unrestricted workspace read, even when it contains parent segments. */
+export function resolveArtifactLink(currentPath: string, href: string, files: string[]): string | null {
+  if (!isLocalArtifactLink(href)) return null
+  let path: string
+  try { path = decodeURIComponent(href.split(/[?#]/)[0]) } catch { return null }
+  if (!path || path.includes('\\') || path.includes('\0')) return null
+  const normalize = (value: string): string | null => {
+    const parts: string[] = []
+    for (const part of value.split('/')) {
+      if (part === '..') { if (!parts.length) return null; parts.pop() }
+      else if (part && part !== '.') parts.push(part)
+    }
+    return parts.join('/')
+  }
+  const relative = normalize(`${currentPath.slice(0, currentPath.lastIndexOf('/') + 1)}${path}`)
+  const workspace = normalize(path)
+  return [relative, workspace].find((candidate) => candidate !== null && files.includes(candidate)) || null
+}

--- a/src/shared/artifacts.ts
+++ b/src/shared/artifacts.ts
@@ -71,6 +71,8 @@ export interface ArtifactFileEntry {
   /** Stable logical output identity. Multiple supporting files can belong to
    * one workpiece while `path` points at its selected preview entry file. */
   workpieceKey?: string
+  /** All owned files, addressed relative to the task workspace. */
+  files?: string[]
 }
 
 /** Metadata returned by the explicit artifact/workpiece tools. Files are
@@ -125,6 +127,8 @@ export interface Artifact {
   path?: string
   url?: string
   workpieceKey?: string
+  /** All owned files, addressed relative to the task workspace. */
+  files?: string[]
   updatedAt: number
   reloadTrigger: number
 }


### PR DESCRIPTION
An artifact can contain a report and supporting files, but the viewer received only the preview path. Markdown links opened as browser URLs. HTML links had no route to the artifact reader. For example, a link from `docs/start.md` to `../data.csv` could not open the CSV.

This change sends the file list through the desktop and mobile data paths. Both viewers keep one artifact tab and provide a file selector. Markdown and HTML file links select an owned file in that viewer. Copy and save use the selected file. Missing links show an error. Registered binary files can be copied or saved; common script files have a text preview.

File links must match the artifact inventory. Workspace path checks and the HTML sandbox remain in place. HTML messages must come from the displayed frame. The existing Markdown external link handler remains in use.

Validation:
- 103 focused tests passed, including desktop and mobile file links, selection, copy, path checks, registry data, and fast file switching.
- Five regression cases fail on the original code.
- Lint passed with existing warnings; typecheck and desktop/mobile builds passed.
- Both artifact viewer entry points and their scan/update data paths were checked. No live desktop or phone session was used.

HTML asset bundling and links from the conversation transcript are outside this change.
