### PR TITLE
fix: start feedback learning after a saved session expires

### DIFF
--- a/src/main/agent-manager.test.ts
+++ b/src/main/agent-manager.test.ts
@@ -1967,13 +1967,13 @@ describe('AgentManager session ID re-keying redirect', () => {
 })
 
 describe('AgentManager resumeAdapterSession — SESSION_ENDED for completed tasks', () => {
-  it('returns empty string instead of throwing for ReadyForReview tasks', async () => {
+  it.each([TaskStatus.ReadyForReview, TaskStatus.AgentLearning])('returns an ended session for %s with user feedback intent', async (status) => {
     const mockDb = {
       getTask: vi.fn(() => ({
         id: 'task-1',
         title: 'Test',
         agent_id: 'agent-1',
-        status: TaskStatus.ReadyForReview,
+        status,
       })),
       getAgent: vi.fn(() => ({
         id: 'agent-1',
@@ -1985,7 +1985,7 @@ describe('AgentManager resumeAdapterSession — SESSION_ENDED for completed task
       getMcpServer: vi.fn(() => null),
       getSecretsByIds: vi.fn(() => []),
       getSecretsWithValues: vi.fn(() => []),
-      getSetting: vi.fn(() => null),
+      getSetting: vi.fn((key: string) => key === 'session-feedback-completion:task-1' ? '{"completeAtSource":false}' : null),
     } as unknown as ConstructorParameters<typeof AgentManager>[0]
 
     const mgr = new AgentManager(mockDb)

--- a/src/main/agent-manager.ts
+++ b/src/main/agent-manager.ts
@@ -2973,7 +2973,9 @@ Only create this file when there's genuinely useful monitoring to do. Do not cre
         // Don't show the alarming "incompatible" dialog — just clear the session_id
         // so the UI shows "Start" instead. This commonly happens with subtask sessions.
         const currentTask = this.db.getTask(taskId)
-        if (currentTask && (currentTask.status === TaskStatus.ReadyForReview || currentTask.status === TaskStatus.Completed)) {
+        const pendingFeedback = currentTask?.status === TaskStatus.AgentLearning
+          && this.db.getSetting(`session-feedback-completion:${taskId}`)
+        if (currentTask && (currentTask.status === TaskStatus.ReadyForReview || currentTask.status === TaskStatus.Completed || pendingFeedback)) {
           console.log(`[AgentManager] Session ended normally for ${currentTask.status} task ${taskId} — clearing session_id`)
           this.updateTaskFromLocalAgent(taskId, { session_id: null })
           this.sendToRenderer('task:updated', { taskId, updates: { session_id: null } })

--- a/src/mobile/pages/TaskDetailPage.test.tsx
+++ b/src/mobile/pages/TaskDetailPage.test.tsx
@@ -116,6 +116,33 @@ describe('TaskDetailPage', () => {
     }
   })
 
+  it.each([true, false])('starts learning when the saved session ended, source completion %s', async (completeAtSource) => {
+    const task = makeTask({agent_id: 'agent-1', source_id: 'notion', source: 'Notion', session_id: 'ended'})
+    const originalUpdate = useTaskStore.getState().updateTask
+    const updateTask = vi.fn().mockResolvedValue(true)
+    const resume = vi.spyOn(api.sessions, 'resume').mockResolvedValue({sessionId: ''})
+    const start = vi.spyOn(api.sessions, 'start').mockResolvedValue({sessionId: 'learning'})
+    const send = vi.spyOn(api.sessions, 'send').mockResolvedValue({success: true})
+    useTaskStore.setState({tasks: [task], isLoading: false, updateTask})
+    try {
+      const view = render(<TaskDetailPage taskId="task-1" onNavigate={mockNavigate} />)
+      fireEvent.click(view.getByTestId('main-cta-complete'))
+      if (!completeAtSource) fireEvent.click(view.getByRole('radio', {name: "I'll do it manually"}))
+      fireEvent.click(view.getByRole('button', {name: 'Rate 5'}))
+      fireEvent.click(view.getByRole('button', {name: 'Submit Feedback'}))
+      await waitFor(() => expect(send).toHaveBeenCalledWith('learning', expect.stringContaining('User rated this session 5/5'), task.id, task.agent_id))
+      expect(start).toHaveBeenCalledWith('agent-1', task.id, true)
+      expect(updateTask).toHaveBeenCalledWith(task.id, expect.objectContaining({status: 'agent_learning', feedback_rating: 5, complete_at_source: completeAtSource}))
+      expect(completeMock).not.toHaveBeenCalled()
+    } finally {
+      cleanup()
+      useTaskStore.setState({updateTask: originalUpdate})
+      resume.mockRestore()
+      start.mockRestore()
+      send.mockRestore()
+    }
+  })
+
   it.each(['approve', undefined])('shows the Session Feedback action %s before Skip completes', async (action) => {
     const task = makeTask({ agent_id: 'agent-1', source_id: 'session-feedback', source: 'Session Feedback',
       output_fields: action ? [{ id: 'action', value: action }] : [] })

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -101,7 +101,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   agentSession: {
     start: (agentId: string, taskId: string, workspaceDir?: string, skipInitialPrompt?: boolean): Promise<{ sessionId: string }> =>
       ipcRenderer.invoke('agentSession:start', agentId, taskId, workspaceDir, skipInitialPrompt),
-    resume: (agentId: string, taskId: string, ocSessionId: string): Promise<{ sessionId: string }> =>
+    resume: (agentId: string, taskId: string, ocSessionId: string): Promise<{ sessionId: string; ended?: boolean }> =>
       ipcRenderer.invoke('agentSession:resume', agentId, taskId, ocSessionId),
     abort: (sessionId: string): Promise<{ success: boolean }> =>
       ipcRenderer.invoke('agentSession:abort', sessionId),

--- a/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.test.tsx
@@ -1,3 +1,4 @@
+import { useProgressToastStore } from '@/stores/progress-toast-store'
 import { useTaskSourceStore } from '@/stores/task-source-store'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, act, fireEvent, screen, waitFor, cleanup } from '@testing-library/react'
@@ -177,6 +178,42 @@ describe('TaskWorkspace keyboard actions', () => {
       await waitFor(() => expect(noopFn).toHaveBeenCalledWith(completeAtSource))
       expect(window.electronAPI.agentSession.send).not.toHaveBeenCalled()
     }
+  })
+
+  it.each([true, false])('starts learning after an ended session with source completion %s', async (completeAtSource) => {
+    vi.mocked(window.electronAPI.agentSession.resume).mockResolvedValueOnce({ sessionId: '', ended: true })
+    vi.mocked(window.electronAPI.agentSession.start).mockResolvedValueOnce({ sessionId: 'learning-session' })
+    const task = makeRendererTask({ status: TaskStatus.ReadyForReview, session_id: 'ended-session', source: 'Notion', source_id: 'notion' })
+    renderWorkspace(task)
+    act(() => dispatchTaskShortcut({ action: TaskShortcutAction.COMPLETE, taskId: task.id }))
+    if (!completeAtSource) fireEvent.click(screen.getByRole('radio', { name: "I'll do it manually" }))
+    fireEvent.click(screen.getAllByRole('button').filter(button => button.querySelector('svg.lucide-star'))[4])
+    fireEvent.click(screen.getByRole('button', { name: 'Submit Feedback' }))
+    await waitFor(() => expect(window.electronAPI.agentSession.send).toHaveBeenCalledWith(
+      'learning-session', expect.stringContaining('User rated this session 5/5'), task.id, 'agent-1', undefined
+    ))
+    expect(window.electronAPI.agentSession.start).toHaveBeenCalledWith('agent-1', task.id, undefined, true)
+    expect(window.electronAPI.db.updateTask).toHaveBeenCalledWith(task.id, expect.objectContaining({
+      status: TaskStatus.AgentLearning, complete_at_source: completeAtSource, feedback_rating: 5
+    }))
+    expect(window.electronAPI.db.updateTask).not.toHaveBeenCalledWith(task.id, { status: TaskStatus.ReadyForReview })
+    expect(noopFn).not.toHaveBeenCalled()
+  })
+
+  it('shows a retryable error when the learning session cannot start', async () => {
+    vi.mocked(window.electronAPI.agentSession.resume).mockRejectedValueOnce(new Error('Agent is unavailable'))
+    const task = makeRendererTask({status: TaskStatus.ReadyForReview, session_id: 'saved', source: 'Notion', source_id: 'notion'})
+    renderWorkspace(task)
+    act(() => dispatchTaskShortcut({action: TaskShortcutAction.COMPLETE, taskId: task.id}))
+    fireEvent.click(screen.getAllByRole('button').filter(button => button.querySelector('svg.lucide-star'))[4])
+    fireEvent.click(screen.getByRole('button', {name: 'Submit Feedback'}))
+    await waitFor(() => expect(useProgressToastStore.getState().toasts.get('feedback-task-1')).toMatchObject({
+      status: 'error', message: 'Agent is unavailable'
+    }))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    expect(window.electronAPI.db.updateTask).toHaveBeenCalledWith(task.id, {status: TaskStatus.ReadyForReview})
+    expect(window.electronAPI.agentSession.send).not.toHaveBeenCalled()
+    expect(noopFn).not.toHaveBeenCalled()
   })
 
   it.each(['approve', undefined])('shows the Session Feedback source action %s before completion', async (action) => {

--- a/src/renderer/src/components/tasks/TaskWorkspace.tsx
+++ b/src/renderer/src/components/tasks/TaskWorkspace.tsx
@@ -717,26 +717,13 @@ tags:
 Update existing skills that were helpful or create new ones for patterns worth reusing.`
 
     try {
-      if (!session.sessionId) {
-        const readySessionId = await ensureChatSession()
+      // Resume if possible, or start a learning-only session when the old
+      // adapter session has ended. The feedback prompt is the sole new task.
+      if (!useAgentStore.getState().sessions.get(task.id)?.sessionId) {
+        const readySessionId = task.session_id
+          ? await ensureChatSession(true)
+          : await start(task.agent_id, task.id, undefined, true)
         if (!readySessionId) throw new Error('Could not start the learning session.')
-
-        // Wait for messages to load (poll for session to be ready)
-        await new Promise<void>((resolve) => {
-          const checkReady = () => {
-            const latestSession = useAgentStore.getState().sessions.get(task.id)
-            if (latestSession?.messages && latestSession.messages.length > 0) {
-              resolve()
-            } else {
-              setTimeout(checkReady, 500)
-            }
-          }
-          setTimeout(checkReady, 500)
-          // Timeout after 10 seconds
-          setTimeout(() => {
-            resolve()
-          }, 10000)
-        })
       }
 
       // Send feedback message through normal flow so it shows in UI
@@ -745,9 +732,13 @@ Update existing skills that were helpful or create new ones for patterns worth r
       // Backend will handle skill sync and task completion when session goes idle
     } catch (error) {
       console.error('Failed to send feedback:', error)
+      const toastId = `feedback-${task.id}`
+      showProgressToast(toastId, 'Learning could not start')
+      failProgressToast(toastId, error instanceof Error ? error.message : String(error))
       await taskApi.update(task.id, { status: TaskStatus.ReadyForReview })
+      setShowFeedback(true)
     }
-  }, [ensureChatSession, sendMessage, session.sessionId, task, onCompleteTask])
+  }, [ensureChatSession, sendMessage, start, task])
 
   const handleFeedbackSkip = useCallback(async (completeAtSource: boolean) => {
     if (!task?.id) return

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -252,7 +252,7 @@ interface ElectronAPI {
   }
   agentSession: {
     start: (agentId: string, taskId: string, workspaceDir?: string, skipInitialPrompt?: boolean) => Promise<AgentSessionStartResult>
-    resume: (agentId: string, taskId: string, ocSessionId: string) => Promise<AgentSessionStartResult>
+    resume: (agentId: string, taskId: string, ocSessionId: string) => Promise<AgentSessionStartResult & { ended?: boolean }>
     abort: (sessionId: string) => Promise<AgentSessionSuccessResult>
     stop: (sessionId: string) => Promise<AgentSessionSuccessResult>
     stopByTaskId: (taskId: string) => Promise<AgentSessionSuccessResult & { sessionId: string | null }>


### PR DESCRIPTION
Submitting feedback for a reviewed task could close the dialog without starting Agent Learning when its saved adapter session had expired. Feedback first sets AgentLearning, but expired-session recovery only accepted Review/Completed. Desktop also stopped on the ended-session response and hid startup failures.

Allow expired-session recovery for learning with an explicit pending user-feedback marker. Desktop starts a fresh session with only the learning prompt, removes the transcript-message polling delay, and shows startup failures with a retry dialog. Keep the independent source completion choice unchanged. Correct the resume response types to include the existing ended flag.

Validation: 2,836 tests passed (4 skipped), typecheck and build passed; lint passed with existing warnings. New tests failed before the fix for both desktop source choices and backend learning recovery. Added mobile expired-session coverage and desktop error reporting coverage. These tests simulate adapter/API responses; the reported live task has not yet been identified or reproduced. No live Notion records were changed.

Follow-up to #542.
