### PR TITLE
fix: preserve artifact content during refresh and resize

### DIFF
--- a/src/mobile/pages/ArtifactViewerPage.test.tsx
+++ b/src/mobile/pages/ArtifactViewerPage.test.tsx
@@ -5,6 +5,8 @@ import { ArtifactViewerPage } from './ArtifactViewerPage'
 import { api } from '../api/client'
 import { useArtifactStore } from '../stores/artifact-store'
 
+vi.mock('mermaid', () => ({ default: { initialize: vi.fn(), render: vi.fn().mockResolvedValue({ svg: '<svg data-testid="stable-diagram" />' }) } }))
+
 const writeText = vi.fn().mockResolvedValue(undefined)
 
 beforeEach(() => {
@@ -17,9 +19,30 @@ beforeEach(() => {
   })
 })
 
-afterEach(cleanup)
+afterEach(() => { cleanup(); vi.restoreAllMocks() })
 
 describe('ArtifactViewerPage', () => {
+  it('keeps the diagram and scroll container through parent renders and refresh', async () => {
+    let refresh!: () => void
+    vi.spyOn(window, 'setInterval').mockImplementation((callback, timeout) => { if (timeout === 30_000) refresh = callback as () => void; return 1 as unknown as ReturnType<typeof window.setInterval> })
+    vi.spyOn(window, 'clearInterval').mockImplementation(() => {})
+    useArtifactStore.setState({ artifactsByTask: new Map([['task-1', [{ id: 'report', taskId: 'task-1', title: 'Report', type: ArtifactType.MARKDOWN, path: 'report.md', updatedAt: 1, reloadTrigger: 0 }]]]) })
+    vi.mocked(api.artifacts.content).mockResolvedValue({ kind: ArtifactContentKind.TEXT, content: '```mermaid\ngraph TD\nA --> B\n```\n\nEnd of report' })
+    const view = render(<ArtifactViewerPage taskId="task-1" artifactId="report" onNavigate={vi.fn()} />)
+    const diagram = await view.findByTestId('stable-diagram')
+    const paragraph = view.getByText('End of report')
+    const scroll = paragraph.closest('.overflow-auto')!
+    scroll.scrollTop = 320
+    view.rerender(<ArtifactViewerPage taskId="task-1" artifactId="report" onNavigate={vi.fn()} />)
+    expect(view.getByTestId('stable-diagram')).toBe(diagram)
+    const reads = vi.mocked(api.artifacts.content).mock.calls.length
+    await act(async () => refresh())
+    expect(api.artifacts.content).toHaveBeenCalledTimes(reads + 1)
+    expect(view.getByTestId('stable-diagram')).toBe(diagram)
+    expect(view.getByText('End of report')).toBe(paragraph)
+    expect(scroll.scrollTop).toBe(320)
+  })
+
   it('opens nested file links and copies the selected file content', async () => {
     const files = ['artifacts/demo/docs/start.md', 'artifacts/demo/data.csv', 'artifacts/demo/index.html']
     useArtifactStore.setState({ artifactsByTask: new Map([['task-1', [{ id: 'demo', taskId: 'task-1', title: 'Report', type: ArtifactType.MARKDOWN, path: files[0], files, updatedAt: 1, reloadTrigger: 0 }]]]) })

--- a/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
+++ b/src/renderer/src/components/artifacts/ArtifactsPanel.test.tsx
@@ -4,6 +4,8 @@ import { ArtifactClipboardMode, ArtifactContentKind, ArtifactType, type Artifact
 import { PinnedArtifactTabId } from '@/stores/artifact-store'
 import { ACTIVE_ARTIFACT_REFRESH_INTERVAL_MS, ArtifactsPanel } from './ArtifactsPanel'
 
+vi.mock('mermaid', () => ({ default: { initialize: vi.fn(), render: vi.fn().mockResolvedValue({ svg: '<svg data-testid="stable-diagram" />' }) } }))
+
 const artifactApi: ArtifactApi = {
   scan: vi.fn().mockResolvedValue([]),
   read: vi.fn().mockResolvedValue(null),
@@ -22,6 +24,27 @@ afterEach(() => {
 })
 
 describe('ArtifactsPanel', () => {
+  it('keeps the document and diagram mounted through resize and background refresh', async () => {
+    let refresh!: () => void
+    vi.spyOn(window, 'setInterval').mockImplementation((callback, timeout) => { if (timeout === 30_000) refresh = callback as () => void; return 1 as unknown as ReturnType<typeof window.setInterval> })
+    vi.spyOn(window, 'clearInterval').mockImplementation(() => {})
+    const read = vi.fn().mockResolvedValue({ kind: ArtifactContentKind.TEXT, content: '```mermaid\ngraph TD\nA --> B\n```\n\nEnd of report' })
+    const artifact: Artifact = { id: 'report', taskId: 'task-1', title: 'Report', type: ArtifactType.MARKDOWN, path: 'report.md', updatedAt: 1, reloadTrigger: 0 }
+    const props = { taskId: 'task-1', artifacts: [artifact], ui: { ...baseUi, activeTabId: 'report' }, artifactApi: { scan: vi.fn(), read }, hasChanges: false, hasOutput: false, onSelectTab: vi.fn(), onCloseTab: vi.fn(), onToggleOpen: vi.fn(), onToggleRail: vi.fn(), details: null, changes: null, output: null }
+    const view = render(<ArtifactsPanel {...props} className="w-96" />)
+    const diagram = await view.findByTestId('stable-diagram')
+    const paragraph = view.getByText('End of report')
+    const scroll = paragraph.closest('.overflow-y-auto')!
+    scroll.scrollTop = 320
+    view.rerender(<ArtifactsPanel {...props} className="w-80" />)
+    expect(view.getByTestId('stable-diagram')).toBe(diagram)
+    await act(async () => refresh())
+    expect(read).toHaveBeenCalledTimes(2)
+    expect(view.getByText('End of report')).toBe(paragraph)
+    expect(view.getByTestId('stable-diagram')).toBe(diagram)
+    expect(scroll.scrollTop).toBe(320)
+  })
+
   it('opens supporting file links, selects files, and copies the selected file', async () => {
     const files = ['artifacts/demo/docs/start.md', 'artifacts/demo/data.csv', 'artifacts/demo/index.html']
     const artifact: Artifact = { id: 'demo', taskId: 'task-1', title: 'Report', type: ArtifactType.MARKDOWN, path: files[0], files, updatedAt: 1, reloadTrigger: 0 }

--- a/src/renderer/src/components/ui/Markdown.stability.test.tsx
+++ b/src/renderer/src/components/ui/Markdown.stability.test.tsx
@@ -1,0 +1,35 @@
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import mermaid from 'mermaid'
+import { Markdown } from './Markdown'
+
+vi.mock('mermaid', () => ({ default: {
+  initialize: vi.fn(),
+  render: vi.fn().mockResolvedValue({ svg: '<svg data-testid="diagram"><rect /></svg>' })
+} }))
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+it('keeps rendered content when the link callback changes and uses the current callback', async () => {
+  const first = vi.fn().mockReturnValue(true)
+  const latest = vi.fn().mockReturnValue(true)
+  const text = '[File](data.csv)\n\n```mermaid\ngraph TD\nA --> B\n```\n\nEnd of report'
+  const view = render(<Markdown onLinkClick={first}>{text}</Markdown>)
+  const diagram = await view.findByTestId('diagram')
+  const paragraph = view.getByText('End of report')
+  view.rerender(<Markdown onLinkClick={latest}>{text}</Markdown>)
+  expect(view.getByTestId('diagram')).toBe(diagram)
+  expect(view.getByText('End of report')).toBe(paragraph)
+  fireEvent.click(view.getByRole('link', { name: 'File' }))
+  expect(latest).toHaveBeenCalledWith('data.csv')
+  expect(first).not.toHaveBeenCalled()
+  await act(async () => {})
+  expect(mermaid.render).toHaveBeenCalledTimes(1)
+
+  view.rerender(<Markdown onLinkClick={latest}>{text.replace('End of report', 'Updated report')}</Markdown>)
+  expect(view.getByText('Updated report')).toBe(paragraph)
+  expect(view.getByTestId('diagram')).toBe(diagram)
+
+  view.rerender(<Markdown onLinkClick={latest}>{text.replace('A --> B', 'A --> C')}</Markdown>)
+  await act(async () => {})
+  expect(mermaid.render).toHaveBeenCalledTimes(2)
+})

--- a/src/renderer/src/components/ui/Markdown.tsx
+++ b/src/renderer/src/components/ui/Markdown.tsx
@@ -14,7 +14,7 @@
  * ever need this.
  */
 
-import React, { Fragment, memo, useMemo, useState } from 'react'
+import React, { Fragment, memo, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Check, Copy } from 'lucide-react'
@@ -198,6 +198,11 @@ const SIZE_CLASSES = {
  */
 export const Markdown = memo(function Markdown({ children, size = 'sm', className, highlightQuery, onLinkClick }: MarkdownProps) {
   const classes = SIZE_CLASSES[size]
+  // Link behavior can change on resize, refresh, or file selection. Keep it
+  // current without replacing the component types passed to ReactMarkdown:
+  // replacing those types unmounts the content and redraws Mermaid diagrams.
+  const linkClickRef = useRef(onLinkClick)
+  useLayoutEffect(() => { linkClickRef.current = onLinkClick }, [onLinkClick])
 
   // Memoize the components config object per `size` to avoid creating a new
   // object reference on every render — ReactMarkdown does a shallow comparison.
@@ -268,7 +273,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
     },
     // Links
     a: ({ children, ...props }: React.ComponentPropsWithoutRef<'a'>) => (
-      <a className="text-primary hover:underline cursor-pointer" target={props.href?.startsWith('#') ? undefined : '_blank'} rel="noopener noreferrer" {...props} onClick={(event) => { if (props.href && onLinkClick?.(props.href)) event.preventDefault() }}>{highlightReactNode(children, highlightQuery)}</a>
+      <a className="text-primary hover:underline cursor-pointer" target={props.href?.startsWith('#') ? undefined : '_blank'} rel="noopener noreferrer" {...props} onClick={(event) => { if (props.href && linkClickRef.current?.(props.href)) event.preventDefault() }}>{highlightReactNode(children, highlightQuery)}</a>
     ),
     // Images
     img: ({ alt, src, ...props }: React.ComponentPropsWithoutRef<'img'>) => (
@@ -301,7 +306,7 @@ export const Markdown = memo(function Markdown({ children, size = 'sm', classNam
     tr: ({ children, ...props }: React.ComponentPropsWithoutRef<'tr'>) => (
       <tr className="hover:bg-muted/50 transition-colors" {...props}>{children}</tr>
     ),
-  }), [classes, highlightQuery, onLinkClick]) // Only recreate when rendered styling or highlight changes
+  }), [classes, highlightQuery]) // Only recreate when rendered styling or highlight changes
 
   // Pure string transform. `memo` above already gates re-renders of this
   // component on `children` changing, so an unrelated parent re-render never


### PR DESCRIPTION
Fixes a regression from #543. Resize and background refresh create a new artifact link callback. Markdown used that callback as a dependency for its component definitions. React then removed and rebuilt the document content, which made Mermaid diagrams disappear and redraw. The temporary loss of content could also move the viewer to the top of the file.

Keep the Markdown component definitions stable and use a ref for the current link callback. Refresh and resize retain the rendered text and diagrams. Links still use the current handler, text updates still appear, and changed Mermaid source still triggers a render. The shared fix applies to desktop and mobile.

Validation:
- 60 focused tests passed; lint and typecheck passed.
- All three new regression tests fail on the merged code.
- Desktop and mobile tests retain the diagram, document nodes, and scroll offset through parent renders and a background refresh.
- The shared Markdown test checks the current link handler, text updates, and a changed Mermaid source.
